### PR TITLE
feature(#2437): S-7 trend pullback — fifth firing strategy, first with a stop and no target

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -760,6 +760,10 @@ def _resolved_level_outcomes_for_arms(
             outcome_name = outcome.outcome
             exit_price = outcome.exit_price
             if outcome_name == "ambiguous":
+                # An ambiguous outcome needs BOTH levels touched in one bar, so a
+                # stop-only bracket (take_profit=None, S-7) can never reach here —
+                # the resolver's rule 3 tests a target that does not exist.
+                assert levels.take_profit is not None
                 outcome_name = "tp_hit" if ambiguity_arm == "best_case" else "sl_hit"
                 exit_price = levels.take_profit if ambiguity_arm == "best_case" else levels.stop_loss
             resolved[ambiguity_arm].append(

--- a/app/services/outcome_resolver.py
+++ b/app/services/outcome_resolver.py
@@ -28,10 +28,18 @@ decision. So the discipline is instead:
    favourably (§3.5.4), and a window whose evidence runs out is ``unresolved``
    rather than ``expired``.
 
-⚠ LONG ONLY. ``stop_loss < entry < take_profit`` is validated. That is the
-repo's v1 risk posture (``.claude/CLAUDE.md``), not an oversight — a short
-bracket inverts every comparison below and would be a different rule set with a
-different version, not a flag on this one.
+⚠ LONG ONLY. ``stop_loss < entry`` is validated, and ``entry < take_profit``
+whenever a target exists. That is the repo's v1 risk posture
+(``.claude/CLAUDE.md``), not an oversight — a short bracket inverts every
+comparison below and would be a different rule set with a different version,
+not a flag on this one.
+
+⚠ A bracket may be STOP-ONLY (``take_profit is None``). S-7 is the case: §3
+gives it a stop, an exit signal and a hold cap, and no target — the first
+strategy between the signal-pair shape (S-1/S-3, no levels at all) and the
+full-bracket shape (S-4/S-5/S-6/S-8/S-9). With no target, precedence rows 2, 3
+and 5 below are simply unreachable — nothing reorders — and the close comes
+from the stop, the position layer's exit signal, or the hold cap.
 """
 
 from __future__ import annotations
@@ -116,9 +124,15 @@ class ExitLevels:
     ``entry_timing._compute_take_profit`` reads a thesis ``base_value`` — a
     fundamental valuation target — and returns ``None`` without one. It is not
     ATR-based and does not apply to a TA strategy.
+
+    ⚠ ``take_profit is None`` is a STOP-ONLY bracket (see the module
+    docstring), not an omission: the field has no default, so a caller states
+    the ``None`` visibly (#2288 — a field with a default is a field a writer
+    can forget). A stop is still mandatory; a strategy with neither is not
+    level-based and never constructs this class (S-3's recorded shape).
     """
 
-    take_profit: Decimal
+    take_profit: Decimal | None
     stop_loss: Decimal
     max_hold_bars: int
 
@@ -127,7 +141,7 @@ class ExitLevels:
             raise ValueError(f"max_hold_bars must be >= 1, got {self.max_hold_bars}")
         if self.stop_loss <= 0:
             raise ValueError(f"stop_loss must be > 0, got {self.stop_loss}")
-        if self.stop_loss >= self.take_profit:
+        if self.take_profit is not None and self.stop_loss >= self.take_profit:
             raise ValueError(
                 f"stop_loss {self.stop_loss} is not below take_profit {self.take_profit} "
                 "— this resolver is long-only (.claude/CLAUDE.md risk posture)"
@@ -277,6 +291,11 @@ def resolve_outcome(
     conservative, it is a different bias — it makes TP-first strategies look
     systematically worse, and the distortion scales with how tight the TP is."*
 
+    ⚠ A STOP-ONLY bracket (``take_profit is None``) reaches rules 1 and 4 only;
+    rules 2, 3 and 5 test a target that does not exist and cannot fire. With one
+    level there is no unknowable touch order, so ``ambiguous`` is unreachable
+    for such a bracket by construction — not by a resolution policy.
+
     REFUSALS, and why each is not ``expired``
     -----------------------------------------
     Checked per bar before the rules, in this order: past the end of the series
@@ -377,10 +396,15 @@ def resolve_outcome(
             f"entry_price {entry_price} disagrees with open[{fill_index}] = {fill_open} on "
             f"{series.dates[fill_index]} — the fill and the series must come from the same corpus"
         )
-    if not levels.stop_loss < entry_price < levels.take_profit:
+    if levels.stop_loss >= entry_price:
         raise ValueError(
-            f"levels {levels.stop_loss}/{levels.take_profit} do not bracket the entry {entry_price}: "
-            "a stop at or above entry, or a target at or below it, triggers immediately and is not a trade"
+            f"stop {levels.stop_loss} is not below the entry {entry_price}: "
+            "a stop at or above entry triggers immediately and is not a trade"
+        )
+    if levels.take_profit is not None and entry_price >= levels.take_profit:
+        raise ValueError(
+            f"target {levels.take_profit} is not above the entry {entry_price}: "
+            "a target at or below entry triggers immediately and is not a trade"
         )
     if segment_end_index is not None and segment_end_index < fill_index:
         raise ValueError(
@@ -421,7 +445,7 @@ def resolve_outcome(
                 exit_price=bar_open,
                 entry_price=entry_price,
             )
-        if bar_open >= target:
+        if target is not None and bar_open >= target:
             return _booked(
                 "tp_hit",
                 series=series,
@@ -430,7 +454,8 @@ def resolve_outcome(
                 exit_price=bar_open,
                 entry_price=entry_price,
             )
-        touched_stop, touched_target = low <= stop, high >= target
+        touched_stop = low <= stop
+        touched_target = target is not None and high >= target
         if touched_stop and touched_target:
             return Outcome(
                 outcome="ambiguous",
@@ -450,6 +475,7 @@ def resolve_outcome(
                 entry_price=entry_price,
             )
         if touched_target:
+            assert target is not None  # touched_target requires it
             return _booked(
                 "tp_hit",
                 series=series,

--- a/app/services/strategies/s7_trend_pullback.py
+++ b/app/services/strategies/s7_trend_pullback.py
@@ -1,0 +1,295 @@
+"""S-7 — trend pullback. Fifth of the S-5…S-10 set.
+
+Parent spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §3 (S-7),
+§1 (regime). Registry contract: ``app/services/strategy_registry.py``.
+Refs #2437, #2240.
+
+THE RULE, VERBATIM FROM §3
+-------------------------
+    Setup: close > 200-SMA **and** 50-SMA > 200-SMA; regime ∈ {``bull_quiet``,
+    ``bull_volatile``}. Signal: RSI(14) crosses back **above** 40 having been
+    below it within 5 bars. ⚠ Wilder's RSI, smoothed his way — not a simple
+    moving average of gains. 40 (not 30) because in an uptrend RSI rarely
+    reaches 30; frozen by construction. Exit: stop ``entry − 2.0 × ATR(14)``;
+    exit-signal on ``close < 50-SMA``; max hold 60 bars. Params: 5. Data: OHLC.
+
+⚠⚠ THE FIRST STRATEGY WITH A STOP AND NO TARGET. S-1/S-3 carry an exit rule and
+no levels at all; S-4/S-5/S-6/S-8/S-9 carry a full stop/target bracket. S-7
+sits between them: the stop is position state (an ``ExitLevels`` with
+``take_profit=None`` — the stop-only bracket the resolver documents), while
+"the trend is over" is a per-bar verdict (``close < 50-SMA``) and therefore an
+exit LEG, the same shape as S-3's. Its exit regime is the first to declare
+``signal_pair`` and ``level_based`` together; ``position_builder`` evaluates
+all declared close sources together and the earliest wins, so nothing new is
+needed there.
+
+⚠ THE CROSSING IS EDGE-TRIGGERED, AND THE READING IS RECORDED HERE BECAUSE §3
+COMPRESSES IT INTO ONE SENTENCE. "Crosses back above 40" is taken as the bar
+``t`` with ``rsi(t) > 40`` and ``rsi(t-1) <= 40`` — a crossing, not a state, for
+S-6's measured reason (a state re-fires on every bar of the recovery). "Having
+been below it within 5 bars" is the existential reading: some bar in
+``t-5 … t-1`` with ``rsi < 40`` STRICTLY. Given the cross, ``rsi(t-1) <= 40``
+already holds, so the clause binds only at the equality edge (an RSI that
+touched exactly 40.0 and never dipped below) — it is stated in §3 and evaluated
+literally rather than silently folded into the cross. No published formulation
+exists for the pullback-depth window; 5 bars is §3's own construction, frozen
+in the identity hash.
+
+⚠ A ``None`` IN THE LOOKBACK REFUSES THE CROSS, NOT THE BAR. The bar's own
+inputs decide evaluability (registry §3.1); prior bars may be masked. An
+unevaluable ``rsi(t-1)`` means the crossing cannot be confirmed, so the entry
+verdict is False — the same treatment as S-6's ``prior_close`` — rather than
+``not_evaluable``, which would misreport a judgeable bar as unjudgeable.
+
+⚠⚠ THE EXIT LEG DOES NOT DECLARE THE REGIME INPUT, AND THAT IS DELIBERATE.
+Both legs declare the same four INSTRUMENT inputs (S-3's rule: evaluability is
+a property of the strategy, so the exit does not go half-live 150 bars before
+the entry). The regime is different in kind: it gates the DECISION to enter,
+and ``close < 50-SMA`` reads nothing from the benchmark. Declaring it on the
+exit leg would let a missing benchmark session refuse the exit verdict for a
+position that is already open — the "gate that can retroactively invalidate an
+open position's exit" S-6's level lookup already refuses to be.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+
+from app.services.indicator_series import (
+    BarSeries,
+    IndicatorSeries,
+    Universe,
+    atr_series,
+    rsi_series,
+    sma_series,
+)
+from app.services.market_regime import REGIME_RULE_VERSION, Regime, RegimeSeries
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+
+S7_STRATEGY_ID = "s7-trend-pullback"
+
+#: ⚠ FIXED, NEVER TUNED. Wilder's defaults for RSI and ATR; the 50/200 pair is
+#: the standard trend filter §3 states outright.
+RSI_PERIOD = 14
+ATR_PERIOD = 14
+PULLBACK_SMA_PERIOD = 50
+TREND_SMA_PERIOD = 200
+
+#: ⚠ 40, NOT 30, and §3 says why: in an uptrend RSI rarely reaches 30, so an
+#: oversold threshold tuned for all regimes would make the rule near-mute in the
+#: only regimes it is permitted in. Frozen by construction.
+RSI_REENTRY_THRESHOLD = 40.0
+
+#: The dip window for "having been below it within 5 bars". ⚠ No published
+#: formulation exists for a pullback-depth window; §3's own construction.
+RSI_DIP_LOOKBACK_BARS = 5
+
+#: The stop, in ATR multiples at the signal bar. ⚠ NO TARGET — see the module
+#: docstring. The other close sources are the exit leg and the hold cap.
+ATR_STOP_MULTIPLE = 2.0
+MAX_HOLD_BARS = 60
+
+#: Both bull regimes. A pullback needs a trend to pull back FROM, so the bear
+#: regimes are excluded; unlike S-6, ``bull_volatile`` is permitted — a Bulge is
+#: hostile to breakouts, not to buying a dip inside an intact uptrend, and §3
+#: states the pair outright.
+PERMITTED_REGIMES = frozenset({Regime.BULL_QUIET, Regime.BULL_VOLATILE})
+
+#: ⚠ §3 says "Params: 5" (what a sweep would move); criterion 11 hashes
+#: everything that makes this a distinct strategy, including the shared regime
+#: rule version — the same bars under a different regime boundary produce
+#: different signals.
+S7_PARAMS: Mapping[str, object] = {
+    "rsi_period": RSI_PERIOD,
+    "atr_period": ATR_PERIOD,
+    "pullback_sma_period": PULLBACK_SMA_PERIOD,
+    "trend_sma_period": TREND_SMA_PERIOD,
+    "rsi_reentry_threshold": RSI_REENTRY_THRESHOLD,
+    "rsi_dip_lookback_bars": RSI_DIP_LOOKBACK_BARS,
+    "atr_stop_multiple": ATR_STOP_MULTIPLE,
+    "max_hold_bars": MAX_HOLD_BARS,
+    "permitted_regimes": tuple(sorted(r.value for r in PERMITTED_REGIMES)),
+    "regime_rule_version": REGIME_RULE_VERSION,
+}
+
+#: DERIVED. The 200-SMA binds by a wide margin — warm from bar 199; RSI at 14,
+#: ATR at 14, the 50-SMA at 49.
+WARMUP_BARS = TREND_SMA_PERIOD - 1
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s7_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-7 on one universe under one cost model.
+
+    Both arguments REQUIRED with no default, per S-4: criterion 11 makes universe
+    and cost model part of the identity, so a default would silently register a
+    strategy the caller never declared.
+    """
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "pass app.services.cost_model.COST_MODEL_ID rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S7_STRATEGY_ID,
+        params=S7_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, in the shape the runner checks for evaluability.
+
+    ⚠ ``not_evaluable_indices`` is the point — a bare series of closes carries
+    values but declares no masked bars, so a masked close would fall through to
+    whichever input refused first and record the WRONG reason (S-6's
+    ``test_the_reason_code_reaches_the_verdict``).
+    """
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
+def s7_exit_bracket(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> tuple[None, Decimal, int]:
+    """``(take_profit, stop_loss, max_hold_bars)`` for a fill against S-7's signal bar.
+
+    ⚠⚠ ORDER MATCHES ``s4_exit_bracket`` — TARGET FIRST, THEN STOP — and the
+    target slot is ``None`` BY TYPE, not by value: S-7 has no target, and typing
+    the slot ``None`` makes assigning one a type error rather than a silent
+    strategy change. The triple keeps the sibling factories' shape so a
+    positional inversion stays impossible to miss (#2623) — an inverted build
+    would put ``None`` in ``stop_loss`` and fail loudly at construction.
+
+    ⚠ ATR is read at ``signal_index``, never at the fill bar. Sizing a stop off
+    the fill bar's own range leaks that bar into the decision that produced it.
+    ⚠ The stop is ENTRY-anchored (``entry − 2.0 × ATR``), unlike S-5/S-6's
+    level-anchored stops — §3 measures S-7's risk from the position, because
+    there is no level whose failure defines the trade being wrong.
+    """
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    atr_at_signal = atr.values[signal_index]
+    if atr_at_signal is None:
+        raise ValueError(f"S-7 bracket needs ATR at the signal bar; index {signal_index} is unevaluable")
+    stop = entry_price - Decimal(str(ATR_STOP_MULTIPLE * atr_at_signal))
+    return None, stop, MAX_HOLD_BARS
+
+
+def s7_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    """Both legs of S-7 over ``series``: one entry verdict and one exit verdict per bar.
+
+    Returns entries followed by exits — ``signal_ledger.resolve_fills`` keys on
+    ``(signal_bar_date, kind)``, so the two legs coexist on one bar (S-3's
+    recorded shape). Both legs declare the same four instrument inputs; only the
+    entry declares the regime — see the module docstring for both decisions.
+    """
+    if masked_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {masked_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+    if len(regime) != len(series):
+        raise ValueError(f"regime series has {len(regime)} bars against {len(series)} price bars; they must align")
+
+    closes = series.float_closes
+    rsi = rsi_series(series, universe=universe, period=RSI_PERIOD)
+    pullback_sma = sma_series(series, universe=universe, period=PULLBACK_SMA_PERIOD)
+    trend_sma = sma_series(series, universe=universe, period=TREND_SMA_PERIOD)
+
+    instrument_inputs = (
+        StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
+        StrategyInput(series=rsi, reason=masked_reason),
+        StrategyInput(series=pullback_sma, reason=masked_reason),
+        StrategyInput(series=trend_sma, reason=masked_reason),
+    )
+    # ⚠⚠ THE REGIME IS AN INPUT ON THE ENTRY LEG, NOT JUST A GATE IN THE BODY
+    # (#2437): a date the benchmark could not classify must be refused as
+    # `missing_market_context`, never recorded as a bar the strategy judged and
+    # declined. ⚠ DECLARED LAST — `_unevaluable_reason_at` returns the FIRST
+    # matching input's reason, and an instrument defect should headline over the
+    # market-context fallback. ⚠ ABSENT from the exit leg — module docstring.
+    entry_inputs = (
+        *instrument_inputs,
+        StrategyInput(series=regime, reason="missing_market_context"),
+    )
+
+    def entry(index: int) -> bool:
+        close = closes[index]
+        rsi_now = rsi.values[index]
+        pullback_now = pullback_sma.values[index]
+        trend_now = trend_sma.values[index]
+        # Not reachable through `evaluate`, which refuses the bar first.
+        assert close is not None and rsi_now is not None and pullback_now is not None and trend_now is not None
+        if not regime.permits(index, PERMITTED_REGIMES):
+            return False
+        if close <= trend_now or pullback_now <= trend_now:
+            return False
+        if rsi_now <= RSI_REENTRY_THRESHOLD:
+            return False
+        # The crossing: prior bar at or below the threshold. An unevaluable
+        # prior bar cannot confirm a cross — False, per the module docstring.
+        prior_rsi = rsi.values[index - 1] if index > 0 else None
+        if prior_rsi is None or prior_rsi > RSI_REENTRY_THRESHOLD:
+            return False
+        # "Having been below it within 5 bars": a STRICT dip somewhere in the
+        # window. Masked bars contribute nothing — a dip must be observed.
+        window = rsi.values[max(0, index - RSI_DIP_LOOKBACK_BARS) : index]
+        return any(value is not None and value < RSI_REENTRY_THRESHOLD for value in window)
+
+    def exit_(index: int) -> bool:
+        close = closes[index]
+        pullback_now = pullback_sma.values[index]
+        assert close is not None and pullback_now is not None
+        return close < pullback_now
+
+    n_bars = len(series)
+    return [
+        *evaluate(entry, inputs=entry_inputs, n_bars=n_bars, kind="entry"),
+        *evaluate(exit_, inputs=instrument_inputs, n_bars=n_bars, kind="exit"),
+    ]
+
+
+__all__ = [
+    "ATR_PERIOD",
+    "ATR_STOP_MULTIPLE",
+    "MAX_HOLD_BARS",
+    "PERMITTED_REGIMES",
+    "PULLBACK_SMA_PERIOD",
+    "RSI_DIP_LOOKBACK_BARS",
+    "RSI_PERIOD",
+    "RSI_REENTRY_THRESHOLD",
+    "S7_PARAMS",
+    "S7_STRATEGY_ID",
+    "TREND_SMA_PERIOD",
+    "WARMUP_BARS",
+    "s7_exit_bracket",
+    "s7_identity",
+    "s7_signals",
+]

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -113,6 +113,15 @@ from app.services.strategies.s6_resistance_breakout import (
     s6_identity,
     s6_signals,
 )
+from app.services.strategies.s7_trend_pullback import (
+    MAX_HOLD_BARS as S7_MAX_HOLD_BARS,
+)
+from app.services.strategies.s7_trend_pullback import (
+    S7_STRATEGY_ID,
+    s7_exit_bracket,
+    s7_identity,
+    s7_signals,
+)
 from app.services.strategies.s8_range_mean_reversion import (
     MAX_HOLD_BARS as S8_MAX_HOLD_BARS,
 )
@@ -529,6 +538,62 @@ def _s9_exit_levels(
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
 
+def _s7_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    return s7_signals(series, universe=universe, masked_reason=masked_reason, regime=regime)
+
+
+def _s7_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-7 exits on its own exit leg, an entry-anchored ATR stop, or the hold cap.
+
+    ⚠⚠ THE FIRST REGIME DECLARING ``signal_pair`` AND ``level_based`` TOGETHER.
+    That is S-7's §3 shape — a stop with no target plus a ``close < 50-SMA``
+    exit rule — not a contradiction: ``build_positions`` evaluates every
+    declared close source together and the earliest wins, so the two compose
+    exactly as S-3's signal pair composes with its hold cap.
+    """
+    _reject_decision_dates(S7_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=True, level_based=True, max_hold_bars=S7_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s7_exit_levels(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> ExitLevels | UnresolvedReason:
+    """Adapt S-7's stop-only bracket to the outcome reason contract.
+
+    ⚠ ``take_profit=None`` is the STOP-ONLY bracket ``outcome_resolver``
+    documents — rules 2/3/5 of its precedence table are unreachable and the
+    target-side close comes from the exit leg or the hold cap instead.
+    ⚠ ``stop <= 0`` replaces the siblings' ``target <= stop`` orderability
+    check: with no target the only unorderable state is a stop at or below
+    zero, which a low-priced high-ATR name genuinely produces (``ExitLevels``
+    itself refuses it, so it must be a typed refusal here, not a raise that
+    aborts the whole batch).
+    """
+    try:
+        target, stop, max_hold = s7_exit_bracket(
+            series, signal_index=signal_index, entry_price=entry_price, universe=universe
+        )
+    except ValueError, IndexError:
+        # ⚠ BOTH, deliberately — `ValueError` is the bracket's own refusal (no
+        # ATR); `IndexError` is an out-of-range `signal_index` inside
+        # `atr_series`. A narrow except that reads as exhaustive is worse than
+        # none (S-5's recorded lesson).
+        return "unorderable_exit_levels"
+    if stop <= 0:
+        return "unorderable_exit_levels"
+    return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+
+
 def _s8_signals(
     series: BarSeries,
     *,
@@ -743,6 +808,17 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             decision_calendar=_no_decision_calendar,
             signals=_s6_signals,
             exit_levels=_s6_exit_levels,
+        ),
+        S7_STRATEGY_ID: StrategyEntry(
+            strategy_id=S7_STRATEGY_ID,
+            purpose="harness_validation",
+            identity=s7_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry", "exit"}),
+            exit_regime=_s7_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s7_signals,
+            exit_levels=_s7_exit_levels,
         ),
         S8_STRATEGY_ID: StrategyEntry(
             strategy_id=S8_STRATEGY_ID,

--- a/scripts/probe_2240_outcome_resolver.py
+++ b/scripts/probe_2240_outcome_resolver.py
@@ -72,9 +72,12 @@ PROBES: list[tuple[str, list[tuple[str, str]], str]] = [
         "ambiguity resolved favourably",
         [
             (
-                "        touched_stop, touched_target = low <= stop, high >= target\n"
+                "        touched_stop = low <= stop\n"
+                "        touched_target = target is not None and high >= target\n"
                 "        if touched_stop and touched_target:",
-                "        touched_stop, touched_target = low <= stop, high >= target\n        if False:",
+                "        touched_stop = low <= stop\n"
+                "        touched_target = target is not None and high >= target\n"
+                "        if False:",
             )
         ],
         "test_one_bar_spanning_both_levels_is_ambiguous or "

--- a/scripts/verify_2240_outcome_resolver.py
+++ b/scripts/verify_2240_outcome_resolver.py
@@ -521,6 +521,7 @@ def equivalence(conn: psycopg.Connection[tuple]) -> int:
                 sids.append(sid)
                 rns.append(fill_index + 1)  # row_number() is 1-based
                 stops.append(levels.stop_loss)
+                assert levels.take_profit is not None  # _levels always builds a full bracket
                 targets.append(levels.take_profit)
                 mine[(sid, fill_index + 1)] = out.outcome
 

--- a/tests/test_2437_s7_trend_pullback.py
+++ b/tests/test_2437_s7_trend_pullback.py
@@ -1,0 +1,245 @@
+"""S-7 trend pullback (#2437) — the first strategy with a stop and no target.
+
+⚠ DB-free by design: everything here is a walk over a bar array, per the repo's
+stated default of extracting the decision into a pure function and table-testing
+it.
+
+THE FIXTURE IS VALIDATED, NOT TRUSTED. A monotonic uptrend never dips RSI below
+40 (no losses at all reads RSI 100), so the pullback's depth and the recovery's
+size were tuned against ``rsi_series`` itself and the tests assert the fixture's
+own premises (RSI crossed, trend gates hold) before asserting the verdict —
+S-8's recorded pattern.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services.indicator_series import BarSeries, OHLCVRow, atr_series, rsi_series, sma_series
+from app.services.market_regime import Regime, RegimeSeries
+from app.services.strategies.s7_trend_pullback import (
+    ATR_STOP_MULTIPLE,
+    MAX_HOLD_BARS,
+    PERMITTED_REGIMES,
+    RSI_REENTRY_THRESHOLD,
+    S7_PARAMS,
+    S7_STRATEGY_ID,
+    s7_exit_bracket,
+    s7_identity,
+    s7_signals,
+)
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+
+U = "survivor_only"
+
+
+def _bars(closes: list[float], *, start: date = date(2020, 1, 1)) -> BarSeries:
+    """Closes with a half-point range either side; open tracks the close."""
+    rows: list[OHLCVRow] = [
+        {
+            "open": Decimal(str(c)),
+            "high": Decimal(str(c + 0.5)),
+            "low": Decimal(str(c - 0.5)),
+            "close": Decimal(str(c)),
+            "volume": 1_000,
+        }  # type: ignore[typeddict-item]
+        for c in closes
+    ]
+    return BarSeries(dates=tuple(start + timedelta(days=i) for i in range(len(closes))), rows=tuple(rows))
+
+
+def _regime(n: int, value: Regime | None = Regime.BULL_QUIET) -> RegimeSeries:
+    return RegimeSeries(values=(value,) * n)
+
+
+#: 210 rising bars, a 6-bar pullback deep enough to drag Wilder RSI below 40,
+#: then a recovery whose first bar crosses back above it. Cross at index 216.
+_UP_BARS = 210
+_DIP_BARS = 6
+_CROSS = _UP_BARS + _DIP_BARS
+
+
+def _pullback() -> list[float]:
+    closes = [100 + 0.5 * i for i in range(_UP_BARS)]
+    top = closes[-1]
+    closes.extend(top - 1.5 * j for j in range(1, _DIP_BARS + 1))
+    bottom = closes[-1]
+    closes.extend(bottom + 2.0 * j for j in range(1, 8))
+    return closes
+
+
+class TestS7FiresOnTheRuleAsWritten:
+    @staticmethod
+    def _entry_verdicts(closes: list[float], regime: RegimeSeries | None = None) -> list[str]:
+        signals = s7_signals(
+            _bars(closes),
+            universe=U,
+            masked_reason="quarantined_bar",
+            regime=regime if regime is not None else _regime(len(closes)),
+        )
+        return [s.verdict for s in signals[: len(closes)]]
+
+    def test_the_fixture_actually_crosses(self) -> None:
+        """The premise, asserted rather than trusted — see the module docstring."""
+        series = _bars(_pullback())
+        rsi = rsi_series(series, universe=U, period=14)
+        now, prior = rsi.values[_CROSS], rsi.values[_CROSS - 1]
+        assert now is not None and now > RSI_REENTRY_THRESHOLD
+        assert prior is not None and prior <= RSI_REENTRY_THRESHOLD
+        sma50 = sma_series(series, universe=U, period=50).values[_CROSS]
+        sma200 = sma_series(series, universe=U, period=200).values[_CROSS]
+        assert sma50 is not None and sma200 is not None and sma50 > sma200
+        close = series.float_closes[_CROSS]
+        assert close is not None and close > sma200
+
+    def test_it_fires_on_the_crossing_bar(self) -> None:
+        assert self._entry_verdicts(_pullback())[_CROSS] == "fired"
+
+    def test_it_does_not_fire_while_rsi_is_still_below(self) -> None:
+        verdicts = self._entry_verdicts(_pullback())
+        assert verdicts[_CROSS - 1] == "not_fired"
+
+    def test_it_does_not_refire_while_rsi_stays_above(self) -> None:
+        """⚠ The crossing is an EDGE, not a state — a state re-fires on every
+        bar of the recovery (S-6's measured defect, one strategy over)."""
+        verdicts = self._entry_verdicts(_pullback())
+        assert verdicts[_CROSS + 1 :].count("fired") == 0
+
+    def test_a_monotonic_uptrend_never_fires(self) -> None:
+        """No pullback, no signal: RSI never leaves the top of its range."""
+        assert "fired" not in self._entry_verdicts([100 + 0.5 * i for i in range(230)])
+
+    def test_a_refused_regime_blocks_it(self) -> None:
+        assert Regime.BEAR_QUIET not in PERMITTED_REGIMES
+        closes = _pullback()
+        assert "fired" not in self._entry_verdicts(closes, _regime(len(closes), Regime.BEAR_QUIET))
+
+    def test_bull_volatile_is_permitted(self) -> None:
+        """⚠ Unlike S-6: a Bulge is hostile to breakouts, not to buying a dip
+        inside an intact uptrend. §3 states the pair outright."""
+        closes = _pullback()
+        assert self._entry_verdicts(closes, _regime(len(closes), Regime.BULL_VOLATILE))[_CROSS] == "fired"
+
+    def test_an_unknown_regime_is_not_evaluable_not_not_fired(self) -> None:
+        """#2437's contract, inherited by every strategy in the set."""
+        closes = _pullback()
+        regime = RegimeSeries(
+            values=tuple(None if i == _CROSS else Regime.BULL_QUIET for i in range(len(closes))),
+            not_evaluable_indices=(_CROSS,),
+        )
+        signals = s7_signals(_bars(closes), universe=U, masked_reason="quarantined_bar", regime=regime)
+        assert (signals[_CROSS].verdict, signals[_CROSS].reason) == ("not_evaluable", "missing_market_context")
+
+    def test_below_the_trend_sma_never_fires(self) -> None:
+        """An RSI recovery inside a downtrend is not a pullback — there is no
+        trend to pull back FROM, and the 200-SMA gate says so."""
+        closes = [300 - 0.8 * i for i in range(210)]
+        bottom = closes[-1]
+        closes.extend(bottom + 2.0 * j for j in range(1, 8))
+        assert "fired" not in self._entry_verdicts(closes)
+
+
+class TestS7ExitLeg:
+    def test_it_fires_below_the_50_sma_and_not_above(self) -> None:
+        """⚠ The exit leg declares the same four instrument inputs as the entry
+        (S-3's uniformity rule), so it is live only from the 200-SMA's warmup —
+        the fixture must run past bar 199 before the verdicts mean anything."""
+        closes = [100 + 0.5 * i for i in range(210)]
+        closes.extend(closes[-1] - 3.0 * j for j in range(1, 41))
+        series = _bars(closes)
+        sma50 = sma_series(series, universe=U, period=50)
+        signals = s7_signals(series, universe=U, masked_reason="quarantined_bar", regime=_regime(len(closes)))
+        exits = signals[len(closes) :]
+        assert all(s.kind == "exit" for s in exits)
+        judged = [i for i, s in enumerate(exits) if s.verdict != "not_evaluable"]
+        below = [i for i in judged if (v := sma50.values[i]) is not None and closes[i] < v]
+        above = [i for i in judged if (v := sma50.values[i]) is not None and closes[i] > v]
+        assert below and above, "fixture must exercise both sides of the 50-SMA"
+        assert all(exits[i].verdict == "fired" for i in below)
+        assert all(exits[i].verdict == "not_fired" for i in above)
+
+    def test_the_exit_is_evaluable_without_the_regime(self) -> None:
+        """⚠⚠ THE POINT OF THE ASYMMETRIC INPUT DECLARATION. A missing benchmark
+        session refuses the ENTRY (`missing_market_context`) and must NOT refuse
+        the exit verdict for a position that is already open — `close < 50-SMA`
+        reads nothing from the benchmark."""
+        closes = _pullback()
+        regime = RegimeSeries(
+            values=tuple(None for _ in closes),
+            not_evaluable_indices=tuple(range(len(closes))),
+        )
+        signals = s7_signals(_bars(closes), universe=U, masked_reason="quarantined_bar", regime=regime)
+        entries, exits = signals[: len(closes)], signals[len(closes) :]
+        assert entries[_CROSS].verdict == "not_evaluable"
+        assert entries[_CROSS].reason == "missing_market_context"
+        assert exits[_CROSS].verdict in {"fired", "not_fired"}
+
+
+class TestS7Bracket:
+    def test_the_stop_is_entry_minus_two_atr_and_there_is_no_target(self) -> None:
+        closes = _pullback()
+        series = _bars(closes)
+        atr = atr_series(series, universe=U, period=14).values[_CROSS]
+        assert atr is not None
+        entry_price = Decimal("200")
+        target, stop, max_hold = s7_exit_bracket(series, signal_index=_CROSS, entry_price=entry_price, universe=U)
+        assert target is None
+        assert stop == entry_price - Decimal(str(ATR_STOP_MULTIPLE * atr))
+        assert max_hold == MAX_HOLD_BARS
+
+    def test_the_adapter_builds_a_stop_only_bracket(self) -> None:
+        entry = STRATEGY_MANIFEST[S7_STRATEGY_ID]
+        assert entry.exit_levels is not None
+        levels = entry.exit_levels(_bars(_pullback()), signal_index=_CROSS, entry_price=Decimal("200"), universe=U)
+        assert not isinstance(levels, str)
+        assert levels.take_profit is None
+        assert levels.max_hold_bars == MAX_HOLD_BARS
+
+    def test_a_nonpositive_stop_is_refused_not_raised(self) -> None:
+        """A low-priced high-ATR name puts `entry - 2 x ATR` at or below zero;
+        `ExitLevels` refuses that state, so the adapter must return the typed
+        refusal rather than abort the whole outcome batch."""
+        entry = STRATEGY_MANIFEST[S7_STRATEGY_ID]
+        assert entry.exit_levels is not None
+        result = entry.exit_levels(_bars(_pullback()), signal_index=_CROSS, entry_price=Decimal("0.5"), universe=U)
+        assert result == "unorderable_exit_levels"
+
+    def test_an_unevaluable_signal_bar_is_refused_not_raised(self) -> None:
+        entry = STRATEGY_MANIFEST[S7_STRATEGY_ID]
+        assert entry.exit_levels is not None
+        result = entry.exit_levels(_bars(_pullback()), signal_index=3, entry_price=Decimal("100"), universe=U)
+        assert result == "unorderable_exit_levels"
+
+
+class TestS7ExitRegime:
+    def test_the_first_hybrid_regime_declares_both_close_sources(self) -> None:
+        """S-7's §3 shape: a stop (level) AND a `close < 50-SMA` rule (signal
+        pair) AND a hold cap. `build_positions` evaluates all declared sources
+        together and the earliest wins, so the combination needs no new code."""
+        entry = STRATEGY_MANIFEST[S7_STRATEGY_ID]
+        regime = entry.exit_regime(entry.decision_calendar(()))
+        assert regime.signal_pair is True
+        assert regime.level_based is True
+        assert regime.max_hold_bars == MAX_HOLD_BARS
+        assert regime.rebalance_dates is None
+        assert entry.signal_kinds == frozenset({"entry", "exit"})
+
+
+class TestS7Identity:
+    def test_the_identity_names_this_strategy(self) -> None:
+        identity = s7_identity(universe=U, cost_model_id="cost-v1")
+        assert identity.strategy_id == S7_STRATEGY_ID
+        assert identity.params == S7_PARAMS
+
+    def test_an_empty_cost_model_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="cost_model_id must be a non-empty declaration"):
+            s7_identity(universe=U, cost_model_id="  ")
+
+    def test_the_regime_rule_version_is_inside_the_identity(self) -> None:
+        """⚠ Criterion 11: the same bars under a different regime boundary
+        produce different signals, so the boundary is part of what this
+        strategy IS."""
+        assert "regime_rule_version" in S7_PARAMS

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -194,6 +194,7 @@ class TestRunnableStrategies:
             "s4-volatility-compression-breakout",
             "s5-support-bounce",
             "s6-resistance-breakout",
+            "s7-trend-pullback",
             "s8-range-mean-reversion",
             "s9-squeeze-expansion",
         ]

--- a/tests/test_outcome_resolver.py
+++ b/tests/test_outcome_resolver.py
@@ -70,7 +70,7 @@ def _resolve(
     masked_bar_reasons: dict[int, str] | None = None,
     segment_end_index: int | None = None,
     stop: Decimal = _STOP,
-    target: Decimal = _TARGET,
+    target: Decimal | None = _TARGET,
 ) -> Outcome:
     return resolve_outcome(
         series=_series(rows),
@@ -143,6 +143,45 @@ def test_gap_above_the_target_resolves_at_the_open_even_when_the_low_breaks_the_
     assert out.outcome == "tp_hit"
     assert out.exit_price == Decimal("120")  # the OPEN, better than the 110 target
     assert out.gross_return_pct == Decimal("0.2")
+
+
+def test_a_stop_only_bracket_books_sl_at_the_level() -> None:
+    """S-7's shape: ``take_profit=None``. The stop side is unchanged."""
+    out = _resolve([_bar(), _bar(low=Decimal("90"))], target=None)
+    assert out.outcome == "sl_hit"
+    assert out.exit_price == _STOP
+
+
+def test_a_stop_only_bracket_gap_below_the_stop_books_at_the_open() -> None:
+    out = _resolve([_bar(), _bar(open_=Decimal("92"), low=Decimal("90"))], target=None)
+    assert out.outcome == "sl_hit"
+    assert out.exit_price == Decimal("92")  # rule 1: the open, not the level
+
+
+def test_a_stop_only_bracket_never_books_tp_or_ambiguous() -> None:
+    """With one level there is no unknowable touch order: a bar that would have
+    spanned BOTH levels of a full bracket is a plain stop touch here, and a
+    huge high alone decides nothing."""
+    spanning = _resolve([_bar(), _bar(high=Decimal("500"), low=Decimal("90"))], target=None)
+    assert spanning.outcome == "sl_hit"
+    soaring = _resolve([_bar(), _bar(high=Decimal("500")), _bar()], target=None, max_hold_bars=2)
+    assert soaring.outcome == "expired"
+
+
+def test_a_stop_only_bracket_expires_at_the_next_open() -> None:
+    out = _resolve([_bar(), _bar(), _bar(), _bar(open_=Decimal("104"))], target=None)
+    assert out.outcome == "expired"
+    assert out.exit_price == Decimal("104")
+
+
+def test_a_stop_only_bracket_still_requires_the_stop_below_the_entry() -> None:
+    with pytest.raises(ValueError, match="not below the entry"):
+        _resolve([_bar()], target=None, stop=Decimal("100"))
+
+
+def test_stop_only_levels_still_validate_the_stop() -> None:
+    with pytest.raises(ValueError, match="stop_loss must be > 0"):
+        ExitLevels(take_profit=None, stop_loss=Decimal("0"), max_hold_bars=3)
 
 
 def test_the_fill_bar_is_inside_the_window() -> None:
@@ -321,7 +360,7 @@ def test_levels_validate_themselves(stop: Decimal, target: Decimal, max_hold: in
 def test_levels_must_bracket_the_entry(stop: Decimal, target: Decimal) -> None:
     """Acceptance 11. A stop at or above entry, or a target at or below it,
     triggers immediately and is not a trade."""
-    with pytest.raises(ValueError, match="do not bracket the entry"):
+    with pytest.raises(ValueError, match="triggers immediately and is not a trade"):
         _resolve([_bar(), _bar()], stop=stop, target=target)
 
 

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -50,6 +50,7 @@ SPEC_S4 = "s4-volatility-compression-breakout"
 #: §3 of the S-5..S-10 set. Written out for the same reason as the four above.
 SPEC_S5 = "s5-support-bounce"
 SPEC_S6 = "s6-resistance-breakout"
+SPEC_S7 = "s7-trend-pullback"
 SPEC_S8 = "s8-range-mean-reversion"
 SPEC_S9 = "s9-squeeze-expansion"
 
@@ -64,6 +65,9 @@ SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
     SPEC_S4: (False, True, 40, False),
     SPEC_S5: (False, True, 30, False),
     SPEC_S6: (False, True, 40, False),
+    #: ⚠ The first hybrid: a stop with no target PLUS a `close < 50-SMA` exit
+    #: rule — both close sources declared, per §3 of the S-5..S-10 set.
+    SPEC_S7: (True, True, 60, False),
     SPEC_S8: (False, True, 15, False),
     SPEC_S9: (False, True, 40, False),
 }
@@ -77,6 +81,7 @@ SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
     SPEC_S4: frozenset({"entry"}),
     SPEC_S5: frozenset({"entry"}),
     SPEC_S6: frozenset({"entry"}),
+    SPEC_S7: frozenset({"entry", "exit"}),
     SPEC_S8: frozenset({"entry"}),
     SPEC_S9: frozenset({"entry"}),
 }
@@ -88,13 +93,14 @@ SPEC_CLASSES: dict[str, str] = {
     SPEC_S4: "per_series",
     SPEC_S5: "per_series",
     SPEC_S6: "per_series",
+    SPEC_S7: "per_series",
     SPEC_S8: "per_series",
     SPEC_S9: "per_series",
 }
 
 SPEC_PURPOSES = {
     strategy_id: "harness_validation"
-    for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S8, SPEC_S9)
+    for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S7, SPEC_S8, SPEC_S9)
 }
 
 
@@ -169,7 +175,7 @@ class TestManifestIsComplete:
         forever. Pin that it is actually reading the modules it claims to — the
         prevention-log lesson from a probe that matched nothing."""
         declared = self._declared_strategy_ids()
-        assert len(declared) == 8, f"expected the eight catalogue modules, walked {sorted(declared)}"
+        assert len(declared) == 9, f"expected the nine catalogue modules, walked {sorted(declared)}"
         assert declared["s1_time_series_momentum.py"] == SPEC_S1
 
     def test_every_strategy_module_is_registered(self) -> None:
@@ -202,6 +208,7 @@ class TestManifestIsComplete:
             SPEC_S4,
             SPEC_S5,
             SPEC_S6,
+            SPEC_S7,
             SPEC_S8,
             SPEC_S9,
         }


### PR DESCRIPTION
Fifth of the S-5…S-10 set. Spec: `docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md` §3 (S-7). Refs #2437.

Two commits, deliberately ordered: the `ExitLevels` contract widening lands first with its own tests, then S-7 on top — the order the researched handoff on #2437 prescribed.

## The rule, and where every number comes from

| leg | rule | source |
| --- | --- | --- |
| Setup | close > 200-SMA and 50-SMA > 200-SMA | §3 |
| Setup | regime ∈ {`bull_quiet`, `bull_volatile`} | §1, shared classifier |
| Signal | Wilder RSI(14) crosses back above **40**, having been below it within 5 bars | §3 — 40 not 30 because in an uptrend RSI rarely reaches 30; frozen by construction |
| Exit | stop `entry − 2.0 × ATR(14)`; exit signal `close < 50-SMA`; max hold 60 | §3 |

The crossing is edge-triggered (`rsi(t) > 40` and `rsi(t−1) ≤ 40`) — a state re-fires on every bar of the recovery, S-6's measured defect one strategy over. The 5-bar dip clause is evaluated literally (a strict dip somewhere in `t−5 … t−1`); given the cross it binds only at the equality edge, and the reading is recorded in the module docstring and frozen in the identity hash. No published formulation exists for a pullback-depth window; 5 is §3's own construction.

## Commit 1 — `ExitLevels` learns the stop-only bracket

S-7 has a stop, an exit signal, a hold cap, and **no target**. `ExitLevels` required a `take_profit` and `resolve_outcome` validated `stop < entry < target`, so the bracket was unexpressible — the exact blocker the prior session researched on #2437.

The fix is the one the resolver's own precedence table dictates: with `take_profit=None`, rules 2/3/5 test a target that does not exist and cannot fire; rules 1/4 (the stop) and the expiry exit are untouched, and nothing reorders. `ambiguous` becomes unreachable for a stop-only bracket **by construction** (one level has no unknowable touch order) — the ambiguity-arm consumer in `backtest_run` narrows on that with a stated assert. The field keeps no default, so a caller states the `None` visibly (#2288). `RULE_SET_VERSION` moves via the module's source hash; stored outcomes at the prior version stay pinned under `sql/256`'s version-pair key — no data migration.

## Commit 2 — S-7, the first hybrid exit regime

`ExitRegime(signal_pair=True, level_based=True, max_hold_bars=60)` — the first strategy declaring both close sources. **No position-layer change needed:** `build_positions` already evaluates every declared source together and the earliest wins; both `backtest_run` sites pass exits unconditionally from `_fills`, and `run_outcome_resolution` selects on `entry.exit_levels`. Verified by reading each consumer, and the fast tier exercises them.

Two input-declaration decisions worth naming:

- **Both legs declare the same four instrument inputs** (closes, RSI, 50-SMA, 200-SMA) — S-3's uniformity rule: evaluability is a property of the strategy, so the exit leg does not go live 150 bars before the entry.
- **The exit leg does NOT declare the regime input.** `close < 50-SMA` reads nothing from the benchmark, and a missing benchmark session must never refuse the exit verdict for a position that is already open — the "gate that can retroactively invalidate an open position's exit" S-6's level lookup already refuses to be. Pinned by `test_the_exit_is_evaluable_without_the_regime`.

The bracket factory returns `(None, stop, max_hold)` keeping the siblings' target-first triple — an inverted build would put `None` in `stop_loss` and fail loudly at construction (#2623). The adapter's orderability check becomes `stop <= 0` (reachable on a low-priced high-ATR name), refused as `unorderable_exit_levels` rather than raised.

## It fires — full-population census

Validated universe, 3,854 instruments scanned (2,920 of 6,774 below the 250-bar floor), production segmentation via `load_unresolved_breaks`, regime from the live `MarketRegimeProvider`:

| verdict (entry leg) | count |
| --- | ---: |
| **`fired`** | **24,721**, across **3,344 distinct instruments** |
| `not_fired` | 2,313,965 |
| `not_evaluable/insufficient_warmup` | 752,916 |
| `not_evaluable/missing_market_context` | 106,093 |
| `not_evaluable/quarantined_bar` | 16,140 |
| `not_evaluable/no_fill_bar` | 4,157 |

Fired by year: **2023 4,520 · 2024 7,407 · 2025 7,728 · 2026 5,066** — spread across the classifiable span. For scale: S-5 132,437 / 3,660 · S-6 27,269 / 3,539 · S-8 3,355 / 2,129 · S-9 1,319 / 948. The exit leg fired 1,194,757 times, which is correct for a stateless per-bar state (`close < 50-SMA`) — the same shape as S-1/S-3's exit legs; pairing is `build_positions`' job.

**Turnover, checked first per `.claude/skills/quant/strategy-evidence.md`:** ~2.1 entries per name per year against a 60-bar max hold — nowhere near the Novy-Marx/Velikov ~50%/month bar that disqualified S-1.

The warmup census cross-checks against S-8's: S-7's `insufficient_warmup` is larger (752,916 vs 453,828) because the 200-SMA needs more lead-in than S-8's ADX, and declared reasons beat structural warmup per the #2719 contract.

## Codex checkpoint 2

One P2: the `except ValueError, IndexError:` form "parses as `except ValueError as IndexError`". **Rebutted empirically:** this repo runs Python 3.14.4, where PEP 758 makes the unparenthesised form a tuple — probed in-interpreter (`raise IndexError` is caught by that exact handler), and it is the same form the merged S-5/S-6/S-8/S-9 adapters use on main.

The third commit re-anchors `probe_2240_outcome_resolver.py`'s ambiguity probe to the split `touched_target` lines; the harness reports all 9 probes caught, restored suite PASS.

## Security

No security surface: pure research/backtest path — no endpoints, no broker calls, no user input.

## Verification

- `ruff check` / `ruff format --check` / `pyright`: clean (0 errors)
- `pytest -m "not db"`: pass; `pytest tests/smoke`: pass
- probe harness: 9/9 caught
- census above run against the dev DB at this branch
