### PR TITLE
feature(#2437): S-8 range mean reversion — the fourth strategy, and the first that bets on a range holding

### DIFF
--- a/app/services/indicator_series.py
+++ b/app/services/indicator_series.py
@@ -482,6 +482,133 @@ def atr_series(series: BarSeries, *, universe: Universe, period: int = 14) -> In
     return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
 
 
+def adx_series(series: BarSeries, *, universe: Universe, period: int = 14) -> IndicatorSeries:
+    """Wilder's ADX — Average Directional Index.
+
+    SOURCE RULE: J. Welles Wilder Jr., *New Concepts in Technical Trading
+    Systems* (1978), ch. 4. Nothing here is ours to choose, and the steps are
+    named so a reader can check them against the book rather than against this
+    docstring:
+
+    1. ``+DM`` = ``high[i] - high[i-1]`` when that exceeds both
+       ``low[i-1] - low[i]`` and zero, else 0. ``-DM`` mirrors it. ⚠ A bar with
+       BOTH moves larger keeps only the larger one; an inside bar contributes
+       neither. Taking both — the obvious vectorisation — makes every bar
+       directional and drives ADX up.
+    2. ``TR`` exactly as ``atr_series`` computes it.
+    3. Wilder-smooth all three over ``period``.
+    4. ``+DI = 100 * smoothed(+DM) / smoothed(TR)``, ``-DI`` likewise.
+    5. ``DX = 100 * |+DI - -DI| / (+DI + -DI)``.
+    6. ``ADX`` = Wilder average of ``DX``, seeded with the mean of its first
+       ``period`` values.
+
+    ⚠ WILDER'S RUNNING-SUM FORM AND THE AVERAGE FORM ARE INTERCHANGEABLE HERE,
+    and the average form is used to match ``atr_series``. The book smooths as
+    ``S = S_prev - S_prev/period + current`` (a running SUM); this smooths as
+    ``S = (S_prev*(period-1) + current)/period`` (its average, i.e. the sum over
+    ``period``). ``+DI`` is a RATIO of two identically-smoothed series, so the
+    constant factor cancels exactly and the DI values are the book's. Stated
+    because the two forms differ by ``period``x and comparing one to the other
+    looks like a bug.
+
+    ⚠ FAIL-CLOSED FROM THE FIRST MASKED FIELD, matching ``atr_series`` rather
+    than skipping the bar. Wilder smoothing is recursive: a gap does not affect
+    one value, it shifts every value after it. Resuming past a hole would
+    produce numbers that look valid and are not, so everything from the first
+    unusable bar is ``not_evaluable``.
+
+    ⚠ ``DX`` DENOMINATOR OF ZERO is possible — a stretch with no directional
+    movement at all gives ``+DI = -DI = 0``. Wilder does not define DX there.
+    It is reported as unevaluable rather than as ``DX = 0``: zero means "equal
+    directional pressure", which is a measurement, and this is its absence.
+    """
+    _check_period(period)
+    rows = series.rows
+    n = len(rows)
+    values: list[float | None] = [None] * n
+
+    highs, lows, closes_f = series.float_highs, series.float_lows, series.float_closes
+    trs: list[float | None] = [None] * n
+    plus_dm: list[float] = [0.0] * n
+    minus_dm: list[float] = [0.0] * n
+    for i in range(1, n):
+        high, low, prev_high, prev_low = highs[i], lows[i], highs[i - 1], lows[i - 1]
+        prev_close = closes_f[i - 1]
+        # Same guard as `atr_series`, plus the previous bar's range, which the
+        # directional movement needs and the true range does not.
+        if (
+            high is None
+            or low is None
+            or prev_high is None
+            or prev_low is None
+            or prev_close is None
+            or closes_f[i] is None
+        ):
+            continue
+        trs[i] = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        up_move = high - prev_high
+        down_move = prev_low - low
+        if up_move > down_move and up_move > 0:
+            plus_dm[i] = up_move
+        if down_move > up_move and down_move > 0:
+            minus_dm[i] = down_move
+
+    first_null = next((i for i in range(1, n) if trs[i] is None), None)
+    horizon = n if first_null is None else first_null
+    unevaluable: list[int] = [] if first_null is None else list(range(first_null, n))
+    # ADX needs `period` smoothed bars, then `period` DX values to seed its own
+    # average: the first reading sits at index `2 * period - 1`.
+    if horizon <= 2 * period - 1:
+        return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+
+    window = [t for t in trs[1 : period + 1] if t is not None]
+    smooth_tr = sum(window) / period
+    smooth_plus = sum(plus_dm[1 : period + 1]) / period
+    smooth_minus = sum(minus_dm[1 : period + 1]) / period
+
+    dx_values: list[float | None] = [None] * n
+
+    def _dx(tr: float, plus: float, minus: float) -> float | None:
+        if tr <= 0:
+            return None
+        plus_di = 100.0 * plus / tr
+        minus_di = 100.0 * minus / tr
+        total = plus_di + minus_di
+        if total <= 0:
+            return None
+        return 100.0 * abs(plus_di - minus_di) / total
+
+    dx_values[period] = _dx(smooth_tr, smooth_plus, smooth_minus)
+    for i in range(period + 1, horizon):
+        tr = trs[i]
+        assert tr is not None
+        smooth_tr = (smooth_tr * (period - 1) + tr) / period
+        smooth_plus = (smooth_plus * (period - 1) + plus_dm[i]) / period
+        smooth_minus = (smooth_minus * (period - 1) + minus_dm[i]) / period
+        dx_values[i] = _dx(smooth_tr, smooth_plus, smooth_minus)
+
+    seed = dx_values[period : 2 * period]
+    if any(value is None for value in seed):
+        # A flat stretch inside the seed window leaves ADX undefined from the
+        # start. Refusing the whole series is the fail-closed reading and keeps
+        # the recursion from being seeded with a fabricated zero.
+        unevaluable = sorted(set(unevaluable) | set(range(2 * period - 1, n)))
+        return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+
+    current = sum(value for value in seed if value is not None) / period
+    values[2 * period - 1] = current
+    for i in range(2 * period, horizon):
+        dx = dx_values[i]
+        if dx is None:
+            # An undefined DX mid-series breaks the recursion for everything
+            # after it, for the same reason a masked bar does.
+            unevaluable = sorted(set(unevaluable) | set(range(i, n)))
+            return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+        current = (current * (period - 1) + dx) / period
+        values[i] = current
+    return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+
+
 def macd_series(
     series: BarSeries,
     *,

--- a/app/services/strategies/s8_range_mean_reversion.py
+++ b/app/services/strategies/s8_range_mean_reversion.py
@@ -1,0 +1,303 @@
+"""S-8 — mean reversion in range. Fourth of the S-5…S-10 set.
+
+Parent spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §3 (S-8),
+§1 (regime). Registry contract: ``app/services/strategy_registry.py``.
+Refs #2437, #2240.
+
+THE RULE, VERBATIM FROM §3
+-------------------------
+    Setup: regime ∈ {``bear_quiet``, ``bull_quiet``}; ADX(14) < 20 (no trend —
+    Wilder's ADX). Signal: ``close(t)`` < lower Bollinger band (20, 2) **and**
+    ``close(t) > close(t-1)``. Exit: target = middle band (20-SMA); stop
+    ``entry - 1.5 x ATR(14)``; max hold 15 bars. Params: 5. Data: OHLC.
+
+WHY THIS ONE IS DIFFERENT FROM THE THREE ALREADY SHIPPED
+--------------------------------------------------------
+S-5, S-6 and S-9 are all *continuation or reaction at a structure* — a level, or
+a volatility state. S-8 is the only one that bets on a range HOLDING, and it is
+the only one permitted in a bear regime. That is deliberate breadth rather than
+a fifth variant: a portfolio of shots with stated domains needs at least one
+whose domain is "the market is going nowhere".
+
+⚠⚠ EVERY GATE HERE IS A PUBLISHED FORMULATION, AND THE 20 IS WILDER'S.
+ADX below 20 as "no trend" is Wilder's own reading in *New Concepts in Technical
+Trading Systems* (1978) ch. 4, not a percentile of our corpus and not a number
+picked to make the funnel look right. The Bollinger band is (20, 2), Bollinger's
+own defaults, same as the regime's. Nothing in this module is tuned.
+
+⚠ THE SECOND SIGNAL LEG IS THE WHOLE DIFFERENCE BETWEEN THIS AND CATCHING A
+FALLING KNIFE. ``close(t) < lower band`` alone fires on every bar of a decline
+once price leaves the band, which in a genuine breakdown is many bars in a row
+and each one worse than the last. ``close(t) > close(t-1)`` requires the bar to
+have turned up — one day of evidence that the excursion is being bought rather
+than continued. It is the cheapest possible confirmation and it is the reason
+the rule is mean reversion rather than momentum-in-reverse.
+
+⚠ THE TARGET IS THE MIDDLE BAND, WHICH IS NOT AN ATR MULTIPLE, AND THAT IS THE
+POINT. The band is where the rule says price is going — the mean it is reverting
+to. An ATR-sized target would be a different strategy that happens to enter on
+the same bar. It also means the reward is NOT fixed: a wide band gives a large
+target and a narrow one gives a small target, which is the correct behaviour for
+a rule whose thesis is "this excursion is too big for this regime".
+
+⚠ NO EXIT SIGNAL LEG. Target, stop and max-hold are all measured from the entry
+or from the signal bar, so all three are position state — the same shape as
+S-4/S-5/S-6/S-9 and unlike S-1/S-3, which carry a per-bar exit rule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+
+from app.services.indicator_series import (
+    BarSeries,
+    IndicatorSeries,
+    Universe,
+    adx_series,
+    atr_series,
+    bollinger_series,
+)
+from app.services.market_regime import (
+    BOLLINGER_NUM_STD,
+    BOLLINGER_PERIOD,
+    REGIME_RULE_VERSION,
+    Regime,
+    RegimeSeries,
+)
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+
+S8_STRATEGY_ID = "s8-range-mean-reversion"
+
+#: ⚠ FIXED, NEVER TUNED.
+ATR_PERIOD = 14
+ADX_PERIOD = 14
+
+#: Wilder's own "no trend" reading. ⚠ NOT a percentile of our corpus — see the
+#: module docstring. Moving it is a new strategy, not a calibration.
+ADX_TREND_CEILING = 20.0
+
+#: ⚠ IMPORTED FROM ``market_regime`` RATHER THAN RESTATED. The regime's
+#: volatility leg and this strategy's entry band must be the SAME band: if they
+#: drifted apart, S-8 would measure an excursion against one distribution while
+#: being gated on another, and the disagreement would show only at the extreme
+#: — which is the only place either is consulted. S-9 restates its constants
+#: deliberately (to hold a comparison against S-4 fixed); S-8 has no such
+#: comparison, so the shared definition is the safer choice.
+ENTRY_BAND_PERIOD = BOLLINGER_PERIOD
+ENTRY_BAND_NUM_STD = BOLLINGER_NUM_STD
+
+#: The bracket. ⚠ Only the STOP is an ATR multiple — the target is the middle
+#: band, which is a price, not a distance.
+ATR_STOP_MULTIPLE = 1.5
+MAX_HOLD_BARS = 15
+
+#: ⚠ THE ONLY STRATEGY IN THE SET PERMITTED IN A BEAR REGIME, and §3 says so.
+#: A range is a range whichever side of the 200-SMA it sits on; what S-8 cannot
+#: survive is a BULGE, because an expanding band is the market telling you the
+#: excursion is not an excursion. Both volatile regimes are therefore excluded,
+#: which is the same exclusion S-6 makes and for the same reason.
+PERMITTED_REGIMES = frozenset({Regime.BEAR_QUIET, Regime.BULL_QUIET})
+
+#: ⚠ §3 says "Params: 5"; criterion 11 hashes everything that makes this a
+#: distinct strategy, including the shared regime rule version — the same bars
+#: under a different regime boundary produce different signals.
+S8_PARAMS: Mapping[str, object] = {
+    "atr_period": ATR_PERIOD,
+    "adx_period": ADX_PERIOD,
+    "adx_trend_ceiling": ADX_TREND_CEILING,
+    "entry_band_period": ENTRY_BAND_PERIOD,
+    "entry_band_num_std": ENTRY_BAND_NUM_STD,
+    "atr_stop_multiple": ATR_STOP_MULTIPLE,
+    "max_hold_bars": MAX_HOLD_BARS,
+    "permitted_regimes": tuple(sorted(r.value for r in PERMITTED_REGIMES)),
+    "regime_rule_version": REGIME_RULE_VERSION,
+}
+
+#: DERIVED. ADX(14) binds by a wide margin: Wilder's index needs ``period``
+#: smoothed bars and then ``period`` DX readings to seed its own average, so its
+#: first value sits at ``2 * ADX_PERIOD - 1``. The band is ready at 19 and ATR
+#: at 14.
+WARMUP_BARS = 2 * ADX_PERIOD - 1
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s8_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-8 on one universe under one cost model."""
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "pass app.services.cost_model.COST_MODEL_ID rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S8_STRATEGY_ID,
+        params=S8_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, in the shape the runner checks for evaluability.
+
+    ⚠ ``not_evaluable_indices`` is load-bearing: without it a MASKED close is
+    recorded as ``insufficient_warmup``. The verdict stays "not evaluable" so
+    nothing breaks — only the REASON is wrong, which survives every test that
+    checks whether a bar fired. S-6 shipped that bug; a guard caught it.
+    """
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
+def _prior_close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """``close(t-1)``, declared so the turn-up leg cannot be judged without it.
+
+    ⚠⚠ DECLARED, NOT READ INLINE, AND THAT IS THE POINT OF THE REGISTRY.
+    ``close(t) > close(t-1)`` reaches one bar back, so a masked ``close(t-1)``
+    makes bar ``t`` unjudgeable even though every input AT ``t`` is fine. Reading
+    it inside the body and returning ``False`` would store that bar as
+    ``not_fired`` — the exact defect #2437 fixed for the regime, one input over.
+
+    ⚠ Index 0 is a bare ``None`` (warm-up: there is no prior bar), while a
+    masked prior close is listed. The two are different facts and the registry
+    counts them separately.
+    """
+    closes = series.float_closes
+    values: list[float | None] = [None] + list(closes[:-1])
+    return IndicatorSeries(
+        values=tuple(values),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i in range(1, len(closes)) if closes[i - 1] is None),
+    )
+
+
+def s8_exit_bracket(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> tuple[Decimal, Decimal, int]:
+    """``(take_profit, stop_loss, max_hold_bars)`` for a fill against S-8's signal bar.
+
+    ⚠ ORDER MATCHES S-4, S-5, S-6 AND S-9 — target first. All return
+    ``tuple[Decimal, Decimal, int]``, so a mismatched order is invisible to the
+    type checker and would invert every bracket (#2623's shape).
+
+    ⚠⚠ THE TARGET IS READ AT THE SIGNAL BAR AND NEVER MOVES. The middle band is
+    recomputed every bar, so a target that tracked it would be a trailing exit —
+    a different rule, and one whose exit price depends on bars after the entry.
+    §3.5's "levels are fixed at signal time and never move" is inherited from the
+    parent catalogue and is what makes the outcome attributable to the signal.
+
+    ⚠ AN INVERTED BRACKET IS REACHABLE AND IS NOT A BUG TO PREVENT. The target
+    is anchored to the signal bar's band while the stop is anchored to the FILL,
+    so a gap up through the middle band on the open of ``t+1`` leaves
+    ``target <= stop``. The manifest adapter refuses it as
+    ``unorderable_exit_levels``, which is the truthful state: the rule's thesis
+    was consumed by the gap before the position existed.
+    """
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    atr_at_signal = atr.values[signal_index]
+    if atr_at_signal is None:
+        raise ValueError(f"S-8 bracket needs ATR at the signal bar; index {signal_index} is unevaluable")
+    bands = bollinger_series(series, universe=universe, period=ENTRY_BAND_PERIOD, num_std=ENTRY_BAND_NUM_STD)
+    middle = bands.components["middle"][signal_index]
+    if middle is None:
+        raise ValueError(f"S-8 bracket needs the middle band at the signal bar; index {signal_index} is unevaluable")
+    stop = entry_price - Decimal(str(ATR_STOP_MULTIPLE * atr_at_signal))
+    target = Decimal(str(middle))
+    return target, stop, MAX_HOLD_BARS
+
+
+def s8_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    """S-8's entry verdict for every bar. ⚠ ENTRIES ONLY — see the module docstring."""
+    if masked_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {masked_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+    if len(regime) != len(series):
+        raise ValueError(f"regime series has {len(regime)} bars against {len(series)} price bars; they must align")
+
+    closes = series.float_closes
+    prior_closes = _prior_close_input(series, universe=universe)
+    adx = adx_series(series, universe=universe, period=ADX_PERIOD)
+    bands = bollinger_series(series, universe=universe, period=ENTRY_BAND_PERIOD, num_std=ENTRY_BAND_NUM_STD)
+    lower = bands.components["lower"]
+
+    inputs = (
+        StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
+        StrategyInput(series=prior_closes, reason=masked_reason),
+        StrategyInput(series=adx, reason=masked_reason),
+        StrategyInput(series=bands, reason=masked_reason),
+        # ⚠⚠ THE REGIME IS AN INPUT, NOT JUST A GATE IN THE BODY (#2437). A date
+        # on which the benchmark contributed no bar cannot be judged by this
+        # strategy at all; without this line it would be stored as `not_fired`.
+        # ⚠ DECLARED LAST: `_unevaluable_reason_at` returns the FIRST matching
+        # input's reason, and a bar that is both quarantined and missing its
+        # market context is counted under the instrument's own defect.
+        StrategyInput(series=regime, reason="missing_market_context"),
+    )
+
+    def entry(index: int) -> bool:
+        close = closes[index]
+        prior = prior_closes.values[index]
+        adx_now = adx.values[index]
+        band = lower[index]
+        # Not reachable through `evaluate`, which refuses the bar first.
+        assert close is not None and prior is not None and adx_now is not None and band is not None
+        # ⚠ The regime is the cheapest refusal and the most fundamental, so it
+        # is checked first — the same ordering S-6 uses.
+        if not regime.permits(index, PERMITTED_REGIMES):
+            return False
+        # ⚠ STRICTLY BELOW the ceiling. Wilder's reading is "below 20"; `<= 20`
+        # would admit the boundary, and a boundary admitted on one side of a
+        # published threshold is a redefinition of it.
+        if adx_now >= ADX_TREND_CEILING:
+            return False
+        if close >= band:
+            return False
+        # The turn-up. ⚠ STRICT: an unchanged close is not a turn.
+        return close > prior
+
+    return evaluate(entry, inputs=inputs, n_bars=len(series), kind="entry")
+
+
+__all__ = [
+    "ADX_PERIOD",
+    "ADX_TREND_CEILING",
+    "ATR_PERIOD",
+    "ATR_STOP_MULTIPLE",
+    "ENTRY_BAND_NUM_STD",
+    "ENTRY_BAND_PERIOD",
+    "MAX_HOLD_BARS",
+    "PERMITTED_REGIMES",
+    "S8_PARAMS",
+    "S8_STRATEGY_ID",
+    "WARMUP_BARS",
+    "s8_exit_bracket",
+    "s8_identity",
+    "s8_signals",
+]

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -113,6 +113,15 @@ from app.services.strategies.s6_resistance_breakout import (
     s6_identity,
     s6_signals,
 )
+from app.services.strategies.s8_range_mean_reversion import (
+    MAX_HOLD_BARS as S8_MAX_HOLD_BARS,
+)
+from app.services.strategies.s8_range_mean_reversion import (
+    S8_STRATEGY_ID,
+    s8_exit_bracket,
+    s8_identity,
+    s8_signals,
+)
 from app.services.strategies.s9_squeeze_expansion import (
     MAX_HOLD_BARS as S9_MAX_HOLD_BARS,
 )
@@ -520,6 +529,48 @@ def _s9_exit_levels(
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
 
+def _s8_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    return s8_signals(series, universe=universe, masked_reason=masked_reason, regime=regime)
+
+
+def _s8_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-8 exits on the signal bar's middle band / an entry-anchored ATR stop, or the hold cap."""
+    _reject_decision_dates(S8_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=False, level_based=True, max_hold_bars=S8_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s8_exit_levels(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> ExitLevels | UnresolvedReason:
+    """Adapt S-8's bracket to the outcome reason contract.
+
+    ⚠ ``target <= stop`` is MORE reachable here than for the entry-anchored
+    strategies and is still not a bug. S-8's target is the signal bar's middle
+    band while its stop is anchored to the fill, so a gap up through the band on
+    the open of ``t+1`` inverts them — the rule's thesis was consumed before the
+    position existed, and an unresolved outcome is the truthful record of that.
+    """
+    try:
+        target, stop, max_hold = s8_exit_bracket(
+            series, signal_index=signal_index, entry_price=entry_price, universe=universe
+        )
+    except ValueError, IndexError:
+        return "unorderable_exit_levels"
+    if target <= stop:
+        return "unorderable_exit_levels"
+    return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+
+
 def _s5_signals(
     series: BarSeries,
     *,
@@ -692,6 +743,17 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             decision_calendar=_no_decision_calendar,
             signals=_s6_signals,
             exit_levels=_s6_exit_levels,
+        ),
+        S8_STRATEGY_ID: StrategyEntry(
+            strategy_id=S8_STRATEGY_ID,
+            purpose="harness_validation",
+            identity=s8_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s8_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s8_signals,
+            exit_levels=_s8_exit_levels,
         ),
         S9_STRATEGY_ID: StrategyEntry(
             strategy_id=S9_STRATEGY_ID,

--- a/tests/test_2437_s8_range_mean_reversion.py
+++ b/tests/test_2437_s8_range_mean_reversion.py
@@ -1,0 +1,362 @@
+"""S-8 range mean reversion, and the Wilder ADX it needs (#2437).
+
+Two subjects, deliberately in one file: ``adx_series`` exists only because S-8
+needs it, and testing an indicator apart from the rule that consumes it is how
+an indicator ends up correct in isolation and wrong in use.
+
+⚠⚠ THE ADX CROSS-CHECK IS AN INDEPENDENT IMPLEMENTATION, NOT A GOLDEN FILE.
+``adx_series`` smooths with the AVERAGE form (matching ``atr_series``);
+``_wilder_reference`` below smooths with the RUNNING-SUM form Wilder actually
+publishes (``S = S_prev - S_prev/period + current``). The two are algebraically
+equivalent for ``+DI``/``-DI`` because those are ratios, but they are written
+independently and neither is derived from the other — so agreement between them
+is evidence rather than a tautology. A golden file produced by this module would
+have proved only that it still does what it did.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services.indicator_series import BarSeries, OHLCVRow, adx_series, bollinger_series
+from app.services.market_regime import Regime, RegimeSeries
+from app.services.strategies.s8_range_mean_reversion import (
+    ADX_PERIOD,
+    ADX_TREND_CEILING,
+    MAX_HOLD_BARS,
+    PERMITTED_REGIMES,
+    S8_PARAMS,
+    S8_STRATEGY_ID,
+    WARMUP_BARS,
+    s8_exit_bracket,
+    s8_identity,
+    s8_signals,
+)
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+
+U = "survivor_only"
+
+
+def _bars(rows: list[tuple[float, float, float]], *, start: date = date(2020, 1, 1)) -> BarSeries:
+    """``(high, low, close)`` per bar; open tracks the close."""
+    built: list[OHLCVRow] = [
+        {
+            "open": Decimal(str(c)),
+            "high": Decimal(str(h)),
+            "low": Decimal(str(low)),
+            "close": Decimal(str(c)),
+            "volume": 1_000,
+        }  # type: ignore[typeddict-item]
+        for h, low, c in rows
+    ]
+    return BarSeries(dates=tuple(start + timedelta(days=i) for i in range(len(rows))), rows=tuple(built))
+
+
+def _trending(n: int, *, step: float = 1.0) -> list[tuple[float, float, float]]:
+    return [(100 + i * step + 0.5, 100 + i * step - 0.5, 100 + i * step) for i in range(n)]
+
+
+def _ranging(n: int, *, amplitude: float = 3.0) -> list[tuple[float, float, float]]:
+    out = []
+    for i in range(n):
+        mid = 100 + amplitude * math.sin(i * math.pi / 6)
+        out.append((mid + 0.5, mid - 0.5, mid))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Wilder's ADX
+# ---------------------------------------------------------------------------
+
+
+def _wilder_reference(rows: list[tuple[float, float, float]], period: int) -> list[float | None]:
+    """ADX in Wilder's own RUNNING-SUM smoothing, written from the book's steps.
+
+    ⚠ Independent of ``adx_series`` on purpose — see the module docstring. The
+    only thing shared is the definition, which is the thing being checked.
+    """
+    n = len(rows)
+    tr: list[float] = [0.0] * n
+    pdm: list[float] = [0.0] * n
+    mdm: list[float] = [0.0] * n
+    for i in range(1, n):
+        high, low, _ = rows[i]
+        prev_high, prev_low, prev_close = rows[i - 1]
+        tr[i] = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        up, down = high - prev_high, prev_low - low
+        if up > down and up > 0:
+            pdm[i] = up
+        if down > up and down > 0:
+            mdm[i] = down
+
+    out: list[float | None] = [None] * n
+    if n <= 2 * period - 1:
+        return out
+    # Wilder seeds each smoothed SUM with the sum of the first `period` values.
+    s_tr, s_p, s_m = sum(tr[1 : period + 1]), sum(pdm[1 : period + 1]), sum(mdm[1 : period + 1])
+    dx: list[float | None] = [None] * n
+
+    def _dx(t: float, p: float, m: float) -> float | None:
+        if t <= 0:
+            return None
+        pdi, mdi = 100.0 * p / t, 100.0 * m / t
+        return None if pdi + mdi <= 0 else 100.0 * abs(pdi - mdi) / (pdi + mdi)
+
+    dx[period] = _dx(s_tr, s_p, s_m)
+    for i in range(period + 1, n):
+        s_tr = s_tr - s_tr / period + tr[i]
+        s_p = s_p - s_p / period + pdm[i]
+        s_m = s_m - s_m / period + mdm[i]
+        dx[i] = _dx(s_tr, s_p, s_m)
+
+    seed = dx[period : 2 * period]
+    if any(v is None for v in seed):
+        return out
+    current = sum(v for v in seed if v is not None) / period
+    out[2 * period - 1] = current
+    for i in range(2 * period, n):
+        value = dx[i]
+        if value is None:
+            return out
+        current = (current * (period - 1) + value) / period
+        out[i] = current
+    return out
+
+
+class TestAdxAgreesWithAnIndependentWilderImplementation:
+    @pytest.mark.parametrize(
+        "rows",
+        [_trending(80), _trending(80, step=-1.0), _ranging(80), _ranging(80, amplitude=8.0)],
+        ids=["uptrend", "downtrend", "range", "wide-range"],
+    )
+    def test_values_match(self, rows: list[tuple[float, float, float]]) -> None:
+        ours = adx_series(_bars(rows), universe=U, period=ADX_PERIOD).values
+        theirs = _wilder_reference(rows, ADX_PERIOD)
+        assert len(ours) == len(theirs)
+        for index, (mine, ref) in enumerate(zip(ours, theirs, strict=True)):
+            if ref is None:
+                assert mine is None, f"index {index}: we produced {mine} where Wilder's form has none"
+            else:
+                assert mine is not None
+                assert mine == pytest.approx(ref, rel=1e-9), f"index {index}"
+
+    def test_the_reference_actually_produced_values(self) -> None:
+        """⚠ A comparison against an all-``None`` reference passes and proves
+        nothing — the prevention-log lesson from a probe that matched nothing."""
+        assert sum(1 for v in _wilder_reference(_trending(80), ADX_PERIOD) if v is not None) > 40
+
+
+class TestAdxShape:
+    def test_first_value_is_at_twice_the_period_less_one(self) -> None:
+        """Wilder needs ``period`` smoothed bars, then ``period`` DX readings."""
+        values = adx_series(_bars(_trending(80)), universe=U, period=ADX_PERIOD).values
+        assert all(v is None for v in values[: 2 * ADX_PERIOD - 1])
+        assert values[2 * ADX_PERIOD - 1] is not None
+        assert WARMUP_BARS == 2 * ADX_PERIOD - 1
+
+    def test_a_series_shorter_than_the_warmup_is_all_none(self) -> None:
+        values = adx_series(_bars(_trending(20)), universe=U, period=ADX_PERIOD).values
+        assert set(values) == {None}
+
+    def test_values_stay_inside_zero_and_one_hundred(self) -> None:
+        for rows in (_trending(120), _ranging(120, amplitude=12.0)):
+            for value in adx_series(_bars(rows), universe=U, period=ADX_PERIOD).values:
+                if value is not None:
+                    assert 0.0 <= value <= 100.0
+
+    def test_a_clean_trend_reads_higher_than_a_range(self) -> None:
+        """⚠ The DIRECTION of the index, checked on the two cases it exists to
+        separate. Not a threshold assertion — the constant belongs to Wilder,
+        not to this test."""
+        trend = [v for v in adx_series(_bars(_trending(120)), universe=U, period=ADX_PERIOD).values if v is not None]
+        rng = [v for v in adx_series(_bars(_ranging(120)), universe=U, period=ADX_PERIOD).values if v is not None]
+        assert trend[-1] > rng[-1]
+        assert rng[-1] < ADX_TREND_CEILING < trend[-1]
+
+    def test_a_masked_field_makes_everything_after_it_unevaluable(self) -> None:
+        """⚠ Wilder smoothing is RECURSIVE: a hole does not spoil one value, it
+        shifts every value after it. Matching ``atr_series``'s fail-closed
+        horizon rather than resuming past the gap."""
+        rows = _trending(80)
+        series = _bars(rows)
+        holed = BarSeries(
+            dates=series.dates,
+            rows=tuple(
+                {**row, "high": None} if index == 50 else row  # type: ignore[typeddict-item]
+                for index, row in enumerate(series.rows)
+            ),
+        )
+        result = adx_series(holed, universe=U, period=ADX_PERIOD)
+        assert 50 in result.not_evaluable_indices
+        assert 79 in result.not_evaluable_indices
+        assert all(result.values[i] is None for i in range(50, 80))
+
+    def test_a_flat_series_has_no_defined_dx(self) -> None:
+        """No range and no directional movement: ``+DI == -DI == 0``, which
+        Wilder does not define. Reported as absent, never as ``ADX = 0`` — zero
+        means "equal directional pressure", which is a measurement."""
+        flat = [(100.0, 100.0, 100.0)] * 80
+        result = adx_series(_bars(flat), universe=U, period=ADX_PERIOD)
+        assert set(result.values) == {None}
+        assert result.not_evaluable_indices != ()
+
+
+# ---------------------------------------------------------------------------
+# S-8
+# ---------------------------------------------------------------------------
+
+
+def _regime(n: int, value: Regime | None = Regime.BULL_QUIET) -> RegimeSeries:
+    return RegimeSeries(values=(value,) * n)
+
+
+def _excursion(n: int = 120) -> list[tuple[float, float, float]]:
+    """A range with one dip below the lower band that turns up on the next bar.
+
+    ⚠⚠ THE DIP IS SHALLOW ON PURPOSE, AND THE FIRST ATTEMPT AT THIS FIXTURE WAS
+    NOT. A dip to 85 against a lower band of 88.65 cleared the band comfortably
+    and then FAILED to fire, because the excursion itself is directional
+    movement: ADX read **20.14** at the turn bar, just over Wilder's ceiling of
+    20. That is the rule working — a violent drop is not a range excursion, it
+    is the start of a trend, and S-8 declining it is the ADX gate earning its
+    place. The fixture was made milder rather than the ceiling being moved.
+    """
+    rows = _ranging(n)
+    rows[n - 12] = (88.6, 87.6, 88.0)
+    rows[n - 11] = (88.8, 88.0, 88.4)
+    return rows
+
+
+class TestS8FiresOnTheRuleAsWritten:
+    @staticmethod
+    def _verdicts(rows: list[tuple[float, float, float]], regime: RegimeSeries | None = None) -> list[str]:
+        series = _bars(rows)
+        signals = s8_signals(
+            series,
+            universe=U,
+            masked_reason="quarantined_bar",
+            regime=regime if regime is not None else _regime(len(rows)),
+        )
+        return [s.verdict for s in signals]
+
+    def test_it_fires_on_a_turn_up_from_below_the_lower_band(self) -> None:
+        rows = _excursion()
+        series = _bars(rows)
+        bands = bollinger_series(series, universe=U, period=20, num_std=2.0)
+        turn = len(rows) - 11
+        lower = bands.components["lower"][turn]
+        assert lower is not None and rows[turn][2] < lower, "fixture must actually sit below the band"
+        assert rows[turn][2] > rows[turn - 1][2], "fixture must actually turn up"
+        assert self._verdicts(rows)[turn] == "fired"
+
+    def test_it_does_not_fire_while_still_falling(self) -> None:
+        """⚠ THE LEG THAT SEPARATES THIS FROM A FALLING KNIFE. The dip bar is
+        below the band and is DOWN on the day; only the bar that turns up
+        fires."""
+        rows = _excursion()
+        dip = len(rows) - 12
+        assert rows[dip][2] < rows[dip - 1][2]
+        assert self._verdicts(rows)[dip] == "not_fired"
+
+    def test_a_refused_regime_blocks_it(self) -> None:
+        rows = _excursion()
+        assert Regime.BULL_VOLATILE not in PERMITTED_REGIMES
+        verdicts = self._verdicts(rows, _regime(len(rows), Regime.BULL_VOLATILE))
+        assert "fired" not in verdicts
+
+    def test_an_unknown_regime_is_not_evaluable_not_not_fired(self) -> None:
+        """#2437's contract, inherited by every strategy in the set."""
+        rows = _excursion()
+        turn = len(rows) - 11
+        regime = RegimeSeries(
+            values=tuple(None if i == turn else Regime.BULL_QUIET for i in range(len(rows))),
+            not_evaluable_indices=(turn,),
+        )
+        signals = s8_signals(_bars(rows), universe=U, masked_reason="quarantined_bar", regime=regime)
+        assert (signals[turn].verdict, signals[turn].reason) == ("not_evaluable", "missing_market_context")
+
+    def test_a_trending_series_never_fires(self) -> None:
+        """⚠ The ADX gate, exercised through the rule rather than asserted on
+        the indicator. A clean trend reads well above Wilder's 20."""
+        assert "fired" not in self._verdicts(_trending(120))
+
+    def test_a_masked_prior_close_is_a_data_reason_not_warmup(self) -> None:
+        """⚠⚠ ``close(t) > close(t-1)`` reaches one bar BACK, so a masked
+        ``close(t-1)`` makes bar ``t`` unjudgeable even though every input AT
+        ``t`` is fine. Reading it inside the body would have stored `not_fired`
+        — #2437's defect, one input over."""
+        rows = _excursion()
+        series = _bars(rows)
+        hole = 60
+        holed = BarSeries(
+            dates=series.dates,
+            rows=tuple(
+                {**row, "close": None} if index == hole else row  # type: ignore[typeddict-item]
+                for index, row in enumerate(series.rows)
+            ),
+        )
+        signals = s8_signals(holed, universe=U, masked_reason="quarantined_bar", regime=_regime(len(rows)))
+        assert (signals[hole + 1].verdict, signals[hole + 1].reason) == ("not_evaluable", "quarantined_bar")
+
+
+class TestS8Bracket:
+    def test_the_target_is_the_signal_bars_middle_band(self) -> None:
+        rows = _excursion()
+        series = _bars(rows)
+        turn = len(rows) - 11
+        middle = bollinger_series(series, universe=U, period=20, num_std=2.0).components["middle"][turn]
+        assert middle is not None
+        target, stop, max_hold = s8_exit_bracket(series, signal_index=turn, entry_price=Decimal("86"), universe=U)
+        assert target == pytest.approx(Decimal(str(middle)))
+        assert stop < Decimal("86")
+        assert max_hold == MAX_HOLD_BARS
+
+    def test_the_target_does_not_track_the_band_after_the_signal(self) -> None:
+        """§3.5: levels are fixed at signal time and never move. A target that
+        tracked the band would depend on bars after the entry."""
+        rows = _excursion()
+        series = _bars(rows)
+        turn = len(rows) - 11
+        first, _, _ = s8_exit_bracket(series, signal_index=turn, entry_price=Decimal("86"), universe=U)
+        longer = _bars(rows + _ranging(10, amplitude=30.0))
+        again, _, _ = s8_exit_bracket(longer, signal_index=turn, entry_price=Decimal("86"), universe=U)
+        assert first == again
+
+    def test_an_inverted_bracket_is_refused_not_raised(self) -> None:
+        """⚠ Reachable: the target is anchored to the signal bar's band and the
+        stop to the FILL, so a gap up through the band inverts them. The
+        manifest adapter must refuse rather than store a backwards bracket."""
+        rows = _excursion()
+        turn = len(rows) - 11
+        entry = STRATEGY_MANIFEST[S8_STRATEGY_ID]
+        assert entry.exit_levels is not None
+        result = entry.exit_levels(_bars(rows), signal_index=turn, entry_price=Decimal("1000"), universe=U)
+        assert result == "unorderable_exit_levels"
+
+    def test_an_unevaluable_signal_bar_is_refused_not_raised(self) -> None:
+        entry = STRATEGY_MANIFEST[S8_STRATEGY_ID]
+        assert entry.exit_levels is not None
+        result = entry.exit_levels(_bars(_ranging(120)), signal_index=3, entry_price=Decimal("100"), universe=U)
+        assert result == "unorderable_exit_levels"
+
+
+class TestS8Identity:
+    def test_the_identity_names_this_strategy(self) -> None:
+        identity = s8_identity(universe=U, cost_model_id="cost-v1")
+        assert identity.strategy_id == S8_STRATEGY_ID
+        assert identity.params == S8_PARAMS
+
+    def test_an_empty_cost_model_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="cost_model_id must be a non-empty declaration"):
+            s8_identity(universe=U, cost_model_id="  ")
+
+    def test_the_regime_rule_version_is_inside_the_identity(self) -> None:
+        """⚠ Criterion 11: the same bars under a different regime boundary
+        produce different signals, so the boundary is part of what this
+        strategy IS."""
+        assert "regime_rule_version" in S8_PARAMS
+        assert "adx_trend_ceiling" in S8_PARAMS

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -194,6 +194,7 @@ class TestRunnableStrategies:
             "s4-volatility-compression-breakout",
             "s5-support-bounce",
             "s6-resistance-breakout",
+            "s8-range-mean-reversion",
             "s9-squeeze-expansion",
         ]
         assert excluded == ()

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -50,6 +50,7 @@ SPEC_S4 = "s4-volatility-compression-breakout"
 #: §3 of the S-5..S-10 set. Written out for the same reason as the four above.
 SPEC_S5 = "s5-support-bounce"
 SPEC_S6 = "s6-resistance-breakout"
+SPEC_S8 = "s8-range-mean-reversion"
 SPEC_S9 = "s9-squeeze-expansion"
 
 #: Spec §3's table, verbatim, as ``(signal_pair, level_based, max_hold_bars,
@@ -63,6 +64,7 @@ SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
     SPEC_S4: (False, True, 40, False),
     SPEC_S5: (False, True, 30, False),
     SPEC_S6: (False, True, 40, False),
+    SPEC_S8: (False, True, 15, False),
     SPEC_S9: (False, True, 40, False),
 }
 
@@ -75,6 +77,7 @@ SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
     SPEC_S4: frozenset({"entry"}),
     SPEC_S5: frozenset({"entry"}),
     SPEC_S6: frozenset({"entry"}),
+    SPEC_S8: frozenset({"entry"}),
     SPEC_S9: frozenset({"entry"}),
 }
 
@@ -85,11 +88,13 @@ SPEC_CLASSES: dict[str, str] = {
     SPEC_S4: "per_series",
     SPEC_S5: "per_series",
     SPEC_S6: "per_series",
+    SPEC_S8: "per_series",
     SPEC_S9: "per_series",
 }
 
 SPEC_PURPOSES = {
-    strategy_id: "harness_validation" for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S9)
+    strategy_id: "harness_validation"
+    for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S8, SPEC_S9)
 }
 
 
@@ -164,7 +169,7 @@ class TestManifestIsComplete:
         forever. Pin that it is actually reading the modules it claims to — the
         prevention-log lesson from a probe that matched nothing."""
         declared = self._declared_strategy_ids()
-        assert len(declared) == 7, f"expected the seven catalogue modules, walked {sorted(declared)}"
+        assert len(declared) == 8, f"expected the eight catalogue modules, walked {sorted(declared)}"
         assert declared["s1_time_series_momentum.py"] == SPEC_S1
 
     def test_every_strategy_module_is_registered(self) -> None:
@@ -197,6 +202,7 @@ class TestManifestIsComplete:
             SPEC_S4,
             SPEC_S5,
             SPEC_S6,
+            SPEC_S8,
             SPEC_S9,
         }
 
@@ -301,7 +307,7 @@ class TestUniformInvocationEqualsTheDirectCall:
         )
         assert via_manifest == s4_signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
 
-    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S9])
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S8, SPEC_S9])
     def test_the_reason_code_reaches_the_verdict(self, strategy_id: str) -> None:
         """⚠ An adapter could accept ``masked_reason`` and drop it, defaulting
         the module's own argument. Equality against the direct call would still
@@ -318,7 +324,7 @@ class TestUniformInvocationEqualsTheDirectCall:
         assert signals[0].verdict == "not_evaluable"
         assert signals[0].reason == REASON
 
-    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S9])
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S8, SPEC_S9])
     def test_emitted_kinds_are_the_declared_kinds(self, strategy_id: str) -> None:
         """⚠ ``signal_kinds`` is a claim about the strategy, so it is measured
         from what it emits rather than trusted."""


### PR DESCRIPTION
Fourth of the S-5…S-10 set, on the foundation merged in #2708 / #2714 / #2715 / #2719. Spec: `docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md` §3 (S-8).

## Why this one is not a fourth variant

S-5, S-6 and S-9 all react to a *structure* — a level, or a volatility state. **S-8 is the only one that bets on a range HOLDING, and the only one permitted in a bear regime.** §4 of the spec is explicit that the purpose is a portfolio of independent shots with stated domains; that portfolio needs one whose domain is "the market is going nowhere", and until now it had none.

## The rule, and where every number comes from

| leg | rule | source |
| --- | --- | --- |
| Setup | regime ∈ {`bear_quiet`, `bull_quiet`} | §1, shared classifier |
| Setup | ADX(14) **< 20** | Wilder, *New Concepts in Technical Trading Systems* (1978) ch. 4 — his own "no trend" reading |
| Signal | `close(t)` < lower Bollinger band (20, 2) | Bollinger's defaults, **imported from `market_regime`** |
| Signal | `close(t) > close(t-1)` | §3 |
| Exit | target = middle band (20-SMA) at the signal bar; stop `entry − 1.5 × ATR(14)`; max hold 15 | §3 |

Nothing here is tuned, and no threshold is a percentile of our corpus. The band constants are **imported** rather than restated: if the strategy's entry band and the regime's volatility leg drifted apart, S-8 would measure an excursion against one distribution while being gated on another, and the disagreement would appear only at the extreme — the only place either is consulted. (S-9 restates its constants deliberately, to hold a controlled comparison against S-4 fixed. S-8 has no such comparison.)

### The second signal leg is what separates this from catching a falling knife

`close(t) < lower band` alone fires on **every** bar of a decline once price leaves the band — in a genuine breakdown that is many bars in a row, each worse than the last. `close(t) > close(t-1)` requires the bar to have turned up. It is the cheapest possible confirmation and it is why the rule is mean reversion rather than momentum-in-reverse.

### The target is the middle band, which is not an ATR multiple

The band is where the rule *says* price is going. An ATR-sized target would be a different strategy that happens to enter on the same bar. It also means the reward is not fixed — a wide band gives a large target — which is correct for a rule whose thesis is "this excursion is too big for this regime".

⚠ The target is read at the **signal bar and never moves** (§3.5). A target tracking the live band would be a trailing exit whose exit price depends on bars after the entry. Pinned by `test_the_target_does_not_track_the_band_after_the_signal`.

⚠ `target <= stop` is **more reachable here** than for the entry-anchored strategies and is still not a bug: the target is anchored to the signal bar's band while the stop is anchored to the *fill*, so a gap up through the band on the open of `t+1` inverts them. `_s8_exit_levels` refuses it as `unorderable_exit_levels` — the truthful record that the rule's thesis was consumed before the position existed.

## New: `indicator_series.adx_series`

The repo had no ADX — grepped, not assumed. Wilder's, implemented in full (±DM with the larger-move-only rule, TR, Wilder smoothing, ±DI, DX, then the Wilder average of DX).

**⚠⚠ The cross-check is an independent implementation, not a golden file.** `adx_series` smooths with the *average* form (matching `atr_series`); `_wilder_reference` in the test smooths with the *running-sum* form Wilder actually publishes (`S = S_prev − S_prev/period + current`). The two are algebraically equivalent for `±DI` because those are ratios, and they are written separately — so agreement is evidence. A golden file generated by this module would have proved only that it still does what it did. Four series (uptrend, downtrend, range, wide range), every index, `rel=1e-9`.

Two contract decisions worth naming:

- **Fail-closed from the first masked field**, matching `atr_series` rather than skipping the bar. Wilder smoothing is recursive: a gap does not spoil one value, it shifts every value after it. Resuming past a hole produces numbers that look valid and are not.
- **An undefined DX is absent, not zero.** A stretch with no directional movement gives `+DI = −DI = 0` and Wilder does not define DX there. Zero means "equal directional pressure", which is a *measurement*; this is its absence.

⚠ `indicator_series.RULE_SET_VERSION` hashes that module's source and is a registry-wide `INPUT_RULE_SETS` member, so **adding `adx_series` moves every strategy identity**. That is the documented, deliberate over-invalidation this epic has already taken three times (`price_quarantine`, `price_structure`, `indicator_series`): stored signals become visibly stale rather than silently mixed.

## It fires — full-population census

Validated universe, 3,854 instruments scanned (2,920 of 6,774 below the 250-bar floor), production segmentation via `load_unresolved_breaks`, regime from the live `MarketRegimeProvider`:

| verdict | count |
| --- | ---: |
| **`fired`** | **3,355**, across **2,129 distinct instruments** |
| `not_fired` | 2,604,189 |
| `not_evaluable/insufficient_warmup` | 453,828 |
| `not_evaluable/missing_market_context` | 99,402 |
| `not_evaluable/quarantined_bar` | 53,061 |
| `not_evaluable/no_fill_bar` | 4,157 |

Fired by year: **2023 675 · 2024 1,014 · 2025 1,098 · 2026 568** — spread across the whole classifiable span rather than concentrated in one period. (The span starts in 2023 because the benchmark's stored series does; see #2719.)

For scale against the set: S-5 fires 132,437 / 3,660 instruments, S-6 27,269 / 3,539, S-9 1,319 / 948. S-8 sits between S-9 and S-6 — selective, and not so selective it cannot be measured.

**Turnover, checked first per `.claude/skills/quant/strategy-evidence.md`:** ~0.25 signals per name per year against a 15-bar max hold. Nowhere near the Novy-Marx/Velikov ~50%/month bar that disqualified S-1 at 56×/yr.

## A fixture that failed, and why it is worth reading

The first `_excursion` fixture dipped to 85 against a lower band of 88.65 — comfortably below — and **did not fire**. ADX read **20.14** at the turn bar, just over Wilder's ceiling. That is the rule working: a violent drop is not a range excursion, it is the start of a trend, and S-8 declining it is the ADX gate earning its place. The fixture was made milder; the ceiling was not moved. The reasoning is kept in the fixture's docstring.

## Verification

- `ruff check .` · `ruff format --check .` · `pyright` — clean (0 errors)
- `pytest -m "not db"` — green · `pytest tests/smoke` — green
- `codex exec review --base origin/main` (checkpoint 2, corpus rung) — no findings
- 27 new tests in `tests/test_2437_s8_range_mean_reversion.py`
- `test_backtest_run.py::TestRunnableStrategies` and the `test_strategy_manifest.py` spec fixtures updated — S-8 is **runnable**, not excluded, so its outcome producer is wired

## Security model

Not applicable — no authentication, authorisation, user input or broker surface is touched. This adds a pure per-bar rule and a pure indicator.

Refs #2437.
