### PR TITLE
fix(#2437): a missing benchmark session is not_evaluable, not not_fired

### DIFF
--- a/app/services/market_regime.py
+++ b/app/services/market_regime.py
@@ -96,16 +96,97 @@ class RegimeSeries:
     to fire on ``None`` rather than treat it as permissive. That is the same
     fail-closed posture as an unevaluable indicator, and the reason this is
     ``Regime | None`` rather than a fifth enum member.
+
+    ⚠⚠ TWO DIFFERENT FACTS PRODUCE ``None`` AND ONLY ONE OF THEM IS WARM-UP.
+    ``permits`` collapses both into ``False``, which is the correct *gating*
+    answer and the wrong *bookkeeping* one:
+
+    * the benchmark HAS a bar on this date and it is not yet classifiable — the
+      200-SMA or the 126-bar BandWidth window is still filling. Warm-up.
+    * the benchmark has NO bar on this date at all. Measured on the full
+      validated universe (dev DB, 2026-08-14): **9,688 bars across 360 dates**,
+      worst single date 2026-02-06 with **1,735 instruments trading and SPY
+      absent**. These are holes in our stored benchmark series, not warm-up, and
+      they are a *data-availability fact about a different instrument*.
+
+    ``not_evaluable_indices`` names the second set, and it exists so that
+    ``strategy_registry.evaluate`` can refuse the bar as ``not_evaluable`` before
+    the strategy body runs. Without it the bar reaches ``permits``, returns
+    ``False``, and is stored as ``not_fired`` — parent criterion 8's exact
+    prohibition, a data gap wearing a rule verdict's clothes, silently shrinking
+    the ``not_fired`` denominator of every regime-gated strategy.
+
+    ⚠ THE FIELD NAME MATCHES ``IndicatorSeries.not_evaluable_indices`` ON
+    PURPOSE. That is what lets a ``RegimeSeries`` be declared directly as a
+    ``StrategyInput`` (see ``strategy_registry.EvaluableSeries``) with no adapter
+    — an adapter would have to mint an ``IndicatorSeries``, and an
+    ``IndicatorSeries`` carries ``indicator_series.RULE_SET_VERSION``, which the
+    regime did not come from. Structural agreement beats a converted object
+    stamped with a provenance it does not have.
+
+    ⚠ A regime that IS classifiable and simply is not one the strategy permits
+    stays ``not_fired``. That bar WAS judged, and spec §0 rule 2 makes firing
+    outside a declared domain the defect. Only an *unknown* regime is
+    ``not_evaluable``.
     """
 
     values: tuple[Regime | None, ...]
+    #: Indices where the benchmark contributed no observation at all — see the
+    #: class docstring. ⚠ NOT warm-up, and not every ``None``.
+    not_evaluable_indices: tuple[int, ...] = ()
     rule_set_version: str = REGIME_RULE_VERSION
+
+    def __post_init__(self) -> None:
+        # ⚠ An index outside the series, or one carrying a real regime, would
+        # make this field describe a series other than the one it is attached
+        # to. Both are silent: the first is simply never looked up, and the
+        # second would report a CLASSIFIED bar as a benchmark hole — a refusal
+        # manufactured out of nothing, which is the inverse of the defect this
+        # field closes.
+        for index in self.not_evaluable_indices:
+            if index < 0 or index >= len(self.values):
+                raise ValueError(f"not_evaluable_indices contains {index}, outside a series of {len(self.values)} bars")
+            if self.values[index] is not None:
+                raise ValueError(
+                    f"index {index} is marked not-evaluable but carries regime {self.values[index]!r}; "
+                    "a classified bar is not a benchmark hole"
+                )
 
     def __len__(self) -> int:
         return len(self.values)
 
+    def segment(self, start: int, end: int) -> RegimeSeries:
+        """Bars ``[start, end)`` as a series indexed from zero.
+
+        ⚠⚠ THE INDICES ARE REMAPPED, AND THIS METHOD EXISTS BECAUSE SLICING
+        CANNOT BE. ``RegimeSeries(values=regime.values[start:end])`` is the
+        obvious form, type-checks, and SILENTLY DISCARDS
+        ``not_evaluable_indices`` — every benchmark hole in the segment reverts
+        to a bare ``None`` and is then miscounted as the benchmark's own
+        warm-up. Nothing raises; the count simply moves to the wrong code.
+
+        ``strategy_segmented_evaluation.segmented_signals`` already carries a
+        ⚠⚠ about the same class of bug for ``values`` (a segment starting at bar
+        400 aligning its bar 0 with the market's bar 0), so putting the remap on
+        the data rather than at the call site is what keeps the next resegmenter
+        from re-deriving it.
+        """
+        if start < 0 or end > len(self.values) or start > end:
+            raise ValueError(f"segment [{start}, {end}) is not inside a series of {len(self.values)} bars")
+        return RegimeSeries(
+            values=self.values[start:end],
+            not_evaluable_indices=tuple(index - start for index in self.not_evaluable_indices if start <= index < end),
+            rule_set_version=self.rule_set_version,
+        )
+
     def permits(self, index: int, allowed: frozenset[Regime]) -> bool:
-        """True only when the bar is classifiable AND inside ``allowed``."""
+        """True only when the bar is classifiable AND inside ``allowed``.
+
+        ⚠ The ``None`` branch is now unreachable for any strategy that declares
+        this series as a ``StrategyInput`` — ``evaluate`` refuses such a bar
+        first. It is kept rather than removed: this method is public, a direct
+        caller has no such gate, and the fail-closed posture is the point.
+        """
         if index < 0 or index >= len(self.values):
             return False
         current = self.values[index]

--- a/app/services/market_regime_provider.py
+++ b/app/services/market_regime_provider.py
@@ -134,8 +134,25 @@ class MarketRegimeProvider:
         return cls(regime_by_date=dict(zip(dates, series.values, strict=True)))
 
     def for_dates(self, dates: tuple[date, ...]) -> RegimeSeries:
-        """The regime on each of ``dates``, ``None`` where the benchmark has no bar."""
-        return RegimeSeries(values=tuple(self._by_date.get(day) for day in dates))
+        """The regime on each of ``dates``, ``None`` where the benchmark has no bar.
+
+        ⚠⚠ THE TWO KINDS OF ``None`` ARE SEPARATED HERE, AND THIS IS THE ONLY
+        PLACE THAT CAN SEPARATE THEM. ``dict.get`` returns ``None`` both for a
+        date the benchmark never traded and for a date it traded but could not
+        yet be classified — and only this map knows which. By the time a
+        strategy sees the ``RegimeSeries`` the distinction is gone.
+
+        Membership in ``self._by_date`` is the discriminator: present means the
+        benchmark contributed an observation (warm-up if its value is ``None``),
+        absent means it contributed nothing (``not_evaluable``).
+
+        ⚠ ``in`` rather than ``get() is None`` — a benchmark bar that classified
+        to ``None`` is IN the map, so the two tests disagree exactly on the
+        population this method exists to split.
+        """
+        values = tuple(self._by_date.get(day) for day in dates)
+        unobserved = tuple(index for index, day in enumerate(dates) if day not in self._by_date)
+        return RegimeSeries(values=values, not_evaluable_indices=unobserved)
 
     @property
     def classified_days(self) -> int:

--- a/app/services/strategies/s5_support_bounce.py
+++ b/app/services/strategies/s5_support_bounce.py
@@ -256,6 +256,12 @@ def s5_signals(
     inputs = (
         StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
         StrategyInput(series=atr, reason=masked_reason),
+        # ⚠⚠ THE REGIME IS AN INPUT, NOT JUST A GATE IN THE BODY (#2437) — see
+        # the identical note in `s6_signals` for why, and why it is declared
+        # LAST. A benchmark hole is `missing_market_context`; a benchmark bar
+        # that exists but is not yet classifiable stays `insufficient_warmup`,
+        # which `evaluate` derives structurally from the bare `None`.
+        StrategyInput(series=regime, reason="missing_market_context"),
     )
 
     def entry(index: int) -> bool:

--- a/app/services/strategies/s6_resistance_breakout.py
+++ b/app/services/strategies/s6_resistance_breakout.py
@@ -327,6 +327,19 @@ def s6_signals(
         StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
         StrategyInput(series=atr, reason=masked_reason),
         StrategyInput(series=avg_volume, reason=masked_reason),
+        # ⚠⚠ THE REGIME IS AN INPUT, NOT JUST A GATE IN THE BODY (#2437). Without
+        # this line a date on which the benchmark contributed no bar reaches
+        # `entry`, `regime.permits` returns False, and `evaluate` stores
+        # `not_fired` — a bar this strategy COULD NOT JUDGE, recorded as one it
+        # judged and declined. Declaring it here lets `evaluate` refuse the bar
+        # first, which is the guarantee that function exists for.
+        #
+        # ⚠ DECLARED LAST on purpose. `_unevaluable_reason_at` returns the FIRST
+        # matching input's reason, and a bar that is both quarantined and
+        # missing its market context should be counted under the instrument's
+        # own defect — the more specific fact, and the one an operator can act
+        # on. The market-context code is the fallback, not the headline.
+        StrategyInput(series=regime, reason="missing_market_context"),
     )
 
     def entry(index: int) -> bool:

--- a/app/services/strategies/s9_squeeze_expansion.py
+++ b/app/services/strategies/s9_squeeze_expansion.py
@@ -257,6 +257,12 @@ def s9_signals(
         StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
         StrategyInput(series=atr, reason=masked_reason),
         StrategyInput(series=prior_high, reason=masked_reason),
+        # ⚠⚠ THE REGIME IS AN INPUT, NOT JUST A GATE IN THE BODY (#2437) — see
+        # the identical note in `s6_signals` for why, and why it is declared
+        # LAST. A benchmark hole is `missing_market_context`; a benchmark bar
+        # that exists but is not yet classifiable stays `insufficient_warmup`,
+        # which `evaluate` derives structurally from the bare `None`.
+        StrategyInput(series=regime, reason="missing_market_context"),
     )
 
     def entry(index: int) -> bool:

--- a/app/services/strategy_registry.py
+++ b/app/services/strategy_registry.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from types import MappingProxyType
-from typing import Literal, get_args
+from typing import Literal, Protocol, get_args
 
 from app.services.indicator_series import RULE_SET_VERSION as INDICATOR_SERIES_RULE_SET_VERSION
 from app.services.indicator_series import IndicatorSeries, MultiIndicatorSeries, Universe
@@ -120,6 +120,22 @@ SignalKind = Literal["entry", "exit"]
 #: measured in sql/270), so this is the split it pre-registered. The pair is
 #: exactly criterion 8's distinction: the edge of the series is a real absence,
 #: an unpriceable bar is a data gap.
+#:
+#: ⚠ ``missing_market_context`` is an ELEVENTH (#2437, sql/351 widens the three
+#: CHECKs), and it is the first code that is a property of a DIFFERENT
+#: INSTRUMENT than the one being judged. S-5…S-10 gate on a market regime
+#: classified from the benchmark; when the benchmark contributed no bar at all
+#: on a date the instrument traded, the strategy cannot judge that bar.
+#: ``thin_cross_section`` is the nearest relative and is still wrong — that
+#: describes a panel which EXISTS and is too small, not a series that is absent.
+#:
+#: ⚠ Measured before it was minted, full validated universe (dev DB,
+#: 2026-08-14): 9,688 bars over 360 dates, worst 2026-02-06 with 1,735
+#: instruments trading against no SPY bar. Every one was stored as
+#: ``not_fired`` — a bar the strategy could not judge, recorded as one it judged
+#: and declined. ⚠ A benchmark bar that EXISTS and is merely unclassifiable
+#: (200-SMA still warming) stays ``insufficient_warmup``; only an absent
+#: benchmark observation earns this code. See ``market_regime.RegimeSeries``.
 NotEvaluableReason = Literal[
     "missing_volume",
     "missing_spread",
@@ -131,6 +147,7 @@ NotEvaluableReason = Literal[
     "no_fill_bar",
     "thin_cross_section",
     "unusable_fill_price",
+    "missing_market_context",
 ]
 
 # ⚠ DERIVED from the Literals above, never restated. Review flagged the
@@ -143,11 +160,13 @@ VERDICTS: frozenset[str] = frozenset(get_args(Verdict))
 SIGNAL_KINDS: frozenset[str] = frozenset(get_args(SignalKind))
 NOT_EVALUABLE_REASONS: frozenset[str] = frozenset(get_args(NotEvaluableReason))
 
-#: The seven from parent criterion 8. `no_fill_bar`, `thin_cross_section` and
-#: `unusable_fill_price` are OURS and are excluded deliberately — see
-#: NotEvaluableReason. Kept as an explicit subtraction so adding a parent code
-#: later cannot silently land on our side of the line.
-OUR_ADDITIONAL_REASON_CODES: frozenset[str] = frozenset({"no_fill_bar", "thin_cross_section", "unusable_fill_price"})
+#: The seven from parent criterion 8. `no_fill_bar`, `thin_cross_section`,
+#: `unusable_fill_price` and `missing_market_context` are OURS and are excluded
+#: deliberately — see NotEvaluableReason. Kept as an explicit subtraction so
+#: adding a parent code later cannot silently land on our side of the line.
+OUR_ADDITIONAL_REASON_CODES: frozenset[str] = frozenset(
+    {"no_fill_bar", "thin_cross_section", "unusable_fill_price", "missing_market_context"}
+)
 PARENT_REASON_CODES: frozenset[str] = NOT_EVALUABLE_REASONS - OUR_ADDITIONAL_REASON_CODES
 
 
@@ -259,6 +278,52 @@ class StrategyIdentity:
 StrategyBody = Callable[[int], bool]
 
 
+class EvaluableSeries(Protocol):
+    """What ``evaluate`` actually needs from a declared input.
+
+    ⚠⚠ A PROTOCOL RATHER THAN A UNION, AND THE ALTERNATIVE IS WHY (#2437).
+
+    ``StrategyInput`` was typed ``IndicatorSeries | MultiIndicatorSeries``, so a
+    ``market_regime.RegimeSeries`` — the one input S-5…S-10 gate on — could not
+    be declared at all, and the regime check ended up INSIDE each strategy body
+    instead. That is not a style difference: ``evaluate``'s whole guarantee is
+    that evaluability is decided before the body runs, so an input checked
+    inside the body has no way to report ``not_evaluable`` and reports
+    ``not_fired`` instead. 9,688 bars were stored that way.
+
+    The two ways to let a regime in were both worse:
+
+    * **Widen the union.** ``strategy_registry`` is the generic contract and
+      ``market_regime`` is one strategy family's rule; importing the second into
+      the first inverts the layering, and every future family would add another
+      arm.
+    * **Adapt to an ``IndicatorSeries``.** That object carries
+      ``indicator_series.RULE_SET_VERSION``, which the regime did not come from,
+      so the adapter would have to stamp a provenance that is false — and
+      ``market_regime`` deliberately does not import ``indicator_series`` (see
+      its ``_trailing_sma``) precisely to keep the two versions uncoupled.
+
+    A structural protocol needs neither. Any object exposing per-bar values plus
+    the indices it could not support satisfies the contract, and nothing has to
+    know about anything else.
+
+    ⚠ ``values`` is ``Sequence[object | None]``, not ``float | None`` — a regime
+    value is a ``Regime`` enum member. ``evaluate`` only ever asks whether it
+    ``is None``, never what it is.
+
+    ⚠ ``MultiIndicatorSeries`` does NOT satisfy this (it exposes ``components``,
+    not ``values``) and is kept as an explicit union arm below.
+    """
+
+    @property
+    def values(self) -> Sequence[object | None]: ...
+
+    @property
+    def not_evaluable_indices(self) -> tuple[int, ...]: ...
+
+    def __len__(self) -> int: ...
+
+
 @dataclass(frozen=True)
 class StrategyInput:
     """One indicator series a strategy depends on, WITH the reason code to
@@ -283,7 +348,7 @@ class StrategyInput:
     up, and is always ``insufficient_warmup``.
     """
 
-    series: IndicatorSeries | MultiIndicatorSeries
+    series: EvaluableSeries | MultiIndicatorSeries
     #: Recorded when this input is unevaluable for a data reason.
     reason: NotEvaluableReason
 
@@ -300,12 +365,18 @@ def _unevaluable_reason_at(inputs: Sequence[StrategyInput], index: int) -> NotEv
         series = declared.series
         if index in series.not_evaluable_indices:
             return declared.reason
-        if isinstance(series, IndicatorSeries):
-            if series.values[index] is None:
-                warming = True
-        else:
+        # ⚠ The isinstance test is on the MULTI arm, not the single one. It used
+        # to read `isinstance(series, IndicatorSeries)` with the multi case in
+        # `else`, which silently treated any non-`IndicatorSeries` as having
+        # `.components` — so the `EvaluableSeries` protocol widening (#2437)
+        # would have sent a `RegimeSeries` down the multi branch and raised
+        # `AttributeError` on the first warm-up bar. Testing the arm that has
+        # the distinctive shape leaves the protocol as the default.
+        if isinstance(series, MultiIndicatorSeries):
             if any(component[index] is None for component in series.components.values()):
                 warming = True
+        elif series.values[index] is None:
+            warming = True
     return "insufficient_warmup" if warming else None
 
 

--- a/app/services/strategy_segmented_evaluation.py
+++ b/app/services/strategy_segmented_evaluation.py
@@ -47,7 +47,11 @@ def segmented_signals(
     signals: list[StrategySignal] = []
     for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
         segment = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
-        segment_regime = RegimeSeries(values=regime.values[start:end])
+        # ⚠ `regime.segment(...)`, NOT `RegimeSeries(values=regime.values[start:end])`.
+        # The latter type-checks and silently drops `not_evaluable_indices`, so
+        # every benchmark hole inside the segment would be re-counted as the
+        # benchmark's own warm-up (#2437). The remap lives on the data.
+        segment_regime = regime.segment(start, end)
         signals.extend(
             StrategySignal(
                 verdict=signal.verdict,

--- a/scripts/verify_2437_missing_market_context.py
+++ b/scripts/verify_2437_missing_market_context.py
@@ -1,0 +1,189 @@
+"""Full-population A/B for the ``missing_market_context`` reason code (#2437).
+
+WHY AN A/B AND NOT A COUNT
+--------------------------
+The change moves a verdict: a bar on a date the benchmark did not trade was
+``not_fired`` and becomes ``not_evaluable / missing_market_context``. Two things
+have to be true and only one of them is obvious:
+
+1. the bars that move are exactly the benchmark holes, and
+2. **no signal that fired stops firing, and no new signal starts** — the fix is
+   about bookkeeping, and a change to the fired set would mean it is not.
+
+(2) is the claim worth the run. It is asserted per (strategy, instrument) on the
+fired INDEX SETS, not on counts, so an equal-sized substitution cannot hide.
+
+⚠⚠ THE CONTROL ARM IS THE SHIPPED SOURCE, RUN COLD, NOT A SIMULATION.
+There is no way to reproduce the old behaviour from inside the new code: passing
+``not_evaluable_indices=()`` looks like it should, and does not — the regime is
+now a DECLARED input, so an unclassifiable value takes the structural warm-up
+path and yields ``insufficient_warmup`` where the old code yielded
+``not_fired``. A simulated control would have understated the diff by the whole
+benchmark warm-up population. So this script is designed to run UNCHANGED on
+both arms (it imports nothing this branch adds) and is executed once in a
+worktree at ``origin/main`` and once here.
+
+Usage
+-----
+    uv run python scripts/verify_2437_missing_market_context.py --dump /tmp/control.json
+    uv run python scripts/verify_2437_missing_market_context.py --compare /tmp/control.json /tmp/treatment.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+
+import psycopg
+
+from app.config import settings
+from app.services.market_regime_provider import MarketRegimeProvider
+from app.services.price_masked_bars import MASKED_REASON, load_masked_bars
+from app.services.price_segments import load_unresolved_breaks
+from app.services.strategies.validated_universe import load_validated_universe
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_segmented_evaluation import segmented_signals
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
+
+#: The three regime-gated per-series strategies. S-10 does not exist yet and
+#: S-1…S-4 take no regime, so neither arm can differ on them.
+GATED = ("s5-support-bounce", "s6-resistance-breakout", "s9-squeeze-expansion")
+
+#: Below this a strategy cannot produce a decided verdict anyway (200-SMA plus a
+#: 126-bar BandWidth window). ⚠ Reported in the dump, never silently applied —
+#: a bound that shrinks the population without saying so is how an A/B lies.
+MIN_BARS = 250
+
+
+def dump_arm(conn: psycopg.Connection, path: str) -> None:
+    universe = sorted(load_validated_universe(conn))
+    provider = MarketRegimeProvider.load(conn)
+    # ⚠ The production scan segments on unresolved scale breaks, and the regime
+    # is re-sliced per segment — which is exactly where this change could go
+    # wrong. Loading them here rather than passing `()` keeps the arms running
+    # the shape production runs.
+    breaks_by_instrument = load_unresolved_breaks(conn, universe)
+
+    per_strategy: dict[str, dict[str, object]] = {
+        strategy_id: {"counts": Counter(), "fired": {}} for strategy_id in GATED
+    }
+    scanned = skipped_short = 0
+    for position, instrument_id in enumerate(universe):
+        loaded = load_masked_bars(conn, instrument_id)
+        series = loaded.series
+        if len(series) < MIN_BARS:
+            skipped_short += 1
+            continue
+        scanned += 1
+        regime = provider.for_dates(series.dates)
+        breaks = tuple(breaks_by_instrument.get(instrument_id, ()))
+        for strategy_id in GATED:
+            signals = segmented_signals(
+                STRATEGY_MANIFEST[strategy_id],
+                series,
+                universe=SCAN_UNIVERSE,
+                masked_reason=MASKED_REASON,
+                unresolved_breaks=breaks,
+                regime=regime,
+            )
+            bucket = per_strategy[strategy_id]
+            counts: Counter = bucket["counts"]  # type: ignore[assignment]
+            fired: dict[str, list[str]] = bucket["fired"]  # type: ignore[assignment]
+            for signal in signals:
+                counts[f"{signal.verdict}/{signal.reason or ''}"] += 1
+            # ⚠ Fired bars keyed by DATE, not index. Index equality across arms
+            # would also be satisfied by a series that loaded differently; the
+            # date is the thing a trade would actually be placed on.
+            hits = [series.dates[s.signal_index].isoformat() for s in signals if s.verdict == "fired"]
+            if hits:
+                fired[str(instrument_id)] = hits
+        if position % 250 == 0:
+            print(f"  … {position}/{len(universe)} instruments", flush=True)
+
+    payload = {
+        "scanned_instruments": scanned,
+        "skipped_short_of_min_bars": skipped_short,
+        "min_bars": MIN_BARS,
+        "universe_size": len(universe),
+        "strategies": {
+            strategy_id: {
+                "counts": dict(bucket["counts"]),  # type: ignore[arg-type]
+                "fired": bucket["fired"],
+            }
+            for strategy_id, bucket in per_strategy.items()
+        },
+    }
+    with open(path, "w") as handle:
+        json.dump(payload, handle, indent=1, sort_keys=True)
+    print(f"wrote {path}: {scanned} instruments scanned, {skipped_short} below {MIN_BARS} bars")
+
+
+def compare(control_path: str, treatment_path: str) -> int:
+    with open(control_path) as handle:
+        control = json.load(handle)
+    with open(treatment_path) as handle:
+        treatment = json.load(handle)
+
+    failures: list[str] = []
+    if control["scanned_instruments"] != treatment["scanned_instruments"]:
+        failures.append(
+            f"arms scanned different populations: {control['scanned_instruments']} vs "
+            f"{treatment['scanned_instruments']} — the comparison is meaningless"
+        )
+
+    for strategy_id in sorted(set(control["strategies"]) | set(treatment["strategies"])):
+        before = control["strategies"][strategy_id]
+        after = treatment["strategies"][strategy_id]
+        print(f"\n=== {strategy_id}")
+        keys = sorted(set(before["counts"]) | set(after["counts"]))
+        print(f"{'verdict/reason':<42}{'control':>12}{'treatment':>12}{'delta':>12}")
+        for key in keys:
+            lhs = before["counts"].get(key, 0)
+            rhs = after["counts"].get(key, 0)
+            print(f"{key:<42}{lhs:>12,}{rhs:>12,}{rhs - lhs:>+12,}")
+
+        # ⚠⚠ THE CLAIM. Distinct instruments, and the exact date sets.
+        moved_instruments = {
+            key
+            for key in set(before["fired"]) | set(after["fired"])
+            if before["fired"].get(key, []) != after["fired"].get(key, [])
+        }
+        total_before = sum(len(v) for v in before["fired"].values())
+        total_after = sum(len(v) for v in after["fired"].values())
+        print(
+            f"fired signals: {total_before:,} control / {total_after:,} treatment across "
+            f"{len(before['fired']):,} / {len(after['fired']):,} distinct instruments"
+        )
+        if moved_instruments:
+            failures.append(
+                f"{strategy_id}: the FIRED set changed on {len(moved_instruments)} instruments "
+                f"(first few: {sorted(moved_instruments)[:5]}) — this change must not move a signal"
+            )
+
+    if failures:
+        print("\nFAILED:")
+        for line in failures:
+            print(f"  - {line}")
+        return 1
+    print("\nOK: no fired signal moved on any instrument in either arm.")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dump", metavar="PATH", help="run one arm and write its digest")
+    parser.add_argument("--compare", nargs=2, metavar=("CONTROL", "TREATMENT"))
+    args = parser.parse_args()
+
+    if args.compare:
+        sys.exit(compare(*args.compare))
+    if not args.dump:
+        parser.error("one of --dump or --compare is required")
+    with psycopg.connect(settings.database_url) as conn:
+        dump_arm(conn, args.dump)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/351_strategy_signals_missing_market_context.sql
+++ b/sql/351_strategy_signals_missing_market_context.sql
@@ -1,0 +1,145 @@
+-- 351_strategy_signals_missing_market_context.sql
+--
+-- #2437 — the eleventh `not_evaluable` reason code. Registry:
+-- app/services/strategy_registry.py (NotEvaluableReason). Producer:
+-- app/services/market_regime_provider.py (MarketRegimeProvider.for_dates).
+-- Tables: sql/255 (widened by sql/260, sql/270) and sql/276.
+--
+--
+-- WHAT WAS BEING RECORDED WRONGLY
+-- ---------------------------------------------------------------------------
+-- S-5, S-6 and S-9 gate on a market regime classified from the benchmark (SPY).
+-- The regime was checked INSIDE each strategy body rather than declared as a
+-- `StrategyInput`, so `strategy_registry.evaluate` never got the chance to
+-- refuse the bar. A date on which the instrument traded and the benchmark did
+-- not therefore produced `regime.permits(...) == False`, and was stored as
+-- `not_fired`.
+--
+-- That is parent criterion 8's stated prohibition — a data-availability fact
+-- wearing a rule verdict's clothes — and it silently shrinks the `not_fired`
+-- denominator of every regime-gated strategy.
+--
+-- Full validated universe, dev DB 2026-08-14 (6,774 instruments):
+--
+--     WITH bench AS (
+--       SELECT p.price_date FROM price_daily p
+--       JOIN instruments i ON i.instrument_id = p.instrument_id
+--       WHERE i.symbol = 'SPY' AND p.close IS NOT NULL
+--     )
+--     SELECT count(*) AS bars, count(DISTINCT p.price_date) AS dates
+--     FROM price_daily p
+--     WHERE p.instrument_id = ANY(<validated universe>) AND p.close IS NOT NULL
+--       AND p.price_date >= (SELECT min(price_date) FROM bench)
+--       AND NOT EXISTS (SELECT 1 FROM bench b WHERE b.price_date = p.price_date);
+--     -- 9,688 | 360
+--
+-- Worst single date is 2026-02-06: 1,735 instruments traded and SPY has no bar.
+-- These are holes in our stored benchmark series rather than market holidays —
+-- most are thin weekend/holiday rows contributed by `.24-7` instruments, but a
+-- minority are ordinary sessions (2023-06-30, a Friday, has 237 instruments
+-- trading and no SPY bar).
+--
+--
+-- WHY NOT AN EXISTING CODE
+-- ---------------------------------------------------------------------------
+-- This is the first code that is a property of a DIFFERENT INSTRUMENT than the
+-- one being judged, so none of the ten fits:
+--
+--   * `insufficient_warmup` is the benchmark's OTHER failure and stays separate.
+--     A benchmark bar that EXISTS but is not yet classifiable (the 200-SMA or
+--     the 126-bar BandWidth window still filling) is warm-up, and `evaluate`
+--     already derives that structurally from a bare `None`. Only an ABSENT
+--     benchmark observation earns the new code. `MarketRegimeProvider.for_dates`
+--     is the only place that can tell the two apart — by the time a strategy
+--     holds the `RegimeSeries` both are `None`.
+--   * `thin_cross_section` is the nearest relative and is still wrong: it
+--     describes a ranked panel that EXISTS and is too small, not a series that
+--     is absent.
+--   * `series_break` / `not_listed` are statements about the instrument's own
+--     series, which here is intact — it is the market context that is missing.
+--
+-- ⚠ A regime that IS classifiable and simply is not one the strategy permits
+-- stays `not_fired`. That bar WAS judged, and the parent spec's §0 rule 2 makes
+-- firing outside a declared domain the defect, not evidence the rule is broken.
+--
+-- ⚠ OURS, NOT THE PARENT'S. Criterion 8 lists seven codes; `no_fill_bar` was
+-- the eighth, `thin_cross_section` the ninth, `unusable_fill_price` the tenth,
+-- and this is the eleventh. All four are flagged as additions in
+-- strategy_registry.py rather than passed off as the parent's, and
+-- `OUR_ADDITIONAL_REASON_CODES` keeps the two sets separable in Python.
+--
+-- ⚠ THE PYTHON LITERAL IS THE SOURCE, THIS IS THE MIRROR — unchanged from
+-- sql/260 and sql/270. tests/test_strategy_registry.py reads the LATEST
+-- migration that redefines each list, which is this file from here on.
+--
+--
+-- WHAT THIS DOES TO STORED ROWS
+-- ---------------------------------------------------------------------------
+-- Declaring the regime as an input moves `REGIME_RULE_VERSION` (it hashes
+-- market_regime.py's source) and therefore all three strategy identities. What
+-- is currently stored under the OLD versions, dev DB 2026-08-14:
+--
+--     select strategy_id, verdict, count(*) from strategy_signals
+--     where strategy_id in ('s5-support-bounce','s6-resistance-breakout','s9-squeeze-expansion')
+--     group by 1,2;
+--     -- s5-support-bounce | fired | 316
+--     -- s6-resistance-breakout | fired | 36
+--     -- s9-squeeze-expansion | fired | 3
+--
+-- 355 rows, all `fired`, all from the single scan of 2026-08-12, and NONE of
+-- them is referenced by a `strategy_outcomes` row (measured: 0). They are left
+-- in place under their old `strategy_version`, which is this repo's standing
+-- trade — visibly stale beats silently mixed — and the next scan re-emits under
+-- the new versions.
+--
+-- ⚠ An earlier note on #2437 said all three had "0 stored strategy_signals
+-- rows, so nothing is lost". That was wrong on the count and right on the
+-- consequence; the figures above are the measured replacement.
+
+ALTER TABLE strategy_signals
+    DROP CONSTRAINT IF EXISTS strategy_signals_reason_codes;
+
+ALTER TABLE strategy_signals
+    ADD CONSTRAINT strategy_signals_reason_codes
+    CHECK (not_evaluable_reason IS NULL OR not_evaluable_reason IN (
+        'missing_volume', 'missing_spread', 'insufficient_warmup',
+        'quarantined_bar', 'series_break', 'not_listed',
+        'ambiguous_intrabar', 'no_fill_bar', 'thin_cross_section',
+        'unusable_fill_price', 'missing_market_context'
+    ));
+
+COMMENT ON COLUMN strategy_signals.not_evaluable_reason IS
+    'Closed vocabulary: parent criterion 8''s seven codes, plus no_fill_bar '
+    '(the series has no t+1), thin_cross_section (the ranked panel was smaller '
+    'than the ranking rule is defined on), unusable_fill_price (bar t+1 '
+    'exists and its open is NULL or <= 0, so no fill can be priced) and '
+    'missing_market_context (the benchmark the strategy''s regime gate reads '
+    'contributed no bar on this date). The Python Literal in '
+    'strategy_registry.NotEvaluableReason is the source; this CHECK mirrors it.';
+
+-- The same vocabulary, in the two sql/276 relations. ⚠ Both spell "no reason"
+-- as the empty string so it can sit in a primary key, so the widened list keeps
+-- '' as its first member; dropping it would reject every non-not_evaluable row.
+ALTER TABLE strategy_signal_daily_counts
+    DROP CONSTRAINT IF EXISTS strategy_signal_daily_counts_reason_code_check;
+
+ALTER TABLE strategy_signal_daily_counts
+    ADD CONSTRAINT strategy_signal_daily_counts_reason_code_check
+    CHECK (reason_code IN (
+        '', 'missing_volume', 'missing_spread', 'insufficient_warmup',
+        'quarantined_bar', 'series_break', 'not_listed',
+        'ambiguous_intrabar', 'no_fill_bar', 'thin_cross_section',
+        'unusable_fill_price', 'missing_market_context'
+    ));
+
+ALTER TABLE strategy_signal_observations
+    DROP CONSTRAINT IF EXISTS strategy_signal_observations_reason_code_check;
+
+ALTER TABLE strategy_signal_observations
+    ADD CONSTRAINT strategy_signal_observations_reason_code_check
+    CHECK (reason_code IN (
+        '', 'missing_volume', 'missing_spread', 'insufficient_warmup',
+        'quarantined_bar', 'series_break', 'not_listed',
+        'ambiguous_intrabar', 'no_fill_bar', 'thin_cross_section',
+        'unusable_fill_price', 'missing_market_context'
+    ));

--- a/tests/test_2437_missing_market_context.py
+++ b/tests/test_2437_missing_market_context.py
@@ -1,0 +1,285 @@
+"""#2437 — a benchmark hole is ``not_evaluable``, not ``not_fired``.
+
+S-5, S-6 and S-9 gate on a market regime classified from SPY. The regime was
+checked INSIDE each strategy body, so ``strategy_registry.evaluate`` never got
+the chance to refuse a bar whose regime was unknown: ``permits`` returned
+``False`` and the bar was stored as ``not_fired``. Measured on the full
+validated universe (dev DB, 2026-08-14) that is **9,688 bars over 360 dates**,
+worst 2026-02-06 with **1,735 instruments trading against no SPY bar**.
+
+⚠ THE WHOLE DIFFICULTY IS THAT TWO DIFFERENT FACTS BOTH ARRIVE AS ``None``, so
+every test here is really about the same distinction:
+
+* the benchmark traded and is not yet classifiable  → ``insufficient_warmup``
+* the benchmark did not trade at all                → ``missing_market_context``
+* the benchmark traded, classified, and the regime is one the strategy declines
+                                                    → ``not_fired``, unchanged
+
+The third is not a data gap and must NOT move — the bar WAS judged, and the
+parent spec's §0 rule 2 makes firing outside a declared domain the defect.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services.indicator_series import BarSeries, IndicatorSeries, OHLCVRow
+from app.services.market_regime import Regime, RegimeSeries
+from app.services.market_regime_provider import MarketRegimeProvider
+from app.services.price_segments import series_segment_bounds
+from app.services.strategies.s5_support_bounce import PERMITTED_REGIMES as S5_REGIMES
+from app.services.strategies.s5_support_bounce import S5_STRATEGY_ID, s5_signals
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_registry import (
+    OUR_ADDITIONAL_REASON_CODES,
+    PARENT_REASON_CODES,
+    StrategyInput,
+    evaluate,
+)
+from app.services.strategy_segmented_evaluation import segmented_signals
+
+U = "survivor_only"
+
+
+def _days(count: int, start: date = date(2020, 1, 1)) -> tuple[date, ...]:
+    return tuple(start + timedelta(days=i) for i in range(count))
+
+
+class TestRegimeSeriesRefusesAnIncoherentRefusalSet:
+    """``not_evaluable_indices`` describes THIS series or it describes nothing."""
+
+    def test_an_index_past_the_end_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="outside a series of 2 bars"):
+            RegimeSeries(values=(None, None), not_evaluable_indices=(2,))
+
+    def test_a_negative_index_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="outside a series"):
+            RegimeSeries(values=(None,), not_evaluable_indices=(-1,))
+
+    def test_a_classified_bar_cannot_be_marked_a_benchmark_hole(self) -> None:
+        """⚠ The inverse defect, and it is the silent one: this would
+        manufacture a refusal for a bar the benchmark actually classified."""
+        with pytest.raises(ValueError, match="is not a benchmark hole"):
+            RegimeSeries(values=(Regime.BULL_QUIET,), not_evaluable_indices=(0,))
+
+    def test_the_default_is_an_empty_set(self) -> None:
+        """Every existing construction site keeps its meaning — an unpopulated
+        series claims no holes rather than claiming all of its ``None``s are."""
+        assert RegimeSeries(values=(None, Regime.BEAR_QUIET)).not_evaluable_indices == ()
+
+
+class TestSegmentRemapsTheRefusalSet:
+    """⚠⚠ THE DEFECT THIS CHANGE WOULD OTHERWISE HAVE SHIPPED.
+
+    ``segmented_signals`` re-slices the regime once per series segment (a scale
+    break splits an instrument's history). It did so as
+    ``RegimeSeries(values=regime.values[start:end])`` — which type-checks, and
+    drops ``not_evaluable_indices`` on the floor. Every benchmark hole inside a
+    segmented instrument would have reverted to a bare ``None`` and been counted
+    as the benchmark's own warm-up: the new reason code would read zero on
+    exactly the instruments most likely to have gaps, and nothing would raise.
+    """
+
+    def test_indices_are_rebased_to_the_segment(self) -> None:
+        series = RegimeSeries(
+            values=(Regime.BULL_QUIET, None, Regime.BEAR_QUIET, None, Regime.BULL_QUIET),
+            not_evaluable_indices=(1, 3),
+        )
+        assert series.segment(2, 5).not_evaluable_indices == (1,)
+
+    def test_holes_outside_the_segment_are_dropped(self) -> None:
+        series = RegimeSeries(values=(None, Regime.BULL_QUIET, Regime.BULL_QUIET), not_evaluable_indices=(0,))
+        assert series.segment(1, 3).not_evaluable_indices == ()
+
+    def test_the_values_still_line_up(self) -> None:
+        series = RegimeSeries(values=(Regime.BULL_QUIET, None, Regime.BEAR_QUIET), not_evaluable_indices=(1,))
+        segment = series.segment(1, 3)
+        assert segment.values == (None, Regime.BEAR_QUIET)
+        assert len(segment) == 2
+
+    def test_the_rule_set_version_is_carried(self) -> None:
+        """A segment is the same classification, not a new one."""
+        series = RegimeSeries(values=(Regime.BULL_QUIET, Regime.BULL_QUIET))
+        assert series.segment(0, 1).rule_set_version == series.rule_set_version
+
+    @pytest.mark.parametrize("bounds", [(-1, 2), (0, 4), (2, 1)])
+    def test_bounds_outside_the_series_are_rejected(self, bounds: tuple[int, int]) -> None:
+        series = RegimeSeries(values=(Regime.BULL_QUIET,) * 3)
+        with pytest.raises(ValueError, match="is not inside a series of 3 bars"):
+            series.segment(*bounds)
+
+    def test_a_hole_after_a_scale_break_still_reports_the_new_code(self) -> None:
+        """⚠⚠ PINNED AT THE CALL SITE, NOT JUST ON THE METHOD. A correct
+        ``segment`` that nothing calls fixes nothing, and the wrong form is the
+        one a reader writes by reflex. The hole here sits in the SECOND segment,
+        where a dropped index set is indistinguishable from warm-up — which is
+        exactly how this would have shipped looking green.
+        """
+        closes = [100.0 + (i % 11) for i in range(120)]
+        series = _bars(closes)
+        break_date = series.dates[60]
+        permitted = next(iter(S5_REGIMES))
+        values: list[Regime | None] = [permitted] * len(closes)
+        values[95] = None
+        regime = RegimeSeries(values=tuple(values), not_evaluable_indices=(95,))
+
+        bounds = series_segment_bounds(series, unresolved_breaks=(break_date,))
+        assert len(bounds) == 2, "the fixture must actually segment, or this proves nothing"
+
+        signals = segmented_signals(
+            STRATEGY_MANIFEST[S5_STRATEGY_ID],
+            series,
+            universe=U,
+            masked_reason="quarantined_bar",
+            unresolved_breaks=(break_date,),
+            regime=regime,
+        )
+        at_95 = next(s for s in signals if s.signal_index == 95)
+        assert (at_95.verdict, at_95.reason) == ("not_evaluable", "missing_market_context")
+
+
+class TestProviderSplitsTheTwoKindsOfNone:
+    """``MarketRegimeProvider.for_dates`` is the ONLY place that can split them.
+
+    Once a ``RegimeSeries`` is built, "absent" and "present but unclassifiable"
+    are both ``None`` and the distinction is unrecoverable.
+    """
+
+    @staticmethod
+    def _provider() -> MarketRegimeProvider:
+        days = _days(3)
+        # Day 0: classified.  Day 1: benchmark TRADED and is unclassifiable
+        # (warm-up).  Day 2: absent from the map entirely.
+        return MarketRegimeProvider(regime_by_date={days[0]: Regime.BULL_QUIET, days[1]: None})
+
+    def test_a_missing_benchmark_date_is_flagged(self) -> None:
+        series = self._provider().for_dates(_days(3))
+        assert series.not_evaluable_indices == (2,)
+
+    def test_a_present_but_unclassifiable_benchmark_bar_is_not_flagged(self) -> None:
+        """⚠ THE `in`-VERSUS-`get() is None` DISTINCTION, pinned. Day 1 is in the
+        map with value ``None``; treating that as a hole would report the
+        benchmark's own warm-up as a data gap and inflate the new code by the
+        whole 200-SMA + 126-bar BandWidth run-up (~326 bars per instrument)."""
+        series = self._provider().for_dates(_days(3))
+        assert series.values[1] is None
+        assert 1 not in series.not_evaluable_indices
+
+    def test_a_classified_date_carries_its_regime(self) -> None:
+        series = self._provider().for_dates(_days(3))
+        assert series.values[0] is Regime.BULL_QUIET
+
+
+def _regime_input(series: RegimeSeries) -> StrategyInput:
+    return StrategyInput(series=series, reason="missing_market_context")
+
+
+class TestEvaluateRefusesAnUnknownRegimeBeforeTheBodyRuns:
+    """The point of the change: ``evaluate`` decides evaluability, not the body."""
+
+    @staticmethod
+    def _verdicts(series: RegimeSeries) -> list[tuple[str, str | None]]:
+        # ⚠ The body would fire on EVERY bar. Any `not_fired` below therefore
+        # comes from the gate and not from the rule declining — which is what
+        # makes the reason codes attributable.
+        signals = evaluate(lambda _index: True, inputs=(_regime_input(series),), n_bars=len(series))
+        return [(s.verdict, s.reason) for s in signals]
+
+    def test_a_benchmark_hole_is_missing_market_context(self) -> None:
+        series = RegimeSeries(values=(Regime.BULL_QUIET, None, Regime.BULL_QUIET), not_evaluable_indices=(1,))
+        assert self._verdicts(series)[1] == ("not_evaluable", "missing_market_context")
+
+    def test_benchmark_warmup_stays_insufficient_warmup(self) -> None:
+        """⚠ Derived structurally from the bare ``None``, not declared. A caller
+        cannot get this one wrong, which is why it is not a parameter."""
+        series = RegimeSeries(values=(None, Regime.BULL_QUIET, Regime.BULL_QUIET))
+        assert self._verdicts(series)[0] == ("not_evaluable", "insufficient_warmup")
+
+    def test_a_warmup_bar_does_not_raise_on_the_multi_series_branch(self) -> None:
+        """⚠ REGRESSION GUARD for the isinstance flip in
+        ``_unevaluable_reason_at``. It used to read
+        ``isinstance(series, IndicatorSeries)`` with ``.components`` in the
+        ``else``, so a ``RegimeSeries`` warm-up bar would have taken the multi
+        branch and raised ``AttributeError``. The test above only reaches that
+        line because this one asserts it does not explode."""
+        series = RegimeSeries(values=(None, Regime.BULL_QUIET))
+        verdicts = self._verdicts(series)
+        assert verdicts[0][0] == "not_evaluable"
+
+    def test_a_classified_bar_reaches_the_body(self) -> None:
+        series = RegimeSeries(values=(Regime.BEAR_VOLATILE, Regime.BULL_QUIET))
+        # Index 1 is the last bar (`no_fill_bar`); index 0 is the live one.
+        assert self._verdicts(series)[0] == ("fired", None)
+
+    def test_an_instrument_level_reason_wins_over_the_market_one(self) -> None:
+        """⚠ Declaration ORDER is load-bearing, and this pins the intent rather
+        than the accident. A bar that is both quarantined and missing its market
+        context is counted under the instrument's own defect — the more specific
+        fact, and the one an operator can act on."""
+        quarantined = IndicatorSeries(values=(None, 1.0), universe=U, not_evaluable_indices=(0,))
+        regime = RegimeSeries(values=(None, Regime.BULL_QUIET), not_evaluable_indices=(0,))
+        signals = evaluate(
+            lambda _index: True,
+            inputs=(
+                StrategyInput(series=quarantined, reason="quarantined_bar"),
+                _regime_input(regime),
+            ),
+            n_bars=2,
+        )
+        assert (signals[0].verdict, signals[0].reason) == ("not_evaluable", "quarantined_bar")
+
+
+def _bars(closes: list[float], *, start: date = date(2020, 1, 1)) -> BarSeries:
+    rows: list[OHLCVRow] = [
+        {
+            "open": Decimal(str(c)),
+            "high": Decimal(str(c + 1)),
+            "low": Decimal(str(c - 1)),
+            "close": Decimal(str(c)),
+            "volume": 1_000,
+        }  # type: ignore[typeddict-item]
+        for c in closes
+    ]
+    return BarSeries(dates=tuple(start + timedelta(days=i) for i in range(len(closes))), rows=tuple(rows))
+
+
+class TestAStrategyEndToEnd:
+    """S-5 is the smallest of the three; the input wiring is identical in all."""
+
+    _CLOSES = [100.0 + (i % 11) for i in range(120)]
+
+    def _run(self, regime: RegimeSeries) -> list[tuple[str, str | None]]:
+        series = _bars(self._CLOSES)
+        signals = s5_signals(series, universe=U, masked_reason="quarantined_bar", regime=regime)
+        return [(s.verdict, s.reason) for s in signals]
+
+    def test_a_benchmark_hole_is_reported_by_the_strategy(self) -> None:
+        n = len(self._CLOSES)
+        permitted = next(iter(S5_REGIMES))
+        values: list[Regime | None] = [permitted] * n
+        values[80] = None
+        verdicts = self._run(RegimeSeries(values=tuple(values), not_evaluable_indices=(80,)))
+        assert verdicts[80] == ("not_evaluable", "missing_market_context")
+
+    def test_a_refused_regime_is_still_not_fired(self) -> None:
+        """⚠⚠ THE HALF THAT MUST NOT MOVE. ``bear_quiet`` is outside S-5's
+        declared domain, and that bar WAS judged — turning it into
+        ``not_evaluable`` would delete the denominator the strategy's own
+        selectivity is measured against."""
+        n = len(self._CLOSES)
+        assert Regime.BEAR_QUIET not in S5_REGIMES
+        verdicts = self._run(RegimeSeries(values=(Regime.BEAR_QUIET,) * n))
+        # Every bar but the last (`no_fill_bar`) and the ATR warm-up run.
+        assert ("not_evaluable", "missing_market_context") not in verdicts
+        assert verdicts[80] == ("not_fired", None)
+
+
+class TestTheNewCodeIsDeclaredAsOurs:
+    def test_it_is_not_claimed_as_the_parents(self) -> None:
+        """Criterion 8 lists seven codes; this is our fourth addition."""
+        assert "missing_market_context" in OUR_ADDITIONAL_REASON_CODES
+        assert "missing_market_context" not in PARENT_REASON_CODES
+        assert len(PARENT_REASON_CODES) == 7

--- a/tests/test_strategy_registry.py
+++ b/tests/test_strategy_registry.py
@@ -430,10 +430,28 @@ class TestVocabularyIsDefinedOnce:
         """Pins the resolution itself: a helper that silently fell back to 255
         would agree with a stale Python Literal and prove nothing."""
         name, _ = self._defining_migration("strategy_signals", "not_evaluable_reason")
-        assert name == "270_strategy_signals_unusable_fill_price.sql"
+        assert name == "351_strategy_signals_missing_market_context.sql"
 
     def test_sql_reason_codes_match_the_python_vocabulary(self) -> None:
         assert self._check_values("strategy_signals", "not_evaluable_reason") == NOT_EVALUABLE_REASONS
+
+    @pytest.mark.parametrize("table", ["strategy_signal_daily_counts", "strategy_signal_observations"])
+    def test_sql_276_reason_vocabularies_match_too(self, table: str) -> None:
+        """⚠ THE VOCABULARY LIVES IN THREE TABLES, AND ONLY ONE WAS PINNED.
+
+        sql/276 gave `strategy_signal_daily_counts` and
+        `strategy_signal_observations` their own copies of the reason list, and
+        nothing checked either against Python — which is the exact
+        closed-vocabulary-in-N-places defect (#2218) this class was written for,
+        reintroduced one table over. #2437 had to widen all three; without this
+        the eleventh code could have been added to `strategy_signals` alone and
+        the bounded writer would have failed at INSERT with a green suite.
+
+        ⚠ `''` is these two tables' non-null spelling of "no reason" so it can
+        sit in the primary key (sql/276). It is a storage encoding, not a
+        reason, so it is added here rather than to the Python Literal.
+        """
+        assert self._check_values(table, "reason_code") == NOT_EVALUABLE_REASONS | {""}
 
     def test_sql_verdicts_match(self) -> None:
         assert self._check_values("strategy_signals", "verdict") == VERDICTS


### PR DESCRIPTION
## The defect

S-5, S-6 and S-9 gate on a market regime classified from the benchmark (SPY), but the gate lived **inside each strategy body** rather than being declared as a `StrategyInput`:

```python
def entry(index: int) -> bool:
    ...
    if not regime.permits(index, PERMITTED_REGIMES):
        return False
```

`strategy_registry.evaluate` therefore never got the chance to refuse the bar. A date on which the instrument traded and the benchmark did not produced `permits(...) == False`, and was stored as **`not_fired`** — a bar the strategy *could not judge*, recorded as one it *judged and declined*.

That is parent criterion 8's stated prohibition (a data-availability fact wearing a rule verdict's clothes), and it silently shrinks the `not_fired` denominator of every regime-gated strategy.

⚠ The measurement on the issue said all three strategies had "0 stored `strategy_signals` rows, so nothing is lost". That was wrong on the count. Measured on the dev DB: **355 rows** (s5 316, s6 36, s9 3), all `fired`, all from the single 2026-08-12 scan, and **none referenced by a `strategy_outcomes` row**. They stay under their old `strategy_version`; the next scan re-emits under the new ones. The consequence the note drew was right, the figure was not.

## What changed

| | |
| --- | --- |
| `market_regime.RegimeSeries` | gains `not_evaluable_indices` — the bars where the benchmark contributed **no observation at all**, as distinct from a benchmark bar that exists and is not yet classifiable. `__post_init__` rejects an out-of-range index and an index carrying a real regime. |
| `market_regime_provider.for_dates` | populates it. ⚠ **This is the only place that can.** `dict.get` returns `None` both for a date the benchmark never traded and for one it traded but could not classify; membership (`day in self._by_date`) is the discriminator, and once a `RegimeSeries` is built the distinction is unrecoverable. |
| `strategy_registry` | an **eleventh** reason code, `missing_market_context`, plus an `EvaluableSeries` protocol. |
| `RegimeSeries.segment()` | remaps the indices; `segmented_signals` now calls it. |
| `sql/351` | widens the CHECK on all three tables carrying this vocabulary. |
| the three strategies | declare `StrategyInput(series=regime, reason="missing_market_context")`. |

### Why a protocol rather than a union or an adapter

`StrategyInput.series` was `IndicatorSeries | MultiIndicatorSeries`, so a `RegimeSeries` could not be declared at all — which is *why* the check ended up in the body. Both obvious fixes are worse:

- **Widen the union** → `strategy_registry` is the generic contract and `market_regime` is one family's rule; importing the second into the first inverts the layering, and every future family adds an arm.
- **Adapt to an `IndicatorSeries`** → that object carries `indicator_series.RULE_SET_VERSION`, which the regime did not come from, so the adapter must stamp a false provenance. `market_regime` deliberately does not import `indicator_series` (see its `_trailing_sma`) precisely to keep the two versions uncoupled.

`RegimeSeries` already has the shape `evaluate` needs; naming its field `not_evaluable_indices` makes it satisfy the protocol with no conversion.

⚠ `_unevaluable_reason_at`'s isinstance test was flipped from the `IndicatorSeries` arm to the `MultiIndicatorSeries` arm. It previously treated any non-`IndicatorSeries` as having `.components`, so the widening would have sent a `RegimeSeries` down the multi branch and raised `AttributeError` on the first warm-up bar.

### The defect this change would otherwise have shipped

`segmented_signals` re-slices the regime once per series segment, as `RegimeSeries(values=regime.values[start:end])`. That **type-checks and silently discards `not_evaluable_indices`** — every benchmark hole inside a segmented instrument reverts to a bare `None` and is re-counted as the benchmark's own warm-up. Nothing raises; the count just moves to the wrong code. `RegimeSeries.segment()` puts the remap on the data, and `TestSegmentRemapsTheRefusalSet::test_a_hole_after_a_scale_break_still_reports_the_new_code` pins it at the call site with a two-segment fixture.

## What stays `not_fired`

⚠⚠ A regime that **is** classifiable and simply is not one the strategy permits. That bar *was* judged, and the parent spec's §0 rule 2 makes firing outside a declared domain the defect, not evidence the rule is broken. Only an *unknown* regime becomes `not_evaluable`. Pinned by `test_a_refused_regime_is_still_not_fired`.

## Full-population A/B

`scripts/verify_2437_missing_market_context.py`. **Both arms run cold against shipped source** — control in a `git worktree` at `origin/main`, treatment here. The control cannot be simulated from inside the new code: passing `not_evaluable_indices=()` looks like it should reproduce the old behaviour and does not, because the regime is now a *declared* input, so an unclassifiable value takes the structural warm-up path and yields `insufficient_warmup` where the old code yielded `not_fired`. A simulated control would have understated the diff by the entire benchmark warm-up population.

3,854 instruments of the validated universe scanned (2,920 of 6,774 below the 250-bar floor — reported, not silently applied), production segmentation via `load_unresolved_breaks`:

| s5-support-bounce | control | treatment | delta |
| --- | ---: | ---: | ---: |
| `fired` | 132,437 | 132,437 | **+0** |
| `not_evaluable/insufficient_warmup` | 55,332 | 435,042 | +379,710 |
| `not_evaluable/missing_market_context` | 0 | 99,551 | +99,551 |
| `not_fired` | 2,974,573 | 2,495,312 | −479,261 |

| s6-resistance-breakout | control | treatment | delta |
| --- | ---: | ---: | ---: |
| `fired` | 27,269 | 27,269 | **+0** |
| `not_evaluable/insufficient_warmup` | 723,985 | 632,602 | −91,383 |
| `not_evaluable/missing_market_context` | 0 | 99,551 | +99,551 |
| `not_fired` | 2,411,088 | 2,402,920 | −8,168 |

| s9-squeeze-expansion | control | treatment | delta |
| --- | ---: | ---: | ---: |
| `fired` | 1,319 | 1,319 | **+0** |
| `not_evaluable/insufficient_warmup` | 78,746 | 443,890 | +365,144 |
| `not_evaluable/missing_market_context` | 0 | 99,551 | +99,551 |
| `not_fired` | 3,082,277 | 2,617,582 | −464,695 |

**No fired signal moved on any instrument in either arm** — distinct-entity, compared on exact fired **date sets** per instrument (3,660 / 3,539 / 948 distinct instruments), not on counts, so an equal-sized substitution cannot hide. `--compare` exits non-zero if any set differs.

S-6's `insufficient_warmup` falls while the other two rise because S-6 already refused most of those bars on its volume-average input; the new code takes precedence on the overlap (a data reason beats warm-up), so its 91,383 move sideways rather than up.

## ⚠⚠ The A/B surfaced something the pre-implementation query missed

The estimate on the issue was ~9,688 bars. The measured effect is **99,551 per strategy**, because that query only counted dates *after* the benchmark's first stored bar. It is not:

```
SPY stored span: 2022-05-10 → 2026-08-13, 1,044 bars
benchmark-absent bars, whole validated universe: 108,176 before SPY's first bar / 9,688 inside its span
MarketRegimeProvider: 1,044 benchmark days, 845 classifiable, first 2023-02-27
```

**`price_daily` holds only 1,044 SPY bars, so the regime is classifiable only from 2023-02-27 onward.** Every S-5/S-6/S-9 bar before that is unevaluable — a hard ceiling on the addressable history of all three strategies, and previously invisible because it read as `not_fired`. Making it countable is the point of the change; **filling the benchmark series is separate work and is not in this PR.**

## Verification

- `uv run ruff check .` · `ruff format --check .` · `pyright` — clean (0 errors)
- `pytest -m "not db"` — green · `pytest tests/smoke` — green
- `codex exec review --base origin/main` (checkpoint 2, corpus rung) — no findings
- 23 new tests in `tests/test_2437_missing_market_context.py`; the `strategy_signals` vocabulary pin retargeted to sql/351 and extended to the two sql/276 tables, which had **no** pin at all — the #2218 closed-vocabulary-in-N-places defect one table over.
- sql/351 replayed against the dev DB and verified idempotent (`DROP CONSTRAINT IF EXISTS` + `ADD`).

⚠ Note for the operator: the dev DB carried a phantom `schema_migrations` row for this filename from an abandoned sibling attempt at 16:47 UTC (constraint state identical, file gone from disk, no branch or PR). Resolved with the runner's own documented remedy — reset `content_sha256` to NULL and re-record. A fresh database applies sql/351 cleanly.

## Security model

Not applicable — no authentication, authorisation, user input or broker surface is touched. The change is confined to how a strategy's own verdict is classified and stored.

Refs #2437.
