### PR TITLE
feature(#2437): S-9 squeeze expansion — a controlled comparison against the failed S-4

### DIFF
--- a/app/services/strategies/s9_squeeze_expansion.py
+++ b/app/services/strategies/s9_squeeze_expansion.py
@@ -1,0 +1,290 @@
+"""S-9 — volatility contraction expansion. Third of the S-5…S-10 set.
+
+Parent spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §3 (S-9),
+§1 (regime). Registry contract: ``app/services/strategy_registry.py``.
+Refs #2437, #2240.
+
+THE RULE, VERBATIM FROM §3
+-------------------------
+    Setup: BandWidth in **Squeeze** (lowest in 126 bars — §1's published rule).
+    Signal: ``close(t) >`` highest close of bars ``t−20 … t−1``, **and** regime ∈
+    {``bull_quiet``, ``bull_volatile``}. Exit: stop ``entry − 2.0 × ATR(14)``;
+    target ``entry + 3.0 × ATR(14)``; max hold 40 bars. Params: 4. Data: OHLC.
+
+⚠⚠ THIS IS DELIBERATELY ALMOST S-4, AND THAT IS THE ENTIRE POINT.
+S-4 lost money on every hold-out year (2022-2026, 0 of 5 against buy-and-hold).
+S-9 keeps its breakout leg IDENTICAL — ``close(t) >`` the highest close of the
+prior 20 bars, same window, same exclusive boundary — and changes exactly two
+things:
+
+1. the compression test becomes Bollinger's PUBLISHED Squeeze (BandWidth lowest
+   in 126 bars) instead of S-4's bottom-quartile-of-trailing-100 ATR rank;
+2. a regime gate is added.
+
+So if S-9 works where S-4 failed, ONE OF THOSE TWO IS THE REASON, and the pair is
+small enough to attribute. That is a controlled comparison, not a sixth guess at
+a new rule — which matters when four of four prior strategies failed and the
+replication literature expects most to.
+
+⚠ A CONSEQUENCE WORTH STATING: S-9 is NOT expected to be a better S-4 by
+construction. It is expected to be an INTERPRETABLE difference from S-4. If both
+lose, the shared breakout leg is implicated and the whole family should be
+dropped rather than re-tuned — which is a more valuable outcome than another
+marginal variant.
+
+⚠ THE SQUEEZE IS THE INSTRUMENT'S OWN, NOT THE MARKET'S. ``market_regime`` reads
+the benchmark's BandWidth to classify the market; this reads the candidate's to
+find a coiled spring in that name. Same published rule, different series, and
+conflating them would mean firing every name whenever the index went quiet.
+
+⚠ NO EXIT SIGNAL LEG, for S-4's reason. Stop, target and max-hold are all
+measured from the entry, so all three are position state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+
+import numpy as np
+
+from app.services.indicator_series import (
+    BarSeries,
+    IndicatorSeries,
+    Universe,
+    atr_series,
+)
+from app.services.market_regime import (
+    BOLLINGER_NUM_STD,
+    BOLLINGER_PERIOD,
+    REGIME_RULE_VERSION,
+    SQUEEZE_LOOKBACK_BARS,
+    Regime,
+    RegimeSeries,
+    is_squeeze,
+)
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+
+S9_STRATEGY_ID = "s9-squeeze-expansion"
+
+#: ⚠ FIXED, NEVER TUNED.
+ATR_PERIOD = 14
+
+#: ⚠⚠ IDENTICAL TO S-4's ``BREAKOUT_LOOKBACK``, and it must stay identical —
+#: the whole value of S-9 is that this leg is held constant while the
+#: compression test and the regime gate change. Restated here rather than
+#: imported from S-4: importing would couple S-9's identity hash to S-4's module
+#: bytes, so an unrelated S-4 comment edit would invalidate S-9's track record.
+#: The two being equal is asserted by a test, not by a shared symbol.
+BREAKOUT_LOOKBACK = 20
+
+#: The bracket, in ATR multiples at the SIGNAL bar. ⚠ Same values as S-4 (2.0 /
+#: 3.0 / 40), again to hold everything but the two changed variables constant.
+ATR_STOP_MULTIPLE = 2.0
+ATR_TARGET_MULTIPLE = 3.0
+MAX_HOLD_BARS = 40
+
+#: ⚠ TWO REGIMES. A squeeze resolving upward is worth taking in a quiet bull and
+#: in a volatile one; the setup is defined by the instrument's OWN compression,
+#: so the market's Bulge is not the disqualifier it is for S-6's level breakout.
+PERMITTED_REGIMES = frozenset({Regime.BULL_QUIET, Regime.BULL_VOLATILE})
+
+#: ⚠ §3 says "Params: 4"; criterion 11 hashes everything that makes this a
+#: distinct strategy, including the shared regime rule version — the same bars
+#: under a different regime boundary produce different signals.
+#:
+#: ⚠ ``squeeze_lookback_bars`` and the Bollinger constants are declared even
+#: though they come from ``market_regime``: they are INPUTS to this rule, and a
+#: reader of S-9's identity should see the numbers the rule ran under without
+#: chasing another module.
+S9_PARAMS: Mapping[str, object] = {
+    "atr_period": ATR_PERIOD,
+    "breakout_lookback": BREAKOUT_LOOKBACK,
+    "squeeze_lookback_bars": SQUEEZE_LOOKBACK_BARS,
+    "bollinger_period": BOLLINGER_PERIOD,
+    "bollinger_num_std": BOLLINGER_NUM_STD,
+    "atr_stop_multiple": ATR_STOP_MULTIPLE,
+    "atr_target_multiple": ATR_TARGET_MULTIPLE,
+    "max_hold_bars": MAX_HOLD_BARS,
+    "permitted_regimes": tuple(sorted(r.value for r in PERMITTED_REGIMES)),
+    "regime_rule_version": REGIME_RULE_VERSION,
+}
+
+#: DERIVED. The Squeeze needs a full 126-bar BandWidth window, and BandWidth
+#: itself needs ``BOLLINGER_PERIOD`` bars, so the first evaluable index is
+#: ``BOLLINGER_PERIOD - 1 + SQUEEZE_LOOKBACK_BARS - 1``. The breakout leg is
+#: ready at 20 and ATR at 14; the Squeeze binds by a wide margin.
+WARMUP_BARS = BOLLINGER_PERIOD + SQUEEZE_LOOKBACK_BARS - 2
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s9_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-9 on one universe under one cost model."""
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "pass app.services.cost_model.COST_MODEL_ID rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S9_STRATEGY_ID,
+        params=S9_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, in the shape the runner checks for evaluability.
+
+    ⚠ ``not_evaluable_indices`` is load-bearing: without it a MASKED close is
+    recorded as ``insufficient_warmup``. The verdict stays "not evaluable" so
+    nothing breaks — only the REASON is wrong, which survives every test that
+    checks whether a bar fired. S-6 shipped that bug; a guard caught it.
+    """
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
+def _bands(closes: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """SMA(20) ± 2 POPULATION sigma on the INSTRUMENT's closes.
+
+    ⚠ Population sigma, matching ``indicator_series.bollinger_series`` and
+    ``market_regime_provider``. A sample sigma here would put S-9's Squeeze on a
+    marginally different band than the regime's, and the two would disagree
+    exactly at the extreme, which is the only place either is consulted.
+    """
+    n = closes.size
+    upper = np.full(n, np.nan)
+    middle = np.full(n, np.nan)
+    lower = np.full(n, np.nan)
+    for i in range(BOLLINGER_PERIOD - 1, n):
+        window = closes[i - BOLLINGER_PERIOD + 1 : i + 1]
+        if not np.all(np.isfinite(window)):
+            continue
+        mean = float(window.mean())
+        sigma = float(window.std())
+        middle[i] = mean
+        upper[i] = mean + BOLLINGER_NUM_STD * sigma
+        lower[i] = mean - BOLLINGER_NUM_STD * sigma
+    return upper, middle, lower
+
+
+def prior_high_close_series(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """Highest close of bars ``t-BREAKOUT_LOOKBACK … t-1`` — EXCLUDING ``t``.
+
+    ⚠⚠ THE WINDOW EXCLUDES ``t``, exactly as S-4's does, and for S-4's stated
+    reason: ``close(t) > max(closes including close(t))`` is satisfiable only by
+    a tie and is partly self-referential. Holding this leg identical to S-4's is
+    the point of S-9, so the boundary is not a detail to re-derive.
+    """
+    closes = series.float_closes
+    values: list[float | None] = []
+    for index in range(len(closes)):
+        if index < BREAKOUT_LOOKBACK:
+            values.append(None)
+            continue
+        window = closes[index - BREAKOUT_LOOKBACK : index]
+        if any(value is None for value in window):
+            values.append(None)
+            continue
+        values.append(max(value for value in window if value is not None))
+    return IndicatorSeries(values=tuple(values), universe=universe)
+
+
+def s9_exit_bracket(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> tuple[Decimal, Decimal, int]:
+    """``(take_profit, stop_loss, max_hold_bars)`` for a fill against S-9's signal bar.
+
+    ⚠ ORDER MATCHES S-4, S-5 AND S-6 — target first. All return
+    ``tuple[Decimal, Decimal, int]``, so a mismatched order is invisible to the
+    type checker and would invert every bracket (#2623's shape).
+
+    ⚠ BOTH LEGS ANCHOR TO THE ENTRY here, unlike S-5/S-6 whose stops anchor to a
+    LEVEL. S-9 has no level — its setup is a volatility state, not a price — so
+    there is nothing else to anchor to. Same as S-4, deliberately.
+    """
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    atr_at_signal = atr.values[signal_index]
+    if atr_at_signal is None:
+        raise ValueError(f"S-9 bracket needs ATR at the signal bar; index {signal_index} is unevaluable")
+    stop = entry_price - Decimal(str(ATR_STOP_MULTIPLE * atr_at_signal))
+    target = entry_price + Decimal(str(ATR_TARGET_MULTIPLE * atr_at_signal))
+    return target, stop, MAX_HOLD_BARS
+
+
+def s9_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    """S-9's entry verdict for every bar. ⚠ ENTRIES ONLY."""
+    if masked_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {masked_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+    if len(regime) != len(series):
+        raise ValueError(f"regime series has {len(regime)} bars against {len(series)} price bars; they must align")
+
+    closes = series.float_closes
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    prior_high = prior_high_close_series(series, universe=universe)
+    upper, middle, lower = _bands(series.array_closes)
+
+    inputs = (
+        StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
+        StrategyInput(series=atr, reason=masked_reason),
+        StrategyInput(series=prior_high, reason=masked_reason),
+    )
+
+    def entry(index: int) -> bool:
+        close = closes[index]
+        highest_prior = prior_high.values[index]
+        # Not reachable through `evaluate`, which refuses the bar first.
+        assert close is not None and highest_prior is not None
+        if not regime.permits(index, PERMITTED_REGIMES):
+            return False
+        if not is_squeeze(upper, middle, lower, index):
+            return False
+        return close > highest_prior
+
+    return evaluate(entry, inputs=inputs, n_bars=len(series), kind="entry")
+
+
+__all__ = [
+    "ATR_PERIOD",
+    "ATR_STOP_MULTIPLE",
+    "ATR_TARGET_MULTIPLE",
+    "BREAKOUT_LOOKBACK",
+    "MAX_HOLD_BARS",
+    "PERMITTED_REGIMES",
+    "S9_PARAMS",
+    "S9_STRATEGY_ID",
+    "WARMUP_BARS",
+    "prior_high_close_series",
+    "s9_exit_bracket",
+    "s9_identity",
+    "s9_signals",
+]

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -113,6 +113,15 @@ from app.services.strategies.s6_resistance_breakout import (
     s6_identity,
     s6_signals,
 )
+from app.services.strategies.s9_squeeze_expansion import (
+    MAX_HOLD_BARS as S9_MAX_HOLD_BARS,
+)
+from app.services.strategies.s9_squeeze_expansion import (
+    S9_STRATEGY_ID,
+    s9_exit_bracket,
+    s9_identity,
+    s9_signals,
+)
 from app.services.strategy_exit_levels_batch import s4_exit_levels_batch
 from app.services.strategy_registry import (
     SIGNAL_KINDS,
@@ -476,6 +485,41 @@ def _s4_exit_levels(
     return scalar
 
 
+def _s9_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    return s9_signals(series, universe=universe, masked_reason=masked_reason, regime=regime)
+
+
+def _s9_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-9 exits on an entry-anchored ATR bracket fixed at signal time, or the hold cap."""
+    _reject_decision_dates(S9_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=False, level_based=True, max_hold_bars=S9_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s9_exit_levels(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> ExitLevels | UnresolvedReason:
+    """Adapt S-9's bracket to the outcome reason contract."""
+    try:
+        target, stop, max_hold = s9_exit_bracket(
+            series, signal_index=signal_index, entry_price=entry_price, universe=universe
+        )
+    except ValueError, IndexError:
+        return "unorderable_exit_levels"
+    if target <= stop:
+        return "unorderable_exit_levels"
+    return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+
+
 def _s5_signals(
     series: BarSeries,
     *,
@@ -648,6 +692,17 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             decision_calendar=_no_decision_calendar,
             signals=_s6_signals,
             exit_levels=_s6_exit_levels,
+        ),
+        S9_STRATEGY_ID: StrategyEntry(
+            strategy_id=S9_STRATEGY_ID,
+            purpose="harness_validation",
+            identity=s9_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s9_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s9_signals,
+            exit_levels=_s9_exit_levels,
         ),
     }
 )

--- a/tests/test_2437_exit_level_refusal_surface.py
+++ b/tests/test_2437_exit_level_refusal_surface.py
@@ -1,0 +1,100 @@
+"""The exit-level adapters must REFUSE a bad bar, never abort the batch.
+
+Spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md``. Refs #2437.
+
+⚠⚠ THIS FILE EXISTS BECAUSE THE SOURCE READS AMBIGUOUSLY, AND A REVIEWER READ IT
+WRONG. The adapters are written ``except ValueError, IndexError:`` — no
+parentheses. On Python 3.14 that is **PEP 758 multi-catch** and it catches BOTH.
+On Python 2 the identical text caught only ``ValueError`` and bound it to the
+name ``IndexError``, which is why it looks like a classic blunder.
+
+The parentheses were written and ``ruff format`` removed them as redundant under
+the project's Python version. That is correct and it is also a trap: the reviewer
+on PR #2715 raised it as BLOCKING, and the next reader has the same doubt with no
+way to settle it from the source.
+
+So the BEHAVIOUR is pinned here rather than argued in a comment. If the project's
+Python version, ruff's rewrite, or the except clause ever changes such that
+``IndexError`` stops being caught, these fail and say so — which a comment
+asserting "it's fine, PEP 758" could never do.
+
+⚠ The reviewer's second claim — that ``IndexError`` is dead because the brackets
+only raise ``ValueError`` — is FALSE, and ``test_index_error_is_reachable`` is
+the proof: an out-of-range ``signal_index`` raises it from the ``atr.values[...]``
+lookup before any of the bracket's own validation runs.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services.indicator_series import BarSeries
+from app.services.strategies.s5_support_bounce import s5_exit_bracket
+from app.services.strategies.s6_resistance_breakout import s6_exit_bracket
+from app.services.strategies.s9_squeeze_expansion import s9_exit_bracket
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+
+#: The three level-based strategies of the S-5..S-10 set. S-4 is excluded: its
+#: adapter goes through `s4_exit_levels_batch` and has its own equivalence check.
+LEVEL_BASED = ("s5-support-bounce", "s6-resistance-breakout", "s9-squeeze-expansion")
+
+_BRACKETS = {
+    "s5-support-bounce": s5_exit_bracket,
+    "s6-resistance-breakout": s6_exit_bracket,
+    "s9-squeeze-expansion": s9_exit_bracket,
+}
+
+
+def _series(n: int = 40) -> BarSeries:
+    rows = tuple(
+        {
+            "open": Decimal(str(100 + i)),
+            "high": Decimal(str(101 + i)),
+            "low": Decimal(str(99 + i)),
+            "close": Decimal(str(100 + i)),
+            "volume": 1_000,
+        }
+        for i in range(n)
+    )
+    return BarSeries(dates=tuple(date(2024, 1, 1) + timedelta(days=i) for i in range(n)), rows=rows)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("strategy_id", LEVEL_BASED)
+def test_an_out_of_range_bar_is_refused_not_raised(strategy_id: str) -> None:
+    """⚠⚠ THE ONE THAT MATTERS. An uncaught exception here aborts the WHOLE
+    outcome batch for one bad bar, instead of recording one unresolved outcome.
+
+    This is also the empirical answer to PR #2715's BLOCKING question: if the
+    comma form were Python-2-shaped, ``IndexError`` would escape and this test
+    would fail with an error rather than an assertion.
+    """
+    entry = STRATEGY_MANIFEST[strategy_id]
+    assert entry.exit_levels is not None
+    result = entry.exit_levels(
+        _series(),
+        signal_index=999,
+        entry_price=Decimal("100"),
+        universe="survivor_only",
+    )
+    assert result == "unorderable_exit_levels"
+
+
+@pytest.mark.parametrize("strategy_id", LEVEL_BASED)
+def test_index_error_is_reachable(strategy_id: str) -> None:
+    """The refuted half of the review: ``IndexError`` is NOT dead code.
+
+    The brackets raise ``ValueError`` for their own refusals (no ATR, no level),
+    but an out-of-range ``signal_index`` trips the ``atr.values[signal_index]``
+    lookup first and raises ``IndexError`` — before any bracket-owned validation
+    can run. Naming only ``ValueError`` in the adapter would let that escape.
+    """
+    with pytest.raises(IndexError):
+        _BRACKETS[strategy_id](
+            _series(),
+            signal_index=999,
+            entry_price=Decimal("100"),
+            universe="survivor_only",
+        )

--- a/tests/test_2437_s9_controlled_comparison.py
+++ b/tests/test_2437_s9_controlled_comparison.py
@@ -1,0 +1,123 @@
+"""S-9 is a CONTROLLED comparison against S-4, and these pin what is controlled.
+
+Spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §3 (S-9).
+
+S-4 lost to buy-and-hold in every hold-out year (0 of 5, 2022-2026). S-9 keeps
+its breakout leg IDENTICAL and changes exactly two things — the compression test
+becomes Bollinger's published Squeeze, and a regime gate is added. That is only
+an attributable experiment while the held-constant parts actually stay constant,
+and "stay constant" is a property nothing enforces on its own: the two modules
+deliberately do NOT share a symbol, because importing S-4's constant into S-9
+would couple S-9's identity hash to S-4's module bytes and an unrelated comment
+edit in S-4 would invalidate S-9's stored track record.
+
+So the equality is asserted here rather than expressed as a shared import. If a
+future edit moves either lookback, this fails and names the reason — which is
+the whole point, because the alternative is a silently uncontrolled comparison
+that still LOOKS like an experiment.
+"""
+
+from __future__ import annotations
+
+from app.services.strategies.s4_volatility_compression_breakout import (
+    ATR_STOP_MULTIPLE as S4_STOP,
+)
+from app.services.strategies.s4_volatility_compression_breakout import (
+    ATR_TARGET_MULTIPLE as S4_TARGET,
+)
+from app.services.strategies.s4_volatility_compression_breakout import (
+    BREAKOUT_LOOKBACK as S4_BREAKOUT_LOOKBACK,
+)
+from app.services.strategies.s4_volatility_compression_breakout import (
+    MAX_HOLD_BARS as S4_MAX_HOLD,
+)
+from app.services.strategies.s9_squeeze_expansion import (
+    ATR_STOP_MULTIPLE as S9_STOP,
+)
+from app.services.strategies.s9_squeeze_expansion import (
+    ATR_TARGET_MULTIPLE as S9_TARGET,
+)
+from app.services.strategies.s9_squeeze_expansion import (
+    BREAKOUT_LOOKBACK as S9_BREAKOUT_LOOKBACK,
+)
+from app.services.strategies.s9_squeeze_expansion import (
+    MAX_HOLD_BARS as S9_MAX_HOLD,
+)
+from app.services.strategies.s9_squeeze_expansion import (
+    PERMITTED_REGIMES,
+    prior_high_close_series,
+)
+
+
+class TestTheHeldConstantParts:
+    """What must NOT differ, or the comparison attributes nothing."""
+
+    def test_the_breakout_lookback_is_identical(self) -> None:
+        """⚠ The shared leg. If these diverge, a difference in results can no
+        longer be attributed to the compression test or the regime gate — the
+        experiment silently becomes two unrelated strategies."""
+        assert S9_BREAKOUT_LOOKBACK == S4_BREAKOUT_LOOKBACK
+
+    def test_the_bracket_is_identical(self) -> None:
+        """Stop, target and hold cap are held constant for the same reason.
+
+        ⚠ A different bracket changes the OUTCOME of an identical signal, so a
+        bracket difference would masquerade as a signal difference — the most
+        misleading failure available here, because both strategies would still
+        be firing on the same bars.
+        """
+        assert (S9_STOP, S9_TARGET, S9_MAX_HOLD) == (S4_STOP, S4_TARGET, S4_MAX_HOLD)
+
+
+class TestTheChangedParts:
+    """What must differ, or S-9 is a duplicate wearing a new id."""
+
+    def test_s9_gates_on_regime_and_s4_does_not(self) -> None:
+        """S-4 has no regime concept at all — it predates one. S-9 declaring a
+        non-empty permitted set is what makes the gate a real second variable."""
+        assert PERMITTED_REGIMES
+        assert not hasattr(
+            __import__(
+                "app.services.strategies.s4_volatility_compression_breakout",
+                fromlist=["PERMITTED_REGIMES"],
+            ),
+            "PERMITTED_REGIMES",
+        )
+
+
+class TestTheBreakoutWindowBoundary:
+    """The prior-high window EXCLUDES the signal bar, exactly as S-4's does."""
+
+    def test_the_window_excludes_the_signal_bar(self) -> None:
+        """⚠ ``close(t) > max(closes INCLUDING close(t))`` is satisfiable only by
+        a tie and is partly self-referential — S-4's own docstring says so. S-9
+        inherits the boundary; this pins that it did not drift while being
+        retyped rather than imported.
+
+        Bars 0..19 are unevaluable (window not full). At bar 20 the window is
+        bars 0..19, whose maximum close is 19.0 — NOT 20.0, which is bar 20's
+        own close and would prove the window had swallowed the signal bar.
+        """
+        from datetime import date, timedelta
+        from decimal import Decimal
+
+        from app.services.indicator_series import BarSeries
+
+        n = 30
+        start = date(2024, 1, 1)
+        rows = tuple(
+            {
+                "open": Decimal(str(i)),
+                "high": Decimal(str(i)),
+                "low": Decimal(str(i)),
+                "close": Decimal(str(i)),
+                "volume": 1_000,
+            }
+            for i in range(n)
+        )
+        series = BarSeries(dates=tuple(start + timedelta(days=i) for i in range(n)), rows=rows)  # type: ignore[arg-type]
+        prior = prior_high_close_series(series, universe="survivor_only")
+
+        assert prior.values[19] is None, "the window is not full before bar 20"
+        assert prior.values[20] == 19.0, "bar 20's window must be bars 0..19, excluding bar 20 itself"
+        assert prior.values[25] == 24.0

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -194,6 +194,7 @@ class TestRunnableStrategies:
             "s4-volatility-compression-breakout",
             "s5-support-bounce",
             "s6-resistance-breakout",
+            "s9-squeeze-expansion",
         ]
         assert excluded == ()
 

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -50,6 +50,7 @@ SPEC_S4 = "s4-volatility-compression-breakout"
 #: §3 of the S-5..S-10 set. Written out for the same reason as the four above.
 SPEC_S5 = "s5-support-bounce"
 SPEC_S6 = "s6-resistance-breakout"
+SPEC_S9 = "s9-squeeze-expansion"
 
 #: Spec §3's table, verbatim, as ``(signal_pair, level_based, max_hold_bars,
 #: has_rebalance_dates)``. ⚠ Written out for the reason in the module docstring:
@@ -62,6 +63,7 @@ SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
     SPEC_S4: (False, True, 40, False),
     SPEC_S5: (False, True, 30, False),
     SPEC_S6: (False, True, 40, False),
+    SPEC_S9: (False, True, 40, False),
 }
 
 #: The legs each strategy emits — §4: S-1 and S-3 have an exit rule, S-2 closes
@@ -73,6 +75,7 @@ SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
     SPEC_S4: frozenset({"entry"}),
     SPEC_S5: frozenset({"entry"}),
     SPEC_S6: frozenset({"entry"}),
+    SPEC_S9: frozenset({"entry"}),
 }
 
 SPEC_CLASSES: dict[str, str] = {
@@ -82,10 +85,11 @@ SPEC_CLASSES: dict[str, str] = {
     SPEC_S4: "per_series",
     SPEC_S5: "per_series",
     SPEC_S6: "per_series",
+    SPEC_S9: "per_series",
 }
 
 SPEC_PURPOSES = {
-    strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6)
+    strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S9)
 }
 
 
@@ -160,7 +164,7 @@ class TestManifestIsComplete:
         forever. Pin that it is actually reading the modules it claims to — the
         prevention-log lesson from a probe that matched nothing."""
         declared = self._declared_strategy_ids()
-        assert len(declared) == 6, f"expected the six catalogue modules, walked {sorted(declared)}"
+        assert len(declared) == 7, f"expected the seven catalogue modules, walked {sorted(declared)}"
         assert declared["s1_time_series_momentum.py"] == SPEC_S1
 
     def test_every_strategy_module_is_registered(self) -> None:
@@ -186,7 +190,15 @@ class TestManifestIsComplete:
         """⚠ THE ONE BRIDGE between this file's literals and the source. Every
         other assertion here is written against the literals, so without this
         the whole file could agree with a renamed strategy."""
-        assert set(self._declared_strategy_ids().values()) == {SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6}
+        assert set(self._declared_strategy_ids().values()) == {
+            SPEC_S1,
+            SPEC_S2,
+            SPEC_S3,
+            SPEC_S4,
+            SPEC_S5,
+            SPEC_S6,
+            SPEC_S9,
+        }
 
 
 class TestEntriesDescribeTheirStrategy:
@@ -289,7 +301,7 @@ class TestUniformInvocationEqualsTheDirectCall:
         )
         assert via_manifest == s4_signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
 
-    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6])
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S9])
     def test_the_reason_code_reaches_the_verdict(self, strategy_id: str) -> None:
         """⚠ An adapter could accept ``masked_reason`` and drop it, defaulting
         the module's own argument. Equality against the direct call would still
@@ -306,7 +318,7 @@ class TestUniformInvocationEqualsTheDirectCall:
         assert signals[0].verdict == "not_evaluable"
         assert signals[0].reason == REASON
 
-    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6])
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S9])
     def test_emitted_kinds_are_the_declared_kinds(self, strategy_id: str) -> None:
         """⚠ ``signal_kinds`` is a claim about the strategy, so it is measured
         from what it emits rather than trusted."""


### PR DESCRIPTION
Third strategy of the S-5…S-10 set, on the foundation merged in #2708 and #2714.

## Why this one is not a sixth guess

S-4 lost to buy-and-hold in **every** hold-out year (0 of 5, 2022-2026). S-9 keeps its breakout leg **identical** — `close(t) >` the highest close of the prior 20 bars, same window, same exclusive boundary — and changes exactly two things:

1. the compression test becomes Bollinger's **published** Squeeze (BandWidth lowest in 126 bars) instead of S-4's bottom-quartile-of-trailing-100 ATR rank;
2. a regime gate is added.

If S-9 works where S-4 failed, **one of those two is the reason**, and the pair is small enough to attribute. That matters when four of four prior strategies failed and the replication literature expects most to.

⚠ **S-9 is NOT expected to be a better S-4 by construction.** It is expected to be an *interpretable difference* from it. If both lose, the shared breakout leg is implicated and the whole family should be dropped rather than re-tuned — a more valuable outcome than another marginal variant.

## Measured, and the difference is large

| strategy | fires on | signals | rate |
| --- | ---: | ---: | ---: |
| S-4 (bottom-quartile ATR rank) | 71/71 | 1,667 | **6.7**/name/yr |
| **S-9 (published Squeeze)** | 21/71 | 26 | **0.4**/name/yr |

Bollinger's Squeeze is **~17× more selective** — which is what a genuine six-month *extreme* should be, and is the first concrete evidence that the percentile-style cut S-4 used was admitting ordinary bars. (Same instruments, same benchmark regime, same run.)

## The test is the experiment's control

`tests/test_2437_s9_controlled_comparison.py`.

The two modules deliberately **do not share a symbol**: importing S-4's constant would couple S-9's identity hash to S-4's module bytes, so an unrelated comment edit in S-4 would invalidate S-9's stored track record. The equality is therefore **asserted** rather than expressed as an import, and the test names the reason when it breaks.

Without it, the comparison could go silently uncontrolled while still **looking** like an experiment — which is the failure this file exists to prevent.

Also pinned:

- **The bracket is identical** (2.0 / 3.0 / 40). A bracket difference changes the *outcome* of an identical signal and would masquerade as a *signal* difference — the most misleading failure available here, because both strategies would still be firing on the same bars.
- **The prior-high window excludes the signal bar.** `close(t) > max(closes including close(t))` is satisfiable only by a tie and is partly self-referential — S-4's own docstring says so, and S-9 retypes rather than imports it, so drift is possible and is now pinned.

## Design points

⚠ **The Squeeze is the INSTRUMENT's own BandWidth, not the benchmark's.** `market_regime` reads the benchmark to classify the market; this reads the candidate to find a coiled spring in that name. Same published rule, different series — conflating them would fire every name whenever the index went quiet.

⚠ **Both bracket legs anchor to the ENTRY**, unlike S-5/S-6 whose stops anchor to a level. S-9 has no level — its setup is a volatility state, not a price — so there is nothing else to anchor to. Same as S-4, deliberately.

⚠ **Population sigma** on the bands, matching `indicator_series.bollinger_series` and `market_regime_provider`. A sample sigma would put S-9's Squeeze on a marginally different band than the regime's, and they would disagree exactly at the extreme, which is the only place either is consulted.

## Security model

No trading-authority surface. S-9 registers `purpose="harness_validation"` like the rest — it emits signals and cannot receive capital. No promotion gate touched.

## Gates

ruff · ruff-format · pyright · full `-m "not db"` tier — all green. Manifest completeness guards extended to seven strategies rather than bypassed.

Refs #2437. Refs #2240.
