### PR TITLE
feature(#2437): S-6 resistance breakout with volume confirmation — the first regime-gated strategy

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -579,6 +579,30 @@ def runnable_strategies(
     excluded: list[ExcludedStrategy] = []
     for strategy_id in sorted(manifest):
         entry = manifest[strategy_id]
+        # ⚠ A REGIME-GATED STRATEGY IS EXCLUDED FROM THE BACKTEST BY NAME, not
+        # run ungated (#2437). The market context is built from `price_daily`
+        # via `market_context.load_market_context`; this job runs over the
+        # RESEARCH corpus (`research_price_*`), whose benchmark series are a
+        # separate store, so no context exists here yet. Running S-6 without its
+        # gate would not measure S-6 — it would measure a strictly more
+        # permissive strategy that also fires in the `bull_volatile` Bulge its
+        # rule excludes by name, and it would store that under S-6's identity.
+        #
+        # Reported through `ExcludedStrategy` because that is what this function
+        # exists for: "a three-of-four run reporting '3 strategies evaluated' is
+        # exactly the silent narrowing criterion 9 forbids".
+        if entry.requires_market_context:
+            excluded.append(
+                ExcludedStrategy(
+                    strategy_id=strategy_id,
+                    reason=(
+                        "requires a MarketContext, which is built from the live corpus; the research corpus "
+                        "has no classified benchmark series yet, and running the strategy without its regime "
+                        "gate would measure a different, more permissive rule under this identity"
+                    ),
+                )
+            )
+            continue
         regime = _regime_for(entry, calendar)
         if not regime.level_based:
             if entry.exit_levels is not None or entry.exit_levels_batch is not None:

--- a/app/services/market_context.py
+++ b/app/services/market_context.py
@@ -1,0 +1,214 @@
+"""The benchmark's regime, per DATE, as every regime-gated strategy reads it.
+
+Spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §1. Refs #2437.
+
+WHY THIS IS DATE-KEYED AND NOT INDEX-ALIGNED
+--------------------------------------------
+The regime is a property of the MARKET on a day, not of the instrument being
+judged. Every S-5…S-10 strategy reads the same classification, computed once on
+one benchmark series, and each instrument then has to find its own bars in it.
+
+Bar INDEX cannot carry that. Index ``i`` is a different date on every
+instrument, so an index-aligned regime array would silently pair a 2026 bar of
+one name with a 2023 bar of another — the identical argument
+``CrossSectionalMember`` already makes for its own ranking key (*"Grouping on
+the bar INDEX would rank a 2019 bar against a 2007 one"*). It also survives
+``strategy_segmented_evaluation``, which slices a series into price-scale
+segments: a date key needs no re-basing, an index key needs re-basing at every
+segment boundary and is wrong the first time somebody forgets.
+
+⚠⚠ THE THREE STATES ARE DISTINCT AND STAY DISTINCT.
+
+1. **Classified** — the benchmark has a session and both legs are warm. The gate
+   is a real ``True``/``False`` and the strategy decides.
+2. **Before the benchmark's first classifiable bar** — the 200-SMA or the
+   126-bar BandWidth window is still filling. That is warm-up, and
+   ``gate_series`` leaves a bare ``None`` so the registry reports
+   ``insufficient_warmup``.
+3. **After it, with no session** — a hole in the benchmark series. That is a
+   DATA GAP in a series the strategy does not own, and it is reported as
+   ``missing_market_context`` (the registry's eleventh code).
+
+Measured on the validated universe before the code was written, because the
+whole point of the split is that the third class is not empty: of 3,650,325
+loadable bars, 85.26% are state 1, 14.48% state 2, and **9,405 bars over 353
+dates** are state 3 — worst single date 2026-02-06, on which 1,735 instruments
+traded and SPY has no bar. Collapsing 3 into 2 would report a permanent hole as
+a series that had not started yet.
+
+⚠ THE BENCHMARK IS PINNED BY SYMBOL AND ITS FRESHNESS IS SOMEBODY'S JOB.
+Prevention log, #1818: *"when a read path pins a specific symbol/entity, that
+symbol must appear in … the ingest scope that maintains its data — and a test
+should pin the cross-reference"*. SPX500 froze for weeks precisely because no
+refresh scope named it. ``BENCHMARK_SYMBOL`` is in
+``scheduler.BENCHMARK_SYMBOLS`` and ``tests/test_strategy_s6.py`` binds the two.
+
+⚠ SPY AND SPY.RTH ARE THE SAME FUND and only ``.RTH`` carries a ``real`` arm, so
+the spec requires the series to be pinned rather than resolved loosely. The
+lookup below is exact symbol equality and refuses anything but a unique match —
+a ``LIKE`` or a canonical-redirect hop is what would land on the wrong one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Final
+
+import numpy as np
+import psycopg
+
+from app.services.indicator_series import BarSeries, IndicatorSeries, Universe
+from app.services.market_regime import (
+    BOLLINGER_NUM_STD,
+    BOLLINGER_PERIOD,
+    REGIME_RULE_VERSION,
+    Regime,
+    classify_regimes,
+)
+
+#: ⚠ Pinned, and it is part of every regime-gated strategy's identity — a
+#: strategy gated on QQQ's regime is a different strategy from one gated on
+#: SPY's. Strategy modules hash this into their params rather than assuming it.
+BENCHMARK_SYMBOL: Final[str] = "SPY"
+
+
+class MarketContextUnavailable(RuntimeError):
+    """The benchmark could not be resolved or classified at all.
+
+    ⚠ Raised rather than returning an empty context, because an empty context is
+    indistinguishable from "the market was never classifiable", and a strategy
+    handed one would refuse every bar of every instrument while reporting a
+    perfectly ordinary reason code. A scan that cannot build its benchmark has a
+    configuration problem, and it should say so where the operator will see it.
+    """
+
+
+@dataclass(frozen=True)
+class MarketContext:
+    """One benchmark's classified regime, keyed by session date."""
+
+    #: Only CLASSIFIABLE sessions appear. A benchmark bar whose regime is
+    #: ``None`` is absent from this map, which is why ``first_classified`` is
+    #: carried separately — the map alone cannot tell warm-up from a hole.
+    regime_by_date: Mapping[date, Regime]
+    #: The earliest classified session. Everything before it is benchmark
+    #: warm-up; everything after it and absent is a gap.
+    first_classified: date
+    benchmark_instrument_id: int
+    benchmark_symbol: str
+    rule_set_version: str = REGIME_RULE_VERSION
+
+    def gate_series(
+        self,
+        dates: Sequence[date],
+        *,
+        allowed: frozenset[Regime],
+        universe: Universe,
+    ) -> IndicatorSeries:
+        """Per-bar permission for one instrument, in the shape ``evaluate`` checks.
+
+        ``1.0`` permitted, ``0.0`` refused by the rule, ``None`` undecidable.
+
+        ⚠ PERMISSION, NOT THE REGIME ITSELF. Encoding which of the four states a
+        bar is in would put a categorical value in a ``float`` series and invite
+        a caller to compare it to a number. Every strategy reads the same
+        question — *may I fire here* — so that is the question the series
+        answers, and ``allowed`` is what makes it per-strategy.
+
+        ⚠ A refused regime is ``0.0``, NOT ``None``. Firing outside a strategy's
+        declared domain is the defect (spec §0 rule 2), so a bar in
+        ``bear_quiet`` is a bar the strategy CONSIDERED and declined — a real
+        ``not_fired`` verdict. Reporting it as unevaluable would delete the
+        denominator that shows the regime gate doing its job.
+        """
+        if not allowed:
+            raise ValueError("a regime gate with no permitted regimes can never fire; declare at least one")
+        values: list[float | None] = []
+        unevaluable: list[int] = []
+        for index, when in enumerate(dates):
+            regime = self.regime_by_date.get(when)
+            if regime is not None:
+                values.append(1.0 if regime in allowed else 0.0)
+                continue
+            values.append(None)
+            # ⚠ Bare `None` BEFORE the first classified session (the registry
+            # reads that as warm-up); a listed refusal at or after it, because
+            # by then the benchmark has started and its absence is a hole.
+            if when >= self.first_classified:
+                unevaluable.append(index)
+        return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+
+
+def classify_benchmark(series: BarSeries, *, universe: Universe) -> dict[date, Regime]:
+    """Classify one benchmark series into ``{date: regime}``, dropping the rest.
+
+    Split out from the loader so the classification can be exercised without a
+    database, and so a caller measuring the corpus uses the same code the scan
+    does rather than a second copy of the band plumbing.
+    """
+    from app.services.indicator_series import bollinger_series
+
+    bands = bollinger_series(series, universe=universe, period=BOLLINGER_PERIOD, num_std=BOLLINGER_NUM_STD)
+
+    def band(name: str) -> np.ndarray:
+        return np.array([np.nan if value is None else value for value in bands.components[name]], dtype=float)
+
+    regimes = classify_regimes(
+        closes=series.array_closes,
+        band_upper=band("upper"),
+        band_middle=band("middle"),
+        band_lower=band("lower"),
+    )
+    return {when: regime for when, regime in zip(series.dates, regimes.values, strict=True) if regime is not None}
+
+
+def load_market_context(
+    conn: psycopg.Connection[Any],
+    *,
+    universe: Universe,
+    symbol: str = BENCHMARK_SYMBOL,
+) -> MarketContext:
+    """Resolve the benchmark, load its masked bars, and classify every session.
+
+    ⚠ Goes through ``load_masked_bars`` like every other series, not through a
+    bespoke query. The benchmark is subject to the same quarantine and the same
+    fail-closed coverage rule as the instruments it gates: a benchmark loaded by
+    a laxer path would let a bar the corpus rejected decide whether 6,774 other
+    instruments may trade.
+    """
+    from app.services.price_masked_bars import load_masked_bars
+
+    rows = conn.execute(
+        "SELECT instrument_id FROM instruments WHERE symbol = %(symbol)s ORDER BY instrument_id",
+        {"symbol": symbol},
+    ).fetchall()
+    if len(rows) != 1:
+        raise MarketContextUnavailable(
+            f"benchmark symbol {symbol!r} resolves to {len(rows)} instruments, expected exactly 1 — "
+            "the regime series must be pinned, not chosen (SPY and SPY.RTH are the same fund)"
+        )
+    instrument_id = int(rows[0][0])
+    series = load_masked_bars(conn, instrument_id).series
+    by_date = classify_benchmark(series, universe=universe)
+    if not by_date:
+        raise MarketContextUnavailable(
+            f"benchmark {symbol!r} (instrument {instrument_id}) has {len(series)} loadable bars and not one "
+            f"classifiable session — every regime-gated strategy would refuse every bar"
+        )
+    return MarketContext(
+        regime_by_date=by_date,
+        first_classified=min(by_date),
+        benchmark_instrument_id=instrument_id,
+        benchmark_symbol=symbol,
+    )
+
+
+__all__ = [
+    "BENCHMARK_SYMBOL",
+    "MarketContext",
+    "MarketContextUnavailable",
+    "classify_benchmark",
+    "load_market_context",
+]

--- a/app/services/price_levels.py
+++ b/app/services/price_levels.py
@@ -29,6 +29,7 @@ tolerance the instrument's own.
 
 from __future__ import annotations
 
+import bisect
 import hashlib
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,6 +37,7 @@ from typing import Final, Literal
 
 import numpy as np
 import numpy.typing as npt
+from numpy.lib.stride_tricks import sliding_window_view
 
 #: Bars either side of a pivot that it must exceed. FROZEN BY CONSTRUCTION.
 #: Larger = fewer, more significant pivots; smaller = noise. 5 is a choice.
@@ -84,38 +86,76 @@ class PriceLevel:
     rule_set_version: str = LEVEL_RULE_VERSION
 
 
-def _swing_indices(
+@dataclass(frozen=True)
+class PivotSet:
+    """Every confirmed swing pivot in one series, detected once.
+
+    ⚠⚠ A PIVOT IS ONLY CONFIRMED ``half_window`` BARS AFTER IT HAPPENS. Whether
+    index ``i`` is a swing high is decided ENTIRELY by bars ``i - half_window ..
+    i + half_window`` and by nothing else, so the verdict is the same whether it
+    is computed while standing at bar ``i + half_window`` or at the end of the
+    series. That independence is what makes precomputing the whole series safe,
+    and it is why ``LevelScan.at`` filters by ``index - half_window`` rather than
+    re-detecting: the filter reproduces "confirmed by bar ``index``" exactly.
+
+    Reading a pivot at ``index`` itself would be lookahead of the most seductive
+    kind — it reads as "today is a swing high", which cannot be known today. It
+    needs the next ``half_window`` bars to fail to exceed it. Every level built
+    from such a pivot would be fitted to bars the strategy has not seen, and the
+    resulting backtest would be silently, spectacularly optimistic.
+    """
+
+    #: Ascending, so ``LevelScan.at`` can bisect rather than filter.
+    high_indices: tuple[int, ...]
+    low_indices: tuple[int, ...]
+    half_window: int
+
+
+def swing_pivots(
     highs: npt.NDArray[np.float64],
     lows: npt.NDArray[np.float64],
     *,
-    upto: int,
-    half_window: int,
-) -> tuple[list[int], list[int]]:
-    """Confirmed swing highs and lows in bars ``<= upto``.
+    half_window: int = PIVOT_HALF_WINDOW,
+) -> PivotSet:
+    """Detect every confirmed swing high and low in one vectorised pass.
 
-    ⚠⚠ A PIVOT IS ONLY CONFIRMED ``half_window`` BARS AFTER IT HAPPENS, and this
-    function refuses to return unconfirmed ones. The last candidate index is
-    ``upto - half_window``, never ``upto``.
+    ⚠ THE TIE RULE IS ``argmax == half_window``, NOT ``high == max``, AND THE
+    DIFFERENCE IS LOAD-BEARING. ``argmax`` returns the FIRST occurrence, so when
+    two bars in a window share the maximum only the earlier one is a pivot. The
+    redundant-looking ``>=`` comparison is kept beside it because the two
+    together are the rule as written, and dropping either changes which of two
+    equal highs is called the turn.
 
-    Returning a pivot at ``upto`` would be lookahead of the most seductive kind:
-    it reads as "today is a swing high", which cannot be known today — it needs
-    the next ``half_window`` bars to fail to exceed it. Every level built from
-    such a pivot would be fitted to bars the strategy has not seen, and the
-    resulting backtest would be silently, spectacularly optimistic.
+    ⚠ A non-finite value in EITHER window disqualifies BOTH kinds at that index.
+    A masked high and a masked low are equally "this bar's shape is unknown", and
+    treating them separately would let a bar with a hidden low be called a swing
+    high. The consequence is stated rather than hidden: a masked bar silently
+    removes pivot candidates, so a level that should exist may not, and a caller
+    that needs that distinction must gate on the mask itself — this function
+    reports pivots, not evaluability.
     """
-    highs_out: list[int] = []
-    lows_out: list[int] = []
-    last = upto - half_window
-    for i in range(half_window, last + 1):
-        window_hi = highs[i - half_window : i + half_window + 1]
-        window_lo = lows[i - half_window : i + half_window + 1]
-        if not np.all(np.isfinite(window_hi)) or not np.all(np.isfinite(window_lo)):
-            continue
-        if highs[i] >= np.max(window_hi) and np.argmax(window_hi) == half_window:
-            highs_out.append(i)
-        if lows[i] <= np.min(window_lo) and np.argmin(window_lo) == half_window:
-            lows_out.append(i)
-    return highs_out, lows_out
+    if half_window < 1:
+        raise ValueError(f"half_window must be at least 1, got {half_window}")
+    if highs.size != lows.size:
+        raise ValueError(f"highs/lows must align: {highs.size} highs against {lows.size} lows")
+    width = 2 * half_window + 1
+    if highs.size < width:
+        return PivotSet(high_indices=(), low_indices=(), half_window=half_window)
+
+    window_hi = sliding_window_view(highs, width)
+    window_lo = sliding_window_view(lows, width)
+    # ⚠ Row `k` of the view covers bars `k .. k + width - 1`, so its CENTRE is
+    # bar `k + half_window`. Reading row `k` as bar `k` is the off-by-five this
+    # alignment array exists to make impossible to write by accident.
+    centres = np.arange(half_window, highs.size - half_window)
+    finite = np.all(np.isfinite(window_hi), axis=1) & np.all(np.isfinite(window_lo), axis=1)
+    is_high = finite & (np.argmax(window_hi, axis=1) == half_window) & (highs[centres] >= np.max(window_hi, axis=1))
+    is_low = finite & (np.argmin(window_lo, axis=1) == half_window) & (lows[centres] <= np.min(window_lo, axis=1))
+    return PivotSet(
+        high_indices=tuple(int(i) for i in centres[is_high]),
+        low_indices=tuple(int(i) for i in centres[is_low]),
+        half_window=half_window,
+    )
 
 
 def _cluster(
@@ -158,6 +198,121 @@ def _cluster(
     return out
 
 
+@dataclass(frozen=True)
+class LevelScan:
+    """One series, prepared once, so levels can be asked for at EVERY bar.
+
+    ⚠⚠ THIS EXISTS FOR A MEASURED REASON, NOT A STYLISTIC ONE. The strategy
+    runner evaluates a strategy over a whole series and filters its OUTPUT
+    (``strategy_signal_scan._scan_per_series``: *"The strategy sees the WHOLE
+    series and the filter is applied to its output"*), so a level-based strategy
+    needs levels at every bar, not just the last one.
+
+    The ORIGINAL form detected pivots inside every call with a per-index Python
+    loop, which makes a full-series walk quadratic: measured on SPY's 1,044 bars
+    at 3.61 ms/bar, extrapolating to **343 minutes** for one pass over the
+    6,774-member validated universe. With detection hoisted here it is
+    0.148 ms/bar. The end-to-end figure that matters is S-6's full-population
+    census — every bar of every scanned instrument — which runs in **91 seconds**::
+
+        uv run python scripts/verify_2437_s6_resistance_breakout.py --census
+
+    ⚠ ``--equivalence`` reports a speedup of only ~2x, and that is NOT a
+    contradiction: it times ``LevelScan.at`` against the CURRENT ``levels_at``,
+    which builds one of these per call and therefore already gets the vectorised
+    detection. The 24x is against the form this replaced. Two different
+    comparisons, and a reader who conflates them will think the hoist barely
+    paid — hence both subjects being named rather than one number quoted.
+
+    ⚠ IT IS NOT A SECOND IMPLEMENTATION, and that is deliberate. ``levels_at``
+    below builds one of these and calls ``at``, so there is exactly one code
+    path and no oracle to keep in agreement — the ``s4_exit_levels_batch``
+    shape, without the scalar-vs-batch divergence that shape has to test for.
+
+    ⚠ Alignment is VALIDATED, not assumed — matching ``classify_regimes``, which
+    raises on mismatched inputs. Misaligned arrays do not fail loudly:
+    ``swing_pivots`` reads ``highs[i]`` and ``lows[i]`` as the same bar, so a
+    shorter ``lows`` silently pairs each high with the WRONG bar's low and the
+    detector returns confident, wrong pivots. Raising rather than returning ()
+    because a caller handing in ragged arrays has a bug, and an empty result
+    reads as "no levels here".
+    """
+
+    highs: npt.NDArray[np.float64]
+    lows: npt.NDArray[np.float64]
+    volumes: npt.NDArray[np.float64] | None
+    pivots: PivotSet
+    #: ``nancumsum`` of ``volumes`` — the running denominator of a cluster's
+    #: volume share. ⚠ ``nancumsum`` and ``nansum`` agree by construction (both
+    #: read a NaN as a zero contribution), so this is the same number the
+    #: per-call ``nansum(volumes[: index + 1])`` produced, not an approximation.
+    volume_cumsum: npt.NDArray[np.float64] | None
+    rule_set_version: str = LEVEL_RULE_VERSION
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        highs: npt.NDArray[np.float64],
+        lows: npt.NDArray[np.float64],
+        volumes: npt.NDArray[np.float64] | None,
+    ) -> LevelScan:
+        if highs.size != lows.size:
+            raise ValueError(f"highs/lows must align: {highs.size} highs against {lows.size} lows")
+        if volumes is not None and volumes.size != highs.size:
+            raise ValueError(f"volumes must align with prices: {volumes.size} volumes against {highs.size} bars")
+        return cls(
+            highs=highs,
+            lows=lows,
+            volumes=volumes,
+            pivots=swing_pivots(highs, lows, half_window=PIVOT_HALF_WINDOW),
+            volume_cumsum=None if volumes is None else np.nancumsum(volumes),
+        )
+
+    def at(self, *, atr: float, index: int) -> tuple[PriceLevel, ...]:
+        """Live support/resistance levels as known at bar ``index``.
+
+        ⚠⚠ CAUSAL. Reads bars ``<= index`` and only pivots CONFIRMED by
+        ``index`` (see ``PivotSet``). ``atr`` must be the value at ``index`` —
+        passing a later ATR would size the clustering tolerance with information
+        from after the decision, which is the same leak in a subtler place.
+        """
+        if index < 0 or index >= self.highs.size:
+            return ()
+        if not np.isfinite(atr) or atr <= 0:
+            return ()
+        tolerance = CLUSTER_ATR_TOLERANCE * atr
+        last_confirmed = index - self.pivots.half_window
+        hi_idx = list(self.pivots.high_indices[: bisect.bisect_right(self.pivots.high_indices, last_confirmed)])
+        lo_idx = list(self.pivots.low_indices[: bisect.bisect_right(self.pivots.low_indices, last_confirmed)])
+
+        total = 0.0 if self.volume_cumsum is None else float(self.volume_cumsum[index])
+        out: list[PriceLevel] = []
+        for kind, idxs, prices in (("resistance", hi_idx, self.highs), ("support", lo_idx, self.lows)):
+            for price, cluster in _cluster(idxs, prices, self.volumes, tolerance=tolerance):
+                touches = len(cluster)
+                last_touch = max(cluster)
+                if touches < MIN_TOUCHES:
+                    continue
+                if index - last_touch > MAX_TOUCH_AGE_BARS:
+                    continue
+                if self.volumes is None:
+                    share = 1.0
+                else:
+                    share = float(np.nansum([self.volumes[i] for i in cluster])) / total if total > 0 else 0.0
+                strength = touches * float(np.log1p(share))
+                out.append(
+                    PriceLevel(
+                        price=price,
+                        kind=kind,  # type: ignore[arg-type]
+                        touches=touches,
+                        last_touch_index=last_touch,
+                        strength=strength,
+                    )
+                )
+        return tuple(sorted(out, key=lambda level: level.strength, reverse=True))
+
+
 def levels_at(
     *,
     highs: npt.NDArray[np.float64],
@@ -166,57 +321,14 @@ def levels_at(
     atr: float,
     index: int,
 ) -> tuple[PriceLevel, ...]:
-    """Live support/resistance levels as known at bar ``index``.
+    """Live support/resistance levels at ONE bar — the convenience form.
 
-    ⚠⚠ CAUSAL. Reads bars ``<= index`` and only CONFIRMED pivots (see
-    ``_swing_indices``). ``atr`` must be the value at ``index`` — passing a
-    later ATR would size the clustering tolerance with information from after
-    the decision, which is the same leak in a subtler place.
+    ⚠ Prepares a whole-series ``LevelScan`` per call, so asking for N bars this
+    way is N times the preparation. Use ``LevelScan.build`` once and ``at`` per
+    bar for anything that walks a series; this form is for a single lookup and
+    for the tests that pin the two against each other.
     """
-    # ⚠ Alignment is VALIDATED, not assumed — matching `classify_regimes`, which
-    # raises on mismatched inputs. Misaligned arrays here do not fail loudly:
-    # `_swing_indices` reads `highs[i]` and `lows[i]` as the same bar, so a
-    # shorter `lows` silently pairs each high with the WRONG bar's low and the
-    # detector returns confident, wrong pivots. An IndexError deep in `_cluster`
-    # is the lucky outcome; the unlucky one is plausible levels built from two
-    # different bars. Raising rather than returning () because a caller handing
-    # in ragged arrays has a bug, and an empty result reads as "no levels here".
-    if highs.size != lows.size:
-        raise ValueError(f"highs/lows must align: {highs.size} highs against {lows.size} lows")
-    if volumes is not None and volumes.size != highs.size:
-        raise ValueError(f"volumes must align with prices: {volumes.size} volumes against {highs.size} bars")
-    if index < 0 or index >= highs.size:
-        return ()
-    if not np.isfinite(atr) or atr <= 0:
-        return ()
-    tolerance = CLUSTER_ATR_TOLERANCE * atr
-
-    hi_idx, lo_idx = _swing_indices(highs, lows, upto=index, half_window=PIVOT_HALF_WINDOW)
-    out: list[PriceLevel] = []
-    for kind, idxs, prices in (("resistance", hi_idx, highs), ("support", lo_idx, lows)):
-        for price, cluster in _cluster(idxs, prices, volumes, tolerance=tolerance):
-            touches = len(cluster)
-            last_touch = max(cluster)
-            if touches < MIN_TOUCHES:
-                continue
-            if index - last_touch > MAX_TOUCH_AGE_BARS:
-                continue
-            if volumes is None:
-                share = 1.0
-            else:
-                total = float(np.nansum(volumes[: index + 1]))
-                share = float(np.nansum([volumes[i] for i in cluster])) / total if total > 0 else 0.0
-            strength = touches * float(np.log1p(share))
-            out.append(
-                PriceLevel(
-                    price=price,
-                    kind=kind,  # type: ignore[arg-type]
-                    touches=touches,
-                    last_touch_index=last_touch,
-                    strength=strength,
-                )
-            )
-    return tuple(sorted(out, key=lambda level: level.strength, reverse=True))
+    return LevelScan.build(highs=highs, lows=lows, volumes=volumes).at(atr=atr, index=index)
 
 
 def nearest_level(levels: tuple[PriceLevel, ...], *, price: float, kind: LevelKind, atr: float) -> PriceLevel | None:
@@ -236,7 +348,10 @@ __all__ = [
     "MIN_TOUCHES",
     "PIVOT_HALF_WINDOW",
     "LevelKind",
+    "LevelScan",
+    "PivotSet",
     "PriceLevel",
     "levels_at",
     "nearest_level",
+    "swing_pivots",
 ]

--- a/app/services/strategies/s6_resistance_breakout.py
+++ b/app/services/strategies/s6_resistance_breakout.py
@@ -1,0 +1,441 @@
+"""S-6 — resistance breakout with volume confirmation. The catalogue's fifth strategy.
+
+Spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §3 (S-6), §1 (the
+regime filter), §2 (level construction), §0 (walk-forward on regime). Registry
+contract: ``app/services/strategy_registry.py``. Refs #2437.
+
+THE RULE, VERBATIM FROM §3
+--------------------------
+    **Setup:** live resistance level; regime ∈ {``bull_quiet``}. ⚠ Excluded from
+    ``bull_volatile`` deliberately — breakouts into a Bulge are the classic
+    false-break regime. **Signal:** ``close(t)`` > level **and** ``volume(t)`` ≥
+    1.2 × 20-bar average volume. ⚠ The 1.2 multiple is retail convention, **not**
+    a published result — frozen by construction, recorded as such. **Exit:** stop
+    ``level − 1.0 × ATR(14)`` (back inside the range = failed break); target
+    ``entry + 3.0 × ATR(14)``; max hold 40 bars. **Params:** 4. **Data:** OHLC +
+    volume.
+
+⚠⚠ THE STOP IS ANCHORED TO THE LEVEL AND THE TARGET TO THE ENTRY, AND MAKING
+THEM CONSISTENT WOULD BE A SPEC VIOLATION. S-4's bracket is symmetric — both
+legs measured from the fill — because S-4 has no level to measure from. S-6
+does, and §3 uses it on purpose: *"back inside the range = failed break"* is a
+statement about the LEVEL, not about the entry. The two are not the same price:
+the fill is ``open(t+1)`` and the level is wherever the cluster sat, so a gap-up
+open makes the stop distance materially wider than ``1 × ATR`` and a marginal
+break makes it narrower. That is the rule doing its job — the trade is wrong when
+price returns inside the range, however far the fill happened to be from it.
+
+⚠⚠ THE LEVEL IS PART OF THE SIGNAL, SO IT IS RE-DERIVED AND NEVER CARRIED.
+A ``StrategySignal`` carries a bar index and nothing else (registry docstring),
+so ``s6_exit_bracket`` cannot be handed the level the signal broke. It recomputes
+it from the same function the signal used, at the same index, from bars ``<= t``.
+That is the S-4 pattern (*"recomputes ``atr_series`` and reads ``signal_index``
+— never ``signal_index + 1``"*) applied to a richer object, and it is safe for
+the same reason: ``LevelScan.at`` is deterministic and causal, so re-deriving it
+cannot produce a level the signal did not see. ``_breakout_level`` is the single
+definition both call.
+
+⚠⚠ WHICH RESISTANCE, WHEN SEVERAL ARE LIVE — FIXED BY CONSTRUCTION.
+§3 says *"live resistance level"* and *"close(t) > level"* without saying which
+of several, and the choice is load-bearing because the stop is anchored to it.
+There is no published rule to cite, so this is declared rather than inferred:
+
+    level(t) := the LOWEST live resistance level strictly above ``close(t-1)``
+
+Two properties make it the one to pick. It is determined **before** bar ``t``
+opens — it is a function of ``close(t-1)`` and of levels known at ``t`` — so
+"the level being broken" is not chosen with knowledge of where the close landed.
+And it is unique: there is exactly one lowest such level, whereas "the level
+closest to close(t)" is ambiguous when the close overshoots several and would let
+a large up-day silently re-select a higher, further stop. Levels above it that
+``close(t)`` also cleared are simply not this signal's level.
+
+⚠ A CONSEQUENCE, STATED RATHER THAN LEFT TO BE FOUND: the strength ranking in
+``PriceLevel`` is NOT used here. ``price_levels`` says strength *"ranks levels
+against each other and is NEVER compared to a threshold"*, and selecting the
+strongest live resistance would make it decide the trade — a fitted parameter
+wearing a score's clothing. Price ordering has no such freedom.
+
+⚠ THE VOLUME AVERAGE EXCLUDES ``t``, for S-4's reason in its own words:
+including it makes the condition *"partly self-referential"*. A bar with enough
+volume to break out raises the average it is compared against, so the test would
+be weaker exactly where the rule means it to bite. The trailing-20 form is also
+the conventional reading of "20-bar average volume". Both windows are pinned by
+``TestVolumeWindowBoundary``.
+
+⚠ THE REGIME IS A DIFFERENT INSTRUMENT'S DATA, AND IT IS A DECLARED INPUT.
+S-1…S-4 read only their own bars. S-6 reads SPY's regime, so a bar of AAPL is
+unjudgeable when SPY has no classifiable session that day — the instrument's own
+data being perfect changes nothing. Declaring the gate among ``inputs`` is what
+makes the registry refuse that bar *before* the condition runs, with the reason
+``missing_market_context`` (its eleventh code) rather than a silent
+``not_fired``. Warm-up on the benchmark stays ``insufficient_warmup``;
+``MarketContext.gate_series`` is where the two are separated.
+
+⚠ A REFUSED REGIME IS ``not_fired``, NOT ``not_evaluable``. ``bear_quiet`` is a
+market this strategy has a stated opinion about — spec §0: *"a strategy that only
+works in one regime is not broken; it is a strategy with a stated domain, and
+firing it outside that domain is the defect"*. The bar was judged and declined.
+
+⚠ A MASKED HIGH OR LOW SILENTLY REMOVES PIVOT CANDIDATES, and this module does
+not pretend otherwise. ``swing_pivots`` skips any window containing a non-finite
+value, so a quarantined bar can delete a level that would otherwise exist and the
+verdict becomes ``not_fired`` on evidence that was hidden — the shape the
+prevention log records against ``price_structure``'s three detectors. It is NOT
+fixed by refusing the trailing 125 bars around every mask, which would be a
+blast radius far larger than the defect: measured on the validated universe, the
+binding rejection is the break itself (1,218,577 of 1,290,429 bars that had a
+resistance above), not level availability. It is instead made VISIBLE — ATR is a
+declared input and is Wilder-smoothed, so a masked bar already refuses the whole
+tail of the ATR series, and ``scripts/verify_2437_s6_resistance_breakout.py
+--census`` counts what each leg rejects.
+
+⚠ WHAT THIS MODULE DOES NOT GUARD, inherited from ``indicator_series``:
+quarantine and adjustment basis are the CALLER's gate. There is no database
+access here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+
+import numpy as np
+
+from app.services.indicator_series import (
+    BarSeries,
+    IndicatorSeries,
+    Universe,
+    atr_series,
+)
+from app.services.market_context import BENCHMARK_SYMBOL, MarketContext
+from app.services.market_regime import Regime
+from app.services.price_levels import PIVOT_HALF_WINDOW, LevelScan, PriceLevel
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+
+S6_STRATEGY_ID = "s6-resistance-breakout-volume"
+
+#: ⚠ FIXED, NEVER TUNED (parent §6: *"Forbidden — continuous re-optimisation"*).
+#: Module constants rather than function arguments, for S-1's and S-4's reason: a
+#: threshold that can be passed in is a threshold that can be swept, and
+#: criterion 11 would then need every sweep value registered as its own strategy.
+ATR_PERIOD = 14
+VOLUME_LOOKBACK = 20
+#: ⚠ Retail convention, NOT a published result. §3 says so in its own text and it
+#: is repeated here because a constant with no provenance note reads as derived.
+VOLUME_MULTIPLE = 1.2
+
+#: The bracket. ⚠ ``LEVEL_STOP_MULTIPLE`` is measured from the LEVEL and
+#: ``ATR_TARGET_MULTIPLE`` from the ENTRY — see the module docstring.
+LEVEL_STOP_MULTIPLE = 1.0
+ATR_TARGET_MULTIPLE = 3.0
+MAX_HOLD_BARS = 40
+
+#: §3's setup gate. ⚠ ``bull_volatile`` is EXCLUDED deliberately: *"breakouts
+#: into a Bulge are the classic false-break regime"*. Widening this set is a new
+#: strategy, not a tuning change — it is hashed into ``S6_PARAMS``.
+PERMITTED_REGIMES: frozenset[Regime] = frozenset({Regime.BULL_QUIET})
+
+#: ⚠ §3 says *"Params: 4"* and this dict carries EIGHT, recorded rather than
+#: resolved by dropping four — S-3 and S-4 record the same discrepancy. §3 counts
+#: FREE parameters (the numbers a sweep would move); criterion 11 hashes
+#: everything that makes this a distinct strategy. ``atr_period`` is Wilder's own
+#: default, but an S-6 computed on ``atr_20`` is a different strategy and must not
+#: inherit this one's track record.
+#:
+#: ⚠⚠ ``benchmark_symbol`` and ``permitted_regimes`` are here for a stronger
+#: reason: they are the only record of WHOSE market this strategy is gated on.
+#: The regime rule's own version travels via ``INPUT_RULE_SETS``, but that names
+#: the *classifier*, not the *series it was run over* — an S-6 gated on QQQ's
+#: regime would produce different signals under an identical rule version and an
+#: identical source hash. Nothing else in the identity would move.
+S6_PARAMS: Mapping[str, object] = {
+    "atr_period": ATR_PERIOD,
+    "volume_lookback": VOLUME_LOOKBACK,
+    "volume_multiple": VOLUME_MULTIPLE,
+    "level_stop_multiple": LEVEL_STOP_MULTIPLE,
+    "atr_target_multiple": ATR_TARGET_MULTIPLE,
+    "max_hold_bars": MAX_HOLD_BARS,
+    "permitted_regimes": sorted(regime.value for regime in PERMITTED_REGIMES),
+    "benchmark_symbol": BENCHMARK_SYMBOL,
+}
+
+#: The first index at which every leg can be evaluated, DERIVED from the rule.
+#:
+#: ``atr_series`` emits its first value at ``ATR_PERIOD``. The volume ratio needs
+#: ``VOLUME_LOOKBACK`` PRIOR bars and is ready at ``VOLUME_LOOKBACK``. A swing
+#: pivot is not expressible at all before ``2 * PIVOT_HALF_WINDOW + 1`` bars
+#: exist. 20 binds.
+#:
+#: ⚠ Above that floor, "no live resistance above the prior close" is a VERDICT
+#: and not warm-up: the rule genuinely has no setup there. Only the fixed-window
+#: legs report warm-up, and they report it by emitting ``None`` rather than by a
+#: length check — an explicit ``len(series) < 20 -> refuse`` would be a second,
+#: weaker copy of the same rule (S-4's argument, unchanged).
+WARMUP_BARS = max(ATR_PERIOD, VOLUME_LOOKBACK, 2 * PIVOT_HALF_WINDOW + 1)
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s6_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-6 on one universe under one cost model."""
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "pass app.services.cost_model.COST_MODEL_ID rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S6_STRATEGY_ID,
+        params=S6_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def _volumes(series: BarSeries) -> np.ndarray:
+    """Bar volumes as floats, with a missing or negative volume as NaN.
+
+    ⚠ A NEGATIVE volume is treated as missing rather than clamped. ``price_daily``
+    stores it unconstrained and the quarantine has no axis for it, so this module
+    is the boundary: a negative value cannot be an observation, and averaging one
+    in would quietly lower the bar the confirmation leg has to clear.
+    """
+    out = np.empty(len(series), dtype=float)
+    for index, row in enumerate(series.rows):
+        value = row.get("volume")
+        out[index] = np.nan if value is None or value < 0 else float(value)
+    return out
+
+
+def volume_ratio_series(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """``volume(t)`` over the mean of the ``VOLUME_LOOKBACK`` bars BEFORE ``t``.
+
+    ⚠ ``t`` IS EXCLUDED from its own denominator — see the module docstring.
+
+    A missing volume anywhere in the window, or at ``t`` itself, is a DATA
+    refusal and is listed in ``not_evaluable_indices``: the field is present and
+    empty, so the window genuinely cannot support an average. Indices with fewer
+    than ``VOLUME_LOOKBACK`` bars behind them are warm-up and stay a bare
+    ``None``. Collapsing the two would destroy what criterion 8 exists for.
+
+    ⚠ A zero-volume window is a DATA refusal too, not an infinite ratio. Twenty
+    consecutive sessions that all traded nothing is a halted or unlisted name,
+    and dividing by it would report every subsequent bar as a spectacular volume
+    surge.
+    """
+    volumes = _volumes(series)
+    n = volumes.size
+    values: list[float | None] = [None] * n
+    unevaluable: list[int] = []
+    for index in range(n):
+        low = index - VOLUME_LOOKBACK
+        if low < 0:
+            continue  # fewer than VOLUME_LOOKBACK prior bars — warm-up.
+        window = volumes[low:index]  # ⚠ excludes `index` itself.
+        if not np.isfinite(volumes[index]) or not np.all(np.isfinite(window)):
+            unevaluable.append(index)
+            continue
+        average = float(window.mean())
+        if average <= 0.0:
+            unevaluable.append(index)
+            continue
+        values[index] = float(volumes[index]) / average
+    return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+
+
+def prior_close_series(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """``close(t-1)`` — the price the chosen level must sit above.
+
+    Index 0 has no predecessor and is warm-up. A masked ``close(t-1)`` is a data
+    refusal: the level selection genuinely cannot be made without it.
+    """
+    closes = series.float_closes
+    n = len(closes)
+    values: list[float | None] = [None] * n
+    unevaluable: list[int] = []
+    for index in range(1, n):
+        previous = closes[index - 1]
+        if previous is None:
+            unevaluable.append(index)
+            continue
+        values[index] = previous
+    return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+
+
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, declared rather than relied upon transitively (S-4's note)."""
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
+def _breakout_level(scan: LevelScan, *, prior_close: float, atr: float, index: int) -> PriceLevel | None:
+    """The lowest live resistance strictly above ``prior_close`` at ``index``.
+
+    ⚠⚠ THE SINGLE DEFINITION. ``s6_signals`` and ``s6_exit_bracket`` both call
+    it, so the level the stop is anchored to is by construction the level the
+    signal broke. Two call sites reading "the level" from two expressions is how
+    a stop comes to be measured from a price the signal never considered.
+    """
+    candidates = [
+        level for level in scan.at(atr=atr, index=index) if level.kind == "resistance" and level.price > prior_close
+    ]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda level: level.price)
+
+
+def s6_exit_bracket(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> tuple[Decimal, Decimal, int]:
+    """S-6's bracket: target from the entry, stop from the broken level.
+
+    Returns ``(target, stop, max_hold_bars)`` — the order ``s4_exit_bracket``
+    established, kept identical so the manifest's adapters read the same way.
+
+    ⚠ Every input is read at ``signal_index``, never at the fill. Recomputing ATR
+    or the level at ``signal_index + 1`` would let the fill bar's own range alter
+    levels that had to exist before that bar was observed.
+    """
+    if not 0 <= signal_index < len(series):
+        raise ValueError(f"signal_index {signal_index} is outside the {len(series)}-bar series")
+    if entry_price <= 0:
+        raise ValueError(f"entry_price must be positive, got {entry_price}")
+    atr = atr_series(series, period=ATR_PERIOD, universe=universe).values[signal_index]
+    if atr is None or atr <= 0:
+        raise ValueError(f"ATR{ATR_PERIOD} is unavailable or non-positive at signal index {signal_index}")
+    prior_close = series.float_closes[signal_index - 1] if signal_index >= 1 else None
+    if prior_close is None:
+        raise ValueError(f"close({signal_index - 1}) is unavailable, so S-6's level cannot be re-derived")
+    scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=_volumes(series))
+    level = _breakout_level(scan, prior_close=prior_close, atr=atr, index=signal_index)
+    if level is None:
+        raise ValueError(
+            f"no live resistance above close({signal_index - 1}) at signal index {signal_index} — "
+            "a bracket was requested for a bar that cannot have fired"
+        )
+    distance = Decimal(str(atr))
+    stop = Decimal(str(level.price)) - Decimal(str(LEVEL_STOP_MULTIPLE)) * distance
+    target = entry_price + Decimal(str(ATR_TARGET_MULTIPLE)) * distance
+    if stop <= 0:
+        raise ValueError(
+            f"S-6's level-anchored stop {stop} is non-positive for level {level.price}; "
+            "the bracket is not broker-orderable"
+        )
+    # ⚠ A level-anchored stop can sit ABOVE the fill: price gapped up through the
+    # break and opened more than 1xATR above the level. Refused rather than
+    # silently entered, because a "stop" above the entry is an immediate exit
+    # wearing a protective order's name, and the outcome resolver would book it
+    # as a loss on the fill bar. Counted by `--census` rather than assumed rare.
+    if stop >= entry_price:
+        raise ValueError(
+            f"S-6's stop {stop} is at or above the entry {entry_price}: the fill gapped more than "
+            f"{LEVEL_STOP_MULTIPLE}xATR above the broken level {level.price}"
+        )
+    return target, stop, MAX_HOLD_BARS
+
+
+def s6_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    market: MarketContext,
+) -> list[StrategySignal]:
+    """S-6's entry verdict for every bar. ⚠ ENTRIES ONLY.
+
+    Like S-4, all three exit conditions are measured FROM THE ENTRY or from a
+    level fixed at entry, so all three are position state and a pure per-bar
+    verdict function has none. ``LEVEL_STOP_MULTIPLE``, ``ATR_TARGET_MULTIPLE``
+    and ``MAX_HOLD_BARS`` are carried in ``S6_PARAMS`` so criterion 11 hashes
+    them, and their consumer is ``s6_exit_bracket``.
+
+    ⚠ The regime is looked up by ``series.dates``, which is why no separate date
+    vector is accepted. ``BarSeries`` validates that its dates and rows align at
+    construction, and ``strategy_segmented_evaluation`` builds each segment as a
+    ``BarSeries`` slice carrying its own dates — so the segment's bars and the
+    days they are gated on cannot come apart. A ``dates=`` parameter would
+    reintroduce exactly that possibility for no caller that needs it.
+    """
+    if masked_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {masked_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+
+    closes = series.float_closes
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    volume_ratio = volume_ratio_series(series, universe=universe)
+    prior_close = prior_close_series(series, universe=universe)
+    gate = market.gate_series(series.dates, allowed=PERMITTED_REGIMES, universe=universe)
+    scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=_volumes(series))
+
+    inputs = (
+        StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
+        StrategyInput(series=atr, reason=masked_reason),
+        StrategyInput(series=prior_close, reason=masked_reason),
+        # ⚠ `missing_volume` is hardcoded and NOT taken from `masked_reason`,
+        # departing from S-4 knowingly. The registry's rule is that the caller
+        # supplies the reason because `indicator_series` "knows THAT a value is
+        # unevaluable but not WHY" — but here the strategy DOES know why:
+        # `load_masked_bars` masks only OHLC, so a null volume is a genuinely
+        # absent field and never a quarantine mask. Passing `masked_reason` would
+        # report a real missing-volume gap as `quarantined_bar`.
+        StrategyInput(series=volume_ratio, reason="missing_volume"),
+        StrategyInput(series=gate, reason="missing_market_context"),
+    )
+
+    def entry(index: int) -> bool:
+        close = closes[index]
+        previous = prior_close.values[index]
+        current_atr = atr.values[index]
+        ratio = volume_ratio.values[index]
+        permitted = gate.values[index]
+        # Not reachable through `evaluate`, which refuses the bar first. Present
+        # to narrow the types and to fail loudly for a direct caller.
+        assert close is not None and previous is not None and current_atr is not None
+        assert ratio is not None and permitted is not None
+        if permitted != 1.0:
+            return False
+        if ratio < VOLUME_MULTIPLE:
+            return False
+        level = _breakout_level(scan, prior_close=previous, atr=current_atr, index=index)
+        return level is not None and close > level.price
+
+    return evaluate(entry, inputs=inputs, n_bars=len(series), kind="entry")
+
+
+__all__ = [
+    "ATR_PERIOD",
+    "ATR_TARGET_MULTIPLE",
+    "LEVEL_STOP_MULTIPLE",
+    "MAX_HOLD_BARS",
+    "PERMITTED_REGIMES",
+    "S6_PARAMS",
+    "S6_STRATEGY_ID",
+    "VOLUME_LOOKBACK",
+    "VOLUME_MULTIPLE",
+    "WARMUP_BARS",
+    "prior_close_series",
+    "s6_exit_bracket",
+    "s6_identity",
+    "s6_signals",
+    "volume_ratio_series",
+]

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -74,6 +74,7 @@ from types import MappingProxyType
 from typing import Literal, Protocol, get_args
 
 from app.services.indicator_series import BarSeries, Universe
+from app.services.market_context import MarketContext
 from app.services.outcome_resolver import ExitLevels, UnresolvedReason
 from app.services.position_builder import ExitRegime
 from app.services.strategies.s1_time_series_momentum import S1_STRATEGY_ID, s1_identity, s1_signals
@@ -93,6 +94,13 @@ from app.services.strategies.s4_volatility_compression_breakout import (
     s4_exit_bracket,
     s4_identity,
     s4_signals,
+)
+from app.services.strategies.s6_resistance_breakout import MAX_HOLD_BARS as S6_MAX_HOLD_BARS
+from app.services.strategies.s6_resistance_breakout import (
+    S6_STRATEGY_ID,
+    s6_exit_bracket,
+    s6_identity,
+    s6_signals,
 )
 from app.services.strategy_exit_levels_batch import s4_exit_levels_batch
 from app.services.strategy_registry import (
@@ -134,10 +142,24 @@ class PerSeriesSignals(Protocol):
     adapters below are exactly where that difference is absorbed — a runner
     passing ``close_reason=`` to S-4 is a ``TypeError`` at call time, which is
     the 19-call-site problem wearing a keyword.
+
+    ⚠⚠ ``market`` IS ON THE UNIFORM CALL AND NOT ON A SECOND PROTOCOL (#2437).
+    S-5…S-10 gate on the market regime measured on a benchmark; S-1…S-4 do not.
+    The alternative shape — a separate ``MarketGatedSignals`` protocol and a
+    second arm on the tagged union — would put a per-strategy ``if`` back in the
+    runner, which is the exact defect this manifest exists to remove. So every
+    per-series strategy takes the parameter and the ones with no use for it
+    ignore it, while ``StrategyEntry.requires_market_context`` is what makes the
+    absence of a context a REFUSAL rather than a silently unfiltered scan.
     """
 
     def __call__(
-        self, series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason
+        self,
+        series: BarSeries,
+        *,
+        universe: Universe,
+        masked_reason: NotEvaluableReason,
+        market: MarketContext | None,
     ) -> list[StrategySignal]: ...
 
 
@@ -234,6 +256,15 @@ class StrategyEntry:
     signal_kinds: frozenset[SignalKind]
     exit_regime: ExitRegimeFactory
     decision_calendar: DecisionCalendar
+    #: Whether this strategy's verdict depends on a benchmark's market regime.
+    #:
+    #: ⚠ DECLARED, not inferred from the signature. Every per-series adapter now
+    #: ACCEPTS ``market``, so "does it take the parameter" no longer answers "does
+    #: it need one" — and a runner that guessed from the signature would scan a
+    #: regime-gated strategy ungated the moment a context failed to build. It is
+    #: the operational contract, not tuning: a runner cannot know whether to
+    #: refuse the whole strategy without it.
+    requires_market_context: bool = False
     #: ``per_series`` only.
     signals: PerSeriesSignals | None = None
     #: ``cross_sectional`` only, all three together.
@@ -294,21 +325,95 @@ class StrategyEntry:
             )
 
 
+def reject_missing_market_context(entry: StrategyEntry, market: MarketContext | None) -> None:
+    """A regime-gated strategy with no context is REFUSED, never scanned ungated.
+
+    ⚠ Fail-closed, and the direction matters. Running S-6 without its gate does
+    not produce fewer signals — it produces MORE, in every market including the
+    ``bull_volatile`` Bulge the rule excludes by name. A silently ungated scan
+    would write a ledger that looks healthy and measures a different strategy.
+    """
+    if entry.requires_market_context and market is None:
+        raise ValueError(
+            f"{entry.strategy_id} declares requires_market_context and was given none — a regime-gated "
+            "strategy run without its gate fires in markets its rule excludes, so this refuses rather "
+            "than scanning; build one with market_context.load_market_context(conn)"
+        )
+
+
 def _no_decision_calendar(calendar: Iterable[date]) -> frozenset[date] | None:
     """A per-series strategy acts on every bar it is evaluable at, not on a calendar."""
     return None
 
 
-def _s1_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+def _s1_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    market: MarketContext | None = None,
+) -> list[StrategySignal]:
+    """⚠ ``market`` is accepted and IGNORED: S-1 reads only its own bars.
+
+    Not rejected when supplied. The runner builds one context and hands it to
+    every strategy uniformly, so a non-``None`` here is the ordinary case and
+    refusing it — the ``_reject_decision_dates`` shape — would be wrong: a
+    decision calendar is a per-strategy artefact a caller could only produce
+    deliberately, whereas the market context is one shared object.
+    """
     return s1_signals(series, universe=universe, close_reason=masked_reason)
 
 
-def _s3_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+def _s3_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    market: MarketContext | None = None,
+) -> list[StrategySignal]:
+    """⚠ ``market`` is accepted and IGNORED: S-3 reads only its own bars.
+
+    Not rejected when supplied. The runner builds one context and hands it to
+    every strategy uniformly, so a non-``None`` here is the ordinary case and
+    refusing it — the ``_reject_decision_dates`` shape — would be wrong: a
+    decision calendar is a per-strategy artefact a caller could only produce
+    deliberately, whereas the market context is one shared object.
+    """
     return s3_signals(series, universe=universe, close_reason=masked_reason)
 
 
-def _s4_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+def _s4_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    market: MarketContext | None = None,
+) -> list[StrategySignal]:
+    """⚠ ``market`` accepted and IGNORED — see ``_s1_signals``."""
     return s4_signals(series, universe=universe, masked_reason=masked_reason)
+
+
+def _s6_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    market: MarketContext | None = None,
+) -> list[StrategySignal]:
+    """⚠ S-6 REQUIRES the context and refuses rather than scanning ungated.
+
+    ``requires_market_context`` already makes ``segmented_signals`` refuse before
+    reaching here, so this raise is the second of two. It is kept because a
+    direct caller bypasses the runner, and a regime-gated strategy silently
+    running with no regime gate would fire in every market — a strictly wrong
+    result that looks like a working scan.
+    """
+    if market is None:
+        raise ValueError(
+            f"{S6_STRATEGY_ID} is gated on the market regime and cannot be evaluated without a MarketContext; "
+            "pass market_context.load_market_context(conn)"
+        )
+    return s6_signals(series, universe=universe, masked_reason=masked_reason, market=market)
 
 
 def _s2_member(
@@ -384,6 +489,47 @@ def _s4_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
     """
     _reject_decision_dates(S4_STRATEGY_ID, decision_dates)
     return ExitRegime(signal_pair=False, level_based=True, max_hold_bars=S4_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s6_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-6 exits on a level-anchored stop / entry-anchored target, or the hold cap.
+
+    Same shape as S-4's — ``level_based=True`` and ``StrategyEntry.exit_levels``
+    move together — but the levels themselves are not: S-6's stop is measured
+    from the broken resistance and only its target from the fill. ``ExitRegime``
+    records THAT there is a bracket; the strategy-owned factory records what it is.
+    """
+    _reject_decision_dates(S6_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=False, level_based=True, max_hold_bars=S6_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s6_exit_levels(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> ExitLevels | UnresolvedReason:
+    """Adapt S-6's hashed scalar bracket to the outcome reason contract.
+
+    ⚠ EVERY refusal ``s6_exit_bracket`` raises becomes ``unorderable_exit_levels``
+    here rather than propagating. S-6 has a refusal S-4 does not — a fill that
+    gapped more than 1xATR above the broken level puts the stop at or above the
+    entry — and an unorderable bracket is an outcome the resolver already has a
+    vocabulary for, not a crash. Converting it here keeps the typed refusal out of
+    the hashed module, exactly as ``_s4_exit_levels`` does for the same reason:
+    adding an exception class to the strategy would mint a new strategy version.
+    """
+    try:
+        target, stop, max_hold = s6_exit_bracket(
+            series,
+            signal_index=signal_index,
+            entry_price=entry_price,
+            universe=universe,
+        )
+    except ValueError:
+        return "unorderable_exit_levels"
+    return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
 
 def _s4_exit_levels(
@@ -475,12 +621,25 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             exit_levels=_s4_exit_levels,
             exit_levels_batch=s4_exit_levels_batch,
         ),
+        S6_STRATEGY_ID: StrategyEntry(
+            strategy_id=S6_STRATEGY_ID,
+            purpose="harness_validation",
+            identity=s6_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s6_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s6_signals,
+            exit_levels=_s6_exit_levels,
+            requires_market_context=True,
+        ),
     }
 )
 
 
 __all__ = [
     "STRATEGY_CLASSES",
+    "reject_missing_market_context",
     "STRATEGY_MANIFEST",
     "DecisionCalendar",
     "ExitRegimeFactory",

--- a/app/services/strategy_registry.py
+++ b/app/services/strategy_registry.py
@@ -43,6 +43,8 @@ from typing import Literal, get_args
 
 from app.services.indicator_series import RULE_SET_VERSION as INDICATOR_SERIES_RULE_SET_VERSION
 from app.services.indicator_series import IndicatorSeries, MultiIndicatorSeries, Universe
+from app.services.market_regime import REGIME_RULE_VERSION
+from app.services.price_levels import LEVEL_RULE_VERSION
 
 STRATEGY_SET_ID = "strategy-registry-v1"
 
@@ -81,9 +83,20 @@ def _module_hash() -> str:
 #: series still moves with them. Both make stored signals visibly stale instead
 #: of silently mixed, which is the trade this epic has already taken three times
 #: (``price_quarantine``, ``price_structure``, ``indicator_series``).
+#:
+#: ⚠ ``market_regime`` and ``price_levels`` join it with S-6 (#2437), and adding
+#: them MOVES S-1…S-4's identities even though none of the four reads either.
+#: That is the registry-wide trade above being paid, not a mistake: the
+#: alternative — a per-strategy declaration so only S-6 moves — is exactly the
+#: "field they must remember to fill" this constant exists to remove. The cost
+#: was measured before taking it: 10,524 stored ``strategy_signals`` rows across
+#: the three strategies that have any, already spread over 2-3 versions each, so
+#: version churn is the normal state here rather than a track record being lost.
 INPUT_RULE_SETS: Mapping[str, str] = MappingProxyType(
     {
         "indicator_series": INDICATOR_SERIES_RULE_SET_VERSION,
+        "market_regime": REGIME_RULE_VERSION,
+        "price_levels": LEVEL_RULE_VERSION,
     }
 )
 
@@ -120,6 +133,23 @@ SignalKind = Literal["entry", "exit"]
 #: measured in sql/270), so this is the split it pre-registered. The pair is
 #: exactly criterion 8's distinction: the edge of the series is a real absence,
 #: an unpriceable bar is a data gap.
+#:
+#: ⚠ ``missing_market_context`` is an ELEVENTH (#2437, sql/351 widens the CHECK),
+#: flagged as an addition for the same reason as the three above. It is the first
+#: code that is a property of a DIFFERENT INSTRUMENT than the one being judged:
+#: S-6 gates on the market regime measured on SPY, so a bar of AAPL is unjudgeable
+#: when SPY has no classifiable session that day. None of the ten describes it —
+#: the instrument's own bar is fine, its data is complete, and the strategy still
+#: cannot decide.
+#:
+#: ⚠ It is NOT ``insufficient_warmup``, and the split is MEASURED rather than
+#: assumed. Over all 3,650,325 loadable bars in the validated universe: 85.26%
+#: have a known regime; 14.48% fall before the benchmark's first classifiable bar,
+#: which genuinely IS warm-up and stays ``insufficient_warmup``; and **9,405 bars
+#: across 353 dates** fall after it with no SPY session at all (worst single date
+#: 2026-02-06, 1,735 instruments trading). That last class is a hole in a series
+#: the strategy does not own, and collapsing it into warm-up would make a
+#: permanent gap read as a series that had not started yet.
 NotEvaluableReason = Literal[
     "missing_volume",
     "missing_spread",
@@ -131,6 +161,7 @@ NotEvaluableReason = Literal[
     "no_fill_bar",
     "thin_cross_section",
     "unusable_fill_price",
+    "missing_market_context",
 ]
 
 # ⚠ DERIVED from the Literals above, never restated. Review flagged the
@@ -143,11 +174,13 @@ VERDICTS: frozenset[str] = frozenset(get_args(Verdict))
 SIGNAL_KINDS: frozenset[str] = frozenset(get_args(SignalKind))
 NOT_EVALUABLE_REASONS: frozenset[str] = frozenset(get_args(NotEvaluableReason))
 
-#: The seven from parent criterion 8. `no_fill_bar`, `thin_cross_section` and
-#: `unusable_fill_price` are OURS and are excluded deliberately — see
-#: NotEvaluableReason. Kept as an explicit subtraction so adding a parent code
-#: later cannot silently land on our side of the line.
-OUR_ADDITIONAL_REASON_CODES: frozenset[str] = frozenset({"no_fill_bar", "thin_cross_section", "unusable_fill_price"})
+#: The seven from parent criterion 8. `no_fill_bar`, `thin_cross_section`,
+#: `unusable_fill_price` and `missing_market_context` are OURS and are excluded
+#: deliberately — see NotEvaluableReason. Kept as an explicit subtraction so
+#: adding a parent code later cannot silently land on our side of the line.
+OUR_ADDITIONAL_REASON_CODES: frozenset[str] = frozenset(
+    {"no_fill_bar", "thin_cross_section", "unusable_fill_price", "missing_market_context"}
+)
 PARENT_REASON_CODES: frozenset[str] = NOT_EVALUABLE_REASONS - OUR_ADDITIONAL_REASON_CODES
 
 

--- a/app/services/strategy_segmented_evaluation.py
+++ b/app/services/strategy_segmented_evaluation.py
@@ -7,8 +7,9 @@ from collections.abc import Sequence
 from datetime import date
 
 from app.services.indicator_series import BarSeries, Universe
+from app.services.market_context import MarketContext
 from app.services.price_segments import series_segment_bounds
-from app.services.strategy_manifest import StrategyEntry
+from app.services.strategy_manifest import StrategyEntry, reject_missing_market_context
 from app.services.strategy_registry import (
     NotEvaluableReason,
     StagedMember,
@@ -24,10 +25,19 @@ def segmented_signals(
     universe: Universe,
     masked_reason: NotEvaluableReason,
     unresolved_breaks: Sequence[date],
+    market: MarketContext | None = None,
 ) -> list[StrategySignal]:
-    """Evaluate every per-series leg with fresh state inside each segment."""
+    """Evaluate every per-series leg with fresh state inside each segment.
+
+    ⚠ ``market`` is passed straight through to each SEGMENT, not re-sliced. The
+    context is keyed by date and each segment is a ``BarSeries`` carrying its own
+    dates, so a regime-gated strategy finds the right day inside a segment with
+    no re-basing — which is the whole reason the context is date-keyed rather
+    than index-aligned (``market_context`` module docstring).
+    """
     if entry.signals is None:
         raise ValueError(f"{entry.strategy_id} has no per-series signal function")
+    reject_missing_market_context(entry, market)
     signals: list[StrategySignal] = []
     for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
         segment = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
@@ -38,7 +48,7 @@ def segmented_signals(
                 kind=signal.kind,
                 reason=signal.reason,
             )
-            for signal in entry.signals(segment, universe=universe, masked_reason=masked_reason)
+            for signal in entry.signals(segment, universe=universe, masked_reason=masked_reason, market=market)
         )
     per_kind = Counter(signal.kind for signal in signals)
     if not per_kind or any(count != len(series) for count in per_kind.values()):

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -51,6 +51,7 @@ import psycopg
 
 from app.services.cost_model import COST_MODEL_ID
 from app.services.indicator_series import BarSeries, Universe
+from app.services.market_context import MarketContext, MarketContextUnavailable, load_market_context
 from app.services.price_masked_bars import (
     MASKED_REASON,
     load_bar_spans,
@@ -113,6 +114,12 @@ StrategyScanStatus = Literal[
     "written",
     "up_to_date",
     "refused_frontier_regressed",
+    #: ⚠ A regime-gated strategy whose benchmark could not be built (#2437). It
+    #: is a NAMED refusal and not a silent omission, and it is not "failed":
+    #: nothing went wrong with the strategy, its market context is missing. The
+    #: distinction is what tells an operator to fix the benchmark series rather
+    #: than to debug the rule.
+    "refused_no_market_context",
     "failed",
 ]
 
@@ -440,6 +447,21 @@ def run_signal_scan(
             "depends on would collapse into one batch"
         )
     universe = load_validated_universe(conn)
+    # ⚠ Built ONCE, before the instrument loop, and never per instrument. It is
+    # one classification of one benchmark shared by every gated strategy and
+    # every name they judge — rebuilding it inside the loop would reload and
+    # re-classify SPY 6,774 times to get the same answer.
+    #
+    # ⚠ A failure here does NOT stop the scan. S-1…S-4 read only their own bars
+    # and must still run; only the gated strategies are refused, by name, below.
+    market: MarketContext | None
+    market_context_error: str | None
+    try:
+        market = load_market_context(conn, universe=SCAN_UNIVERSE)
+        market_context_error = None
+    except MarketContextUnavailable as exc:
+        market, market_context_error = None, str(exc)
+        logger.warning("strategy_signal_scan: no market context — regime-gated strategies refused: %s", exc)
     spans = load_bar_spans(conn, universe)
     frontier = choose_frontier({instrument_id: span.last_bar for instrument_id, span in spans.items()})
     if frontier is None:
@@ -501,6 +523,17 @@ def run_signal_scan(
                     strategy_version=version,
                     status="refused_frontier_regressed" if regressed else "up_to_date",
                     resumed_from=watermark,
+                )
+            )
+            continue
+        if entry.requires_market_context and market is None:
+            results.append(
+                StrategyScanResult(
+                    strategy_id=strategy_id,
+                    strategy_version=version,
+                    status="refused_no_market_context",
+                    resumed_from=watermark,
+                    error=market_context_error,
                 )
             )
             continue
@@ -571,6 +604,7 @@ def run_signal_scan(
                     window,
                     rows[plan.entry.strategy_id],
                     unresolved_breaks=unresolved_breaks.get(instrument_id, ()),
+                    market=market,
                 )
             else:
                 assert panel_dates is not None
@@ -630,6 +664,7 @@ def _scan_per_series(
     out: list[LedgerRow],
     *,
     unresolved_breaks: Sequence[date] = (),
+    market: MarketContext | None = None,
 ) -> None:
     """Full-history recompute, filtered to the window, resolved through the writer.
 
@@ -651,6 +686,7 @@ def _scan_per_series(
         universe=SCAN_UNIVERSE,
         masked_reason=MASKED_REASON,
         unresolved_breaks=unresolved_breaks,
+        market=market,
     )
     windowed = [signal for signal in signals if signal.signal_index in window]
     out.extend(resolve_fills(windowed, series=series, identity=plan.identity, instrument_id=instrument_id))

--- a/scripts/verify_2394_backtest_run.py
+++ b/scripts/verify_2394_backtest_run.py
@@ -533,7 +533,7 @@ def arm(*, limit: int | None, strategy_id: str) -> int:
             )
 
             mark = time.monotonic()
-            signals = entry.signals(series, universe=UNIVERSE, masked_reason="quarantined_bar")
+            signals = entry.signals(series, universe=UNIVERSE, masked_reason="quarantined_bar", market=None)
             rows = resolve_fills(signals, series=series, identity=identity, instrument_id=int(instrument_id))
             entries, exits = _fills(rows, int(instrument_id))
             built = build_positions(

--- a/scripts/verify_2394_signal_scan_cost.py
+++ b/scripts/verify_2394_signal_scan_cost.py
@@ -322,12 +322,12 @@ def arrears() -> bool:
             same_day_index = len(same_day) - 1
             with_next = {
                 (s.kind, s.verdict, s.reason)
-                for s in entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                for s in entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON, market=None)
                 if s.signal_index == index
             }
             without = {
                 (s.kind, s.verdict, s.reason)
-                for s in entry.signals(same_day, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                for s in entry.signals(same_day, universe=UNIVERSE, masked_reason=MASKED_REASON, market=None)
                 if s.signal_index == same_day_index
             }
             compared[entry.strategy_id] += len(with_next)
@@ -406,7 +406,7 @@ def cost() -> bool:
         identity = entry.identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
         started = time.monotonic()
         for instrument_id, series in loaded.items():
-            signals = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            signals = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON, market=None)
             if instrument_id not in at_frontier:
                 continue
             rows = resolve_fills(signals, series=series, identity=identity, instrument_id=instrument_id)
@@ -516,7 +516,7 @@ def truncation() -> bool:
         assert entry.signals is not None
         for series in eligible.values():
             index = len(series) - 1
-            emitted = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            emitted = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON, market=None)
             full = {(s.kind, s.verdict, s.reason) for s in emitted if s.signal_index == index}
             for window in TRUNCATION_WINDOWS:
                 if len(series) <= window:
@@ -526,7 +526,7 @@ def truncation() -> bool:
                 tail_index = len(tail) - 1
                 got = {
                     (s.kind, s.verdict, s.reason)
-                    for s in entry.signals(tail, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                    for s in entry.signals(tail, universe=UNIVERSE, masked_reason=MASKED_REASON, market=None)
                     if s.signal_index == tail_index
                 }
                 compared[(window, entry.strategy_id)] += 1

--- a/scripts/verify_2394_strategy_manifest.py
+++ b/scripts/verify_2394_strategy_manifest.py
@@ -190,7 +190,7 @@ def equivalence() -> bool:
             for key, direct in DIRECT_PER_SERIES.items():
                 entry = STRATEGY_MANIFEST[key]
                 assert entry.signals is not None
-                got = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                got = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON, market=None)
                 want = direct(series, universe=UNIVERSE, close_reason=MASKED_REASON)
                 if got != want:
                     mismatches.append(f"{key} series {series_id}")
@@ -199,7 +199,7 @@ def equivalence() -> bool:
 
             s4 = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
             assert s4.signals is not None
-            got_s4 = s4.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            got_s4 = s4.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON, market=None)
             if got_s4 != s4_signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON):
                 mismatches.append(f"s4-volatility-compression-breakout series {series_id}")
             for signal in got_s4:

--- a/scripts/verify_2437_s6_resistance_breakout.py
+++ b/scripts/verify_2437_s6_resistance_breakout.py
@@ -1,0 +1,264 @@
+"""Verify S-6 against the live corpus (#2437).
+
+Arms
+----
+``--census``      the full-population funnel: what every leg rejects, and how
+                  often S-6 fires. Nothing here is hardcoded — every figure the
+                  PR quotes is printed by this arm.
+``--market``      the benchmark's classified regime, and the three-way split
+                  the eleventh reason code exists for.
+``--equivalence`` the ``LevelScan`` hoist against the scalar ``levels_at`` on
+                  real series, plus the timing that motivated it.
+``--scan``        run the real signal scan on a bounded slice and report S-6's
+                  own census through the manifest and the ledger writer.
+
+⚠ EVERY ARM MEASURES; NONE ASSERTS A THRESHOLD. The full-population rule binds
+descriptive claims as well as gates, so the numbers in the PR come from here
+rather than from a sample or from memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections import Counter
+
+import numpy as np
+import psycopg
+
+from app.config import settings
+from app.services.cost_model import COST_MODEL_ID
+from app.services.indicator_series import atr_series
+from app.services.market_context import load_market_context
+from app.services.price_levels import LevelScan, levels_at
+from app.services.price_masked_bars import load_masked_bars
+from app.services.strategies.s6_resistance_breakout import (
+    PERMITTED_REGIMES,
+    S6_STRATEGY_ID,
+    VOLUME_MULTIPLE,
+    s6_identity,
+    s6_signals,
+)
+from app.services.strategies.validated_universe import load_validated_universe
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
+
+#: ⚠ The label the LIVE SCAN uses, imported rather than retyped — a verify
+#: script measuring under a different universe string measures a different
+#: strategy identity (criterion 11 puts the universe inside the identity).
+UNIVERSE = SCAN_UNIVERSE
+MASKED_REASON = "quarantined_bar"
+
+#: Bars below which a series cannot support a 3-touch level plus the 200-bar
+#: benchmark warm-up it will be gated against. Reported, never silently applied.
+MIN_BARS = 250
+
+
+def _volumes(series: object) -> np.ndarray:
+    rows = series.rows  # type: ignore[attr-defined]
+    out = np.empty(len(rows), dtype=float)
+    for index, row in enumerate(rows):
+        value = row.get("volume")
+        out[index] = np.nan if value is None or value < 0 else float(value)
+    return out
+
+
+def market_arm(conn: psycopg.Connection) -> None:
+    context = load_market_context(conn, universe=UNIVERSE)
+    print(f"benchmark {context.benchmark_symbol} (instrument {context.benchmark_instrument_id})")
+    print(f"  rule set        {context.rule_set_version}")
+    print(f"  classified      {len(context.regime_by_date):,} sessions")
+    print(f"  first / last    {context.first_classified} .. {max(context.regime_by_date)}")
+    distribution = Counter(regime.value for regime in context.regime_by_date.values())
+    for name, count in sorted(distribution.items(), key=lambda kv: -kv[1]):
+        share = count / len(context.regime_by_date)
+        marker = "  <- permitted" if name in {r.value for r in PERMITTED_REGIMES} else ""
+        print(f"    {name:16s} {count:>6,}  {share:6.2%}{marker}")
+
+    universe = load_validated_universe(conn)
+    known = warm = gap = 0
+    gap_dates: Counter = Counter()
+    rows = conn.execute(
+        """
+        SELECT d.price_date, count(*)
+        FROM price_daily d
+        JOIN price_quarantine_coverage cov
+          ON cov.instrument_id = d.instrument_id
+         AND cov.rule_set_version = %(qv)s
+         AND d.price_date BETWEEN cov.first_bar AND cov.last_bar
+        WHERE d.instrument_id = ANY(%(ids)s)
+        GROUP BY 1
+        """,
+        {"qv": _quarantine_version(), "ids": list(universe)},
+    ).fetchall()
+    for when, count in rows:
+        if when in context.regime_by_date:
+            known += count
+        elif when < context.first_classified:
+            warm += count
+        else:
+            gap += count
+            gap_dates[when] = count
+    total = known + warm + gap
+    print(f"\nvalidated-universe loadable bars: {total:,}")
+    print(f"  regime known                    {known:>10,}  {known / total:6.2%}")
+    print(f"  benchmark warm-up               {warm:>10,}  {warm / total:6.2%}  -> insufficient_warmup")
+    print(f"  BENCHMARK GAP                   {gap:>10,}  {gap / total:6.2%}  -> missing_market_context")
+    print(f"    over {len(gap_dates)} dates; worst: {gap_dates.most_common(5)}")
+
+
+def _quarantine_version() -> str:
+    from app.services.price_quarantine import RULE_SET_VERSION
+
+    return RULE_SET_VERSION
+
+
+def equivalence_arm(conn: psycopg.Connection) -> None:
+    """⚠ The hoist is a performance change; prove it changed no verdict."""
+    universe = sorted(load_validated_universe(conn))[:25]
+    checked = mismatches = 0
+    hoisted_seconds = scalar_seconds = 0.0
+    for instrument_id in universe:
+        series = load_masked_bars(conn, instrument_id).series
+        if len(series) < MIN_BARS:
+            continue
+        atr = atr_series(series, universe=UNIVERSE, period=14)
+        volumes = _volumes(series)
+        scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=volumes)
+        for index in range(len(series)):
+            value = atr.values[index]
+            if value is None:
+                continue
+            mark = time.perf_counter()
+            fast = scan.at(atr=value, index=index)
+            hoisted_seconds += time.perf_counter() - mark
+            mark = time.perf_counter()
+            slow = levels_at(highs=series.array_highs, lows=series.array_lows, volumes=volumes, atr=value, index=index)
+            scalar_seconds += time.perf_counter() - mark
+            checked += 1
+            if fast != slow:
+                mismatches += 1
+    print(f"levels: {checked:,} (instrument, bar) pairs compared, {mismatches} mismatches")
+    speedup = scalar_seconds / max(hoisted_seconds, 1e-9)
+    print(f"  hoisted {hoisted_seconds:8.2f}s   scalar {scalar_seconds:8.2f}s   speedup x{speedup:.1f}")
+    if mismatches:
+        sys.exit(1)
+
+
+def census_arm(conn: psycopg.Connection) -> None:
+    """The full-population funnel, straight through ``s6_signals``."""
+    universe = sorted(load_validated_universe(conn))
+    context = load_market_context(conn, universe=UNIVERSE)
+    identity = s6_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+    print(f"strategy {S6_STRATEGY_ID} version {identity.version}")
+    print(f"  volume multiple {VOLUME_MULTIPLE}  permitted {sorted(r.value for r in PERMITTED_REGIMES)}")
+
+    verdicts: Counter = Counter()
+    reasons: Counter = Counter()
+    firing_instruments: set[int] = set()
+    scanned = short = 0
+    started = time.perf_counter()
+    for position, instrument_id in enumerate(universe, start=1):
+        if position % 500 == 0:
+            print(f"  ... {position}/{len(universe)} {time.perf_counter() - started:.0f}s", flush=True)
+        series = load_masked_bars(conn, instrument_id).series
+        if len(series) < MIN_BARS:
+            short += 1
+            continue
+        scanned += 1
+        for signal in s6_signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON, market=context):
+            verdicts[signal.verdict] += 1
+            if signal.reason is not None:
+                reasons[signal.reason] += 1
+            if signal.verdict == "fired":
+                firing_instruments.add(instrument_id)
+
+    total = sum(verdicts.values())
+    decided = verdicts["fired"] + verdicts["not_fired"]
+    print(f"\nelapsed {time.perf_counter() - started:.0f}s")
+    print(f"  instruments scanned            {scanned:>10,}   (short, <{MIN_BARS} bars: {short:,})")
+    print(f"  bar verdicts                   {total:>10,}")
+    for verdict, count in sorted(verdicts.items()):
+        print(f"    {verdict:22s} {count:>10,}  {count / total:6.2%}")
+    print("  not_evaluable reasons:")
+    for reason, count in sorted(reasons.items(), key=lambda kv: -kv[1]):
+        print(f"    {reason:22s} {count:>10,}  {count / total:6.2%}")
+    if decided:
+        print(f"\n  fire rate per DECIDED bar      {verdicts['fired'] / decided:8.4%}")
+    if scanned:
+        print(
+            f"  instruments that ever fire     {len(firing_instruments) / scanned:8.2%}  ({len(firing_instruments):,})"
+        )
+
+
+def scan_arm(conn: psycopg.Connection) -> None:
+    """S-6 through the real runner, on the real manifest, writing nothing."""
+    from app.services.strategy_manifest import STRATEGY_MANIFEST
+    from app.services.strategy_segmented_evaluation import segmented_signals
+
+    entry = STRATEGY_MANIFEST[S6_STRATEGY_ID]
+    context = load_market_context(conn, universe=UNIVERSE)
+    universe = sorted(load_validated_universe(conn))[:200]
+    census: Counter = Counter()
+    fired_examples: list[tuple[int, str]] = []
+    for instrument_id in universe:
+        series = load_masked_bars(conn, instrument_id).series
+        if len(series) < MIN_BARS:
+            continue
+        signals = segmented_signals(
+            entry,
+            series,
+            universe=UNIVERSE,
+            masked_reason=MASKED_REASON,
+            unresolved_breaks=(),
+            market=context,
+        )
+        for signal in signals:
+            census[(signal.verdict, signal.reason or "")] += 1
+            if signal.verdict == "fired" and len(fired_examples) < 10:
+                fired_examples.append((instrument_id, str(series.dates[signal.signal_index])))
+    print(f"segmented_signals over {len(universe)} instruments:")
+    for key, count in sorted(census.items(), key=lambda kv: -kv[1]):
+        print(f"    {key!s:44s} {count:>10,}")
+    print(f"  sample fires (instrument_id, signal date): {fired_examples}")
+
+    print("\n  refusal without a context (must raise):")
+    try:
+        segmented_signals(
+            entry,
+            load_masked_bars(conn, universe[0]).series,
+            universe=UNIVERSE,
+            masked_reason=MASKED_REASON,
+            unresolved_breaks=(),
+            market=None,
+        )
+    except ValueError as exc:
+        print(f"    REFUSED: {exc}")
+    else:
+        print("    NOT REFUSED — the fail-closed guard is not wired")
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--census", action="store_true")
+    parser.add_argument("--market", action="store_true")
+    parser.add_argument("--equivalence", action="store_true")
+    parser.add_argument("--scan", action="store_true")
+    args = parser.parse_args()
+    if not any((args.census, args.market, args.equivalence, args.scan)):
+        parser.error("choose at least one arm")
+
+    with psycopg.connect(settings.database_url) as conn:
+        if args.market:
+            market_arm(conn)
+        if args.equivalence:
+            equivalence_arm(conn)
+        if args.scan:
+            scan_arm(conn)
+        if args.census:
+            census_arm(conn)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/351_strategy_signals_missing_market_context.sql
+++ b/sql/351_strategy_signals_missing_market_context.sql
@@ -1,0 +1,102 @@
+-- 351_strategy_signals_missing_market_context.sql
+--
+-- #2437 — S-6 lands the first REGIME-GATED strategy, and with it the eleventh
+-- `not_evaluable` reason code.
+--
+-- WHAT IT NAMES
+--   `missing_market_context` — the strategy gates on a benchmark's market regime
+--   (S-5…S-10 §1: SPY vs its 200-SMA, plus Bollinger's six-month Bulge) and the
+--   benchmark has no classifiable session on this bar's date.
+--
+-- ⚠ IT IS THE FIRST CODE THAT IS A PROPERTY OF A DIFFERENT INSTRUMENT than the
+-- one being judged. Every one of the ten before it describes the row's own bar:
+-- its volume is missing, its window is warming, it is quarantined, its series
+-- broke, it has no t+1. This one fires when the row's bar is PERFECT and the
+-- strategy still cannot decide, because SPY has no bar that day.
+--
+-- ⚠ IT IS NOT `insufficient_warmup`, AND THE SPLIT WAS MEASURED FIRST. Over all
+-- 3,650,325 loadable bars in the validated universe:
+--
+--     regime known                        3,112,351   85.26%
+--     before the benchmark's first
+--       classifiable bar (real warm-up)     528,569   14.48%
+--     benchmark has no session at all         9,405    0.26%   over 353 dates
+--
+-- The third class is not empty, which is the whole argument for giving it a
+-- code. Its worst single date is 2026-02-06: 1,735 instruments traded and SPY
+-- has no bar, so an entire session of the universe would otherwise be reported
+-- as "the series had not started yet". That is criterion 8's exact prohibition —
+-- *"these have different bias implications and collapsing them loses the ability
+-- to tell a data gap from a real absence"*. Warm-up ends; a hole does not.
+--
+-- ⚠ THE INCIDENTAL FINDING, RECORDED WHERE IT WILL BE READ: those 353 dates are
+-- holes in OUR STORED SPY SERIES, not market holidays. Most are thin
+-- weekend/holiday rows contributed by `.24-7` instruments, but a minority are
+-- ordinary sessions (2023-06-30 — a Friday — has 237 instruments trading and no
+-- SPY bar). SPY is in `scheduler.BENCHMARK_SYMBOLS` so it IS refreshed; the gaps
+-- predate that scope or were dropped by a failed fetch. Every regime-gated
+-- strategy is blind on those days, honestly and countably.
+--
+-- ⚠ OURS, NOT THE PARENT'S. Criterion 8 lists seven codes; `no_fill_bar` was our
+-- eighth, `thin_cross_section` the ninth, `unusable_fill_price` the tenth, and
+-- this is the eleventh. All four are flagged as additions in
+-- strategy_registry.py rather than passed off as the parent's, and
+-- `OUR_ADDITIONAL_REASON_CODES` keeps the two sets separable in Python.
+--
+-- ⚠ THE PYTHON LITERAL IS THE SOURCE, THESE ARE THE MIRRORS — unchanged from
+-- sql/270. tests/test_strategy_registry.py reads the LATEST migration that
+-- redefines each list, which is this file from here on. THREE tables carry the
+-- vocabulary (sql/270 widened one, sql/276 created two more) and all three are
+-- widened here: the prevention log's "a closed vocabulary declared in three
+-- places is validated in none of them" is precisely this shape, and a member
+-- added to two of three writes rows the third refuses at insert time.
+
+ALTER TABLE strategy_signals
+    DROP CONSTRAINT IF EXISTS strategy_signals_reason_codes;
+
+ALTER TABLE strategy_signals
+    ADD CONSTRAINT strategy_signals_reason_codes
+    CHECK (not_evaluable_reason IS NULL OR not_evaluable_reason IN (
+        'missing_volume', 'missing_spread', 'insufficient_warmup',
+        'quarantined_bar', 'series_break', 'not_listed',
+        'ambiguous_intrabar', 'no_fill_bar', 'thin_cross_section',
+        'unusable_fill_price', 'missing_market_context'
+    ));
+
+ALTER TABLE strategy_signal_daily_counts
+    DROP CONSTRAINT IF EXISTS strategy_signal_daily_counts_reason_code_check;
+
+ALTER TABLE strategy_signal_daily_counts
+    ADD CONSTRAINT strategy_signal_daily_counts_reason_code_check
+    CHECK (reason_code IN (
+        '', 'missing_volume', 'missing_spread', 'insufficient_warmup',
+        'quarantined_bar', 'series_break', 'not_listed',
+        'ambiguous_intrabar', 'no_fill_bar', 'thin_cross_section',
+        'unusable_fill_price', 'missing_market_context'
+    ));
+
+-- ⚠ `strategy_signal_observations` is RANGE-PARTITIONED. The CHECK is declared
+-- on the parent, so replacing it there covers every existing and future
+-- partition — a per-partition loop would leave whichever partition is created
+-- next still refusing the new code.
+ALTER TABLE strategy_signal_observations
+    DROP CONSTRAINT IF EXISTS strategy_signal_observations_reason_code_check;
+
+ALTER TABLE strategy_signal_observations
+    ADD CONSTRAINT strategy_signal_observations_reason_code_check
+    CHECK (reason_code IN (
+        '', 'missing_volume', 'missing_spread', 'insufficient_warmup',
+        'quarantined_bar', 'series_break', 'not_listed',
+        'ambiguous_intrabar', 'no_fill_bar', 'thin_cross_section',
+        'unusable_fill_price', 'missing_market_context'
+    ));
+
+COMMENT ON COLUMN strategy_signals.not_evaluable_reason IS
+    'Closed vocabulary: parent criterion 8''s seven codes, plus no_fill_bar '
+    '(the series has no t+1), thin_cross_section (the ranked panel was smaller '
+    'than the ranking rule is defined on), unusable_fill_price (bar t+1 exists '
+    'and its open is NULL or <= 0, so no fill can be priced) and '
+    'missing_market_context (the strategy is gated on a benchmark''s market '
+    'regime and the benchmark has no classifiable session on this date). The '
+    'Python Literal in strategy_registry.NotEvaluableReason is the source; this '
+    'CHECK mirrors it.';

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -426,4 +426,10 @@ def test_overview_declares_only_level_strategies_forward_resolvable(
         "s2-cross-sectional-momentum": False,
         "s3-mean-reversion-in-trend": False,
         "s4-volatility-compression-breakout": True,
+        # ⚠ S-6 is level-based and ships its own causal bracket factory, so the
+        # operator-facing overview declares it forward-resolvable (#2437). Being
+        # regime-gated does not change that: the gate decides whether a bar may
+        # FIRE, while this flag says an entry that did fire has a producer for
+        # its outcome.
+        "s6-resistance-breakout-volume": True,
     }

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -192,7 +192,24 @@ class TestRunnableStrategies:
             "s3-mean-reversion-in-trend",
             "s4-volatility-compression-breakout",
         ]
-        assert excluded == ()
+        assert [item.strategy_id for item in excluded] == ["s6-resistance-breakout-volume"]
+
+    def test_the_regime_gated_strategy_is_excluded_by_name_not_dropped(self) -> None:
+        """⚠⚠ #2437. S-6 gates on a benchmark regime built from the LIVE corpus;
+        this job runs over the research corpus, which has no classified benchmark
+        series. Running it ungated would not measure S-6 — it would measure a
+        strictly more permissive rule and store it under S-6's identity.
+
+        The exclusion must be NAMED. ``runnable_strategies``' own docstring:
+        *"A strategy that is BLOCKED is returned as a named exclusion, never
+        dropped. A three-of-four run reporting '3 strategies evaluated' is
+        exactly the silent narrowing criterion 9 forbids."*
+        """
+        runnable, excluded = runnable_strategies()
+        assert "s6-resistance-breakout-volume" not in runnable
+        (gated,) = [item for item in excluded if item.strategy_id == "s6-resistance-breakout-volume"]
+        assert "MarketContext" in gated.reason
+        assert "regime gate" in gated.reason
 
     def test_every_manifest_entry_is_accounted_for(self) -> None:
         from app.services.strategy_manifest import STRATEGY_MANIFEST

--- a/tests/test_signal_ledger.py
+++ b/tests/test_signal_ledger.py
@@ -20,6 +20,8 @@ import pytest
 
 from app.services.indicator_series import RULE_SET_VERSION as INDICATOR_SERIES_RULE_SET_VERSION
 from app.services.indicator_series import BarSeries
+from app.services.market_regime import REGIME_RULE_VERSION
+from app.services.price_levels import LEVEL_RULE_VERSION
 from app.services.signal_ledger import LedgerRow, resolve_fills
 from app.services.strategy_registry import StrategyIdentity, StrategySignal
 from app.services.technical_analysis import OHLCVRow
@@ -252,7 +254,11 @@ class TestBatchIntegrity:
         object is what stops the column disagreeing with the hash beside it."""
         rows = resolve_fills([_fired_at(0)], series=_series(_CONSECUTIVE), identity=_IDENTITY, instrument_id=7)
         assert rows[0].input_rule_set_versions == _IDENTITY.input_rule_set_versions
-        assert dict(rows[0].input_rule_set_versions) == {"indicator_series": INDICATOR_SERIES_RULE_SET_VERSION}
+        assert dict(rows[0].input_rule_set_versions) == {
+            "indicator_series": INDICATOR_SERIES_RULE_SET_VERSION,
+            "market_regime": REGIME_RULE_VERSION,
+            "price_levels": LEVEL_RULE_VERSION,
+        }
 
 
 class TestLedgerRowRejects:

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -41,11 +41,13 @@ from app.services.technical_analysis import OHLCVRow
 UNIVERSE = "survivor_only"
 REASON = "series_break"
 
-#: §4's four catalogue strategies, written out. See the module docstring.
+#: §4's four catalogue strategies plus the S-5…S-10 set's first, written out.
+#: See the module docstring.
 SPEC_S1 = "s1-time-series-momentum"
 SPEC_S2 = "s2-cross-sectional-momentum"
 SPEC_S3 = "s3-mean-reversion-in-trend"
 SPEC_S4 = "s4-volatility-compression-breakout"
+SPEC_S6 = "s6-resistance-breakout-volume"
 
 #: Spec §3's table, verbatim, as ``(signal_pair, level_based, max_hold_bars,
 #: has_rebalance_dates)``. ⚠ Written out for the reason in the module docstring:
@@ -56,6 +58,7 @@ SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
     SPEC_S2: (False, False, None, True),
     SPEC_S3: (True, False, 10, False),
     SPEC_S4: (False, True, 40, False),
+    SPEC_S6: (False, True, 40, False),
 }
 
 #: The legs each strategy emits — §4: S-1 and S-3 have an exit rule, S-2 closes
@@ -65,6 +68,7 @@ SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
     SPEC_S2: frozenset({"entry"}),
     SPEC_S3: frozenset({"entry", "exit"}),
     SPEC_S4: frozenset({"entry"}),
+    SPEC_S6: frozenset({"entry"}),
 }
 
 SPEC_CLASSES: dict[str, str] = {
@@ -72,9 +76,10 @@ SPEC_CLASSES: dict[str, str] = {
     SPEC_S2: "cross_sectional",
     SPEC_S3: "per_series",
     SPEC_S4: "per_series",
+    SPEC_S6: "per_series",
 }
 
-SPEC_PURPOSES = {strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4)}
+SPEC_PURPOSES = {strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S6)}
 
 
 def _bars(closes: Sequence[float | None], *, start: date = date(2020, 1, 1)) -> BarSeries:
@@ -148,8 +153,11 @@ class TestManifestIsComplete:
         forever. Pin that it is actually reading the modules it claims to — the
         prevention-log lesson from a probe that matched nothing."""
         declared = self._declared_strategy_ids()
-        assert len(declared) == 4, f"expected the four catalogue modules, walked {sorted(declared)}"
+        assert len(declared) == len(SPEC_CLASSES), (
+            f"expected the {len(SPEC_CLASSES)} strategy modules, walked {sorted(declared)}"
+        )
         assert declared["s1_time_series_momentum.py"] == SPEC_S1
+        assert declared["s6_resistance_breakout.py"] == SPEC_S6
 
     def test_every_strategy_module_is_registered(self) -> None:
         missing = {
@@ -174,7 +182,7 @@ class TestManifestIsComplete:
         """⚠ THE ONE BRIDGE between this file's literals and the source. Every
         other assertion here is written against the literals, so without this
         the whole file could agree with a renamed strategy."""
-        assert set(self._declared_strategy_ids().values()) == {SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4}
+        assert set(self._declared_strategy_ids().values()) == {SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S6}
 
 
 class TestEntriesDescribeTheirStrategy:
@@ -233,7 +241,7 @@ class TestExitRegimeTableIsExecutable:
     def test_per_series_decision_calendar_is_none_not_empty(self) -> None:
         """ "No calendar" and "a calendar with no dates" must stay distinct —
         ``ExitRegime`` refuses the empty set for exactly that reason."""
-        for strategy_id in (SPEC_S1, SPEC_S3, SPEC_S4):
+        for strategy_id in (SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S6):
             entry = STRATEGY_MANIFEST[strategy_id]
             assert entry.decision_calendar([date(2020, 1, 1), date(2020, 2, 1)]) is None
 
@@ -260,7 +268,7 @@ class TestUniformInvocationEqualsTheDirectCall:
     def test_close_reason_strategies_match(self, strategy_id: str, direct: object) -> None:
         entry = STRATEGY_MANIFEST[strategy_id]
         assert entry.signals is not None
-        via_manifest = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        via_manifest = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON, market=None)
         expected = direct(_bars(_CLOSES), universe=UNIVERSE, close_reason=REASON)  # type: ignore[operator]
         assert via_manifest == expected
         assert any(signal.verdict == "fired" for signal in via_manifest), (
@@ -270,7 +278,7 @@ class TestUniformInvocationEqualsTheDirectCall:
     def test_masked_reason_strategy_matches(self) -> None:
         entry = STRATEGY_MANIFEST[SPEC_S4]
         assert entry.signals is not None
-        via_manifest = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        via_manifest = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON, market=None)
         assert via_manifest == s4_signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
 
     @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4])
@@ -281,7 +289,7 @@ class TestUniformInvocationEqualsTheDirectCall:
         comes back."""
         entry = STRATEGY_MANIFEST[strategy_id]
         assert entry.signals is not None
-        signals = entry.signals(_bars(_HOLED_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        signals = entry.signals(_bars(_HOLED_CLOSES), universe=UNIVERSE, masked_reason=REASON, market=None)
         assert signals[0].verdict == "not_evaluable"
         assert signals[0].reason == REASON
 
@@ -291,7 +299,8 @@ class TestUniformInvocationEqualsTheDirectCall:
         from what it emits rather than trusted."""
         entry = STRATEGY_MANIFEST[strategy_id]
         assert entry.signals is not None
-        emitted = {signal.kind for signal in entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)}
+        signals = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON, market=None)
+        emitted = {signal.kind for signal in signals}
         assert emitted == set(entry.signal_kinds)
 
     def test_cross_sectional_member_matches_the_direct_call(self) -> None:

--- a/tests/test_strategy_registry.py
+++ b/tests/test_strategy_registry.py
@@ -21,6 +21,8 @@ from app.services.indicator_series import (
     IndicatorSeries,
     sma_series,
 )
+from app.services.market_regime import REGIME_RULE_VERSION
+from app.services.price_levels import LEVEL_RULE_VERSION
 from app.services.strategy_registry import (
     INPUT_RULE_SETS,
     NOT_EVALUABLE_REASONS,
@@ -244,7 +246,11 @@ class TestIdentityCoversMoreThanSource:
         """The writer stores ``identity.input_rule_set_versions`` and the hash
         is built from the same object, so a disagreement is not expressible."""
         assert self._identity().input_rule_set_versions is strategy_registry.INPUT_RULE_SETS
-        assert dict(INPUT_RULE_SETS) == {"indicator_series": INDICATOR_SERIES_RULE_SET_VERSION}
+        assert dict(INPUT_RULE_SETS) == {
+            "indicator_series": INDICATOR_SERIES_RULE_SET_VERSION,
+            "market_regime": REGIME_RULE_VERSION,
+            "price_levels": LEVEL_RULE_VERSION,
+        }
 
     def test_the_registry_constant_is_read_only(self) -> None:
         """A plain dict would let any importer mutate the identity of every
@@ -315,6 +321,20 @@ class TestInputRuleSetsAreComplete:
     versioned pipeline is not caught, and no static rule short of a full import
     graph would catch it. Stated rather than implied — a guard whose blind spot
     is undocumented reads as covering more than it does.
+
+    ⚠⚠ THE GUARD USED TO MATCH ON THE NAME ``RULE_SET_VERSION`` AND WOULD HAVE
+    MISSED S-6 ENTIRELY (#2437). ``market_regime`` and ``price_levels`` name
+    their constants ``REGIME_RULE_VERSION`` and ``LEVEL_RULE_VERSION``, so a
+    strategy reading both would have passed a guard whose entire purpose is to
+    catch that — the #2333 defect evading its own detector on a naming
+    convention. It now matches any module-level ASSIGNMENT whose name ends in
+    ``_VERSION``.
+
+    ⚠ Assignments only, never ``hasattr``. ``strategy_registry`` imports
+    ``INDICATOR_SERIES_RULE_SET_VERSION``, which is a module attribute ending in
+    ``_VERSION`` that the module does not OWN — ``hasattr`` would demand
+    ``strategy_registry`` register itself in its own constant. The AST sees the
+    difference between defining a version and re-exporting one.
     """
 
     _STRATEGIES_DIR = Path(strategies.__file__).parent
@@ -341,12 +361,37 @@ class TestInputRuleSetsAreComplete:
         assert {"s1_time_series_momentum.py", "s3_mean_reversion_in_trend.py"} <= set(imports)
         assert "app.services.indicator_series" in imports["s1_time_series_momentum.py"]
 
+    @staticmethod
+    def _owned_version_constants(dotted: str) -> list[str]:
+        """Module-level ``*_VERSION`` names ASSIGNED by ``dotted`` itself."""
+        module = importlib.import_module(dotted)
+        assert module.__file__ is not None
+        found: list[str] = []
+        for node in ast.parse(Path(module.__file__).read_text()).body:
+            if isinstance(node, ast.Assign):
+                found += [t.id for t in node.targets if isinstance(t, ast.Name) and t.id.endswith("_VERSION")]
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                if node.target.id.endswith("_VERSION"):
+                    found.append(node.target.id)
+        return found
+
+    def test_the_version_walk_distinguishes_owned_from_reexported(self) -> None:
+        """⚠ Pin the AST rule itself, or the widening above is untested.
+
+        ``indicator_series`` DEFINES ``RULE_SET_VERSION``; ``strategy_registry``
+        merely imports one under an alias. A guard that could not tell them apart
+        would demand the registry register itself.
+        """
+        assert self._owned_version_constants("app.services.indicator_series") == ["RULE_SET_VERSION"]
+        assert self._owned_version_constants("app.services.market_regime") == ["REGIME_RULE_VERSION"]
+        assert self._owned_version_constants("app.services.price_levels") == ["LEVEL_RULE_VERSION"]
+        assert self._owned_version_constants("app.services.strategy_registry") == []
+
     def test_every_versioned_pipeline_a_strategy_reads_is_in_the_hash(self) -> None:
         missing: list[str] = []
         for strategy_module, imported in sorted(self._imported_service_modules().items()):
             for dotted in sorted(imported):
-                module = importlib.import_module(dotted)
-                if not hasattr(module, "RULE_SET_VERSION"):
+                if not self._owned_version_constants(dotted):
                     continue
                 if dotted.rsplit(".", 1)[-1] not in INPUT_RULE_SETS:
                     missing.append(f"{strategy_module} reads {dotted}")
@@ -430,7 +475,7 @@ class TestVocabularyIsDefinedOnce:
         """Pins the resolution itself: a helper that silently fell back to 255
         would agree with a stale Python Literal and prove nothing."""
         name, _ = self._defining_migration("strategy_signals", "not_evaluable_reason")
-        assert name == "270_strategy_signals_unusable_fill_price.sql"
+        assert name == "351_strategy_signals_missing_market_context.sql"
 
     def test_sql_reason_codes_match_the_python_vocabulary(self) -> None:
         assert self._check_values("strategy_signals", "not_evaluable_reason") == NOT_EVALUABLE_REASONS

--- a/tests/test_strategy_s6.py
+++ b/tests/test_strategy_s6.py
@@ -1,0 +1,492 @@
+"""S-6 — resistance breakout with volume confirmation (#2437).
+
+Modules under test: ``app/services/strategies/s6_resistance_breakout.py``,
+``app/services/market_context.py``, and the ``LevelScan`` hoist in
+``app/services/price_levels.py``.
+
+⚠ THE EXPECTED VALUES ARE CONSTRUCTED, NOT IMPORTED, wherever a constant is the
+thing under test. ``test_strategy_manifest``'s module docstring states the rule:
+*"a reference that imports the constant it validates is a tautology"*. So the
+volume-boundary tests build a fixture at exactly 1.2x and exactly below it from
+literals, rather than asserting ``ratio >= VOLUME_MULTIPLE``.
+
+Pure tier: no database, no fixtures, no IO.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date, timedelta
+from decimal import Decimal
+
+import numpy as np
+import pytest
+
+from app.services.indicator_series import BarSeries, atr_series
+from app.services.market_context import BENCHMARK_SYMBOL, MarketContext
+from app.services.market_regime import Regime
+from app.services.price_levels import LevelScan, levels_at, swing_pivots
+from app.services.strategies.s6_resistance_breakout import (
+    PERMITTED_REGIMES,
+    S6_PARAMS,
+    S6_STRATEGY_ID,
+    prior_close_series,
+    s6_exit_bracket,
+    s6_identity,
+    s6_signals,
+    volume_ratio_series,
+)
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.technical_analysis import OHLCVRow
+
+UNIVERSE = "survivor_only"
+REASON = "quarantined_bar"
+START = date(2020, 1, 1)
+
+
+def _bars(
+    highs: Sequence[float | None],
+    lows: Sequence[float | None],
+    closes: Sequence[float | None],
+    volumes: Sequence[int | None],
+) -> BarSeries:
+    rows: list[OHLCVRow] = [
+        {
+            "open": None if c is None else Decimal(str(c)),
+            "high": None if h is None else Decimal(str(h)),
+            "low": None if lo is None else Decimal(str(lo)),
+            "close": None if c is None else Decimal(str(c)),
+            "volume": v,
+        }  # type: ignore[typeddict-item]
+        for h, lo, c, v in zip(highs, lows, closes, volumes, strict=True)
+    ]
+    return BarSeries(dates=tuple(START + timedelta(days=i) for i in range(len(closes))), rows=tuple(rows))
+
+
+def _all_bull(series: BarSeries) -> MarketContext:
+    """Every session classified ``bull_quiet``, so the regime gate never binds."""
+    return MarketContext(
+        regime_by_date={when: Regime.BULL_QUIET for when in series.dates},
+        first_classified=series.dates[0],
+        benchmark_instrument_id=1,
+        benchmark_symbol=BENCHMARK_SYMBOL,
+    )
+
+
+class TestVolumeWindowBoundary:
+    """⚠ THE WINDOW EXCLUDES ``t`` AND THE COMPARISON IS ``>=``.
+
+    Both are stated in the module docstring and neither is observable from a
+    happy-path fixture, so they are pinned at the boundary. The exclusion is
+    what stops a breakout bar's own volume inflating the average it must clear.
+    """
+
+    @staticmethod
+    def _series(volumes: Sequence[int]) -> BarSeries:
+        n = len(volumes)
+        return _bars([10.0] * n, [9.0] * n, [9.5] * n, list(volumes))
+
+    def test_the_average_excludes_the_bar_itself(self) -> None:
+        # Twenty bars of 100, then one of 1,000. Excluding t: 1000/100 = 10.0.
+        # Including t would give 1000 / ((20*100 + 1000)/21) = 7.0.
+        series = self._series([100] * 20 + [1_000])
+        ratio = volume_ratio_series(series, universe=UNIVERSE).values[20]
+        assert ratio == pytest.approx(10.0)
+
+    def test_exactly_the_multiple_qualifies_and_a_hair_under_does_not(self) -> None:
+        """§3 says ``volume(t) >= 1.2 x``, so 120 on an average of 100 fires."""
+        at_the_bound = self._series([100] * 20 + [120])
+        just_under = self._series([100] * 20 + [119])
+        assert volume_ratio_series(at_the_bound, universe=UNIVERSE).values[20] == pytest.approx(1.2)
+        assert volume_ratio_series(just_under, universe=UNIVERSE).values[20] == pytest.approx(1.19)
+
+    def test_the_first_full_window_is_index_twenty(self) -> None:
+        series = self._series([100] * 30)
+        values = volume_ratio_series(series, universe=UNIVERSE).values
+        assert values[19] is None, "index 19 has only 19 prior bars — warm-up"
+        assert values[20] is not None
+
+    def test_a_missing_volume_is_a_data_refusal_not_warm_up(self) -> None:
+        """⚠ Criterion 8: a present-and-empty field is a gap, not a warm window."""
+        volumes: list[int | None] = [100] * 30
+        volumes[5] = None
+        n = len(volumes)
+        series = _bars([10.0] * n, [9.0] * n, [9.5] * n, volumes)
+        result = volume_ratio_series(series, universe=UNIVERSE)
+        # Bars 20..25 have index 5 inside their trailing window.
+        assert set(range(20, 26)) <= set(result.not_evaluable_indices)
+        assert 26 not in result.not_evaluable_indices
+
+    def test_an_all_zero_window_is_refused_rather_than_dividing(self) -> None:
+        """A halted name must not report every later bar as an infinite surge."""
+        series = self._series([0] * 20 + [5])
+        assert 20 in volume_ratio_series(series, universe=UNIVERSE).not_evaluable_indices
+
+
+class TestPriorCloseSeries:
+    def test_index_zero_is_warm_up_not_a_refusal(self) -> None:
+        series = _bars([10.0] * 4, [9.0] * 4, [9.5] * 4, [100] * 4)
+        result = prior_close_series(series, universe=UNIVERSE)
+        assert result.values[0] is None
+        assert 0 not in result.not_evaluable_indices
+        assert result.values[1] == pytest.approx(9.5)
+
+    def test_a_masked_previous_close_refuses_the_next_bar(self) -> None:
+        series = _bars([10.0] * 4, [9.0] * 4, [9.5, None, 9.5, 9.5], [100] * 4)
+        result = prior_close_series(series, universe=UNIVERSE)
+        assert 2 in result.not_evaluable_indices
+        assert 3 not in result.not_evaluable_indices
+
+
+class TestRegimeGate:
+    """⚠ THE THREE STATES OF ``gate_series``, WHICH IS THE WHOLE POINT OF IT."""
+
+    @staticmethod
+    def _dates(n: int) -> tuple[date, ...]:
+        return tuple(START + timedelta(days=i) for i in range(n))
+
+    def test_a_permitted_regime_is_one_and_a_refused_one_is_zero_not_none(self) -> None:
+        """⚠ A refused regime is a VERDICT. Reporting it unevaluable would delete
+        the denominator that shows the gate working (spec §0 rule 2)."""
+        dates = self._dates(3)
+        context = MarketContext(
+            regime_by_date={dates[0]: Regime.BULL_QUIET, dates[1]: Regime.BEAR_QUIET, dates[2]: Regime.BULL_VOLATILE},
+            first_classified=dates[0],
+            benchmark_instrument_id=1,
+            benchmark_symbol="SPY",
+        )
+        gate = context.gate_series(dates, allowed=frozenset({Regime.BULL_QUIET}), universe=UNIVERSE)
+        assert gate.values == (1.0, 0.0, 0.0)
+        assert gate.not_evaluable_indices == ()
+
+    def test_before_the_first_classified_bar_is_warm_up_after_it_is_a_gap(self) -> None:
+        """⚠⚠ THE SPLIT THE ELEVENTH REASON CODE EXISTS FOR. Both are ``None``;
+        only one is listed, and the registry reads the difference."""
+        dates = self._dates(4)
+        context = MarketContext(
+            regime_by_date={dates[1]: Regime.BULL_QUIET},
+            first_classified=dates[1],
+            benchmark_instrument_id=1,
+            benchmark_symbol="SPY",
+        )
+        gate = context.gate_series(dates, allowed=frozenset({Regime.BULL_QUIET}), universe=UNIVERSE)
+        assert gate.values == (None, 1.0, None, None)
+        assert 0 not in gate.not_evaluable_indices, "before the benchmark started — warm-up"
+        assert {2, 3} <= set(gate.not_evaluable_indices), "after it started, with no session — a hole"
+
+    def test_an_empty_allowed_set_is_rejected(self) -> None:
+        dates = self._dates(2)
+        context = MarketContext(
+            regime_by_date={dates[0]: Regime.BULL_QUIET},
+            first_classified=dates[0],
+            benchmark_instrument_id=1,
+            benchmark_symbol="SPY",
+        )
+        with pytest.raises(ValueError, match="can never fire"):
+            context.gate_series(dates, allowed=frozenset(), universe=UNIVERSE)
+
+
+class TestLevelScanReproducesTheScalarForm:
+    """⚠ The hoist is a PERFORMANCE change and must not be a behavioural one.
+
+    ``levels_at`` now builds a ``LevelScan`` and calls ``at``, so there is one
+    code path — but the equivalence that made the hoist legal (a pivot's verdict
+    depends only on its own +/- 5 bars, never on where the observer stands) is
+    the claim, and it is asserted rather than argued.
+    """
+
+    @staticmethod
+    def _wavy(n: int = 120) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        i = np.arange(n, dtype=float)
+        highs = 100.0 + 5.0 * np.sin(i / 3.0) + 0.4 * np.sin(i / 11.0)
+        lows = highs - 2.0
+        volumes = np.full(n, 1_000.0)
+        return highs, lows, volumes
+
+    def test_the_hoisted_and_scalar_forms_agree_at_every_index(self) -> None:
+        highs, lows, volumes = self._wavy()
+        scan = LevelScan.build(highs=highs, lows=lows, volumes=volumes)
+        seen = 0
+        for index in range(highs.size):
+            hoisted = scan.at(atr=1.5, index=index)
+            scalar = levels_at(highs=highs, lows=lows, volumes=volumes, atr=1.5, index=index)
+            assert hoisted == scalar
+            seen += len(hoisted)
+        assert seen > 0, "a fixture with no levels would make this vacuous"
+
+    def test_a_pivot_is_never_reported_before_it_is_confirmed(self) -> None:
+        """⚠⚠ The lookahead this whole construction exists to prevent. The last
+        candidate is ``index - 5``, so a pivot at ``index`` is unknowable."""
+        highs, lows, _ = self._wavy()
+        pivots = swing_pivots(highs, lows)
+        assert pivots.high_indices, "no pivots detected — the fixture proves nothing"
+        for index in range(20, highs.size):
+            live = LevelScan.build(highs=highs, lows=lows, volumes=None).at(atr=1.5, index=index)
+            for level in live:
+                assert level.last_touch_index <= index - pivots.half_window
+
+    def test_ragged_inputs_raise_rather_than_returning_nothing(self) -> None:
+        with pytest.raises(ValueError, match="must align"):
+            LevelScan.build(highs=np.zeros(5), lows=np.zeros(4), volumes=None)
+
+
+class TestS6Fires:
+    """A constructed breakout, and the four ways it is refused."""
+
+    @staticmethod
+    def _breakout_series(*, final_volume: int = 5_000, final_close: float = 108.0) -> BarSeries:
+        """Three touches of a ~105 resistance, then a close through it.
+
+        Built rather than sampled: the level has to be a real 3-touch cluster or
+        the fixture proves nothing about the rule.
+        """
+        highs: list[float] = []
+        lows: list[float] = []
+        closes: list[float] = []
+        for i in range(60):
+            # Three symmetric peaks at 105, each isolated by 5 quiet bars.
+            if i in (15, 30, 45):
+                high = 105.0
+            elif i % 15 in (7, 8):
+                high = 99.0
+            else:
+                high = 101.0 + (i % 3) * 0.2
+            highs.append(high)
+            lows.append(high - 3.0)
+            closes.append(high - 1.5)
+        highs.append(final_close + 1.0)
+        lows.append(final_close - 2.0)
+        closes.append(final_close)
+        highs.append(final_close + 1.0)
+        lows.append(final_close - 2.0)
+        closes.append(final_close)
+        volumes = [1_000] * 60 + [final_volume, 1_000]
+        return _bars(highs, lows, closes, volumes)
+
+    def test_the_fixture_fires(self) -> None:
+        series = self._breakout_series()
+        signals = s6_signals(series, universe=UNIVERSE, masked_reason=REASON, market=_all_bull(series))
+        assert any(signal.verdict == "fired" for signal in signals), (
+            "the fixture never fires, so every refusal test below would pass vacuously"
+        )
+
+    def test_thin_volume_refuses_the_same_bar(self) -> None:
+        """1,000 against a 1,000 average is a ratio of 1.0, under the 1.2 bar."""
+        series = self._breakout_series(final_volume=1_000)
+        signals = s6_signals(series, universe=UNIVERSE, masked_reason=REASON, market=_all_bull(series))
+        assert not any(signal.verdict == "fired" for signal in signals)
+
+    def test_no_close_through_the_level_refuses(self) -> None:
+        series = self._breakout_series(final_close=102.0)
+        signals = s6_signals(series, universe=UNIVERSE, masked_reason=REASON, market=_all_bull(series))
+        assert not any(signal.verdict == "fired" for signal in signals)
+
+    def test_a_refused_regime_is_not_fired_not_unevaluable(self) -> None:
+        """⚠ The bar was JUDGED and declined — it must not vanish into a refusal."""
+        series = self._breakout_series()
+        bear = MarketContext(
+            regime_by_date={when: Regime.BEAR_QUIET for when in series.dates},
+            first_classified=series.dates[0],
+            benchmark_instrument_id=1,
+            benchmark_symbol="SPY",
+        )
+        signals = s6_signals(series, universe=UNIVERSE, masked_reason=REASON, market=bear)
+        assert not any(signal.verdict == "fired" for signal in signals)
+        assert signals[60].verdict == "not_fired"
+        assert signals[60].reason is None
+
+    def test_a_missing_benchmark_session_refuses_with_the_eleventh_code(self) -> None:
+        """⚠ NOT ``not_fired``. The strategy could not decide, and the reason
+        names whose data was missing."""
+        series = self._breakout_series()
+        holed = MarketContext(
+            regime_by_date={when: Regime.BULL_QUIET for when in series.dates if when != series.dates[60]},
+            first_classified=series.dates[0],
+            benchmark_instrument_id=1,
+            benchmark_symbol="SPY",
+        )
+        signals = s6_signals(series, universe=UNIVERSE, masked_reason=REASON, market=holed)
+        assert signals[60].verdict == "not_evaluable"
+        assert signals[60].reason == "missing_market_context"
+
+    def test_the_permitted_set_is_bull_quiet_only(self) -> None:
+        """⚠ §3 excludes ``bull_volatile`` BY NAME — breakouts into a Bulge are
+        the classic false-break regime. Pinned as a literal, not imported."""
+        assert {regime.value for regime in PERMITTED_REGIMES} == {"bull_quiet"}
+
+
+class TestS6ExitBracket:
+    """⚠⚠ THE STOP IS ANCHORED TO THE LEVEL, THE TARGET TO THE ENTRY."""
+
+    def test_the_stop_is_measured_from_the_level_and_the_target_from_the_entry(self) -> None:
+        series = TestS6Fires._breakout_series()
+        signal_index = 60
+        entry_price = Decimal("108.5")
+        target, stop, max_hold = s6_exit_bracket(
+            series, signal_index=signal_index, entry_price=entry_price, universe=UNIVERSE
+        )
+        atr = atr_series(series, universe=UNIVERSE, period=14).values[signal_index]
+        assert atr is not None
+        assert target == entry_price + Decimal("3.0") * Decimal(str(atr))
+        assert max_hold == 40
+
+        # ⚠ The stop is NOT entry-anchored, and this is the assertion that says
+        # so: adding the one ATR back must land exactly on a live RESISTANCE
+        # level, which no entry-relative stop could do.
+        implied_level = float(stop) + atr
+        live = LevelScan.build(
+            highs=series.array_highs,
+            lows=series.array_lows,
+            volumes=np.array([float(row["volume"] or 0) for row in series.rows]),
+        ).at(atr=atr, index=signal_index)
+        resistances = [level.price for level in live if level.kind == "resistance"]
+        assert any(implied_level == pytest.approx(price) for price in resistances), (
+            f"stop+ATR = {implied_level} is not one of the live resistances {resistances}"
+        )
+        assert float(stop) < float(entry_price) - atr, "an entry-anchored 1xATR stop would sit higher"
+
+    def test_a_bracket_is_refused_for_a_bar_that_cannot_have_fired(self) -> None:
+        """⚠ Asking for a bracket where no level exists is a caller bug, not a
+        default. Silently returning an entry-anchored stop would be S-4's rule
+        wearing S-6's name."""
+        n = 40
+        flat = _bars([10.0] * n, [9.0] * n, [9.5] * n, [100] * n)
+        with pytest.raises(ValueError, match="no live resistance"):
+            s6_exit_bracket(flat, signal_index=30, entry_price=Decimal("9.5"), universe=UNIVERSE)
+
+    def test_the_manifest_converts_every_refusal_into_the_resolver_vocabulary(self) -> None:
+        """The adapter must not leak ``ValueError`` into the outcome pipeline."""
+        n = 40
+        flat = _bars([10.0] * n, [9.0] * n, [9.5] * n, [100] * n)
+        entry = STRATEGY_MANIFEST[S6_STRATEGY_ID]
+        assert entry.exit_levels is not None
+        assert (
+            entry.exit_levels(flat, signal_index=30, entry_price=Decimal("9.5"), universe=UNIVERSE)
+            == "unorderable_exit_levels"
+        )
+
+
+class TestSegmentLocalStateIsPreservedAcrossTheSignalExitBoundary:
+    """⚠⚠ CODEX CHECKPOINT-2 P1, MEASURED AND REBUTTED — and pinned so it stays so.
+
+    The claim: ``segmented_signals`` evaluates S-6 inside a price-scale segment
+    with fresh indicator state, while the outcome resolver later calls
+    ``s6_exit_bracket`` with the FULL series — so a signal that fired on
+    segment-local ATR and levels would get a bracket built from pre-break
+    history, and could even get a spurious ``unorderable_exit_levels``.
+
+    It does not happen, because BOTH consumers segment before calling:
+
+    * ``strategy_outcome_resolution._resolve_one`` calls ``segment_for_index``
+      and passes ``(signal_segment, local_signal_index)``;
+    * ``backtest_run._exit_levels_for_entries`` walks ``series_segment_bounds``,
+      rebuilds a ``BarSeries`` per segment and passes the local index.
+
+    Segmentation is the CALLER's job and is uniform across S-4 and S-6, so the
+    bracket sees exactly the bars the signal did. That is a property of code this
+    branch does not own, which is precisely why it is asserted here rather than
+    argued: if either caller ever stops segmenting, this fails.
+    """
+
+    @staticmethod
+    def _series_with_a_scale_break() -> tuple[BarSeries, date]:
+        """A breakout series preceded by history at a 10x different price scale."""
+        tail = TestS6Fires._breakout_series()
+        n_pre = 40
+        pre_highs = [1_000.0 + (i % 5) for i in range(n_pre)]
+        highs = pre_highs + [float(row["high"]) for row in tail.rows]  # type: ignore[arg-type]
+        lows = [h - 30.0 for h in pre_highs] + [float(row["low"]) for row in tail.rows]  # type: ignore[arg-type]
+        closes = [h - 15.0 for h in pre_highs] + [float(row["close"]) for row in tail.rows]  # type: ignore[arg-type]
+        volumes: list[int | None] = [1_000] * n_pre + [row["volume"] for row in tail.rows]
+        joined = _bars(highs, lows, closes, volumes)
+        return joined, joined.dates[n_pre]
+
+    def test_the_bracket_uses_the_segment_the_signal_fired_in(self) -> None:
+        from app.services.price_segments import segment_for_index
+
+        series, break_date = self._series_with_a_scale_break()
+        segment, local_index = segment_for_index(series, index=100, unresolved_breaks=[break_date])
+        entry_price = Decimal("108.5")
+
+        segment_bracket = s6_exit_bracket(segment, signal_index=local_index, entry_price=entry_price, universe=UNIVERSE)
+        full_bracket = s6_exit_bracket(series, signal_index=100, entry_price=entry_price, universe=UNIVERSE)
+
+        # ⚠ The two DISAGREE, which is what makes the caller's segmentation
+        # load-bearing rather than decorative. A fixture where they matched
+        # would assert nothing.
+        assert segment_bracket != full_bracket, (
+            "the pre-break history changed neither ATR nor the level, so this fixture cannot "
+            "detect a caller that forgot to segment"
+        )
+
+    def test_both_consumers_pass_a_segment_local_series(self) -> None:
+        """⚠ Read from the SOURCE, not from a docstring — the rebuttal above is
+        only true while these two call sites keep doing it."""
+        from pathlib import Path
+
+        from app.services import backtest_run, strategy_outcome_resolution
+
+        resolution = Path(strategy_outcome_resolution.__file__).read_text()
+        assert "segment_for_index(" in resolution
+        assert "entry.exit_levels(\n        signal_segment," in resolution
+
+        backtest = Path(backtest_run.__file__).read_text()
+        assert "for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):" in backtest
+        assert "signal_series = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])" in backtest
+
+
+class TestS6Identity:
+    def test_the_benchmark_and_the_regime_domain_are_in_the_identity(self) -> None:
+        """⚠⚠ Neither travels via ``INPUT_RULE_SETS``, which names the CLASSIFIER
+        and not the series it ran over. An S-6 gated on QQQ would otherwise share
+        this one's version with an identical source hash."""
+        assert S6_PARAMS["benchmark_symbol"] == "SPY"
+        assert S6_PARAMS["permitted_regimes"] == ["bull_quiet"]
+
+    def test_a_blank_cost_model_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="non-empty declaration"):
+            s6_identity(universe=UNIVERSE, cost_model_id="   ")
+
+
+class TestManifestWiring:
+    def test_s6_declares_that_it_requires_a_market_context(self) -> None:
+        assert STRATEGY_MANIFEST[S6_STRATEGY_ID].requires_market_context is True
+
+    def test_no_other_strategy_claims_to(self) -> None:
+        gated = {key for key, entry in STRATEGY_MANIFEST.items() if entry.requires_market_context}
+        assert gated == {S6_STRATEGY_ID}
+
+    def test_the_adapter_refuses_rather_than_scanning_ungated(self) -> None:
+        """⚠ FAIL-CLOSED IN THE RIGHT DIRECTION. Running S-6 without its gate
+        produces MORE signals, in markets its rule excludes by name."""
+        entry = STRATEGY_MANIFEST[S6_STRATEGY_ID]
+        assert entry.signals is not None
+        series = TestS6Fires._breakout_series()
+        with pytest.raises(ValueError, match="gated on the market regime"):
+            entry.signals(series, universe=UNIVERSE, masked_reason=REASON, market=None)
+
+    def test_the_uniform_call_equals_the_direct_call(self) -> None:
+        entry = STRATEGY_MANIFEST[S6_STRATEGY_ID]
+        assert entry.signals is not None
+        series = TestS6Fires._breakout_series()
+        market = _all_bull(series)
+        via_manifest = entry.signals(series, universe=UNIVERSE, masked_reason=REASON, market=market)
+        assert via_manifest == s6_signals(series, universe=UNIVERSE, masked_reason=REASON, market=market)
+        assert any(signal.verdict == "fired" for signal in via_manifest)
+
+
+class TestBenchmarkFreshnessIsSomebodysJob:
+    """⚠ The #1818 prevention entry, enforced rather than restated.
+
+    *"when a read path pins a specific symbol/entity, that symbol must appear in
+    … the ingest scope that maintains its data — and a test should pin the
+    cross-reference"*. SPX500 froze for weeks because nothing did this.
+    """
+
+    def test_the_benchmark_symbol_is_in_the_refresh_scope(self) -> None:
+        from app.workers.scheduler import BENCHMARK_SYMBOLS
+
+        assert BENCHMARK_SYMBOL in BENCHMARK_SYMBOLS, (
+            f"{BENCHMARK_SYMBOL} gates every regime-aware strategy but is not in the candle-refresh scope, "
+            "so its series would freeze silently and the gate would go blind"
+        )


### PR DESCRIPTION
## What this is

**S-6, resistance breakout with volume confirmation** — the first complete strategy from
`docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md` §3, and the first **regime-gated**
strategy in the catalogue. It consumes the shared foundation landed in `16563dab`
(`market_regime`, `price_levels`) and is registered, scannable, and visible on
`/strategies`.

**The rule, from §3 verbatim:** setup is a live resistance level with regime ∈ {`bull_quiet`};
signal is `close(t) > level` **and** `volume(t) ≥ 1.2 × 20-bar average volume`; exit is a stop
at `level − 1.0 × ATR(14)`, a target at `entry + 3.0 × ATR(14)`, max hold 40 bars.

## Does it actually fire?

Premise falsified on the **full validated universe before any code was written**, then
reproduced through the shipped strategy. Both agree exactly.

`uv run python scripts/verify_2437_s6_resistance_breakout.py --census`

| | |
|---|---|
| instruments scanned | 3,854 (2,920 excluded, <250 bars) |
| bar verdicts | 3,217,992 |
| **fired** | **27,744 (0.86%)** |
| not_fired | 2,396,731 (74.48%) |
| not_evaluable | 793,517 (24.66%) |
| **fire rate per decided bar** | **1.1443%** |
| **instruments that ever fire** | **91.77% (3,537)** |

≈33 signals a day across the universe. The binding rejection is the breakout itself
(1,218,577 of the 1,290,429 bars that had a resistance above), not the regime gate and not
level availability.

Refusals, all countable:

| reason | count | share |
|---|---|---|
| `missing_volume` | 648,524 | 20.15% |
| `insufficient_warmup` | 81,909 | 2.55% |
| `quarantined_bar` | 56,417 | 1.75% |
| `no_fill_bar` | 3,854 | 0.12% |
| `missing_market_context` | 2,813 | 0.09% |

## Three decisions that were not in the spec, and how each was fixed

**1. Which resistance, when several are live.** §3 says *"live resistance level"* without
saying which, and the choice is load-bearing because the stop is anchored to it. No published
rule exists, so it is fixed **by construction** and declared: *the lowest live resistance
strictly above `close(t-1)`*. It is determined before bar `t` opens, so the level is not chosen
knowing where the close landed, and it is unique — "closest to `close(t)`" is ambiguous on an
overshoot and would let a large up-day silently re-select a further stop. `PriceLevel.strength`
is deliberately **not** used to select: `price_levels` says strength *"is NEVER compared to a
threshold"*, and picking the strongest would make it decide the trade.

**2. Whether the 20-bar volume average includes `t`.** It excludes it, for S-4's reason in its
own words — including it makes the condition *"partly self-referential"*, since a bar with
enough volume to break out raises the average it must clear. Pinned at the boundary by
`TestVolumeWindowBoundary` (exactly 1.2× fires, 1.19× does not).

**3. The stop is anchored to the LEVEL, the target to the ENTRY.** This is §3 verbatim
(*"back inside the range = failed break"* is a statement about the level) and it is
deliberately asymmetric with S-4, whose bracket is entry-relative on both legs. A gap-up fill
therefore makes the stop distance wider than 1×ATR, and a fill that gaps more than 1×ATR above
the level is **refused** as `unorderable_exit_levels` rather than entered with a "stop" above
the entry.

## The eleventh reason code — `missing_market_context` (sql/351)

S-6 gates on SPY's regime, so a bar of AAPL is unjudgeable when SPY has no classifiable session
that day. The instrument's own bar is perfect; the strategy still cannot decide. None of the ten
existing codes describes that — it is the first that is a property of a **different instrument**
than the one being judged.

It is **not** `insufficient_warmup`, and the split was measured before it was written. Over all
3,650,325 loadable bars in the validated universe:

| | bars | share | |
|---|---|---|---|
| regime known | 3,112,351 | 85.26% | |
| before the benchmark's first classifiable bar | 528,569 | 14.48% | genuinely warm-up |
| benchmark has no session at all | **9,405** | 0.26% | over **353 dates** |

The third class is not empty, which is the whole argument. Its worst single date is
**2026-02-06: 1,735 instruments traded and SPY has no bar.** Collapsing it into warm-up would
report a permanent hole as a series that had not started yet — criterion 8's exact prohibition.

`sql/351` widens **all three** tables carrying the vocabulary (`strategy_signals`,
`strategy_signal_daily_counts`, `strategy_signal_observations`). The prevention log's *"a closed
vocabulary declared in three places is validated in none of them"* is precisely this shape.

## A performance defect that would have made S-6 unrunnable

`strategy_signal_scan._scan_per_series` evaluates a strategy over the **whole** series and
filters its output, so a level strategy needs levels at every bar. The committed `levels_at`
re-detected pivots inside every call with a per-index Python loop — measured at **3.61 ms/bar**
on SPY, extrapolating to **343 minutes** for one universe pass.

`LevelScan` hoists detection to one vectorised whole-series pass. This is legal because a
pivot's verdict depends only on its own ±5 bars and never on where the observer stands, so
filtering by `index − half_window` reproduces "confirmed by `index`" exactly. It is **one code
path**, not a second implementation — `levels_at` now builds a `LevelScan` and calls `at`, so
there is no oracle to keep in agreement.

Verified: **21,000 (instrument, bar) pairs compared, 0 mismatches** (`--equivalence`), plus an
offline check against the pre-refactor module at `HEAD` across 4 instruments including
quarantine-masked ones and the `volumes=None` arm — 0 mismatches on both arms. The
end-to-end result: the full-population census runs in **91 seconds**.

⚠ `--equivalence` reports only ~2× because it times `LevelScan.at` against the *current*
`levels_at`, which already gets vectorised detection. The 24× is against the form replaced. Both
subjects are named in the docstring so the two are not conflated.

## Identity and versioning

`INPUT_RULE_SETS` now carries `market_regime` and `price_levels`. This **moves S-1…S-4's
identities** even though none of them reads either — that is the registry-wide trade #2333
documented, paid rather than dodged. The alternative (a per-strategy declaration so only S-6
moves) is exactly the *"field they must remember to fill"* that constant exists to remove. Cost
measured before taking it: 10,524 stored `strategy_signals` rows across the three strategies
that have any, already spread over 2-3 versions each.

⚠ **The completeness guard would have missed this entirely.**
`TestInputRuleSetsAreComplete` matched on the literal name `RULE_SET_VERSION`;
`market_regime` and `price_levels` name theirs `REGIME_RULE_VERSION` and `LEVEL_RULE_VERSION`,
so a strategy reading both would have passed a guard whose whole purpose is to catch that. It
now matches any module-level **assignment** ending in `_VERSION` — assignments and not
`hasattr`, because `strategy_registry` re-exports one under an alias and would otherwise be
required to register itself. `test_the_version_walk_distinguishes_owned_from_reexported` pins
the distinction.

`benchmark_symbol` and `permitted_regimes` are in `S6_PARAMS` for a separate reason:
`INPUT_RULE_SETS` names the **classifier**, not the **series it ran over**. An S-6 gated on
QQQ's regime would otherwise share this one's version under an identical source hash.

## Fail-closed, in the right direction

Running S-6 without its gate does not produce *fewer* signals — it produces **more**, in every
market including the `bull_volatile` Bulge §3 excludes by name, and stores them under S-6's
identity. So:

- `StrategyEntry.requires_market_context` is **declared**, not inferred from the signature
  (every per-series adapter now accepts `market`, so the signature no longer answers the
  question).
- `segmented_signals` refuses before evaluating; the S-6 adapter refuses again for direct
  callers.
- `strategy_signal_scan` builds the context **once**, and a failure refuses only the gated
  strategies — under a new named status `refused_no_market_context`, not `failed`, because
  nothing is wrong with the strategy. S-1…S-4 still run.
- `backtest_run` excludes S-6 **by name** through the existing `ExcludedStrategy` channel: the
  research corpus has no classified benchmark series yet, and a silent drop is the narrowing
  criterion 9 forbids.

## Codex checkpoint 2 — one P1, measured and rebutted

> *"When a signal occurs after an `unresolved_break`, `segmented_signals` calculates S-6's ATR
> and resistance using only the reset segment, but the outcome resolver later calls this
> function with the full series."*

**Rebutted.** Both consumers already segment before calling:
`strategy_outcome_resolution._resolve_one` calls `segment_for_index` and passes
`(signal_segment, local_signal_index)`; `backtest_run._exit_levels_for_entries` walks
`series_segment_bounds`, rebuilds a `BarSeries` per segment and passes the local index.
Segmentation is the caller's job and is uniform across S-4 and S-6.

Because that is a property of code this branch does not own, it is **pinned rather than
argued** — `TestSegmentLocalStateIsPreservedAcrossTheSignalExitBoundary` builds a series with a
10× scale break, asserts the segment-local and full-series brackets **disagree** (so the fixture
can actually detect a caller that forgot), and reads both call sites from source.

## Two data findings, noted not ticketed

- **26.13% of validated-universe bars have NULL volume** (953,844 bars, 4,302 of 6,774
  instruments). S-6 requires volume by spec, so it honestly refuses them as `missing_volume` —
  a real ceiling on its addressable corpus, not a bug in the strategy.
- **Our stored SPY series has 353 dates with no bar** inside its own classified span. Most are
  thin weekend/holiday rows contributed by `.24-7` instruments, but a minority are ordinary
  sessions (2023-06-30, a Friday, has 237 instruments trading and no SPY bar). SPY *is* in
  `scheduler.BENCHMARK_SYMBOLS`, so the gaps predate that scope or were dropped by a failed
  fetch. Every regime-gated strategy is blind on those days — honestly and countably.

## Security model

No new surface. No endpoint, no auth path, no user input, no credential handling, no broker
call. The migration widens three `CHECK` constraints; it adds no column and drops no data.

## Not in this PR, and stated so it is not assumed

**S-6 cannot be backtested yet.** The market context is built from `price_daily`; the research
corpus (`research_price_*`) has separate benchmark series that are not yet classified. S-6 is
excluded from `backtest_run` **by name** until that exists. That is the next step for the
walk-forward validation in §0, and it is the honest state — not a silent gap.

## Verification

| gate | result |
|---|---|
| `ruff check` / `ruff format --check` | clean |
| `pyright` | 0 errors |
| fast tier (`-m "not db"`) | pass |
| `tests/smoke` | pass |
| db tier (touched modules) | pass |
| `--market` | benchmark SPY (3000), 845 classified sessions, `bull_quiet` 89.35% |
| `--equivalence` | 21,000 pairs, 0 mismatches |
| `--scan` (real runner, 200 instruments) | 1,317 fires; all three refusal classes present |
| `--census` (full population) | 27,744 fires, 91.77% of instruments |
| migration 351 | applied to dev DB |

⚠ The `bull_quiet` share is 89.35% of classified sessions on a corpus running 2023-02 → 2026-08,
which is a predominantly bullish span. The regime gate barely bites here. That is a property of
the available corpus, not evidence the gate is loose, and it is exactly why §0 requires
per-regime blocks rather than one pooled number.

Refs #2437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
