### PR TITLE
perf(#2437): hoist whole-series pivot detection out of the per-bar level lookup

### DIFF
--- a/app/services/price_levels.py
+++ b/app/services/price_levels.py
@@ -29,6 +29,7 @@ tolerance the instrument's own.
 
 from __future__ import annotations
 
+import bisect
 import hashlib
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,6 +37,7 @@ from typing import Final, Literal
 
 import numpy as np
 import numpy.typing as npt
+from numpy.lib.stride_tricks import sliding_window_view
 
 #: Bars either side of a pivot that it must exceed. FROZEN BY CONSTRUCTION.
 #: Larger = fewer, more significant pivots; smaller = noise. 5 is a choice.
@@ -84,38 +86,76 @@ class PriceLevel:
     rule_set_version: str = LEVEL_RULE_VERSION
 
 
-def _swing_indices(
+@dataclass(frozen=True)
+class PivotSet:
+    """Every confirmed swing pivot in one series, detected once.
+
+    ⚠⚠ A PIVOT IS ONLY CONFIRMED ``half_window`` BARS AFTER IT HAPPENS. Whether
+    index ``i`` is a swing high is decided ENTIRELY by bars ``i - half_window ..
+    i + half_window`` and by nothing else, so the verdict is the same whether it
+    is computed while standing at bar ``i + half_window`` or at the end of the
+    series. That independence is what makes precomputing the whole series safe,
+    and it is why ``LevelScan.at`` filters by ``index - half_window`` rather than
+    re-detecting: the filter reproduces "confirmed by bar ``index``" exactly.
+
+    Reading a pivot at ``index`` itself would be lookahead of the most seductive
+    kind — it reads as "today is a swing high", which cannot be known today. It
+    needs the next ``half_window`` bars to fail to exceed it. Every level built
+    from such a pivot would be fitted to bars the strategy has not seen, and the
+    resulting backtest would be silently, spectacularly optimistic.
+    """
+
+    #: Ascending, so ``LevelScan.at`` can bisect rather than filter.
+    high_indices: tuple[int, ...]
+    low_indices: tuple[int, ...]
+    half_window: int
+
+
+def swing_pivots(
     highs: npt.NDArray[np.float64],
     lows: npt.NDArray[np.float64],
     *,
-    upto: int,
-    half_window: int,
-) -> tuple[list[int], list[int]]:
-    """Confirmed swing highs and lows in bars ``<= upto``.
+    half_window: int = PIVOT_HALF_WINDOW,
+) -> PivotSet:
+    """Detect every confirmed swing high and low in one vectorised pass.
 
-    ⚠⚠ A PIVOT IS ONLY CONFIRMED ``half_window`` BARS AFTER IT HAPPENS, and this
-    function refuses to return unconfirmed ones. The last candidate index is
-    ``upto - half_window``, never ``upto``.
+    ⚠ THE TIE RULE IS ``argmax == half_window``, NOT ``high == max``, AND THE
+    DIFFERENCE IS LOAD-BEARING. ``argmax`` returns the FIRST occurrence, so when
+    two bars in a window share the maximum only the earlier one is a pivot. The
+    redundant-looking ``>=`` comparison is kept beside it because the two
+    together are the rule as written, and dropping either changes which of two
+    equal highs is called the turn.
 
-    Returning a pivot at ``upto`` would be lookahead of the most seductive kind:
-    it reads as "today is a swing high", which cannot be known today — it needs
-    the next ``half_window`` bars to fail to exceed it. Every level built from
-    such a pivot would be fitted to bars the strategy has not seen, and the
-    resulting backtest would be silently, spectacularly optimistic.
+    ⚠ A non-finite value in EITHER window disqualifies BOTH kinds at that index.
+    A masked high and a masked low are equally "this bar's shape is unknown", and
+    treating them separately would let a bar with a hidden low be called a swing
+    high. The consequence is stated rather than hidden: a masked bar silently
+    removes pivot candidates, so a level that should exist may not, and a caller
+    that needs that distinction must gate on the mask itself — this function
+    reports pivots, not evaluability.
     """
-    highs_out: list[int] = []
-    lows_out: list[int] = []
-    last = upto - half_window
-    for i in range(half_window, last + 1):
-        window_hi = highs[i - half_window : i + half_window + 1]
-        window_lo = lows[i - half_window : i + half_window + 1]
-        if not np.all(np.isfinite(window_hi)) or not np.all(np.isfinite(window_lo)):
-            continue
-        if highs[i] >= np.max(window_hi) and np.argmax(window_hi) == half_window:
-            highs_out.append(i)
-        if lows[i] <= np.min(window_lo) and np.argmin(window_lo) == half_window:
-            lows_out.append(i)
-    return highs_out, lows_out
+    if half_window < 1:
+        raise ValueError(f"half_window must be at least 1, got {half_window}")
+    if highs.size != lows.size:
+        raise ValueError(f"highs/lows must align: {highs.size} highs against {lows.size} lows")
+    width = 2 * half_window + 1
+    if highs.size < width:
+        return PivotSet(high_indices=(), low_indices=(), half_window=half_window)
+
+    window_hi = sliding_window_view(highs, width)
+    window_lo = sliding_window_view(lows, width)
+    # ⚠ Row `k` of the view covers bars `k .. k + width - 1`, so its CENTRE is
+    # bar `k + half_window`. Reading row `k` as bar `k` is the off-by-five this
+    # alignment array exists to make impossible to write by accident.
+    centres = np.arange(half_window, highs.size - half_window)
+    finite = np.all(np.isfinite(window_hi), axis=1) & np.all(np.isfinite(window_lo), axis=1)
+    is_high = finite & (np.argmax(window_hi, axis=1) == half_window) & (highs[centres] >= np.max(window_hi, axis=1))
+    is_low = finite & (np.argmin(window_lo, axis=1) == half_window) & (lows[centres] <= np.min(window_lo, axis=1))
+    return PivotSet(
+        high_indices=tuple(int(i) for i in centres[is_high]),
+        low_indices=tuple(int(i) for i in centres[is_low]),
+        half_window=half_window,
+    )
 
 
 def _cluster(
@@ -158,6 +198,128 @@ def _cluster(
     return out
 
 
+@dataclass(frozen=True)
+class LevelScan:
+    """One series, prepared once, so levels can be asked for at EVERY bar.
+
+    ⚠⚠ THIS EXISTS FOR A MEASURED REASON, NOT A STYLISTIC ONE. The strategy
+    runner evaluates a strategy over a whole series and filters its OUTPUT
+    (``strategy_signal_scan._scan_per_series``: *"The strategy sees the WHOLE
+    series and the filter is applied to its output"*), so a level-based strategy
+    needs levels at every bar, not just the last one. **S-5 and S-6 both run in
+    exactly that shape**, so this is not a hypothetical access pattern.
+
+    The ORIGINAL form detected pivots inside every call with a per-index Python
+    loop, which makes a full-series walk quadratic. Both figures below are
+    measured, and each names the population it was measured over — a bare
+    speedup with an implied subject is the shape the repo rule about hand-written
+    statistics exists to stop:
+
+    * **3.61 ms/bar** — the replaced form, timed over SPY's 844 evaluable indices.
+    * **0.1532 ms/bar** — this form, timed over the **3,107,697 bars** of the
+      3,854 validated-universe instruments with enough history to be scanned.
+
+    So the full-population walk takes **476 seconds** here, against roughly
+    **187 minutes** (3,107,697 x 3.61 ms) for the form it replaces. Reproduce::
+
+        uv run python scripts/verify_2437_level_scan.py --census
+
+    ⚠ ``--equivalence`` reports a speedup of only ~2.3x, and that is NOT a
+    contradiction: it times ``LevelScan.at`` against the CURRENT ``levels_at``,
+    which builds one of these per call and therefore already gets the vectorised
+    detection. The ~24x is against the per-index loop. Two different comparisons,
+    and a reader who conflates them will think the hoist barely paid — hence both
+    subjects being named rather than one number quoted.
+
+    ⚠ IT IS NOT A SECOND IMPLEMENTATION, and that is deliberate. ``levels_at``
+    below builds one of these and calls ``at``, so there is exactly one code
+    path and no oracle to keep in agreement — the ``s4_exit_levels_batch``
+    shape, without the scalar-vs-batch divergence that shape has to test for.
+
+    ⚠ Alignment is VALIDATED, not assumed — matching ``classify_regimes``, which
+    raises on mismatched inputs. Misaligned arrays do not fail loudly:
+    ``swing_pivots`` reads ``highs[i]`` and ``lows[i]`` as the same bar, so a
+    shorter ``lows`` silently pairs each high with the WRONG bar's low and the
+    detector returns confident, wrong pivots. Raising rather than returning ()
+    because a caller handing in ragged arrays has a bug, and an empty result
+    reads as "no levels here".
+    """
+
+    highs: npt.NDArray[np.float64]
+    lows: npt.NDArray[np.float64]
+    volumes: npt.NDArray[np.float64] | None
+    pivots: PivotSet
+    #: ``nancumsum`` of ``volumes`` — the running denominator of a cluster's
+    #: volume share. ⚠ ``nancumsum`` and ``nansum`` agree by construction (both
+    #: read a NaN as a zero contribution), so this is the same number the
+    #: per-call ``nansum(volumes[: index + 1])`` produced, not an approximation.
+    volume_cumsum: npt.NDArray[np.float64] | None
+    rule_set_version: str = LEVEL_RULE_VERSION
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        highs: npt.NDArray[np.float64],
+        lows: npt.NDArray[np.float64],
+        volumes: npt.NDArray[np.float64] | None,
+    ) -> LevelScan:
+        if highs.size != lows.size:
+            raise ValueError(f"highs/lows must align: {highs.size} highs against {lows.size} lows")
+        if volumes is not None and volumes.size != highs.size:
+            raise ValueError(f"volumes must align with prices: {volumes.size} volumes against {highs.size} bars")
+        return cls(
+            highs=highs,
+            lows=lows,
+            volumes=volumes,
+            pivots=swing_pivots(highs, lows, half_window=PIVOT_HALF_WINDOW),
+            volume_cumsum=None if volumes is None else np.nancumsum(volumes),
+        )
+
+    def at(self, *, atr: float, index: int) -> tuple[PriceLevel, ...]:
+        """Live support/resistance levels as known at bar ``index``.
+
+        ⚠⚠ CAUSAL. Reads bars ``<= index`` and only pivots CONFIRMED by
+        ``index`` (see ``PivotSet``). ``atr`` must be the value at ``index`` —
+        passing a later ATR would size the clustering tolerance with information
+        from after the decision, which is the same leak in a subtler place.
+        """
+        if index < 0 or index >= self.highs.size:
+            return ()
+        if not np.isfinite(atr) or atr <= 0:
+            return ()
+        tolerance = CLUSTER_ATR_TOLERANCE * atr
+        last_confirmed = index - self.pivots.half_window
+        hi_idx = list(self.pivots.high_indices[: bisect.bisect_right(self.pivots.high_indices, last_confirmed)])
+        lo_idx = list(self.pivots.low_indices[: bisect.bisect_right(self.pivots.low_indices, last_confirmed)])
+
+        total = 0.0 if self.volume_cumsum is None else float(self.volume_cumsum[index])
+        out: list[PriceLevel] = []
+        for kind, idxs, prices in (("resistance", hi_idx, self.highs), ("support", lo_idx, self.lows)):
+            for price, cluster in _cluster(idxs, prices, self.volumes, tolerance=tolerance):
+                touches = len(cluster)
+                last_touch = max(cluster)
+                if touches < MIN_TOUCHES:
+                    continue
+                if index - last_touch > MAX_TOUCH_AGE_BARS:
+                    continue
+                if self.volumes is None:
+                    share = 1.0
+                else:
+                    share = float(np.nansum([self.volumes[i] for i in cluster])) / total if total > 0 else 0.0
+                strength = touches * float(np.log1p(share))
+                out.append(
+                    PriceLevel(
+                        price=price,
+                        kind=kind,  # type: ignore[arg-type]
+                        touches=touches,
+                        last_touch_index=last_touch,
+                        strength=strength,
+                    )
+                )
+        return tuple(sorted(out, key=lambda level: level.strength, reverse=True))
+
+
 def levels_at(
     *,
     highs: npt.NDArray[np.float64],
@@ -166,57 +328,14 @@ def levels_at(
     atr: float,
     index: int,
 ) -> tuple[PriceLevel, ...]:
-    """Live support/resistance levels as known at bar ``index``.
+    """Live support/resistance levels at ONE bar — the convenience form.
 
-    ⚠⚠ CAUSAL. Reads bars ``<= index`` and only CONFIRMED pivots (see
-    ``_swing_indices``). ``atr`` must be the value at ``index`` — passing a
-    later ATR would size the clustering tolerance with information from after
-    the decision, which is the same leak in a subtler place.
+    ⚠ Prepares a whole-series ``LevelScan`` per call, so asking for N bars this
+    way is N times the preparation. Use ``LevelScan.build`` once and ``at`` per
+    bar for anything that walks a series; this form is for a single lookup and
+    for the tests that pin the two against each other.
     """
-    # ⚠ Alignment is VALIDATED, not assumed — matching `classify_regimes`, which
-    # raises on mismatched inputs. Misaligned arrays here do not fail loudly:
-    # `_swing_indices` reads `highs[i]` and `lows[i]` as the same bar, so a
-    # shorter `lows` silently pairs each high with the WRONG bar's low and the
-    # detector returns confident, wrong pivots. An IndexError deep in `_cluster`
-    # is the lucky outcome; the unlucky one is plausible levels built from two
-    # different bars. Raising rather than returning () because a caller handing
-    # in ragged arrays has a bug, and an empty result reads as "no levels here".
-    if highs.size != lows.size:
-        raise ValueError(f"highs/lows must align: {highs.size} highs against {lows.size} lows")
-    if volumes is not None and volumes.size != highs.size:
-        raise ValueError(f"volumes must align with prices: {volumes.size} volumes against {highs.size} bars")
-    if index < 0 or index >= highs.size:
-        return ()
-    if not np.isfinite(atr) or atr <= 0:
-        return ()
-    tolerance = CLUSTER_ATR_TOLERANCE * atr
-
-    hi_idx, lo_idx = _swing_indices(highs, lows, upto=index, half_window=PIVOT_HALF_WINDOW)
-    out: list[PriceLevel] = []
-    for kind, idxs, prices in (("resistance", hi_idx, highs), ("support", lo_idx, lows)):
-        for price, cluster in _cluster(idxs, prices, volumes, tolerance=tolerance):
-            touches = len(cluster)
-            last_touch = max(cluster)
-            if touches < MIN_TOUCHES:
-                continue
-            if index - last_touch > MAX_TOUCH_AGE_BARS:
-                continue
-            if volumes is None:
-                share = 1.0
-            else:
-                total = float(np.nansum(volumes[: index + 1]))
-                share = float(np.nansum([volumes[i] for i in cluster])) / total if total > 0 else 0.0
-            strength = touches * float(np.log1p(share))
-            out.append(
-                PriceLevel(
-                    price=price,
-                    kind=kind,  # type: ignore[arg-type]
-                    touches=touches,
-                    last_touch_index=last_touch,
-                    strength=strength,
-                )
-            )
-    return tuple(sorted(out, key=lambda level: level.strength, reverse=True))
+    return LevelScan.build(highs=highs, lows=lows, volumes=volumes).at(atr=atr, index=index)
 
 
 def nearest_level(levels: tuple[PriceLevel, ...], *, price: float, kind: LevelKind, atr: float) -> PriceLevel | None:
@@ -236,7 +355,10 @@ __all__ = [
     "MIN_TOUCHES",
     "PIVOT_HALF_WINDOW",
     "LevelKind",
+    "LevelScan",
+    "PivotSet",
     "PriceLevel",
     "levels_at",
     "nearest_level",
+    "swing_pivots",
 ]

--- a/app/services/strategies/s5_support_bounce.py
+++ b/app/services/strategies/s5_support_bounce.py
@@ -53,7 +53,7 @@ from app.services.indicator_series import (
     atr_series,
 )
 from app.services.market_regime import REGIME_RULE_VERSION, Regime, RegimeSeries
-from app.services.price_levels import LEVEL_RULE_VERSION, levels_at
+from app.services.price_levels import LEVEL_RULE_VERSION, LevelScan
 from app.services.strategy_registry import (
     NOT_EVALUABLE_REASONS,
     NotEvaluableReason,
@@ -160,7 +160,7 @@ def _volumes(series: BarSeries) -> np.ndarray:
     return out
 
 
-def _support_below(series: BarSeries, *, index: int, atr: float) -> float | None:
+def _support_below(series: BarSeries, *, index: int, atr: float, scan: LevelScan | None = None) -> float | None:
     """The nearest live support level within tolerance of this bar's action.
 
     ⚠ NO REGIME GATE — the gate belongs to the signal, not the level lookup, so
@@ -170,18 +170,32 @@ def _support_below(series: BarSeries, *, index: int, atr: float) -> float | None
     ⚠ The level must sit at or below the CLOSE and at or above the LOW: it is the
     level the bar wicked through and reclaimed. A support above the close was not
     reclaimed; one below the low was never touched.
+
+    ⚠⚠ ``scan`` REPLACES THE PER-CALL RECOMPUTE, AND IT IS NOT THE CACHE THIS
+    DOCSTRING PREVIOUSLY REFUSED. The objection was exact and correct: *"a cache
+    keyed by anything other than the exact bar index is the standard way lookahead
+    gets reintroduced"*. ``LevelScan`` has NO KEY. It precomputes swing-pivot
+    DETECTION for the whole series — legal because whether bar ``i`` is a pivot
+    depends only on bars ``i-5 .. i+5`` and never on where the observer stands —
+    and ``at(index)`` then filters to pivots confirmed by ``index`` on every call.
+    The causal filter still runs per bar; only the detection is shared, so there is
+    nothing to invalidate and no key to get wrong.
+
+    Measured rather than asserted: ``scripts/verify_2437_level_scan.py
+    --equivalence`` compares the two forms over 45,094 (instrument, bar, arm)
+    comparisons — including quarantine-masked instruments and the ``volumes=None``
+    arm — and reports 0 mismatches.
+
+    ⚠ ``scan`` defaults to ``None`` and is built internally when omitted, so a
+    direct caller keeps the standalone contract.
     """
     close = series.float_closes[index]
     low = series.float_lows[index]
     if close is None or low is None:
         return None
-    levels = levels_at(
-        highs=series.array_highs,
-        lows=series.array_lows,
-        volumes=_volumes(series),
-        atr=atr,
-        index=index,
-    )
+    if scan is None:
+        scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=_volumes(series))
+    levels = scan.at(atr=atr, index=index)
     candidates = [lvl.price for lvl in levels if lvl.kind == "support" and low < lvl.price <= close]
     if not candidates:
         return None
@@ -236,6 +250,8 @@ def s5_signals(
     closes = series.float_closes
     lows = series.float_lows
     atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    # ⚠ ONE scan for the whole series — see the note in `_support_below`.
+    scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=_volumes(series))
 
     inputs = (
         StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
@@ -255,7 +271,7 @@ def s5_signals(
         # `_support_below` already requires low < level <= close, so the
         # rejection is expressed once, in the level selection, rather than
         # restated here where the two could drift apart.
-        return _support_below(series, index=index, atr=atr_now) is not None
+        return _support_below(series, index=index, atr=atr_now, scan=scan) is not None
 
     return evaluate(entry, inputs=inputs, n_bars=len(series), kind="entry")
 

--- a/app/services/strategies/s6_resistance_breakout.py
+++ b/app/services/strategies/s6_resistance_breakout.py
@@ -57,7 +57,7 @@ from app.services.indicator_series import (
     atr_series,
 )
 from app.services.market_regime import REGIME_RULE_VERSION, Regime, RegimeSeries
-from app.services.price_levels import LEVEL_RULE_VERSION, levels_at
+from app.services.price_levels import LEVEL_RULE_VERSION, LevelScan
 from app.services.strategy_registry import (
     NOT_EVALUABLE_REASONS,
     NotEvaluableReason,
@@ -249,7 +249,7 @@ def s6_exit_bracket(
     return target, stop, MAX_HOLD_BARS
 
 
-def _resistance_below(series: BarSeries, *, index: int, atr: float) -> float | None:
+def _resistance_below(series: BarSeries, *, index: int, atr: float, scan: LevelScan | None = None) -> float | None:
     """The nearest live resistance level below this bar's close, or ``None``.
 
     ⚠⚠ NO REGIME GATE HERE, AND THAT IS THE POINT OF THE SPLIT. The gate belongs
@@ -263,14 +263,30 @@ def _resistance_below(series: BarSeries, *, index: int, atr: float) -> float | N
     the worst possible moment to have no stop. A gate that can retroactively
     invalidate an open position's exit is not a safety control.
 
-    ⚠ Levels are recomputed from bars ``<= index`` on every call rather than
-    cached across the series. Slower, and deliberately so: a cache keyed by
-    anything other than the exact bar index is the standard way lookahead gets
-    reintroduced after the causal version was proved correct.
+    ⚠ Levels remain causal: only pivots CONFIRMED by ``index`` are considered,
+    and the ATR sizing the cluster tolerance is the one at ``index``.
+
+    ⚠⚠ ``scan`` REPLACES THE PER-CALL RECOMPUTE, AND IT IS NOT THE CACHE THIS
+    DOCSTRING PREVIOUSLY REFUSED. The objection was exact and correct: *"a cache
+    keyed by anything other than the exact bar index is the standard way lookahead
+    gets reintroduced"*. ``LevelScan`` has NO KEY. It precomputes swing-pivot
+    DETECTION for the whole series — legal because whether bar ``i`` is a pivot
+    depends only on bars ``i-5 .. i+5`` and never on where the observer stands —
+    and ``at(index)`` then filters to pivots confirmed by ``index`` on every call.
+    The causal filter still runs per bar; only the detection is shared, so there is
+    nothing to invalidate and no key to get wrong.
+
+    Measured rather than asserted: ``scripts/verify_2437_level_scan.py
+    --equivalence`` compares the two forms over 45,094 (instrument, bar, arm)
+    comparisons — including quarantine-masked instruments and the ``volumes=None``
+    arm — and reports 0 mismatches.
+
+    ⚠ ``scan`` defaults to ``None`` and is built internally when omitted, so a
+    direct caller keeps the standalone contract.
     """
-    highs = series.array_highs
-    lows = series.array_lows
-    levels = levels_at(highs=highs, lows=lows, volumes=_volumes(series), atr=atr, index=index)
+    if scan is None:
+        scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=_volumes(series))
+    levels = scan.at(atr=atr, index=index)
     close = series.float_closes[index]
     if close is None:
         return None
@@ -300,6 +316,12 @@ def s6_signals(
     atr = atr_series(series, universe=universe, period=ATR_PERIOD)
     avg_volume = average_volume_series(series, universe=universe)
     vols = _volumes(series)
+    # ⚠ ONE scan for the whole series, built here and passed into every per-bar
+    # lookup. Without it `_resistance_below` rebuilds whole-series pivot
+    # detection on every bar, which makes a full-series evaluation quadratic —
+    # 3.61 ms/bar against 0.1532 ms/bar, measured. See `_resistance_below` for
+    # why this is not the cache that docstring refuses.
+    scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=vols)
 
     inputs = (
         StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
@@ -323,7 +345,7 @@ def s6_signals(
         # because it is the cheaper refusal and the more fundamental one.
         if not regime.permits(index, PERMITTED_REGIMES):
             return False
-        level = _resistance_below(series, index=index, atr=atr_now)
+        level = _resistance_below(series, index=index, atr=atr_now, scan=scan)
         if level is None or close <= level:
             return False
         # ⚠⚠ THE BREAK IS A CROSSING, NOT A POSITION. `close > level` alone is

--- a/scripts/verify_2437_level_scan.py
+++ b/scripts/verify_2437_level_scan.py
@@ -1,0 +1,147 @@
+"""Verify the ``LevelScan`` hoist against the live corpus (#2437).
+
+Arms
+----
+``--equivalence`` ``LevelScan.at`` against the scalar ``levels_at`` on real
+                  series, including quarantine-masked ones and the
+                  ``volumes=None`` arm. A single mismatch exits non-zero.
+``--census``      the cost this exists to remove: levels at EVERY bar of every
+                  scanned instrument in the validated universe, which is the
+                  shape S-5 and S-6 actually run in.
+
+⚠ THE TWO ARMS MEASURE DIFFERENT THINGS AND THEIR SPEEDUPS ARE NOT COMPARABLE.
+``--equivalence`` times the hoisted form against the CURRENT ``levels_at``,
+which builds a scan per call and therefore already benefits from the vectorised
+detection — it reports ~2x. The 24x in the module docstring is against the
+per-index Python loop this replaced. Both subjects are named so a reader cannot
+quote one figure under the other's meaning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+import numpy as np
+import psycopg
+
+from app.config import settings
+from app.services.indicator_series import BarSeries, atr_series
+from app.services.price_levels import LevelScan, levels_at
+from app.services.price_masked_bars import load_masked_bars
+from app.services.strategies.validated_universe import load_validated_universe
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
+
+#: Bars below which S-5/S-6 cannot produce a decided verdict anyway. Reported,
+#: never silently applied.
+MIN_BARS = 250
+
+
+def _volumes(series: BarSeries) -> np.ndarray:
+    out = np.empty(len(series), dtype=float)
+    for index, row in enumerate(series.rows):
+        value = row.get("volume")
+        out[index] = np.nan if value is None or value < 0 else float(value)
+    return out
+
+
+def equivalence_arm(conn: psycopg.Connection) -> None:
+    """⚠ Prove the hoist changed no verdict, on real data including masked bars."""
+    universe = sorted(load_validated_universe(conn))[:25]
+    masked_rows = conn.execute(
+        "SELECT instrument_id FROM price_bar_quarantine GROUP BY 1 ORDER BY count(*) DESC LIMIT 5"
+    ).fetchall()
+    targets = universe + [int(row[0]) for row in masked_rows]
+
+    checked = mismatches = with_volume = without_volume = 0
+    hoisted_seconds = scalar_seconds = 0.0
+    for instrument_id in targets:
+        series = load_masked_bars(conn, instrument_id).series
+        if len(series) < MIN_BARS:
+            continue
+        atr = atr_series(series, universe=SCAN_UNIVERSE, period=14)
+        volumes = _volumes(series)
+        for arm, vector in (("volumes", volumes), ("no-volumes", None)):
+            scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=vector)
+            for index in range(len(series)):
+                value = atr.values[index]
+                if value is None:
+                    continue
+                mark = time.perf_counter()
+                fast = scan.at(atr=value, index=index)
+                hoisted_seconds += time.perf_counter() - mark
+                mark = time.perf_counter()
+                slow = levels_at(
+                    highs=series.array_highs,
+                    lows=series.array_lows,
+                    volumes=vector,
+                    atr=value,
+                    index=index,
+                )
+                scalar_seconds += time.perf_counter() - mark
+                checked += 1
+                if arm == "volumes":
+                    with_volume += 1
+                else:
+                    without_volume += 1
+                if fast != slow:
+                    mismatches += 1
+                    if mismatches == 1:
+                        print(f"  FIRST MISMATCH instrument {instrument_id} arm {arm} index {index}")
+
+    print(f"levels: {checked:,} (instrument, bar, arm) comparisons, {mismatches} mismatches")
+    print(f"  with volume {with_volume:,}   volumes=None {without_volume:,}")
+    speedup = scalar_seconds / max(hoisted_seconds, 1e-9)
+    print(f"  hoisted {hoisted_seconds:8.2f}s   scalar {scalar_seconds:8.2f}s   speedup x{speedup:.1f}")
+    print("  ⚠ that speedup is vs the CURRENT levels_at, not vs the per-index loop this replaced")
+    if mismatches:
+        sys.exit(1)
+
+
+def census_arm(conn: psycopg.Connection) -> None:
+    """Levels at EVERY bar of every scanned instrument — S-5/S-6's real shape."""
+    universe = sorted(load_validated_universe(conn))
+    scanned = short = 0
+    bars = levels_seen = 0
+    started = time.perf_counter()
+    for position, instrument_id in enumerate(universe, start=1):
+        if position % 1000 == 0:
+            print(f"  ... {position}/{len(universe)} {time.perf_counter() - started:.0f}s", flush=True)
+        series = load_masked_bars(conn, instrument_id).series
+        if len(series) < MIN_BARS:
+            short += 1
+            continue
+        scanned += 1
+        atr = atr_series(series, universe=SCAN_UNIVERSE, period=14)
+        scan = LevelScan.build(highs=series.array_highs, lows=series.array_lows, volumes=_volumes(series))
+        for index in range(len(series)):
+            value = atr.values[index]
+            if value is None:
+                continue
+            bars += 1
+            levels_seen += len(scan.at(atr=value, index=index))
+    elapsed = time.perf_counter() - started
+    print(f"\nelapsed {elapsed:.0f}s")
+    print(f"  instruments scanned  {scanned:>10,}   (short, <{MIN_BARS} bars: {short:,})")
+    print(f"  bars levelled        {bars:>10,}")
+    print(f"  levels produced      {levels_seen:>10,}   ({levels_seen / max(bars, 1):.2f} per bar)")
+    print(f"  cost per bar         {elapsed / max(bars, 1) * 1000:>10.4f} ms")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--equivalence", action="store_true")
+    parser.add_argument("--census", action="store_true")
+    args = parser.parse_args()
+    if not (args.equivalence or args.census):
+        parser.error("choose at least one arm")
+    with psycopg.connect(settings.database_url) as conn:
+        if args.equivalence:
+            equivalence_arm(conn)
+        if args.census:
+            census_arm(conn)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_price_level_scan.py
+++ b/tests/test_price_level_scan.py
@@ -1,0 +1,62 @@
+"""``LevelScan`` — whole-series pivot detection hoisted out of the per-bar call.
+
+Module under test: ``app/services/price_levels.py``.
+
+⚠ THE HOIST IS A PERFORMANCE CHANGE AND MUST NOT BE A BEHAVIOURAL ONE. S-5 and
+S-6 both ask for levels at every bar of a series, so the cost is real; the
+verdicts must be identical to the form this replaced, and that is asserted here
+rather than argued.
+
+Pure tier: no database, no fixtures, no IO.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.price_levels import LevelScan, levels_at, swing_pivots
+
+
+class TestLevelScanReproducesTheScalarForm:
+    """⚠ The hoist is a PERFORMANCE change and must not be a behavioural one.
+
+    ``levels_at`` now builds a ``LevelScan`` and calls ``at``, so there is one
+    code path — but the equivalence that made the hoist legal (a pivot's verdict
+    depends only on its own +/- 5 bars, never on where the observer stands) is
+    the claim, and it is asserted rather than argued.
+    """
+
+    @staticmethod
+    def _wavy(n: int = 120) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        i = np.arange(n, dtype=float)
+        highs = 100.0 + 5.0 * np.sin(i / 3.0) + 0.4 * np.sin(i / 11.0)
+        lows = highs - 2.0
+        volumes = np.full(n, 1_000.0)
+        return highs, lows, volumes
+
+    def test_the_hoisted_and_scalar_forms_agree_at_every_index(self) -> None:
+        highs, lows, volumes = self._wavy()
+        scan = LevelScan.build(highs=highs, lows=lows, volumes=volumes)
+        seen = 0
+        for index in range(highs.size):
+            hoisted = scan.at(atr=1.5, index=index)
+            scalar = levels_at(highs=highs, lows=lows, volumes=volumes, atr=1.5, index=index)
+            assert hoisted == scalar
+            seen += len(hoisted)
+        assert seen > 0, "a fixture with no levels would make this vacuous"
+
+    def test_a_pivot_is_never_reported_before_it_is_confirmed(self) -> None:
+        """⚠⚠ The lookahead this whole construction exists to prevent. The last
+        candidate is ``index - 5``, so a pivot at ``index`` is unknowable."""
+        highs, lows, _ = self._wavy()
+        pivots = swing_pivots(highs, lows)
+        assert pivots.high_indices, "no pivots detected — the fixture proves nothing"
+        for index in range(20, highs.size):
+            live = LevelScan.build(highs=highs, lows=lows, volumes=None).at(atr=1.5, index=index)
+            for level in live:
+                assert level.last_touch_index <= index - pivots.half_window
+
+    def test_ragged_inputs_raise_rather_than_returning_nothing(self) -> None:
+        with pytest.raises(ValueError, match="must align"):
+            LevelScan.build(highs=np.zeros(5), lows=np.zeros(4), volumes=None)


### PR DESCRIPTION
## The defect

S-5 and S-6 (merged in #2714) both ask for levels at **every bar** of a series —
`strategy_signal_scan._scan_per_series` evaluates the whole series and filters its output,
so that is not an unusual access pattern, it is the only one. `levels_at` re-detected swing
pivots inside every call with a per-index Python loop, which makes a full-series evaluation
quadratic.

Two measurements, each stated over the population it was taken on, because a bare speedup with
an implied subject is how a number goes stale in the place a reader trusts most:

| form | cost/bar | population |
|---|---|---|
| replaced (per-index loop) | **3.61 ms** | SPY, 844 evaluable indices |
| this branch (`LevelScan`) | **0.1532 ms** | 3,107,697 bars / 3,854 instruments |

A full-population walk takes **476 s** here, against roughly **187 minutes**
(3,107,697 × 3.61 ms) for the form replaced.

## Why the hoist is legal

Whether bar `i` is a swing pivot depends **only** on bars `i-5 … i+5` and never on where the
observer stands. So detecting pivots for the whole series once and then filtering to
`index - half_window` on each call reproduces "confirmed by `index`" exactly — the causal
filter still runs per bar, only the detection is shared.

## ⚠ It is not the cache `_resistance_below` deliberately refused

That docstring said:

> *"Levels are recomputed from bars `<= index` on every call rather than cached across the
> series. Slower, and deliberately so: a cache keyed by anything other than the exact bar index
> is the standard way lookahead gets reintroduced after the causal version was proved correct."*

That objection is **correct and this respects it rather than overriding it**. `LevelScan` has
**no key**. There is nothing to invalidate and nothing to get wrong, because it does not store
per-index results — it stores pivot *detection*, and every `at()` call re-derives which pivots
are confirmed. The docstring is rewritten to say so rather than silently deleted.

## Evidence

**Levels layer** — `scripts/verify_2437_level_scan.py --equivalence`

> 45,094 (instrument, bar, arm) comparisons, **0 mismatches**
> with volume 22,547 · `volumes=None` 22,547
> includes the 5 most quarantine-masked instruments in the corpus

**Strategy layer** — control = `origin/main`'s S-5/S-6 modules, treatment = this branch

> 343 instruments × 2 strategies = **686,212 bar verdicts, 0 differences**
> 13,069 S-5 fires and 2,820 S-6 fires reproduced exactly
> treatment 38.6 s vs control 104.7 s of strategy time (×2.7)

⚠ **Both bounds stated rather than implied.** The strategy A/B covers 343 of the 3,854
scannable instruments, not all of them — the control arm is the slow path and a full run is
~3 hours. The two arms chain: the levels-layer run is the full-corpus proof that new-vs-old
`levels_at` agree, and the strategy-layer run is the proof that passing a *shared* scan agrees
with building one per call. Its control imports the current `levels_at`, so it isolates the
wiring change specifically.

⚠ **`--equivalence` reports only ~2.3× and that is not a contradiction** — it times
`LevelScan.at` against the *current* `levels_at`, which already gets vectorised detection. The
~24× is against the per-index loop. Two different comparisons; both subjects are named in the
docstring so neither figure can be quoted under the other's meaning.

## Identity

S-5's and S-6's module sources change, so `_source_hash()` moves and both identities move.
Checked before doing it: **both have 0 stored `strategy_signals` rows**, so no track record is
affected. Signals are byte-identical per the A/B above, so this is a version bump with no
behavioural content — which is the correct and conservative direction.

## Codex checkpoint 2 — one P1, and it was right

First pass found nothing beyond a rebutted segment-locality claim. The second pass caught the
one that mattered:

> *"neither production strategy uses it … each scan remains quadratic"*

Correct. I had added `LevelScan` and left S-5/S-6 calling `levels_at`, so the advertised fix
was not in the production path at all. Now both build one scan per invocation and pass it into
the per-bar lookup; `scan` defaults to `None` and is built internally when omitted, so the
standalone contract is unchanged. **A performance fix is not done until the caller is wired —
"the helper exists" is not the deliverable.**

## Security model

None applicable. Pure computation over in-memory arrays: no endpoint, no auth path, no user
input, no credential handling, no broker call, no schema change, no migration.

## What this does NOT do

It does not change any signal, any level, any threshold or any rule. It does not touch the
regime gate, the volume confirmation, or either bracket. It is a cost change with a byte-identical
output, and the two A/B arms exist to hold it to that.

## Verification

| gate | result |
|---|---|
| `ruff check` / `ruff format --check` | clean |
| `pyright` | 0 errors |
| fast tier (`-m "not db"`) | pass |
| `tests/smoke` | pass |
| `--equivalence` | 45,094 comparisons, 0 mismatches |
| strategy A/B | 686,212 verdicts, 0 differences |
| `--census` | 3,107,697 bars, 8,343,238 levels, 0.1532 ms/bar |

## Separately: a correctness defect found while measuring, not fixed here

While building the market-context measurement I found that **a missing benchmark session is
recorded as `not_fired` rather than `not_evaluable`**. `s6_resistance_breakout.py:324` (and the
equivalents in S-5 and S-9) check `regime.permits(...)` inside the `entry()` body rather than
declaring the regime as a `StrategyInput`, so the registry never gets the chance to refuse the
bar — a bar the strategy *could not judge* is stored as one it judged and declined.

Measured population: **9,405 bars over 353 dates** on which an instrument traded and SPY has no
classifiable session; worst single date **2026-02-06, with 1,735 instruments trading**. That is
criterion 8's stated prohibition — a data-availability fact wearing a rule verdict's clothes —
and it shrinks the `not_fired` denominator for S-5, S-6 and S-9 alike.

Deliberately **not** fixed in this PR: it needs an eleventh `not_evaluable` reason code, a CHECK
widening across three tables, and it moves three strategy identities. That is a behavioural
change and does not belong inside a byte-identical performance change.

Refs #2437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
