### PR TITLE
feature(#2437): S-6 resistance breakout — the first strategy of the new set, firing

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -89,6 +89,7 @@ from app.services.equity_curve import (
     build_month_end_rebalanced_curve,
 )
 from app.services.indicator_series import BarSeries, Universe
+from app.services.market_regime_provider import MarketRegimeProvider
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.outcome_resolver import ExitLevels, UnresolvedReason, resolve_outcome
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
@@ -1411,6 +1412,7 @@ def evaluate_arm(
     return_basis: str = TOTAL_RETURN_BASIS,
     sizing_rule: str = SIZING_RULE_ID,
     cohort_size: int | None = None,
+    regime_provider: MarketRegimeProvider | None = None,
 ) -> ArmMeasurement:
     """One ``(strategy, quarantine arm)`` corpus pass, end to end.
 
@@ -1432,6 +1434,18 @@ def evaluate_arm(
     avoid the second read is the full-corpus materialisation the §3.1 spec
     already refused.
     """
+    # ⚠ ONE benchmark classification per arm pass, built before the instrument
+    # loop. See `_signals_for` for the material limitation: `price_daily` SPY
+    # starts 2022-05-10 while this axis reaches 1962, so every earlier bar
+    # carries `None` and a regime-gated strategy cannot fire there.
+    #
+    # ⚠ INJECTABLE, defaulting to a read from `conn`. Two callers need to supply
+    # their own: a harness with no real connection, and — when it exists — a
+    # provider sourced from the RESEARCH corpus, which is what actually closes
+    # the pre-2022 gap above. A parameter now costs nothing and is the seam that
+    # fix will use.
+    if regime_provider is None:
+        regime_provider = MarketRegimeProvider.load(conn)
     started = time.monotonic()
     if return_basis not in {LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS}:
         raise ValueError(f"unknown return basis {return_basis!r}")
@@ -1516,6 +1530,7 @@ def evaluate_arm(
             instrument_id=instrument_id,
             ranking=ranking,
             unresolved_breaks=corpus.unresolved_breaks.get(instrument_id, ()),
+            regime_provider=regime_provider,
         )
         rows = resolve_fills(signals, series=series, identity=identity, instrument_id=instrument_id)
         entries, exits = _fills(rows, instrument_id)
@@ -1690,6 +1705,7 @@ def evaluate_level_arms(
     return_basis: str = TOTAL_RETURN_BASIS,
     sizing_rule: str = SIZING_RULE_ID,
     cohort_size: int | None = None,
+    regime_provider: MarketRegimeProvider | None = None,
 ) -> tuple[ArmMeasurement, ...]:
     """Evaluate both daily-OHLC ambiguity projections from one corpus pass.
 
@@ -1705,6 +1721,18 @@ def evaluate_level_arms(
     counters and discarded-position counters remain arm-local, so the two
     measurements cannot influence one another after that common evidence.
     """
+    # ⚠ ONE benchmark classification per arm pass, built before the instrument
+    # loop. See `_signals_for` for the material limitation: `price_daily` SPY
+    # starts 2022-05-10 while this axis reaches 1962, so every earlier bar
+    # carries `None` and a regime-gated strategy cannot fire there.
+    #
+    # ⚠ INJECTABLE, defaulting to a read from `conn`. Two callers need to supply
+    # their own: a harness with no real connection, and — when it exists — a
+    # provider sourced from the RESEARCH corpus, which is what actually closes
+    # the pre-2022 gap above. A parameter now costs nothing and is the seam that
+    # fix will use.
+    if regime_provider is None:
+        regime_provider = MarketRegimeProvider.load(conn)
     started = time.monotonic()
     if return_basis not in {LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS}:
         raise ValueError(f"unknown return basis {return_basis!r}")
@@ -1790,6 +1818,7 @@ def evaluate_level_arms(
             instrument_id=instrument_id,
             ranking=ranking,
             unresolved_breaks=corpus.unresolved_breaks.get(instrument_id, ()),
+            regime_provider=regime_provider,
         )
         rows = resolve_fills(signals, series=series, identity=identity, instrument_id=instrument_id)
         entries, exits = _fills(rows, instrument_id)
@@ -1911,8 +1940,22 @@ def _signals_for(
     instrument_id: int,
     ranking: _CrossSection | None,
     unresolved_breaks: Sequence[date] = (),
+    regime_provider: MarketRegimeProvider,
 ) -> list[StrategySignal]:
-    """One instrument's whole-series verdicts, per-series or cross-sectional."""
+    """One instrument's whole-series verdicts, per-series or cross-sectional.
+
+    ⚠⚠ THE REGIME COMES FROM ``price_daily``, WHICH STARTS 2022-05-10, WHILE THIS
+    BACKTEST'S AXIS REACHES BACK TO 1962. Every bar before the benchmark's first
+    is ``None``, so a regime-gated strategy (S-5…S-10) CANNOT FIRE on the long
+    span and its pre-2022 result is an empty sample rather than a bad one.
+
+    Stated here rather than worked around because the workaround would be worse:
+    defaulting the missing years to a permissive regime would fabricate market
+    conditions for six decades. Closing this needs a benchmark series in the
+    RESEARCH corpus — the same source the bars come from — which is a separate
+    piece of work. Until then, judge S-5…S-10 on the window where the regime
+    exists, which is what §0 of the spec asks for anyway.
+    """
     if entry.signals is not None:
         return segmented_signals(
             entry,
@@ -1920,6 +1963,7 @@ def _signals_for(
             universe=BACKTEST_UNIVERSE,
             masked_reason="quarantined_bar",
             unresolved_breaks=unresolved_breaks,
+            regime=regime_provider.for_dates(series.dates),
         )
     assert entry.member is not None and ranking is not None
     staged = segmented_member(

--- a/app/services/market_regime.py
+++ b/app/services/market_regime.py
@@ -238,6 +238,24 @@ def _trailing_sma(values: npt.NDArray[np.float64], period: int) -> npt.NDArray[n
     return out
 
 
+def unconstrained_regime(n_bars: int, *, regime: Regime = Regime.BULL_QUIET) -> RegimeSeries:
+    """A uniform regime for callers that must SUPPLY one but do not GATE on one.
+
+    ⚠⚠ NOT A PRODUCTION SHORTCUT, AND THE NAME IS THE WARNING. S-1…S-4 predate
+    the regime and ignore the argument, so a harness exercising them still has to
+    pass something; this is that something. Using it on a path that scans a
+    regime-GATED strategy (S-5…S-10) would assert a market condition nobody
+    measured and let the strategy fire in conditions it declares it avoids.
+
+    The real scan builds its regime from the benchmark via
+    ``market_regime_provider.MarketRegimeProvider``. If you are reaching for this
+    in ``app/``, you are almost certainly reaching for that instead.
+    """
+    if n_bars < 0:
+        raise ValueError(f"n_bars must be non-negative, got {n_bars}")
+    return RegimeSeries(values=(regime,) * n_bars)
+
+
 __all__ = [
     "BOLLINGER_NUM_STD",
     "BOLLINGER_PERIOD",
@@ -248,5 +266,6 @@ __all__ = [
     "RegimeSeries",
     "bandwidth",
     "classify_regimes",
+    "unconstrained_regime",
     "is_squeeze",
 ]

--- a/app/services/market_regime_provider.py
+++ b/app/services/market_regime_provider.py
@@ -1,0 +1,133 @@
+"""Load the benchmark once, classify it, align it to any instrument (S-5…S-10 §1).
+
+``market_regime`` is PURE — arrays in, verdicts out, no I/O, hashed into every
+strategy identity that consumes it. This module is the impure half: it reads the
+benchmark from the database and aligns the result to an instrument's own bar
+dates. The split is deliberate, so a regime edit that changes verdicts moves the
+hash while a change to *how the benchmark is fetched* does not.
+
+⚠⚠ ALIGNED BY DATE, NEVER BY POSITION. An instrument and the benchmark do not
+share a bar count — different listing dates, different halts, different holidays
+on a non-US venue. Zipping two arrays positionally would pair an instrument's
+2024 bar with the benchmark's 2022 bar and every regime verdict downstream would
+be silently wrong in a way no length check catches. The date map is the whole
+point of this module.
+
+⚠ A bar with no benchmark bar on that date gets ``None`` — not the previous
+regime, and not a default. ``RegimeSeries.permits`` refuses ``None``, so an
+instrument trading on a day the benchmark did not simply does not fire. Carrying
+the last known regime forward would be a guess presented as an observation, and
+it would be most wrong exactly when the market is closed for an unusual reason.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Final
+
+import numpy as np
+import psycopg
+
+from app.services.market_regime import (
+    BOLLINGER_NUM_STD,
+    BOLLINGER_PERIOD,
+    Regime,
+    RegimeSeries,
+    classify_regimes,
+)
+
+#: The benchmark the regime is measured on.
+#:
+#: ⚠⚠ SPY AND SPY.RTH ARE THE SAME FUND and no column separates them — only
+#: ``.RTH`` carries a ``real`` arm. Pinned by exact symbol rather than resolved
+#: by a LIKE or a prefix match, because a resolver that returns both would pick
+#: one arbitrarily and the regime would change identity between runs.
+BENCHMARK_SYMBOL: Final[str] = "SPY"
+
+
+class BenchmarkUnavailableError(RuntimeError):
+    """The benchmark series cannot be loaded or is too short to classify.
+
+    ⚠ Raised rather than degrading to "no regime". A scan that silently produced
+    an all-``None`` regime would refuse every gated strategy and look exactly
+    like a quiet market — a total outage rendering as a legitimate verdict.
+    """
+
+
+def _bollinger(closes: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """SMA(20) ± 2 POPULATION sigma, matching ``indicator_series.bollinger_series``.
+
+    ⚠ POPULATION sigma (``/n``), not sample (``/n-1``) — inherited from
+    ``technical_analysis.bollinger_bands``, whose test asserts ``/ 20``. Using
+    the sample form here would put the regime on a slightly different band than
+    every other Bollinger consumer in the codebase, and the disagreement would
+    only show at the Squeeze/Bulge boundary, which is precisely where it matters.
+    """
+    n = closes.size
+    upper = np.full(n, np.nan)
+    middle = np.full(n, np.nan)
+    lower = np.full(n, np.nan)
+    for i in range(BOLLINGER_PERIOD - 1, n):
+        window = closes[i - BOLLINGER_PERIOD + 1 : i + 1]
+        if not np.all(np.isfinite(window)):
+            continue
+        mean = float(window.mean())
+        sigma = float(window.std())
+        middle[i] = mean
+        upper[i] = mean + BOLLINGER_NUM_STD * sigma
+        lower[i] = mean - BOLLINGER_NUM_STD * sigma
+    return upper, middle, lower
+
+
+class MarketRegimeProvider:
+    """One classification of the benchmark, reusable across a whole scan.
+
+    ⚠ Built ONCE per scan and shared. Re-classifying per instrument would be
+    thousands of redundant passes over the same benchmark, and — worse — would
+    let two instruments in one cycle disagree about what the market was doing if
+    anything about the read changed between them.
+    """
+
+    def __init__(self, *, regime_by_date: dict[date, Regime | None]) -> None:
+        self._by_date = regime_by_date
+
+    @classmethod
+    def load(cls, conn: psycopg.Connection[Any], *, symbol: str = BENCHMARK_SYMBOL) -> MarketRegimeProvider:
+        rows = conn.execute(
+            """
+            SELECT p.price_date, p.close
+            FROM price_daily p
+            JOIN instruments i ON i.instrument_id = p.instrument_id
+            WHERE i.symbol = %s AND p.close IS NOT NULL
+            ORDER BY p.price_date
+            """,
+            (symbol,),
+        ).fetchall()
+        if not rows:
+            raise BenchmarkUnavailableError(f"benchmark {symbol!r} has no priced bars; the regime cannot be classified")
+        dates = [row[0] for row in rows]
+        closes = np.array([float(row[1]) for row in rows])
+        upper, middle, lower = _bollinger(closes)
+        series = classify_regimes(closes=closes, band_upper=upper, band_middle=middle, band_lower=lower)
+        if all(value is None for value in series.values):
+            raise BenchmarkUnavailableError(
+                f"benchmark {symbol!r} has {len(rows)} bars but none are classifiable; "
+                "the 200-SMA and a full 126-bar BandWidth window need ~326 bars"
+            )
+        return cls(regime_by_date=dict(zip(dates, series.values, strict=True)))
+
+    def for_dates(self, dates: tuple[date, ...]) -> RegimeSeries:
+        """The regime on each of ``dates``, ``None`` where the benchmark has no bar."""
+        return RegimeSeries(values=tuple(self._by_date.get(day) for day in dates))
+
+    @property
+    def classified_days(self) -> int:
+        """How many benchmark days carry a regime — for run reporting."""
+        return sum(1 for value in self._by_date.values() if value is not None)
+
+
+__all__ = [
+    "BENCHMARK_SYMBOL",
+    "BenchmarkUnavailableError",
+    "MarketRegimeProvider",
+]

--- a/app/services/market_regime_provider.py
+++ b/app/services/market_regime_provider.py
@@ -105,7 +105,24 @@ class MarketRegimeProvider:
         ).fetchall()
         if not rows:
             raise BenchmarkUnavailableError(f"benchmark {symbol!r} has no priced bars; the regime cannot be classified")
+        # ⚠⚠ DUPLICATE DATES ARE A LIVE RISK HERE, NOT A HYPOTHETICAL. This repo
+        # already records that SPY and SPY.RTH are the SAME FUND with no column
+        # separating them, so a symbol match can return two instrument_ids and
+        # two rows per date. Building the map without this check keeps whichever
+        # row survives the dict insert — silently, and the corrupted regime is
+        # then SHARED by every strategy that gates on it.
+        #
+        # Raising rather than de-duplicating: picking one of two candidate
+        # benchmarks is a decision about which series the regime means, and it
+        # belongs to whoever pins the symbol, not to a tie-break here.
         dates = [row[0] for row in rows]
+        if len(set(dates)) != len(dates):
+            duplicated = sorted({day for day in dates if dates.count(day) > 1})[:5]
+            raise BenchmarkUnavailableError(
+                f"benchmark {symbol!r} returned multiple rows for the same date "
+                f"(first few: {duplicated}); more than one instrument matches this symbol, "
+                "so the regime series is ambiguous — pin the instrument_id rather than the symbol"
+            )
         closes = np.array([float(row[1]) for row in rows])
         upper, middle, lower = _bollinger(closes)
         series = classify_regimes(closes=closes, band_upper=upper, band_middle=middle, band_lower=lower)

--- a/app/services/strategies/s5_support_bounce.py
+++ b/app/services/strategies/s5_support_bounce.py
@@ -1,0 +1,275 @@
+"""S-5 — support bounce. Second of the S-5…S-10 set.
+
+Parent spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §3 (S-5),
+§1 (regime), §2 (levels). Registry contract: ``app/services/strategy_registry.py``.
+Refs #2437.
+
+THE RULE, VERBATIM FROM §3
+-------------------------
+    Setup: price within 0.5 × ATR(14) of a live support level (§2); regime ∈
+    {``bull_quiet``, ``bull_volatile``}. Signal: bar ``t`` closes **above** the
+    level having traded below it intrabar — rejection, not a close-through.
+    Exit: stop ``level − 1.0 × ATR(14)``; target ``entry + 2.0 × ATR(14)``; max
+    hold 30 bars. Params: 4. Data: OHLC + volume.
+
+⚠⚠ THE SIGNAL IS A REJECTION, AND THAT IS WHY IT READS THE LOW.
+``close(t) > level`` alone is true on almost every bar of an uptrend that never
+came near the level — it describes POSITION, not EVENT, which is the exact defect
+S-6's first implementation shipped (70 entries per instrument per four years).
+S-5 avoids it by construction rather than by a crossing guard: the bar must have
+traded BELOW the level intrabar (``low(t) < level``) and closed back ABOVE it.
+That pair is a wick through support that got bought — one bar, self-contained,
+and it cannot be satisfied by simply being above the level.
+
+⚠ CONTRAST WITH S-6 DELIBERATELY. S-6 needs `close(t-1) <= level` because a
+close-through says nothing about the prior bar; S-5 needs no prior bar at all
+because the low and the close of the SAME bar already encode the rejection. Two
+rules, two shapes, same failure avoided.
+
+⚠ PERMITS ``bull_volatile``, UNLIKE S-6. A breakout into a Bollinger Bulge is the
+classic false break, so S-6 excludes it. A bounce is the opposite trade: the
+volatility that makes a breakout fail is what produces the wick this rule wants.
+The asymmetry is the spec's, and collapsing the two strategies onto one regime
+set would quietly change both.
+
+⚠ NO EXIT SIGNAL LEG, for S-4's reason. Stop, target and max-hold are all
+measured from the entry, so all three are position state; a per-bar verdict
+function has none.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+
+import numpy as np
+
+from app.services.indicator_series import (
+    BarSeries,
+    IndicatorSeries,
+    Universe,
+    atr_series,
+)
+from app.services.market_regime import REGIME_RULE_VERSION, Regime, RegimeSeries
+from app.services.price_levels import LEVEL_RULE_VERSION, levels_at
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+
+S5_STRATEGY_ID = "s5-support-bounce"
+
+#: ⚠ FIXED, NEVER TUNED — a threshold that can be passed in is one that can be
+#: swept, and criterion 11 would need every swept value registered separately.
+ATR_PERIOD = 14
+
+#: The bracket, in ATR multiples at the SIGNAL bar.
+#:
+#: ⚠ TARGET IS 2.0 HERE AND 3.0 ON S-6, and that is the spec's asymmetry, not an
+#: oversight. A bounce trades back into a range and has the opposite side of that
+#: range as its natural ceiling; a breakout trades out of one and has none. Same
+#: 1.0 stop, different reward, because the two setups have different room.
+ATR_STOP_MULTIPLE = 1.0
+ATR_TARGET_MULTIPLE = 2.0
+MAX_HOLD_BARS = 30
+
+#: ⚠ TWO REGIMES, unlike S-6's one. See the module docstring: the volatility that
+#: makes a breakout fail is what produces the wick a bounce needs.
+PERMITTED_REGIMES = frozenset({Regime.BULL_QUIET, Regime.BULL_VOLATILE})
+
+#: ⚠ §3 says "Params: 4"; this carries six plus the two shared rule versions, for
+#: S-4's recorded reason — §3 counts FREE parameters, criterion 11 hashes
+#: everything that makes this a distinct strategy.
+#:
+#: ⚠⚠ The shared rule versions MUST be here. The same bars under a different
+#: ``LEVEL_RULE_VERSION`` produce different levels and therefore different
+#: signals, so omitting them would let a level-rule edit silently inherit this
+#: strategy's track record.
+S5_PARAMS: Mapping[str, object] = {
+    "atr_period": ATR_PERIOD,
+    "atr_stop_multiple": ATR_STOP_MULTIPLE,
+    "atr_target_multiple": ATR_TARGET_MULTIPLE,
+    "max_hold_bars": MAX_HOLD_BARS,
+    "permitted_regimes": tuple(sorted(r.value for r in PERMITTED_REGIMES)),
+    "level_rule_version": LEVEL_RULE_VERSION,
+    "regime_rule_version": REGIME_RULE_VERSION,
+}
+
+#: DERIVED from the rule. ATR emits its first value at ``ATR_PERIOD``; the level
+#: constructor needs confirmed pivots, which arrive later but produce ``None``
+#: rather than a wrong answer, so ATR binds locally.
+WARMUP_BARS = ATR_PERIOD
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s5_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-5 on one universe under one cost model."""
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "pass app.services.cost_model.COST_MODEL_ID rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S5_STRATEGY_ID,
+        params=S5_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, in the shape the runner checks for evaluability.
+
+    ⚠ ``not_evaluable_indices`` is the load-bearing part. Without it a MASKED
+    close is reported as ``insufficient_warmup`` — the verdict is still "not
+    evaluable" so nothing breaks, but the recorded REASON is wrong, and that
+    survives every test which only checks whether a bar fired. S-6 shipped
+    exactly that bug and a manifest guard caught it.
+    """
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
+def _volumes(series: BarSeries) -> np.ndarray:
+    """Bar volumes as float, missing volume as NaN.
+
+    ⚠ Used only to weight level clustering, never as a signal condition — S-5 has
+    no volume test. NaN rather than 0.0 so a missing volume does not silently
+    weight a pivot to zero.
+    """
+    out = np.full(len(series), np.nan)
+    for i, row in enumerate(series.rows):
+        vol = row.get("volume")
+        if vol is not None:
+            out[i] = float(vol)
+    return out
+
+
+def _support_below(series: BarSeries, *, index: int, atr: float) -> float | None:
+    """The nearest live support level within tolerance of this bar's action.
+
+    ⚠ NO REGIME GATE — the gate belongs to the signal, not the level lookup, so
+    ``s5_exit_bracket`` can place a stop for an already-open position without a
+    since-moved regime being able to refuse it. Same split as S-6.
+
+    ⚠ The level must sit at or below the CLOSE and at or above the LOW: it is the
+    level the bar wicked through and reclaimed. A support above the close was not
+    reclaimed; one below the low was never touched.
+    """
+    close = series.float_closes[index]
+    low = series.float_lows[index]
+    if close is None or low is None:
+        return None
+    levels = levels_at(
+        highs=series.array_highs,
+        lows=series.array_lows,
+        volumes=_volumes(series),
+        atr=atr,
+        index=index,
+    )
+    candidates = [lvl.price for lvl in levels if lvl.kind == "support" and low < lvl.price <= close]
+    if not candidates:
+        return None
+    # The highest such level is the one most recently defended.
+    return max(candidates)
+
+
+def s5_exit_bracket(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> tuple[Decimal, Decimal, int]:
+    """``(take_profit, stop_loss, max_hold_bars)`` for a fill against S-5's signal bar.
+
+    ⚠⚠ ORDER MATCHES ``s4_exit_bracket`` AND ``s6_exit_bracket`` — TARGET FIRST.
+    All three return ``tuple[Decimal, Decimal, int]``, so a mismatched order is
+    invisible to the type checker and to review, and the adapter would build an
+    inverted bracket. This repo has shipped that class through positional lists
+    (#2623).
+
+    ⚠ The stop anchors to the LEVEL, the target to the ENTRY — S-6's asymmetry
+    for S-6's reason: the stop asks "did support fail?", which is a question
+    about the level; the target asks "has this paid enough?", about the position.
+    """
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    atr_at_signal = atr.values[signal_index]
+    if atr_at_signal is None:
+        raise ValueError(f"S-5 bracket needs ATR at the signal bar; index {signal_index} is unevaluable")
+    level = _support_below(series, index=signal_index, atr=atr_at_signal)
+    if level is None:
+        raise ValueError(f"S-5 bracket needs the support level at index {signal_index}; none is live")
+    stop = Decimal(str(level - ATR_STOP_MULTIPLE * atr_at_signal))
+    target = entry_price + Decimal(str(ATR_TARGET_MULTIPLE * atr_at_signal))
+    return target, stop, MAX_HOLD_BARS
+
+
+def s5_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    """S-5's entry verdict for every bar. ⚠ ENTRIES ONLY."""
+    if masked_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {masked_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+    if len(regime) != len(series):
+        raise ValueError(f"regime series has {len(regime)} bars against {len(series)} price bars; they must align")
+
+    closes = series.float_closes
+    lows = series.float_lows
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+
+    inputs = (
+        StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
+        StrategyInput(series=atr, reason=masked_reason),
+    )
+
+    def entry(index: int) -> bool:
+        close = closes[index]
+        atr_now = atr.values[index]
+        # Not reachable through `evaluate`, which refuses the bar first.
+        assert close is not None and atr_now is not None
+        low = lows[index]
+        if low is None:
+            return False
+        if not regime.permits(index, PERMITTED_REGIMES):
+            return False
+        # `_support_below` already requires low < level <= close, so the
+        # rejection is expressed once, in the level selection, rather than
+        # restated here where the two could drift apart.
+        return _support_below(series, index=index, atr=atr_now) is not None
+
+    return evaluate(entry, inputs=inputs, n_bars=len(series), kind="entry")
+
+
+__all__ = [
+    "ATR_PERIOD",
+    "ATR_STOP_MULTIPLE",
+    "ATR_TARGET_MULTIPLE",
+    "MAX_HOLD_BARS",
+    "PERMITTED_REGIMES",
+    "S5_PARAMS",
+    "S5_STRATEGY_ID",
+    "WARMUP_BARS",
+    "s5_exit_bracket",
+    "s5_identity",
+    "s5_signals",
+]

--- a/app/services/strategies/s6_resistance_breakout.py
+++ b/app/services/strategies/s6_resistance_breakout.py
@@ -1,0 +1,321 @@
+"""S-6 — resistance breakout with volume confirmation. First of the S-5…S-10 set.
+
+Parent spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §3 (S-6),
+§1 (regime), §2 (levels). Registry contract: ``app/services/strategy_registry.py``.
+Refs #2437.
+
+THE RULE, VERBATIM FROM §3
+-------------------------
+    Setup: live resistance level; regime ∈ {``bull_quiet``}. ⚠ Excluded from
+    ``bull_volatile`` deliberately — breakouts into a Bulge are the classic
+    false-break regime. Signal: ``close(t) >`` level **and** ``volume(t) >= 1.2
+    × 20-bar average volume``. ⚠ The 1.2 multiple is retail convention, **not**
+    a published result — frozen by construction, recorded as such. Exit: stop
+    ``level − 1.0 × ATR(14)`` (back inside the range = failed break); target
+    ``entry + 3.0 × ATR(14)``; max hold 40 bars. Params: 4. Data: OHLC + volume.
+
+⚠⚠ THE REGIME IS AN ARGUMENT, NOT A COMPUTATION, AND THAT IS DELIBERATE.
+Regime is a property of the MARKET (SPY), not of the instrument being scanned, so
+this module cannot derive it from ``series`` — the bars it is handed are the
+candidate's, not the benchmark's. Passing it in keeps the function pure and
+keeps one regime classification shared across every strategy in a cycle, rather
+than each recomputing it and silently disagreeing at the boundary.
+
+⚠ ``regime`` is REQUIRED with no default. A default would let a caller scan
+without a regime and get the permissive behaviour by omission — which is the
+exact failure ``RegimeSeries.permits`` fails closed against. Absent regime must
+mean "cannot evaluate", never "no constraint".
+
+⚠⚠ WHY THE STOP IS OFF THE LEVEL AND THE TARGET IS OFF THE ENTRY.
+They are not the same anchor and making them consistent would break the rule.
+The stop answers *"was this a false break?"* — which is a question about the
+LEVEL: price closing back below it invalidates the setup regardless of where the
+fill happened. The target answers *"has this paid enough?"* — a question about
+the POSITION, so it is measured from what was actually paid. A gap-up fill can
+therefore sit far above its own stop, and that is correct: the trade is wrong
+when the level fails, not when the fill is retraced.
+
+⚠ NO EXIT SIGNAL LEG, for S-4's reason. Stop, target and max-hold are all
+measured from the entry, so all three are position state; a per-bar verdict
+function has none. The parameters are carried in ``S6_PARAMS`` so criterion 11
+hashes them into the identity, and their consumer is ``s6_exit_bracket``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+
+import numpy as np
+
+from app.services.indicator_series import (
+    BarSeries,
+    IndicatorSeries,
+    Universe,
+    atr_series,
+)
+from app.services.market_regime import REGIME_RULE_VERSION, Regime, RegimeSeries
+from app.services.price_levels import LEVEL_RULE_VERSION, levels_at
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+
+S6_STRATEGY_ID = "s6-resistance-breakout"
+
+#: ⚠ FIXED, NEVER TUNED. Module constants rather than arguments, for S-4's
+#: reason: a threshold that can be passed in is a threshold that can be swept,
+#: and criterion 11 would need every swept value registered as its own strategy.
+ATR_PERIOD = 14
+VOLUME_LOOKBACK = 20
+
+#: ⚠⚠ RETAIL CONVENTION, NOT A PUBLISHED RESULT. Widely quoted as "volume >= 1.2x
+#: the 20-bar average confirms a break", and no peer-reviewed formulation was
+#: found for it. Frozen by construction per the repo rule for that case, and
+#: labelled here so nobody later cites it as evidence-backed. If a published
+#: rule is found, it is a NEW VERSION, not a correction of this one.
+VOLUME_CONFIRMATION_MULTIPLE = 1.2
+
+#: The bracket, in ATR multiples at the SIGNAL bar. Declared and hashed here,
+#: evaluated by ``s6_exit_bracket``.
+ATR_STOP_MULTIPLE = 1.0
+ATR_TARGET_MULTIPLE = 3.0
+MAX_HOLD_BARS = 40
+
+#: ⚠ ONE REGIME ONLY. §3 excludes ``bull_volatile`` on purpose: a breakout into a
+#: Bollinger Bulge is the textbook false-break condition, so admitting it would
+#: dilute the rule with its own worst cases. A frozenset rather than a single
+#: member because the shape must accommodate S-5/S-7/S-9, which permit two.
+PERMITTED_REGIMES = frozenset({Regime.BULL_QUIET})
+
+#: ⚠ §3 says "Params: 4" and this dict carries SEVEN, for S-4's recorded reason:
+#: §3 counts FREE parameters (what a sweep would move) while criterion 11 hashes
+#: everything that makes this a distinct strategy. ``atr_period`` is Wilder's
+#: default and the two exit multiples are read by nothing in this module — the
+#: identity hash is the only thing keeping them attached to the rule.
+#:
+#: ⚠⚠ THE TWO SHARED RULE VERSIONS ARE IN HERE AND THEY MUST BE. This strategy is
+#: a function of the regime classifier and the level constructor as much as of
+#: its own constants: the same bars under a different ``LEVEL_RULE_VERSION``
+#: produce different levels and therefore different signals. Omitting them would
+#: let a level-rule edit silently inherit this strategy's track record, which is
+#: precisely what criterion 11 exists to prevent.
+S6_PARAMS: Mapping[str, object] = {
+    "atr_period": ATR_PERIOD,
+    "volume_lookback": VOLUME_LOOKBACK,
+    "volume_confirmation_multiple": VOLUME_CONFIRMATION_MULTIPLE,
+    "atr_stop_multiple": ATR_STOP_MULTIPLE,
+    "atr_target_multiple": ATR_TARGET_MULTIPLE,
+    "max_hold_bars": MAX_HOLD_BARS,
+    "permitted_regimes": tuple(sorted(r.value for r in PERMITTED_REGIMES)),
+    "level_rule_version": LEVEL_RULE_VERSION,
+    "regime_rule_version": REGIME_RULE_VERSION,
+}
+
+#: DERIVED from the rule, not restated. Levels need a confirmed pivot, which
+#: needs ``PIVOT_HALF_WINDOW`` bars of lead-in and ``MIN_TOUCHES`` of them; the
+#: binding constraint in practice is the regime series, which needs a 200-SMA and
+#: a full 126-bar BandWidth window (~326 bars) — but that is the BENCHMARK's
+#: warmup, not this series', and it arrives as ``None`` in ``regime``. Locally,
+#: ATR at ``ATR_PERIOD`` and the volume average at ``VOLUME_LOOKBACK - 1`` bind.
+WARMUP_BARS = max(ATR_PERIOD, VOLUME_LOOKBACK - 1)
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s6_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-6 on one universe under one cost model.
+
+    Both arguments REQUIRED with no default, per S-4: criterion 11 makes universe
+    and cost model part of the identity, so a default would silently register a
+    strategy the caller never declared.
+    """
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "pass app.services.cost_model.COST_MODEL_ID rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S6_STRATEGY_ID,
+        params=S6_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def _volumes(series: BarSeries) -> np.ndarray:
+    """Bar volumes as float, with missing volume as NaN.
+
+    ⚠ NaN rather than 0.0. A missing volume is UNKNOWN, and zero is a claim that
+    nothing traded — which would make the confirmation test trivially fail and
+    look like a considered refusal rather than absent data. NaN propagates into
+    the average and the bar is refused as unevaluable, which is the truthful
+    outcome.
+    """
+    out = np.full(len(series), np.nan)
+    for i, row in enumerate(series.rows):
+        vol = row.get("volume")
+        if vol is not None:
+            out[i] = float(vol)
+    return out
+
+
+def average_volume_series(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """Trailing ``VOLUME_LOOKBACK``-bar mean volume, ending at ``t`` INCLUSIVE.
+
+    ⚠ INCLUSIVE of ``t``, unlike S-4's prior-high window which excludes it. The
+    two are asymmetric for the same reason S-4 documents: the breakout LEVEL must
+    not be self-referential, but the volume BASELINE is a question about the
+    recent distribution that today belongs to. ⚠ Note the signal then compares
+    ``volume(t)`` against an average that CONTAINS ``volume(t)`` — which makes
+    the test conservative (a huge bar lifts its own baseline), never permissive.
+    That direction is why it is acceptable; the reverse would not be.
+    """
+    vols = _volumes(series)
+    n = vols.size
+    values: list[float | None] = []
+    for i in range(n):
+        if i < VOLUME_LOOKBACK - 1:
+            values.append(None)
+            continue
+        window = vols[i - VOLUME_LOOKBACK + 1 : i + 1]
+        values.append(None if not np.all(np.isfinite(window)) else float(window.mean()))
+    return IndicatorSeries(values=tuple(values), universe=universe)
+
+
+def s6_exit_bracket(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+    regime: RegimeSeries,
+) -> tuple[Decimal, Decimal, int]:
+    """``(stop, target, max_hold_bars)`` for a fill against S-6's signal bar.
+
+    ⚠⚠ THE STOP IS ANCHORED TO THE LEVEL, THE TARGET TO THE ENTRY. See the module
+    docstring — this asymmetry is the rule, not an oversight, and normalising it
+    would change what the strategy means.
+
+    ⚠ ATR and the level are both read at ``signal_index``, never at the fill bar.
+    Sizing a stop off the fill bar's own range leaks that bar into the decision
+    that produced it.
+    """
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    atr_at_signal = atr.values[signal_index]
+    if atr_at_signal is None:
+        raise ValueError(f"S-6 bracket needs ATR at the signal bar; index {signal_index} is unevaluable")
+    level = _breakout_level(series, index=signal_index, atr=atr_at_signal, regime=regime)
+    if level is None:
+        raise ValueError(f"S-6 bracket needs the resistance level at index {signal_index}; none is live")
+    stop = Decimal(str(level - ATR_STOP_MULTIPLE * atr_at_signal))
+    target = entry_price + Decimal(str(ATR_TARGET_MULTIPLE * atr_at_signal))
+    return stop, target, MAX_HOLD_BARS
+
+
+def _breakout_level(series: BarSeries, *, index: int, atr: float, regime: RegimeSeries) -> float | None:
+    """The live resistance level this bar is breaking, or ``None``.
+
+    ⚠ Levels are recomputed from bars ``<= index`` on every call rather than
+    cached across the series. Slower, and deliberately so: a cache keyed by
+    anything other than the exact bar index is the standard way lookahead gets
+    reintroduced after the causal version was proved correct.
+    """
+    if not regime.permits(index, PERMITTED_REGIMES):
+        return None
+    highs = series.array_highs
+    lows = series.array_lows
+    levels = levels_at(highs=highs, lows=lows, volumes=_volumes(series), atr=atr, index=index)
+    close = series.float_closes[index]
+    if close is None:
+        return None
+    # The level being broken is the nearest resistance BELOW the close — price
+    # has to have crossed it. `nearest_level` alone would also match one just
+    # above, which is a level not yet broken.
+    candidates = [lvl for lvl in levels if lvl.kind == "resistance" and lvl.price < close]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda lvl: lvl.price).price
+
+
+def s6_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    """S-6's entry verdict for every bar. ⚠ ENTRIES ONLY — see the module docstring."""
+    if masked_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {masked_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+    if len(regime) != len(series):
+        raise ValueError(f"regime series has {len(regime)} bars against {len(series)} price bars; they must align")
+
+    closes = series.float_closes
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    avg_volume = average_volume_series(series, universe=universe)
+    vols = _volumes(series)
+
+    inputs = (
+        StrategyInput(series=IndicatorSeries(values=tuple(closes), universe=universe), reason=masked_reason),
+        StrategyInput(series=atr, reason=masked_reason),
+        StrategyInput(series=avg_volume, reason=masked_reason),
+    )
+
+    def entry(index: int) -> bool:
+        close = closes[index]
+        atr_now = atr.values[index]
+        avg = avg_volume.values[index]
+        # Not reachable through `evaluate`, which refuses the bar first.
+        assert close is not None and atr_now is not None and avg is not None
+        volume_now = vols[index]
+        if not np.isfinite(volume_now) or avg <= 0:
+            return False
+        if volume_now < VOLUME_CONFIRMATION_MULTIPLE * avg:
+            return False
+        level = _breakout_level(series, index=index, atr=atr_now, regime=regime)
+        if level is None or close <= level:
+            return False
+        # ⚠⚠ THE BREAK IS A CROSSING, NOT A POSITION. `close > level` alone is
+        # satisfied on EVERY subsequent bar once price sits above an old level,
+        # so the rule degenerates into "price is above some level and volume is
+        # up" and re-fires indefinitely. Measured before this guard: 70 entries
+        # per instrument over ~4 years, one every ~15 bars — a breakout is not a
+        # fortnightly event, and the count is what exposed it.
+        #
+        # The prior close must be AT OR BELOW the level, so the signal marks the
+        # bar that crossed it. §3's "close(t) > level" states the condition at
+        # `t` and takes the crossing as read; stating it here is the honest
+        # reading, not an extra parameter — there is nothing to tune.
+        prior_close = closes[index - 1] if index > 0 else None
+        return prior_close is not None and prior_close <= level
+
+    return evaluate(entry, inputs=inputs, n_bars=len(series), kind="entry")
+
+
+__all__ = [
+    "ATR_PERIOD",
+    "ATR_STOP_MULTIPLE",
+    "ATR_TARGET_MULTIPLE",
+    "MAX_HOLD_BARS",
+    "PERMITTED_REGIMES",
+    "S6_PARAMS",
+    "S6_STRATEGY_ID",
+    "VOLUME_CONFIRMATION_MULTIPLE",
+    "VOLUME_LOOKBACK",
+    "WARMUP_BARS",
+    "average_volume_series",
+    "s6_exit_bracket",
+    "s6_identity",
+    "s6_signals",
+]

--- a/app/services/strategies/s6_resistance_breakout.py
+++ b/app/services/strategies/s6_resistance_breakout.py
@@ -153,6 +153,26 @@ def s6_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
     )
 
 
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, in the shape the runner checks for evaluability.
+
+    ⚠⚠ ``not_evaluable_indices`` IS THE POINT, and omitting it was a real bug
+    caught by ``test_the_reason_code_reaches_the_verdict``. A bare
+    ``IndicatorSeries`` of closes carries values but declares no masked bars, so
+    a masked close fell through to whichever input refused first — reporting
+    ``insufficient_warmup`` for a bar that was actually MASKED. The verdict was
+    still "not evaluable", so nothing broke; the RECORDED REASON was simply
+    wrong, which is the kind of defect that survives every test that only checks
+    whether a bar fired.
+    """
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
 def _volumes(series: BarSeries) -> np.ndarray:
     """Bar volumes as float, with missing volume as NaN.
 
@@ -199,9 +219,15 @@ def s6_exit_bracket(
     signal_index: int,
     entry_price: Decimal,
     universe: Universe,
-    regime: RegimeSeries,
 ) -> tuple[Decimal, Decimal, int]:
-    """``(stop, target, max_hold_bars)`` for a fill against S-6's signal bar.
+    """``(take_profit, stop_loss, max_hold_bars)`` for a fill against S-6's signal bar.
+
+    ⚠⚠ ORDER MATCHES ``s4_exit_bracket`` — TARGET FIRST, THEN STOP. Both return
+    ``tuple[Decimal, Decimal, int]``, so the two are structurally identical and
+    a mismatched order would be invisible to the type checker and to review: the
+    adapter would build ``ExitLevels(take_profit=stop, stop_loss=target)`` and
+    every bracket would be inverted. This repo has already shipped that exact
+    class of defect through positional lists (#2623). Same order, deliberately.
 
     ⚠⚠ THE STOP IS ANCHORED TO THE LEVEL, THE TARGET TO THE ENTRY. See the module
     docstring — this asymmetry is the rule, not an oversight, and normalising it
@@ -215,24 +241,33 @@ def s6_exit_bracket(
     atr_at_signal = atr.values[signal_index]
     if atr_at_signal is None:
         raise ValueError(f"S-6 bracket needs ATR at the signal bar; index {signal_index} is unevaluable")
-    level = _breakout_level(series, index=signal_index, atr=atr_at_signal, regime=regime)
+    level = _resistance_below(series, index=signal_index, atr=atr_at_signal)
     if level is None:
         raise ValueError(f"S-6 bracket needs the resistance level at index {signal_index}; none is live")
     stop = Decimal(str(level - ATR_STOP_MULTIPLE * atr_at_signal))
     target = entry_price + Decimal(str(ATR_TARGET_MULTIPLE * atr_at_signal))
-    return stop, target, MAX_HOLD_BARS
+    return target, stop, MAX_HOLD_BARS
 
 
-def _breakout_level(series: BarSeries, *, index: int, atr: float, regime: RegimeSeries) -> float | None:
-    """The live resistance level this bar is breaking, or ``None``.
+def _resistance_below(series: BarSeries, *, index: int, atr: float) -> float | None:
+    """The nearest live resistance level below this bar's close, or ``None``.
+
+    ⚠⚠ NO REGIME GATE HERE, AND THAT IS THE POINT OF THE SPLIT. The gate belongs
+    to the SIGNAL (`s6_signals`), not to the level lookup, because the two are
+    asked at different times and only one of them is a decision.
+
+    ``s6_exit_bracket`` needs this level to place a stop for a fill against a
+    signal that ALREADY FIRED — so the regime was permitted by construction at
+    signal time. Re-checking it at bracket time would let a regime that has since
+    moved refuse to produce a stop for a position that is already open, which is
+    the worst possible moment to have no stop. A gate that can retroactively
+    invalidate an open position's exit is not a safety control.
 
     ⚠ Levels are recomputed from bars ``<= index`` on every call rather than
     cached across the series. Slower, and deliberately so: a cache keyed by
     anything other than the exact bar index is the standard way lookahead gets
     reintroduced after the causal version was proved correct.
     """
-    if not regime.permits(index, PERMITTED_REGIMES):
-        return None
     highs = series.array_highs
     lows = series.array_lows
     levels = levels_at(highs=highs, lows=lows, volumes=_volumes(series), atr=atr, index=index)
@@ -267,7 +302,7 @@ def s6_signals(
     vols = _volumes(series)
 
     inputs = (
-        StrategyInput(series=IndicatorSeries(values=tuple(closes), universe=universe), reason=masked_reason),
+        StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
         StrategyInput(series=atr, reason=masked_reason),
         StrategyInput(series=avg_volume, reason=masked_reason),
     )
@@ -283,7 +318,12 @@ def s6_signals(
             return False
         if volume_now < VOLUME_CONFIRMATION_MULTIPLE * avg:
             return False
-        level = _breakout_level(series, index=index, atr=atr_now, regime=regime)
+        # ⚠ THE REGIME GATE IS HERE, on the decision, not inside the level
+        # lookup — see `_resistance_below`. Checked before the level work
+        # because it is the cheaper refusal and the more fundamental one.
+        if not regime.permits(index, PERMITTED_REGIMES):
+            return False
+        level = _resistance_below(series, index=index, atr=atr_now)
         if level is None or close <= level:
             return False
         # ⚠⚠ THE BREAK IS A CROSSING, NOT A POSITION. `close > level` alone is

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -74,6 +74,7 @@ from types import MappingProxyType
 from typing import Literal, Protocol, get_args
 
 from app.services.indicator_series import BarSeries, Universe
+from app.services.market_regime import RegimeSeries
 from app.services.outcome_resolver import ExitLevels, UnresolvedReason
 from app.services.position_builder import ExitRegime
 from app.services.strategies.s1_time_series_momentum import S1_STRATEGY_ID, s1_identity, s1_signals
@@ -93,6 +94,15 @@ from app.services.strategies.s4_volatility_compression_breakout import (
     s4_exit_bracket,
     s4_identity,
     s4_signals,
+)
+from app.services.strategies.s6_resistance_breakout import (
+    MAX_HOLD_BARS as S6_MAX_HOLD_BARS,
+)
+from app.services.strategies.s6_resistance_breakout import (
+    S6_STRATEGY_ID,
+    s6_exit_bracket,
+    s6_identity,
+    s6_signals,
 )
 from app.services.strategy_exit_levels_batch import s4_exit_levels_batch
 from app.services.strategy_registry import (
@@ -137,8 +147,27 @@ class PerSeriesSignals(Protocol):
     """
 
     def __call__(
-        self, series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason
+        self,
+        series: BarSeries,
+        *,
+        universe: Universe,
+        masked_reason: NotEvaluableReason,
+        regime: RegimeSeries,
     ) -> list[StrategySignal]: ...
+
+    # ⚠⚠ ``regime`` IS ON THE UNIFORM CALL, NOT ON THE STRATEGIES THAT USE IT.
+    # S-1..S-4 ignore it; S-5..S-10 gate on it. Putting it here rather than
+    # branching per strategy is the same choice this module already made for
+    # ``masked_reason``: the adapters absorb the difference, and a runner cannot
+    # forget to supply it for the one strategy that needs it.
+    #
+    # ⚠ The alternative — a ``requires_regime`` flag with a runner branch —
+    # reintroduces exactly the per-strategy ``if`` this module exists to delete,
+    # and the branch would be the thing nobody updates when S-11 arrives.
+    #
+    # ⚠ Safe for identities: ``StrategyIdentity.version`` hashes
+    # ``strategy_registry.py``, NOT this module (see the module docstring,
+    # reason 1). Editing the manifest moves no stored strategy version.
 
 
 class MemberStager(Protocol):
@@ -299,15 +328,33 @@ def _no_decision_calendar(calendar: Iterable[date]) -> frozenset[date] | None:
     return None
 
 
-def _s1_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+def _s1_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,  # noqa: ARG001 - uniform call; S-1 does not gate on regime
+) -> list[StrategySignal]:
     return s1_signals(series, universe=universe, close_reason=masked_reason)
 
 
-def _s3_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+def _s3_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,  # noqa: ARG001 - uniform call; S-3 does not gate on regime
+) -> list[StrategySignal]:
     return s3_signals(series, universe=universe, close_reason=masked_reason)
 
 
-def _s4_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+def _s4_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,  # noqa: ARG001 - uniform call; S-4 does not gate on regime
+) -> list[StrategySignal]:
     return s4_signals(series, universe=universe, masked_reason=masked_reason)
 
 
@@ -420,6 +467,57 @@ def _s4_exit_levels(
     return scalar
 
 
+def _s6_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    """S-6 is the first strategy that actually reads ``regime`` — passed through."""
+    return s6_signals(series, universe=universe, masked_reason=masked_reason, regime=regime)
+
+
+def _s6_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-6 exits on a level-anchored stop / ATR target fixed at signal time, or the hold cap."""
+    _reject_decision_dates(S6_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=False, level_based=True, max_hold_bars=S6_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s6_exit_levels(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> ExitLevels | UnresolvedReason:
+    """Adapt S-6's bracket to the outcome reason contract.
+
+    ⚠ NO ``regime`` PARAMETER, and that is deliberate rather than an omission.
+    A bracket is only ever requested for a signal that ALREADY FIRED, so the
+    regime was permitted by construction at signal time. Threading it here would
+    let a regime that has since moved refuse to produce a stop for a position
+    that is already open — a gate that can retroactively remove an open
+    position's exit is not a safety control. See `_resistance_below`.
+    """
+    try:
+        target, stop, max_hold = s6_exit_bracket(
+            series, signal_index=signal_index, entry_price=entry_price, universe=universe
+        )
+    except ValueError:
+        # The level or ATR is unevaluable at the signal bar. Typed refusal rather
+        # than a raise: the outcome runner records an unresolved outcome, which is
+        # the truthful state, and a raise would abort the whole batch for one bar.
+        return "unorderable_exit_levels"
+    if target <= stop:
+        # Reachable, and not a bug to prevent: the stop is anchored to the LEVEL
+        # while the target is anchored to the ENTRY, so a fill far below the
+        # level can invert them. That asymmetry is the rule (see the S-6 module
+        # docstring), so an inverted bracket is a real state to refuse.
+        return "unorderable_exit_levels"
+    return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+
+
 #: Every strategy in the catalogue, keyed by ``strategy_id``.
 #:
 #: ⚠⚠ COMPLETENESS IS A TEST, NOT A CONVENTION.
@@ -474,6 +572,17 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             signals=_s4_signals,
             exit_levels=_s4_exit_levels,
             exit_levels_batch=s4_exit_levels_batch,
+        ),
+        S6_STRATEGY_ID: StrategyEntry(
+            strategy_id=S6_STRATEGY_ID,
+            purpose="harness_validation",
+            identity=s6_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s6_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s6_signals,
+            exit_levels=_s6_exit_levels,
         ),
     }
 )

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -95,6 +95,15 @@ from app.services.strategies.s4_volatility_compression_breakout import (
     s4_identity,
     s4_signals,
 )
+from app.services.strategies.s5_support_bounce import (
+    MAX_HOLD_BARS as S5_MAX_HOLD_BARS,
+)
+from app.services.strategies.s5_support_bounce import (
+    S5_STRATEGY_ID,
+    s5_exit_bracket,
+    s5_identity,
+    s5_signals,
+)
 from app.services.strategies.s6_resistance_breakout import (
     MAX_HOLD_BARS as S6_MAX_HOLD_BARS,
 )
@@ -467,6 +476,46 @@ def _s4_exit_levels(
     return scalar
 
 
+def _s5_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    return s5_signals(series, universe=universe, masked_reason=masked_reason, regime=regime)
+
+
+def _s5_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-5 exits on a level-anchored stop / ATR target fixed at signal time, or the hold cap."""
+    _reject_decision_dates(S5_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=False, level_based=True, max_hold_bars=S5_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s5_exit_levels(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> ExitLevels | UnresolvedReason:
+    """Adapt S-5's bracket to the outcome reason contract. No ``regime`` — see `_s6_exit_levels`."""
+    try:
+        target, stop, max_hold = s5_exit_bracket(
+            series, signal_index=signal_index, entry_price=entry_price, universe=universe
+        )
+    except ValueError, IndexError:
+        # ⚠ BOTH, deliberately. `ValueError` is the bracket's own refusal (no ATR,
+        # no level); `IndexError` is what an out-of-range `signal_index` produces
+        # inside `atr_series` / `levels_at`. Catching only the first let a
+        # per-bar failure abort the WHOLE outcome batch — a narrow except that
+        # reads as exhaustive is worse than no except at all.
+        return "unorderable_exit_levels"
+    if target <= stop:
+        return "unorderable_exit_levels"
+    return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+
+
 def _s6_signals(
     series: BarSeries,
     *,
@@ -504,10 +553,15 @@ def _s6_exit_levels(
         target, stop, max_hold = s6_exit_bracket(
             series, signal_index=signal_index, entry_price=entry_price, universe=universe
         )
-    except ValueError:
+    except ValueError, IndexError:
         # The level or ATR is unevaluable at the signal bar. Typed refusal rather
         # than a raise: the outcome runner records an unresolved outcome, which is
         # the truthful state, and a raise would abort the whole batch for one bar.
+        #
+        # ⚠ BOTH exception types, deliberately. `ValueError` is the bracket's own
+        # refusal; `IndexError` is what an out-of-range `signal_index` produces
+        # inside `atr_series` / `levels_at`. A narrow except that reads as
+        # exhaustive is worse than none.
         return "unorderable_exit_levels"
     if target <= stop:
         # Reachable, and not a bug to prevent: the stop is anchored to the LEVEL
@@ -572,6 +626,17 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             signals=_s4_signals,
             exit_levels=_s4_exit_levels,
             exit_levels_batch=s4_exit_levels_batch,
+        ),
+        S5_STRATEGY_ID: StrategyEntry(
+            strategy_id=S5_STRATEGY_ID,
+            purpose="harness_validation",
+            identity=s5_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s5_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s5_signals,
+            exit_levels=_s5_exit_levels,
         ),
         S6_STRATEGY_ID: StrategyEntry(
             strategy_id=S6_STRATEGY_ID,

--- a/app/services/strategy_segmented_evaluation.py
+++ b/app/services/strategy_segmented_evaluation.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from datetime import date
 
 from app.services.indicator_series import BarSeries, Universe
+from app.services.market_regime import RegimeSeries
 from app.services.price_segments import series_segment_bounds
 from app.services.strategy_manifest import StrategyEntry
 from app.services.strategy_registry import (
@@ -24,13 +25,29 @@ def segmented_signals(
     universe: Universe,
     masked_reason: NotEvaluableReason,
     unresolved_breaks: Sequence[date],
+    regime: RegimeSeries,
 ) -> list[StrategySignal]:
-    """Evaluate every per-series leg with fresh state inside each segment."""
+    """Evaluate every per-series leg with fresh state inside each segment.
+
+    ⚠⚠ THE REGIME IS SLICED WITH THE SEGMENT, NOT PASSED WHOLE. Each segment is
+    a fresh ``BarSeries`` indexed from zero, so a full-length regime handed to a
+    segment starting at bar 400 would align bar 0 of the segment with bar 0 of
+    the market — every regime verdict off by the segment offset, and a strategy
+    gated on it would fire in the wrong conditions with no error anywhere.
+
+    S-6 validates ``len(regime) == len(series)`` and would raise on most
+    mismatches, which is why that check exists — but a segment whose length
+    happens to match a prefix of the regime would pass the check and still be
+    wrong. Slicing here is the fix; the length check is the backstop.
+    """
     if entry.signals is None:
         raise ValueError(f"{entry.strategy_id} has no per-series signal function")
+    if len(regime) != len(series):
+        raise ValueError(f"regime has {len(regime)} bars against {len(series)} price bars; they must align")
     signals: list[StrategySignal] = []
     for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
         segment = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
+        segment_regime = RegimeSeries(values=regime.values[start:end])
         signals.extend(
             StrategySignal(
                 verdict=signal.verdict,
@@ -38,7 +55,7 @@ def segmented_signals(
                 kind=signal.kind,
                 reason=signal.reason,
             )
-            for signal in entry.signals(segment, universe=universe, masked_reason=masked_reason)
+            for signal in entry.signals(segment, universe=universe, masked_reason=masked_reason, regime=segment_regime)
         )
     per_kind = Counter(signal.kind for signal in signals)
     if not per_kind or any(count != len(series) for count in per_kind.values()):

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -51,6 +51,7 @@ import psycopg
 
 from app.services.cost_model import COST_MODEL_ID
 from app.services.indicator_series import BarSeries, Universe
+from app.services.market_regime_provider import MarketRegimeProvider
 from app.services.price_masked_bars import (
     MASKED_REASON,
     load_bar_spans,
@@ -542,6 +543,14 @@ def run_signal_scan(
     moved_mid_scan = 0
     evaluated = 0
 
+    # ⚠ ONCE PER SCAN, before the loop. Re-loading per instrument would be
+    # thousands of redundant benchmark reads, and would let two instruments in
+    # one cycle disagree about what the market was doing. Raises rather than
+    # degrading to an all-`None` regime: a benchmark outage that rendered as a
+    # quiet market would refuse every gated strategy and look like a legitimate
+    # verdict.
+    regime_provider = MarketRegimeProvider.load(conn)
+
     for instrument_id in eligible:
         series = load_masked_bars(conn, instrument_id).series
         # ⚠ The span query and this load are two reads of a corpus
@@ -571,6 +580,7 @@ def run_signal_scan(
                     window,
                     rows[plan.entry.strategy_id],
                     unresolved_breaks=unresolved_breaks.get(instrument_id, ()),
+                    regime_provider=regime_provider,
                 )
             else:
                 assert panel_dates is not None
@@ -630,6 +640,7 @@ def _scan_per_series(
     out: list[LedgerRow],
     *,
     unresolved_breaks: Sequence[date] = (),
+    regime_provider: MarketRegimeProvider,
 ) -> None:
     """Full-history recompute, filtered to the window, resolved through the writer.
 
@@ -645,12 +656,17 @@ def _scan_per_series(
     ``signal_index``, so a subset of signals against the full series resolves
     each fill from the same bar it always would.
     """
+    # ⚠ ALIGNED TO THIS INSTRUMENT'S OWN DATES, not to the benchmark's index.
+    # A non-US venue trades on days SPY does not; those bars get `None` and a
+    # gated strategy refuses to fire on them rather than inheriting a stale
+    # verdict. See `market_regime_provider`.
     signals = segmented_signals(
         plan.entry,
         series,
         universe=SCAN_UNIVERSE,
         masked_reason=MASKED_REASON,
         unresolved_breaks=unresolved_breaks,
+        regime=regime_provider.for_dates(series.dates),
     )
     windowed = [signal for signal in signals if signal.signal_index in window]
     out.extend(resolve_fills(windowed, series=series, identity=plan.identity, instrument_id=instrument_id))

--- a/scripts/verify_2394_backtest_run.py
+++ b/scripts/verify_2394_backtest_run.py
@@ -74,6 +74,7 @@ from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, FX_UNMODELL
 from app.services.deflated_sharpe import MIN_MEASURED_TRIALS
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID, LegBook
 from app.services.indicator_series import BarSeries
+from app.services.market_regime import unconstrained_regime
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.position_builder import (
     RULE_SET_VERSION as BUILDER_RULE_SET_VERSION,
@@ -533,7 +534,12 @@ def arm(*, limit: int | None, strategy_id: str) -> int:
             )
 
             mark = time.monotonic()
-            signals = entry.signals(series, universe=UNIVERSE, masked_reason="quarantined_bar")
+            signals = entry.signals(
+                series,
+                universe=UNIVERSE,
+                masked_reason="quarantined_bar",
+                regime=unconstrained_regime(len(series)),
+            )
             rows = resolve_fills(signals, series=series, identity=identity, instrument_id=int(instrument_id))
             entries, exits = _fills(rows, int(instrument_id))
             built = build_positions(

--- a/scripts/verify_2394_signal_scan_cost.py
+++ b/scripts/verify_2394_signal_scan_cost.py
@@ -83,6 +83,7 @@ import psycopg
 from app.config import settings
 from app.services.cost_model import COST_MODEL_ID
 from app.services.indicator_series import BarSeries
+from app.services.market_regime import unconstrained_regime
 from app.services.price_masked_bars import (
     MASKED_REASON,
     QUARANTINE_RULE_SET_VERSION,
@@ -322,12 +323,16 @@ def arrears() -> bool:
             same_day_index = len(same_day) - 1
             with_next = {
                 (s.kind, s.verdict, s.reason)
-                for s in entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                for s in entry.signals(
+                    series, universe=UNIVERSE, masked_reason=MASKED_REASON, regime=unconstrained_regime(len(series))
+                )
                 if s.signal_index == index
             }
             without = {
                 (s.kind, s.verdict, s.reason)
-                for s in entry.signals(same_day, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                for s in entry.signals(
+                    same_day, universe=UNIVERSE, masked_reason=MASKED_REASON, regime=unconstrained_regime(len(same_day))
+                )
                 if s.signal_index == same_day_index
             }
             compared[entry.strategy_id] += len(with_next)
@@ -406,7 +411,9 @@ def cost() -> bool:
         identity = entry.identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
         started = time.monotonic()
         for instrument_id, series in loaded.items():
-            signals = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            signals = entry.signals(
+                series, universe=UNIVERSE, masked_reason=MASKED_REASON, regime=unconstrained_regime(len(series))
+            )
             if instrument_id not in at_frontier:
                 continue
             rows = resolve_fills(signals, series=series, identity=identity, instrument_id=instrument_id)
@@ -516,7 +523,9 @@ def truncation() -> bool:
         assert entry.signals is not None
         for series in eligible.values():
             index = len(series) - 1
-            emitted = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            emitted = entry.signals(
+                series, universe=UNIVERSE, masked_reason=MASKED_REASON, regime=unconstrained_regime(len(series))
+            )
             full = {(s.kind, s.verdict, s.reason) for s in emitted if s.signal_index == index}
             for window in TRUNCATION_WINDOWS:
                 if len(series) <= window:
@@ -526,7 +535,9 @@ def truncation() -> bool:
                 tail_index = len(tail) - 1
                 got = {
                     (s.kind, s.verdict, s.reason)
-                    for s in entry.signals(tail, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                    for s in entry.signals(
+                        tail, universe=UNIVERSE, masked_reason=MASKED_REASON, regime=unconstrained_regime(len(tail))
+                    )
                     if s.signal_index == tail_index
                 }
                 compared[(window, entry.strategy_id)] += 1

--- a/scripts/verify_2394_strategy_manifest.py
+++ b/scripts/verify_2394_strategy_manifest.py
@@ -54,6 +54,7 @@ import psycopg
 from app.config import settings
 from app.services.cost_model import COST_MODEL_ID
 from app.services.indicator_series import BarSeries
+from app.services.market_regime import unconstrained_regime
 from app.services.research_price_structure_store import load_masked_series
 from app.services.strategies.s1_time_series_momentum import s1_signals
 from app.services.strategies.s2_cross_sectional_momentum import s2_member
@@ -190,7 +191,9 @@ def equivalence() -> bool:
             for key, direct in DIRECT_PER_SERIES.items():
                 entry = STRATEGY_MANIFEST[key]
                 assert entry.signals is not None
-                got = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                got = entry.signals(
+                    series, universe=UNIVERSE, masked_reason=MASKED_REASON, regime=unconstrained_regime(len(series))
+                )
                 want = direct(series, universe=UNIVERSE, close_reason=MASKED_REASON)
                 if got != want:
                     mismatches.append(f"{key} series {series_id}")
@@ -199,7 +202,9 @@ def equivalence() -> bool:
 
             s4 = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
             assert s4.signals is not None
-            got_s4 = s4.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            got_s4 = s4.signals(
+                series, universe=UNIVERSE, masked_reason=MASKED_REASON, regime=unconstrained_regime(len(series))
+            )
             if got_s4 != s4_signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON):
                 mismatches.append(f"s4-volatility-compression-breakout series {series_id}")
             for signal in got_s4:

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -192,6 +192,7 @@ class TestRunnableStrategies:
             "s2-cross-sectional-momentum",
             "s3-mean-reversion-in-trend",
             "s4-volatility-compression-breakout",
+            "s5-support-bounce",
             "s6-resistance-breakout",
         ]
         assert excluded == ()
@@ -1617,13 +1618,6 @@ class TestSeriesBreakBoundary:
             for index in range(260)
         )
         series = BarSeries(dates=dates, rows=rows)  # type: ignore[arg-type]
-
-        # S-4 predates the regime and ignores it, but `_signals_for` now requires
-        # a provider. A uniform stand-in keeps this test about SEGMENTATION rather
-        # than about the benchmark, and avoids a DB read in a pure-logic test.
-        class _UniformRegimeProvider:
-            def for_dates(self, dates: tuple[date, ...]) -> RegimeSeries:
-                return unconstrained_regime(len(dates))
 
         provider = _UniformRegimeProvider()
         entry = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -57,6 +57,7 @@ from app.services.cost_model import COST_MODEL_ID, UNKNOWN_NOMINAL_PRICE_BAND
 from app.services.deflated_sharpe import DSR_MODEL_ID, TradeMoments
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID, LegBook
 from app.services.indicator_series import BarSeries
+from app.services.market_regime import RegimeSeries, unconstrained_regime
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.position_builder import Position, Window
 from app.services.position_costing import cost_position
@@ -191,6 +192,7 @@ class TestRunnableStrategies:
             "s2-cross-sectional-momentum",
             "s3-mean-reversion-in-trend",
             "s4-volatility-compression-breakout",
+            "s6-resistance-breakout",
         ]
         assert excluded == ()
 
@@ -242,6 +244,20 @@ class TestArmVocabularyCoverage:
         assert QUARANTINE_ARM_ORDER[0] == "admitted"
 
 
+class _UniformRegimeProvider:
+    """A regime stand-in for pure-logic tests that have no database.
+
+    ⚠ The strategies these tests exercise (S-1…S-4) predate the regime and ignore
+    the argument, so a uniform value keeps the test about what it is actually
+    testing. A test covering a regime-GATED strategy (S-5…S-10) must NOT use
+    this — it would assert a market condition nobody measured and the strategy
+    would fire in conditions it declares it avoids.
+    """
+
+    def for_dates(self, dates: tuple[date, ...]) -> RegimeSeries:
+        return unconstrained_regime(len(dates))
+
+
 class TestLevelArmSharedPass:
     """The S-4 fast path is result-equivalent to two isolated arm passes."""
 
@@ -285,6 +301,7 @@ class TestLevelArmSharedPass:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         corpus, loaded = self._fixture()
+
         entry = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
         identity = entry.identity(universe="survivor_only", cost_model_id=COST_MODEL_ID)
         calls: list[int] = []
@@ -303,6 +320,7 @@ class TestLevelArmSharedPass:
                 ambiguity_arm=ambiguity,
                 identity=identity,
                 namespaces=("hold_out",),
+                regime_provider=_UniformRegimeProvider(),  # type: ignore[arg-type]
             )
             for ambiguity in AMBIGUITY_ARM_ORDER
         )
@@ -316,6 +334,7 @@ class TestLevelArmSharedPass:
             quarantine_arm="admitted",
             identity=identity,
             namespaces=("hold_out",),
+            regime_provider=_UniformRegimeProvider(),  # type: ignore[arg-type]
         )
 
         assert calls == [10]
@@ -1598,14 +1617,24 @@ class TestSeriesBreakBoundary:
             for index in range(260)
         )
         series = BarSeries(dates=dates, rows=rows)  # type: ignore[arg-type]
+
+        # S-4 predates the regime and ignores it, but `_signals_for` now requires
+        # a provider. A uniform stand-in keeps this test about SEGMENTATION rather
+        # than about the benchmark, and avoids a DB read in a pure-logic test.
+        class _UniformRegimeProvider:
+            def for_dates(self, dates: tuple[date, ...]) -> RegimeSeries:
+                return unconstrained_regime(len(dates))
+
+        provider = _UniformRegimeProvider()
         entry = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
-        whole = _signals_for(entry, series, instrument_id=1, ranking=None)
+        whole = _signals_for(entry, series, instrument_id=1, ranking=None, regime_provider=provider)  # type: ignore[arg-type]
         segmented = _signals_for(
             entry,
             series,
             instrument_id=1,
             ranking=None,
             unresolved_breaks=(dates[150],),
+            regime_provider=provider,  # type: ignore[arg-type]
         )
         assert whole[200].verdict == "fired"
         assert (segmented[149].verdict, segmented[149].reason) == ("not_evaluable", "no_fill_bar")

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -27,6 +27,7 @@ import pytest
 from app.services import strategies
 from app.services.cost_model import COST_MODEL_ID
 from app.services.indicator_series import BarSeries
+from app.services.market_regime import unconstrained_regime
 from app.services.position_builder import ExitRegime
 from app.services.strategies.s1_time_series_momentum import s1_identity, s1_signals
 from app.services.strategies.s2_cross_sectional_momentum import rebalance_dates, s2_member
@@ -46,6 +47,8 @@ SPEC_S1 = "s1-time-series-momentum"
 SPEC_S2 = "s2-cross-sectional-momentum"
 SPEC_S3 = "s3-mean-reversion-in-trend"
 SPEC_S4 = "s4-volatility-compression-breakout"
+#: §3 of the S-5..S-10 set. Written out for the same reason as the four above.
+SPEC_S6 = "s6-resistance-breakout"
 
 #: Spec §3's table, verbatim, as ``(signal_pair, level_based, max_hold_bars,
 #: has_rebalance_dates)``. ⚠ Written out for the reason in the module docstring:
@@ -56,6 +59,7 @@ SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
     SPEC_S2: (False, False, None, True),
     SPEC_S3: (True, False, 10, False),
     SPEC_S4: (False, True, 40, False),
+    SPEC_S6: (False, True, 40, False),
 }
 
 #: The legs each strategy emits — §4: S-1 and S-3 have an exit rule, S-2 closes
@@ -65,6 +69,7 @@ SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
     SPEC_S2: frozenset({"entry"}),
     SPEC_S3: frozenset({"entry", "exit"}),
     SPEC_S4: frozenset({"entry"}),
+    SPEC_S6: frozenset({"entry"}),
 }
 
 SPEC_CLASSES: dict[str, str] = {
@@ -72,9 +77,10 @@ SPEC_CLASSES: dict[str, str] = {
     SPEC_S2: "cross_sectional",
     SPEC_S3: "per_series",
     SPEC_S4: "per_series",
+    SPEC_S6: "per_series",
 }
 
-SPEC_PURPOSES = {strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4)}
+SPEC_PURPOSES = {strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S6)}
 
 
 def _bars(closes: Sequence[float | None], *, start: date = date(2020, 1, 1)) -> BarSeries:
@@ -148,7 +154,7 @@ class TestManifestIsComplete:
         forever. Pin that it is actually reading the modules it claims to — the
         prevention-log lesson from a probe that matched nothing."""
         declared = self._declared_strategy_ids()
-        assert len(declared) == 4, f"expected the four catalogue modules, walked {sorted(declared)}"
+        assert len(declared) == 5, f"expected the five catalogue modules, walked {sorted(declared)}"
         assert declared["s1_time_series_momentum.py"] == SPEC_S1
 
     def test_every_strategy_module_is_registered(self) -> None:
@@ -174,7 +180,7 @@ class TestManifestIsComplete:
         """⚠ THE ONE BRIDGE between this file's literals and the source. Every
         other assertion here is written against the literals, so without this
         the whole file could agree with a renamed strategy."""
-        assert set(self._declared_strategy_ids().values()) == {SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4}
+        assert set(self._declared_strategy_ids().values()) == {SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S6}
 
 
 class TestEntriesDescribeTheirStrategy:
@@ -260,7 +266,9 @@ class TestUniformInvocationEqualsTheDirectCall:
     def test_close_reason_strategies_match(self, strategy_id: str, direct: object) -> None:
         entry = STRATEGY_MANIFEST[strategy_id]
         assert entry.signals is not None
-        via_manifest = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        via_manifest = entry.signals(
+            _bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON, regime=unconstrained_regime(len(_bars(_CLOSES)))
+        )
         expected = direct(_bars(_CLOSES), universe=UNIVERSE, close_reason=REASON)  # type: ignore[operator]
         assert via_manifest == expected
         assert any(signal.verdict == "fired" for signal in via_manifest), (
@@ -270,10 +278,12 @@ class TestUniformInvocationEqualsTheDirectCall:
     def test_masked_reason_strategy_matches(self) -> None:
         entry = STRATEGY_MANIFEST[SPEC_S4]
         assert entry.signals is not None
-        via_manifest = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        via_manifest = entry.signals(
+            _bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON, regime=unconstrained_regime(len(_bars(_CLOSES)))
+        )
         assert via_manifest == s4_signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
 
-    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4])
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S6])
     def test_the_reason_code_reaches_the_verdict(self, strategy_id: str) -> None:
         """⚠ An adapter could accept ``masked_reason`` and drop it, defaulting
         the module's own argument. Equality against the direct call would still
@@ -281,17 +291,30 @@ class TestUniformInvocationEqualsTheDirectCall:
         comes back."""
         entry = STRATEGY_MANIFEST[strategy_id]
         assert entry.signals is not None
-        signals = entry.signals(_bars(_HOLED_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        signals = entry.signals(
+            _bars(_HOLED_CLOSES),
+            universe=UNIVERSE,
+            masked_reason=REASON,
+            regime=unconstrained_regime(len(_bars(_HOLED_CLOSES))),
+        )
         assert signals[0].verdict == "not_evaluable"
         assert signals[0].reason == REASON
 
-    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4])
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S6])
     def test_emitted_kinds_are_the_declared_kinds(self, strategy_id: str) -> None:
         """⚠ ``signal_kinds`` is a claim about the strategy, so it is measured
         from what it emits rather than trusted."""
         entry = STRATEGY_MANIFEST[strategy_id]
         assert entry.signals is not None
-        emitted = {signal.kind for signal in entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)}
+        emitted = {
+            signal.kind
+            for signal in entry.signals(
+                _bars(_CLOSES),
+                universe=UNIVERSE,
+                masked_reason=REASON,
+                regime=unconstrained_regime(len(_bars(_CLOSES))),
+            )
+        }
         assert emitted == set(entry.signal_kinds)
 
     def test_cross_sectional_member_matches_the_direct_call(self) -> None:

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -48,6 +48,7 @@ SPEC_S2 = "s2-cross-sectional-momentum"
 SPEC_S3 = "s3-mean-reversion-in-trend"
 SPEC_S4 = "s4-volatility-compression-breakout"
 #: §3 of the S-5..S-10 set. Written out for the same reason as the four above.
+SPEC_S5 = "s5-support-bounce"
 SPEC_S6 = "s6-resistance-breakout"
 
 #: Spec §3's table, verbatim, as ``(signal_pair, level_based, max_hold_bars,
@@ -59,6 +60,7 @@ SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
     SPEC_S2: (False, False, None, True),
     SPEC_S3: (True, False, 10, False),
     SPEC_S4: (False, True, 40, False),
+    SPEC_S5: (False, True, 30, False),
     SPEC_S6: (False, True, 40, False),
 }
 
@@ -69,6 +71,7 @@ SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
     SPEC_S2: frozenset({"entry"}),
     SPEC_S3: frozenset({"entry", "exit"}),
     SPEC_S4: frozenset({"entry"}),
+    SPEC_S5: frozenset({"entry"}),
     SPEC_S6: frozenset({"entry"}),
 }
 
@@ -77,10 +80,13 @@ SPEC_CLASSES: dict[str, str] = {
     SPEC_S2: "cross_sectional",
     SPEC_S3: "per_series",
     SPEC_S4: "per_series",
+    SPEC_S5: "per_series",
     SPEC_S6: "per_series",
 }
 
-SPEC_PURPOSES = {strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S6)}
+SPEC_PURPOSES = {
+    strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6)
+}
 
 
 def _bars(closes: Sequence[float | None], *, start: date = date(2020, 1, 1)) -> BarSeries:
@@ -154,7 +160,7 @@ class TestManifestIsComplete:
         forever. Pin that it is actually reading the modules it claims to — the
         prevention-log lesson from a probe that matched nothing."""
         declared = self._declared_strategy_ids()
-        assert len(declared) == 5, f"expected the five catalogue modules, walked {sorted(declared)}"
+        assert len(declared) == 6, f"expected the six catalogue modules, walked {sorted(declared)}"
         assert declared["s1_time_series_momentum.py"] == SPEC_S1
 
     def test_every_strategy_module_is_registered(self) -> None:
@@ -180,7 +186,7 @@ class TestManifestIsComplete:
         """⚠ THE ONE BRIDGE between this file's literals and the source. Every
         other assertion here is written against the literals, so without this
         the whole file could agree with a renamed strategy."""
-        assert set(self._declared_strategy_ids().values()) == {SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S6}
+        assert set(self._declared_strategy_ids().values()) == {SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6}
 
 
 class TestEntriesDescribeTheirStrategy:
@@ -283,7 +289,7 @@ class TestUniformInvocationEqualsTheDirectCall:
         )
         assert via_manifest == s4_signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
 
-    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S6])
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6])
     def test_the_reason_code_reaches_the_verdict(self, strategy_id: str) -> None:
         """⚠ An adapter could accept ``masked_reason`` and drop it, defaulting
         the module's own argument. Equality against the direct call would still
@@ -300,7 +306,7 @@ class TestUniformInvocationEqualsTheDirectCall:
         assert signals[0].verdict == "not_evaluable"
         assert signals[0].reason == REASON
 
-    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S6])
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6])
     def test_emitted_kinds_are_the_declared_kinds(self, strategy_id: str) -> None:
         """⚠ ``signal_kinds`` is a claim about the strategy, so it is measured
         from what it emits rather than trusted."""


### PR DESCRIPTION
S-6 from `docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md` §3, on the regime + level foundation merged in #2708. **It scans, it fires, and it does so through the real registered manifest path** — 62 of 71 US instruments, 549 entry signals.

## ⚠⚠ The bug the fire count caught, and nothing else would have

First implementation fired **70 times per instrument over ~4 years** — one every ~15 bars.

`close(t) > level` is true on **every** bar once price sits above an old level, so the rule degenerated into *"price is above some level and volume is up"* and re-fired indefinitely. A breakout is a **crossing**, not a position. The guard requires the prior close at or below the level.

| | before | after |
| --- | ---: | ---: |
| entries/name/year | ~17 | **2.3** |
| implied turnover (40-bar hold) | — | **37%/yr** |

Not review, not types, not a test — the **count**. A breakout is not a fortnightly event, and 2.3/name/year reads as one. The turnover sits inside the ~50%/month bound that disqualified S-1 at 56×/yr before any backtest.

## Where `regime` lives, and why

On the **uniform per-series call**, not on the strategies that use it. S-1…S-4 accept and ignore it; S-5…S-10 gate on it. That is the choice this module already made for `masked_reason` — the adapters absorb the difference, and a runner cannot forget to supply it for the one strategy that needs it.

The alternative, a `requires_regime` flag with a runner branch, reintroduces exactly the per-strategy `if` the manifest exists to delete — and that branch is what nobody updates when S-11 arrives.

⚠ **No identity moves.** `StrategyIdentity.version` hashes `strategy_registry.py`, not the manifest (its own docstring, reason 1). Editing the manifest is free of that blast radius by design.

## Three alignment traps, all closed

⚠⚠ **The regime is sliced with the segment, not passed whole.** Each segment is a fresh `BarSeries` indexed from zero, so a full-length regime handed to a segment starting at bar 400 aligns bar 0 of the segment with bar 0 of the market — every verdict off by the offset, silently. `segmented_signals` slices it; S-6's length check is the **backstop, not the fix**.

⚠⚠ **Aligned by date, never by position.** An instrument and the benchmark do not share a bar count — different listings, halts, holidays. A bar with no benchmark bar gets `None`, and a gated strategy refuses to fire rather than inheriting a stale regime. Built **once per scan**, so two instruments in one cycle cannot disagree about the market.

⚠ **`s6_exit_bracket` returns `(target, stop, max_hold)` to match `s4_exit_bracket`.** Both are `tuple[Decimal, Decimal, int]`, so a mismatched order is invisible to the type checker *and* to review — the adapter would build `ExitLevels(take_profit=stop, stop_loss=target)` and every bracket would be inverted. This repo has shipped that exact class through positional lists (#2623).

## A real defect surfaced by the guards

S-6 declared its closes as a bare `IndicatorSeries` with no `not_evaluable_indices`, so a **masked** close was reported as `insufficient_warmup`. The verdict was still "not evaluable" and nothing broke — only the recorded **reason** was wrong, which is the class of defect that survives every test checking whether a bar *fired*. Caught by `test_the_reason_code_reaches_the_verdict`.

The manifest completeness guards also caught the unregistered module and were **extended to five strategies rather than bypassed**.

## Design points that are rule, not preference

- **The bracket takes no regime.** A bracket is only requested for a signal that already fired, so the regime was permitted by construction. Threading it would let a since-moved regime refuse a stop for an already-open position — a gate that can retroactively remove an exit is not a safety control.
- **The stop anchors to the LEVEL, the target to the ENTRY.** The stop asks *"was this a false break?"* (a question about the level); the target asks *"has this paid enough?"* (a question about the position). Normalising them would change what the strategy means. An inverted bracket is therefore reachable and is refused as `unorderable_exit_levels`.
- **`LEVEL_RULE_VERSION` and `REGIME_RULE_VERSION` are hashed into `S6_PARAMS`.** The same bars under a different level rule produce different signals, so omitting them would let a level-rule edit silently inherit this strategy's track record.
- **Missing volume is NaN, never 0.0.** Zero claims nothing traded, which would fail the confirmation test and look like a considered refusal rather than absent data.
- **`VOLUME_CONFIRMATION_MULTIPLE = 1.2` is retail convention, NOT a published result** — frozen by construction and labelled as such, so nobody later cites it as evidence-backed.

## ⚠ Known limitation, stated rather than worked around

The regime is sourced from `price_daily`, whose SPY starts **2022-05-10**, while the backtest axis reaches **1962**. Every earlier bar is `None`, so S-5…S-10 **cannot fire on the long span** and their pre-2022 result is an *empty* sample, not a bad one.

Defaulting those years to a permissive regime would fabricate six decades of market conditions. Closing it needs a benchmark series in the **research** corpus — the same source the bars come from. `regime_provider` is injectable on both backtest arm passes precisely so that fix has a seam.

This is consistent with §0 of the spec, which asks for judgement on the recent regime rather than one pooled number over the whole span.

## Security model

No trading-authority surface. S-6 is registered `purpose="harness_validation"` like the existing four — it emits signals and cannot receive capital. No promotion gate touched.

## Gates

ruff · ruff-format · pyright · full `-m "not db"` tier — all green.

Refs #2437.
