### PR TITLE
feature(#2437): S-10 relative-strength leader — sixth firing strategy, second cross-sectional, first with a ranked exit leg

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -128,7 +128,12 @@ from app.services.strategies.validated_universe import (
     load_validated_universe,
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry, StrategyPurpose
-from app.services.strategy_registry import StrategyIdentity, StrategySignal
+from app.services.strategy_registry import (
+    SignalKind,
+    StrategyIdentity,
+    StrategySignal,
+    resolve_participating_bar,
+)
 from app.services.strategy_result import (
     AMBIGUITY_ARMS,
     CORPUS_VERSION,
@@ -1468,14 +1473,15 @@ def evaluate_arm(
     discarded: Counter[str] = Counter()
     raw_closes_by_instrument: dict[int, tuple[int, array[float]]] = {}
     wealth_closes_by_instrument: dict[int, tuple[int, array[float]]] = {}
-    ranking: _CrossSection | None = None
+    ranking: dict[SignalKind, _CrossSection] | None = None
 
     if entry.strategy_class == "cross_sectional":
-        ranking = _rank_cross_section(
+        ranking = _rank_cross_sections(
             conn,
             entry,
             corpus=corpus,
             quarantine_arm=quarantine_arm,
+            regime_provider=regime_provider,
             progress=progress,
         )
 
@@ -1758,11 +1764,12 @@ def evaluate_level_arms(
     raw_closes_by_instrument: dict[int, tuple[int, array[float]]] = {}
     wealth_closes_by_instrument: dict[int, tuple[int, array[float]]] = {}
     ranking = (
-        _rank_cross_section(
+        _rank_cross_sections(
             conn,
             entry,
             corpus=corpus,
             quarantine_arm=quarantine_arm,
+            regime_provider=regime_provider,
             progress=progress,
         )
         if entry.strategy_class == "cross_sectional"
@@ -1942,7 +1949,7 @@ def _signals_for(
     series: BarSeries,
     *,
     instrument_id: int,
-    ranking: _CrossSection | None,
+    ranking: Mapping[SignalKind, _CrossSection] | None,
     unresolved_breaks: Sequence[date] = (),
     regime_provider: MarketRegimeProvider,
 ) -> list[StrategySignal]:
@@ -1970,32 +1977,74 @@ def _signals_for(
             regime=regime_provider.for_dates(series.dates),
         )
     assert entry.member is not None and ranking is not None
-    staged = segmented_member(
-        entry,
-        series,
-        panel_decision_dates=ranking.decision_dates,
-        universe=BACKTEST_UNIVERSE,
-        masked_reason="quarantined_bar",
-        unresolved_breaks=unresolved_breaks,
-    )
     signals: list[StrategySignal] = []
-    for index, verdict in enumerate(staged.verdicts):
-        if verdict is not None:
-            signals.append(verdict)
-            continue
-        when = series.dates[index]
-        if when in ranking.thin:
-            # ⚠ ``min_participants`` is the RUNNER's call, mirroring
-            # ``evaluate_cross_sectional``: an empty return from ``select``
-            # cannot be told apart from "the panel was too thin", and criterion
-            # 8 exists to keep that distinction countable.
+    for leg, leg_ranking in sorted(ranking.items()):
+        staged = segmented_member(
+            entry,
+            series,
+            panel_decision_dates=leg_ranking.decision_dates,
+            universe=BACKTEST_UNIVERSE,
+            masked_reason="quarantined_bar",
+            unresolved_breaks=unresolved_breaks,
+            regime=regime_provider.for_dates(series.dates),
+            leg=leg,
+        )
+        for index, verdict in enumerate(staged.verdicts):
+            if verdict is not None:
+                signals.append(verdict)
+                continue
+            when = series.dates[index]
+            if when in leg_ranking.thin:
+                # ⚠ ``min_participants`` is the RUNNER's call, mirroring
+                # ``evaluate_cross_sectional``: an empty return from ``select``
+                # cannot be told apart from "the panel was too thin", and criterion
+                # 8 exists to keep that distinction countable.
+                signals.append(
+                    StrategySignal(verdict="not_evaluable", signal_index=index, kind=leg, reason="thin_cross_section")
+                )
+                continue
             signals.append(
-                StrategySignal(verdict="not_evaluable", signal_index=index, kind="entry", reason="thin_cross_section")
+                resolve_participating_bar(
+                    when=when,
+                    index=index,
+                    kind=leg,
+                    selected=instrument_id in leg_ranking.winners.get(when, frozenset()),
+                    admissible_dates=staged.admissible_dates,
+                    mandatory_dates=staged.mandatory_dates,
+                )
             )
-            continue
-        fired = instrument_id in ranking.winners.get(when, frozenset())
-        signals.append(StrategySignal(verdict="fired" if fired else "not_fired", signal_index=index, kind="entry"))
     return signals
+
+
+def _rank_cross_sections(
+    conn: psycopg.Connection[Any],
+    entry: StrategyEntry,
+    *,
+    corpus: _Corpus,
+    quarantine_arm: QuarantineArm,
+    regime_provider: MarketRegimeProvider,
+    progress: ProgressCallback | None = None,
+) -> dict[SignalKind, _CrossSection]:
+    """Sub-pass A per ranked leg — one corpus read per leg, S-2 one, S-10 two.
+
+    ⚠ NOT one read shared: S-10's legs rank DIFFERENT panels (the entry panel
+    carries the $1 floor, the exit panel does not), so their score sets
+    genuinely differ and a shared read would silently rank one leg on the
+    other's denominator.
+    """
+    legs: tuple[SignalKind, ...] = ("entry", "exit") if entry.exit_leg is not None else ("entry",)
+    return {
+        leg: _rank_cross_section(
+            conn,
+            entry,
+            corpus=corpus,
+            quarantine_arm=quarantine_arm,
+            regime_provider=regime_provider,
+            leg=leg,
+            progress=progress,
+        )
+        for leg in legs
+    }
 
 
 def _rank_cross_section(
@@ -2004,6 +2053,8 @@ def _rank_cross_section(
     *,
     corpus: _Corpus,
     quarantine_arm: QuarantineArm,
+    regime_provider: MarketRegimeProvider,
+    leg: SignalKind = "entry",
     progress: ProgressCallback | None = None,
 ) -> _CrossSection:
     """Sub-pass A: stage every member and rank each decision date's cross-section.
@@ -2018,7 +2069,12 @@ def _rank_cross_section(
     eligible subset: a name that stopped trading in 1998 still contributed the
     sessions on which the panel rebalanced.
     """
-    assert entry.member is not None and entry.select is not None and entry.min_participants is not None
+    if leg == "entry":
+        select, min_participants = entry.select, entry.min_participants
+    else:
+        assert entry.exit_leg is not None
+        select, min_participants = entry.exit_leg.select, entry.exit_leg.min_participants
+    assert entry.member is not None and select is not None and min_participants is not None
     decision_dates = entry.decision_calendar(corpus.axis)
     if decision_dates is None:  # pragma: no cover - the manifest guarantees one
         raise RuntimeError(f"{entry.strategy_id} is cross_sectional but returned no decision calendar")
@@ -2057,6 +2113,8 @@ def _rank_cross_section(
             universe=BACKTEST_UNIVERSE,
             masked_reason="quarantined_bar",
             unresolved_breaks=corpus.unresolved_breaks.get(instrument_id, ()),
+            regime=regime_provider.for_dates(series.dates),
+            leg=leg,
         )
         for when, value in staged.scores.items():
             scores.setdefault(when, {})[instrument_id] = value
@@ -2074,15 +2132,15 @@ def _rank_cross_section(
     thin: set[date] = set()
     for when in sorted(scores):
         at_date = scores[when]
-        if len(at_date) < entry.min_participants:
+        if len(at_date) < min_participants:
             thin.add(when)
             continue
-        selected = frozenset(entry.select(when, at_date))
+        selected = frozenset(select(when, at_date))
         unknown = selected - at_date.keys()
         if unknown:
             raise ValueError(
-                f"{entry.strategy_id} select returned {sorted(unknown)} on {when}, which did not participate in "
-                "that cross-section — every winner must be one of the members offered"
+                f"{entry.strategy_id} {leg} select returned {sorted(unknown)} on {when}, which did not participate "
+                "in that cross-section — every winner must be one of the members offered"
             )
         winners[when] = selected
     return _CrossSection(decision_dates=decision_dates, winners=winners, thin=frozenset(thin))

--- a/app/services/strategies/s10_relative_strength_leader.py
+++ b/app/services/strategies/s10_relative_strength_leader.py
@@ -1,0 +1,413 @@
+"""S-10 — relative-strength leader. The set's second cross-sectional strategy.
+
+Parent spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §S-10.
+Plan + Codex ckpt-1 resolutions:
+``docs/proposals/ta/2026-08-14-s10-implementation-plan.md``. Contract:
+``app/services/strategy_registry.py`` (``admissible_indices`` /
+``mandatory_indices`` were added FOR this module — S-2 predates and ignores
+them). Refs #2437.
+
+THE RULE, VERBATIM FROM §S-10
+-----------------------------
+    Setup: regime ∈ {bull_quiet}; universe ranked by 63-bar return.
+    Signal: enter the top decile that ALSO closes above its own 50-SMA;
+    rebalance monthly.
+    Exit: leaves the top three deciles, or closes below 50-SMA; no fixed stop
+    (cross-sectional).
+
+⚠⚠ THE EXIT CADENCE IS MONTHLY, PINNED BY THE SPEC'S OWN GATE, NOT BY TASTE.
+§S-10 orders the turnover measurement FIRST and disqualifies above
+~50%/month (Novy-Marx/Velikov). Measured on the full validated universe with
+the exact semantics this module ships (``scripts/verify_2437_s10_turnover.py``
+v4, posted on #2437): both exit legs at rebalance only → **36.5%/month**
+steady-state; the 50-SMA exit checked daily → **83.0%/month**. The daily
+reading is not a viable variant of this strategy; the cadence is frozen in
+``S10_PARAMS`` and hashed into the identity.
+
+TWO LEGS, TWO PANELS — the denominators differ and that is a stated choice
+---------------------------------------------------------------------------
+- The ENTRY panel carries S-2's §9 Q3 price floor (``close >= $1``, evaluated
+  as-of the decision bar): momentum-style ranks concentrate tick-quantised
+  penny names in exactly the decile this strategy buys. ⚠ S-2's caveat
+  applies verbatim: on split-adjusted closes this is an ADJUSTED-price floor,
+  and the deviation runs one way (reverse-split survivors of a sub-$1 past
+  pass a floor they would have failed at the time).
+- The EXIT panel is floor-free: a held name that fell under $1 must still be
+  exitable, and the retention band is cut on the panel that contains it.
+- "The top decile that ALSO closes above its own 50-SMA" is read as: the
+  decile is cut on the whole (floored) ranking, then the SMA condition
+  filters the winners WITHOUT backfilling the slots —
+  ``admissible_indices``' exact semantics, built for this sentence.
+- "Leaves the top three deciles" is the band ``ordered[3 * N // 10 :]`` of
+  the exit panel; "closes below 50-SMA" fires REGARDLESS of the band —
+  ``mandatory_indices``' exact semantics.
+
+⚠ THE EXIT LEG IS EVALUABLE ONLY WHEN THE BAR IS RANKABLE (score, SMA and
+close all present). The below-SMA exit does not logically need the rank, but
+a second evaluability regime for one condition inside one leg would be two
+contracts wearing one kind; an unrankable rebalance bar refuses visibly
+(``not_evaluable``) and the position carries to the next evaluable rebalance.
+Counted by the census, never assumed rare.
+
+⚠ THE EXIT LEG DOES NOT DECLARE THE REGIME — S-7's rule: a missing benchmark
+session must never refuse the exit verdict for an open position. Exits run in
+every regime; only entries are gated.
+
+⚠ NO ``max_hold_bars``, NO LEVELS, NO CALENDAR CLOSE — the exit regime is
+``signal_pair`` alone (S-1/S-3's shape). ``rebalance_dates`` stays ``None``
+deliberately: the position layer's C4 closes at "the next rebalance NOT
+RESELECTED", which is entry-set retention — S-10's retention is the WIDER
+top-three-decile band, and the exit leg carries it. Declaring both would
+close band-surviving positions a month early.
+
+⚠ PRICE RETURNS, NOT TOTAL RETURNS — S-2's note applies unchanged: ``close``
+is the split-adjusted series consistent with OHLC (sql/251); the ranking
+systematically understates high-yield names over a 63-bar lookback.
+
+⚠ THIS MODULE NEVER RESOLVES A FILL, AND CANNOT — S-2's note, unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable, Mapping, Set
+from datetime import date
+from pathlib import Path
+
+from app.services.indicator_series import BarSeries, IndicatorSeries, Universe, sma_series
+from app.services.market_regime import REGIME_RULE_VERSION, Regime, RegimeSeries
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    CrossSectionalMember,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate_cross_sectional,
+)
+
+S10_STRATEGY_ID = "s10-relative-strength-leader"
+
+#: §S-10's four free parameters. ⚠ FIXED, NEVER TUNED (§6 of the catalogue
+#: parent: *"Forbidden — continuous re-optimisation"*). Module constants for
+#: S-1's reason: a period that can be passed in is a period that can be swept.
+LOOKBACK_BARS = 63
+ENTRY_DECILE = 10
+EXIT_BAND_DECILES = 3
+SMA_BARS = 50
+
+#: S-2's §9 Q3 floor, entry panel only — module docstring.
+MIN_CLOSE = 1.0
+
+#: The smallest cross-section either leg ranks on — BY CONSTRUCTION, and much
+#: larger than S-2's 10 on purpose. S-2's floor protects a one-shot decile
+#: cut; S-10's retention BAND is evaluated against the panel the book was
+#: formed from, and a decile band cut on a sliver panel is a calendar hole
+#: wearing a rank. Measured while gating (#2437): ``price_daily`` carries
+#: weekend rows for ~11 instruments and one corpus-hole Friday with 243, while
+#: every real panel ran 2,084–5,747. 1000 refuses every observed junk date
+#: and no observed real one; a thin date refuses BOTH legs
+#: (``thin_cross_section``) and holdings simply carry.
+MIN_CROSS_SECTION = 1000
+
+#: Entries only in the quiet bull — §S-10's one-regime setup, narrower than
+#: S-7's pair by the spec's own text.
+PERMITTED_REGIMES = frozenset({Regime.BULL_QUIET})
+
+#: ⚠ §S-10 says "Params: 4" (what a sweep would move) — the first four. The
+#: rest are by-construction constants recorded so the identity hash moves if
+#: any is edited. ``exit_cadence`` is the measured pin from the module
+#: docstring: it is a parameter precisely so that a daily-exit variant could
+#: never share this identity.
+S10_PARAMS: Mapping[str, object] = {
+    "lookback_bars": LOOKBACK_BARS,
+    "entry_decile": ENTRY_DECILE,
+    "exit_band_deciles": EXIT_BAND_DECILES,
+    "sma_bars": SMA_BARS,
+    "min_close": MIN_CLOSE,
+    "min_cross_section": MIN_CROSS_SECTION,
+    "exit_cadence": "rebalance_only",
+    "permitted_regimes": tuple(sorted(r.value for r in PERMITTED_REGIMES)),
+    "regime_rule_version": REGIME_RULE_VERSION,
+}
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s10_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-10 on one universe under one cost model."""
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "pass app.services.cost_model.COST_MODEL_ID rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S10_STRATEGY_ID,
+        params=S10_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def s10_rebalance_dates(calendar: Iterable[date]) -> frozenset[date]:
+    """First WEEKDAY bar of each new month, from the panel's union calendar.
+
+    S-2's causal first-bar-of-the-new-month rule, with one cut applied first:
+    Saturdays and Sundays are dropped before the month rule runs. Source rule:
+    the validated universe is US-listed stock (§4.0), and US equity venues
+    hold no regular weekend sessions (NYSE/Nasdaq holiday-and-hours
+    calendars) — yet ``price_daily`` carries weekend rows for ~11 instruments,
+    and because the FIRST qualifying bar takes the month, an unfiltered union
+    calendar hands entire months' rebalances to an 11-name Sunday and the
+    real first trading day then never rebalances at all (measured on #2437;
+    S-2 shares the exposure and that is noted there, not silently fixed here
+    — editing its calendar would move its identity).
+
+    ⚠ A corpus-hole WEEKDAY (243 of ~3,500 names on 2023-12-01) still takes
+    its month and is then refused by ``MIN_CROSS_SECTION`` — that month
+    simply does not rebalance. Measured incidence: one date in 43 months;
+    self-healing as the corpus fills; preferred over teaching this pure
+    function participation counts it cannot verify.
+    """
+    weekdays = [when for when in sorted(set(calendar)) if when.weekday() < 5]
+    return frozenset(
+        when
+        for previous, when in zip(weekdays, weekdays[1:], strict=False)
+        if (when.year, when.month) != (previous.year, previous.month)
+    )
+
+
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, declared — S-2's reasoning, unchanged."""
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
+def return_series(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """``close(t) / close(t-63) - 1`` per bar — 63 intervals, 64 observations.
+
+    S-2's interval convention (its 252/21 are interval counts), pinned here
+    because "63-bar return" reads either way. Two kinds of absence, kept
+    apart exactly as ``momentum_series`` keeps them: warm-up bars are ``None``
+    and NOT in ``not_evaluable_indices`` (→ ``insufficient_warmup``); bars
+    with a missing or non-positive endpoint are refused with the caller's
+    reason. The non-positive guard is S-2's, for S-2's measured reason: a
+    negative close ranks as a plausible number, which is worse than a crash.
+    """
+    closes = series.float_closes
+    values: list[float | None] = []
+    unevaluable: list[int] = []
+    for index in range(len(closes)):
+        if index < LOOKBACK_BARS:
+            values.append(None)
+            continue
+        past = closes[index - LOOKBACK_BARS]
+        now = closes[index]
+        if past is None or now is None or past <= 0.0 or now <= 0.0:
+            values.append(None)
+            unevaluable.append(index)
+            continue
+        values.append(now / past - 1.0)
+    return IndicatorSeries(values=tuple(values), universe=universe, not_evaluable_indices=tuple(unevaluable))
+
+
+def s10_entry_member(
+    series: BarSeries,
+    *,
+    panel_decision_dates: Set[date],
+    universe: Universe,
+    close_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> CrossSectionalMember:
+    """One instrument's contribution to the ENTRY panel.
+
+    ⚠ THE PRICE FLOOR IS AN ELIGIBILITY RULE, NOT AN EVALUABILITY ONE — S-2's
+    words: a sub-$1 bar is simply not a decision bar and its verdict is
+    ``not_fired``. It is therefore also not in this panel's denominator,
+    which is what "the entry panel carries the floor" means.
+
+    ⚠ THE REGIME IS A DECLARED INPUT, LAST — S-7's two rules: an unclassified
+    date refuses as ``missing_market_context`` rather than reading as a
+    judged decline, and it is declared last so an instrument defect headlines
+    over the market-context fallback. A CLASSIFIED bar outside
+    ``PERMITTED_REGIMES`` is inadmissible — ``not_fired`` even if the rank
+    selects it, per the resolution rule.
+    """
+    if close_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {close_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+    if len(regime) != len(series):
+        raise ValueError(f"regime series has {len(regime)} bars against {len(series)} price bars; they must align")
+
+    closes = series.float_closes
+    score = return_series(series, universe=universe)
+    sma = sma_series(series, universe=universe, period=SMA_BARS)
+    decision = frozenset(
+        index
+        for index, when in enumerate(series.dates)
+        if when in panel_decision_dates and (close := closes[index]) is not None and close >= MIN_CLOSE
+    )
+    admissible = frozenset(
+        index
+        for index in decision
+        if (close := closes[index]) is not None
+        and (mean := sma.values[index]) is not None
+        and close > mean
+        and regime.permits(index, PERMITTED_REGIMES)
+    )
+    return CrossSectionalMember(
+        dates=series.dates,
+        inputs=(
+            StrategyInput(series=_close_input(series, universe=universe), reason=close_reason),
+            StrategyInput(series=score, reason=close_reason),
+            StrategyInput(series=sma, reason=close_reason),
+            StrategyInput(series=regime, reason="missing_market_context"),
+        ),
+        score=score,
+        decision_indices=decision,
+        admissible_indices=admissible,
+    )
+
+
+def s10_exit_member(
+    series: BarSeries,
+    *,
+    panel_decision_dates: Set[date],
+    universe: Universe,
+    close_reason: NotEvaluableReason,
+) -> CrossSectionalMember:
+    """One instrument's contribution to the EXIT panel.
+
+    Floor-free, regime-free — module docstring. Every rebalance bar is a
+    decision bar; the below-SMA condition is MANDATORY (fires regardless of
+    the band), the band itself comes from ``s10_exit_select``.
+    """
+    if close_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {close_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+
+    closes = series.float_closes
+    score = return_series(series, universe=universe)
+    sma = sma_series(series, universe=universe, period=SMA_BARS)
+    decision = frozenset(index for index, when in enumerate(series.dates) if when in panel_decision_dates)
+    mandatory = frozenset(
+        index
+        for index in decision
+        if (close := closes[index]) is not None and (mean := sma.values[index]) is not None and close < mean
+    )
+    return CrossSectionalMember(
+        dates=series.dates,
+        inputs=(
+            StrategyInput(series=_close_input(series, universe=universe), reason=close_reason),
+            StrategyInput(series=score, reason=close_reason),
+            StrategyInput(series=sma, reason=close_reason),
+        ),
+        score=score,
+        decision_indices=decision,
+        mandatory_indices=mandatory,
+    )
+
+
+def _ordered(scores: Mapping[int, float]) -> list[int]:
+    """S-2's frozen total order: score descending, instrument id ascending."""
+    return [key for key, _ in sorted(scores.items(), key=lambda item: (-item[1], item[0]))]
+
+
+def s10_entry_select(when: date, scores: Mapping[int, float]) -> frozenset[int]:
+    """The top decile of the entry panel — ``N // 10``, S-2's cut verbatim.
+
+    The SMA condition is deliberately NOT here: selection sees scores only,
+    and the winners it names are filtered by ``admissible_indices`` without
+    backfilling — module docstring. ``when`` is in the signature for the
+    contract's reason, unused by the rule.
+    """
+    count = len(scores) // ENTRY_DECILE
+    if count <= 0:
+        return frozenset()
+    return frozenset(_ordered(scores)[:count])
+
+
+def s10_exit_select(when: date, scores: Mapping[int, float]) -> frozenset[int]:
+    """Everyone OUTSIDE the top three deciles — the set that fires the exit.
+
+    The complement of the retention band ``ordered[: 3 * N // 10]``. Returned
+    directly as the firing set (rather than returning the band and inverting
+    at the caller) because ``select`` names winners, and for an exit leg the
+    winners ARE the leavers.
+    """
+    keep = EXIT_BAND_DECILES * len(scores) // ENTRY_DECILE
+    return frozenset(_ordered(scores)[keep:])
+
+
+def s10_signals(
+    panel: Mapping[int, BarSeries],
+    *,
+    universe: Universe,
+    close_reason: NotEvaluableReason,
+    regime_by_member: Mapping[int, RegimeSeries],
+) -> dict[int, list[StrategySignal]]:
+    """S-10 over a whole panel: both legs, one verdict list per member per leg.
+
+    ⚠ HOLDS THE WHOLE PANEL IN MEMORY — S-2's warning verbatim: the right
+    entry point for a bounded panel (a test, a watchlist); a full-corpus
+    sweep streams members through the public pieces instead.
+    """
+    calendar = {when for series in panel.values() for when in series.dates}
+    dates = s10_rebalance_dates(calendar)
+    entries = evaluate_cross_sectional(
+        members={
+            key: s10_entry_member(
+                series,
+                panel_decision_dates=dates,
+                universe=universe,
+                close_reason=close_reason,
+                regime=regime_by_member[key],
+            )
+            for key, series in panel.items()
+        },
+        select=s10_entry_select,
+        min_participants=MIN_CROSS_SECTION,
+        kind="entry",
+    )
+    exits = evaluate_cross_sectional(
+        members={
+            key: s10_exit_member(
+                series,
+                panel_decision_dates=dates,
+                universe=universe,
+                close_reason=close_reason,
+            )
+            for key, series in panel.items()
+        },
+        select=s10_exit_select,
+        min_participants=MIN_CROSS_SECTION,
+        kind="exit",
+    )
+    return {key: entries[key] + exits[key] for key in panel}
+
+
+__all__ = [
+    "ENTRY_DECILE",
+    "EXIT_BAND_DECILES",
+    "LOOKBACK_BARS",
+    "MIN_CLOSE",
+    "MIN_CROSS_SECTION",
+    "PERMITTED_REGIMES",
+    "S10_PARAMS",
+    "S10_STRATEGY_ID",
+    "SMA_BARS",
+    "return_series",
+    "s10_entry_member",
+    "s10_entry_select",
+    "s10_exit_member",
+    "s10_exit_select",
+    "s10_identity",
+    "s10_rebalance_dates",
+    "s10_signals",
+]

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -140,6 +140,18 @@ from app.services.strategies.s9_squeeze_expansion import (
     s9_identity,
     s9_signals,
 )
+from app.services.strategies.s10_relative_strength_leader import (
+    MIN_CROSS_SECTION as S10_MIN_CROSS_SECTION,
+)
+from app.services.strategies.s10_relative_strength_leader import (
+    S10_STRATEGY_ID,
+    s10_entry_member,
+    s10_entry_select,
+    s10_exit_member,
+    s10_exit_select,
+    s10_identity,
+    s10_rebalance_dates,
+)
 from app.services.strategy_exit_levels_batch import s4_exit_levels_batch
 from app.services.strategy_registry import (
     SIGNAL_KINDS,
@@ -213,6 +225,11 @@ class MemberStager(Protocol):
     the whole panel in memory and says so; a full-corpus runner must stream one
     series at a time through this and ``select``, which is what
     ``StagedMember`` is public for.
+
+    ⚠⚠ ``regime`` IS ON THE UNIFORM CALL — the same decision
+    ``PerSeriesSignals`` records above, for the same reason: S-2 ignores it,
+    S-10's entry leg gates on it, and the adapters absorb the difference so a
+    runner cannot forget to supply it for the one member that needs it.
     """
 
     def __call__(
@@ -222,6 +239,7 @@ class MemberStager(Protocol):
         panel_decision_dates: Set[date],
         universe: Universe,
         masked_reason: NotEvaluableReason,
+        regime: RegimeSeries,
     ) -> CrossSectionalMember: ...
 
 
@@ -279,6 +297,30 @@ class ExitLevelsBatchFactory(Protocol):
 
 
 @dataclass(frozen=True)
+class CrossSectionalLeg:
+    """One additional ranked leg of a cross-sectional strategy — S-10's exit.
+
+    A LEG OBJECT rather than parallel ``exit_member`` / ``exit_select`` /
+    ``exit_min_participants`` fields on ``StrategyEntry`` (Codex ckpt-1): the
+    three are meaningless apart, and parallel optional columns are an
+    increasingly unvalidated two-column structure the tagged-union
+    ``__post_init__`` below would have to keep re-learning.
+
+    ``min_participants`` is PER LEG deliberately — S-10 sets both legs to the
+    same floor, but an exit band and an entry decile protect different things
+    and a future strategy may need them apart.
+    """
+
+    member: MemberStager
+    select: CrossSectionalSelect
+    min_participants: int
+
+    def __post_init__(self) -> None:
+        if self.min_participants < 1:
+            raise ValueError(f"min_participants must be at least 1, got {self.min_participants}")
+
+
+@dataclass(frozen=True)
 class StrategyEntry:
     """One registered strategy: how to identify it, how to invoke it, how it exits.
 
@@ -305,6 +347,11 @@ class StrategyEntry:
     member: MemberStager | None = None
     select: CrossSectionalSelect | None = None
     min_participants: int | None = None
+    #: ``cross_sectional`` only, optional — a SECOND ranked leg (S-10's exit).
+    #: Present iff ``"exit"`` is among ``signal_kinds``: a cross-sectional
+    #: strategy's exit verdicts can only come from a ranked leg, so declaring
+    #: one without the other is a registration whose halves disagree.
+    exit_leg: CrossSectionalLeg | None = None
     #: Level-based only. Its absence is a named runner exclusion rather than a
     #: silent max-hold fallback.
     exit_levels: ExitLevelsFactory | None = None
@@ -338,7 +385,7 @@ class StrategyEntry:
         if self.strategy_class == "per_series":
             if self.signals is None:
                 raise ValueError(f"{self.strategy_id} is per_series and declares no signals function")
-            if any(field is not None for field in cross_sectional_fields):
+            if any(field is not None for field in cross_sectional_fields) or self.exit_leg is not None:
                 raise ValueError(
                     f"{self.strategy_id} is per_series but carries cross-sectional fields — the runner would "
                     "invoke whichever half it read first"
@@ -350,6 +397,12 @@ class StrategyEntry:
                 raise ValueError(
                     f"{self.strategy_id} is cross_sectional and must declare member, select and "
                     "min_participants together — a panel runner needs all three to rank anything"
+                )
+            if (self.exit_leg is not None) != ("exit" in self.signal_kinds):
+                raise ValueError(
+                    f"{self.strategy_id} declares signal_kinds {sorted(self.signal_kinds)} with "
+                    f"exit_leg {'present' if self.exit_leg is not None else 'absent'} — a cross-sectional "
+                    "exit verdict can only come from a ranked exit leg, so the two must agree"
                 )
         if self.min_participants is not None and self.min_participants < 1:
             raise ValueError(f"min_participants must be at least 1, got {self.min_participants}")
@@ -400,10 +453,45 @@ def _s2_member(
     panel_decision_dates: Set[date],
     universe: Universe,
     masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,  # noqa: ARG001 - uniform call; S-2 does not gate on regime
 ) -> CrossSectionalMember:
     return s2_member(
         series,
         panel_rebalance_dates=panel_decision_dates,
+        universe=universe,
+        close_reason=masked_reason,
+    )
+
+
+def _s10_entry_member(
+    series: BarSeries,
+    *,
+    panel_decision_dates: Set[date],
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> CrossSectionalMember:
+    """S-10's entry leg is the first cross-sectional member that reads ``regime``."""
+    return s10_entry_member(
+        series,
+        panel_decision_dates=panel_decision_dates,
+        universe=universe,
+        close_reason=masked_reason,
+        regime=regime,
+    )
+
+
+def _s10_exit_member(
+    series: BarSeries,
+    *,
+    panel_decision_dates: Set[date],
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,  # noqa: ARG001 - deliberate: a missing benchmark must never refuse an exit (S-7's rule)
+) -> CrossSectionalMember:
+    return s10_exit_member(
+        series,
+        panel_decision_dates=panel_decision_dates,
         universe=universe,
         close_reason=masked_reason,
     )
@@ -732,6 +820,25 @@ def _s6_exit_levels(
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
 
+def _s10_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-10 closes on its own ranked exit leg — ``signal_pair`` alone.
+
+    ⚠ ``rebalance_dates`` stays ``None`` even though S-10 has a calendar: C4
+    closes at "the next rebalance NOT RESELECTED", which is ENTRY-set
+    retention, and S-10's retention is the wider top-three-decile band the
+    exit leg carries. Declaring both would close band-surviving positions a
+    month early. The calendar argument is still accepted (and ignored)
+    because the runner hands every cross-sectional strategy its own
+    ``decision_calendar`` output.
+    """
+    if decision_dates is None:
+        raise ValueError(
+            f"{S10_STRATEGY_ID} is cross_sectional and its runner must pass its decision calendar — "
+            "a None here means the runner skipped decision_calendar()"
+        )
+    return ExitRegime(signal_pair=True, level_based=False, max_hold_bars=None, rebalance_dates=None)
+
+
 #: Every strategy in the catalogue, keyed by ``strategy_id``.
 #:
 #: ⚠⚠ COMPLETENESS IS A TEST, NOT A CONVENTION.
@@ -842,6 +949,23 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             signals=_s9_signals,
             exit_levels=_s9_exit_levels,
         ),
+        S10_STRATEGY_ID: StrategyEntry(
+            strategy_id=S10_STRATEGY_ID,
+            purpose="harness_validation",
+            identity=s10_identity,
+            strategy_class="cross_sectional",
+            signal_kinds=frozenset({"entry", "exit"}),
+            exit_regime=_s10_exit_regime,
+            decision_calendar=s10_rebalance_dates,
+            member=_s10_entry_member,
+            select=s10_entry_select,
+            min_participants=S10_MIN_CROSS_SECTION,
+            exit_leg=CrossSectionalLeg(
+                member=_s10_exit_member,
+                select=s10_exit_select,
+                min_participants=S10_MIN_CROSS_SECTION,
+            ),
+        ),
     }
 )
 
@@ -849,6 +973,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
 __all__ = [
     "STRATEGY_CLASSES",
     "STRATEGY_MANIFEST",
+    "CrossSectionalLeg",
     "DecisionCalendar",
     "ExitRegimeFactory",
     "ExitLevelsBatchFactory",

--- a/app/services/strategy_registry.py
+++ b/app/services/strategy_registry.py
@@ -466,12 +466,38 @@ class CrossSectionalMember:
     bar it is eligible for. Everything else is an ordinary ``not_fired``: the
     rule is *"fire iff a decision bar AND selected"*, so a non-decision bar did
     not fire. It is a verdict, not an absence.
+
+    TWO OPTIONAL REFINEMENTS OF THE DECISION RULE (#2437 S-10), both ``None``
+    for a strategy that does not use them — ``None`` is exactly today's
+    behaviour and S-2 passes it implicitly:
+
+    - ``admissible_indices`` — decision bars allowed to fire WHEN SELECTED.
+      A selected bar outside it is ``not_fired``; its score still entered the
+      ranking, so the panel denominator is unchanged. This is what makes
+      *"the top decile that ALSO closes above its own 50-SMA"* expressible:
+      the decile is cut on the whole panel, the SMA condition then filters
+      the winners without backfilling the slots.
+    - ``mandatory_indices`` — decision bars that fire REGARDLESS of
+      selection. S-10's *"closes below 50-SMA"* exit fires whether or not the
+      name also left the retention band.
+
+    The one resolution rule, applied AFTER every refusal (``no_fill_bar``,
+    unevaluable inputs, non-decision, ``thin_cross_section`` — precedence is
+    unchanged and mandatory does NOT beat a refusal):
+
+        fired iff mandatory OR (selected AND admissible)
+
+    ⚠ Both are constrained to ``decision_indices`` and that is checked: an
+    admissibility or mandate on a bar that never ranks is a contradiction the
+    author should hear about, not a key silently ignored.
     """
 
     dates: tuple[date, ...]
     inputs: tuple[StrategyInput, ...]
     score: IndicatorSeries
     decision_indices: frozenset[int]
+    admissible_indices: frozenset[int] | None = None
+    mandatory_indices: frozenset[int] | None = None
 
     def __post_init__(self) -> None:
         n = len(self.dates)
@@ -491,6 +517,16 @@ class CrossSectionalMember:
         for index in self.decision_indices:
             if not 0 <= index < n:
                 raise ValueError(f"decision index {index} is outside the {n}-bar series")
+        refinements = (("admissible_indices", self.admissible_indices), ("mandatory_indices", self.mandatory_indices))
+        for name, refined in refinements:
+            if refined is None:
+                continue
+            stray = refined - self.decision_indices
+            if stray:
+                raise ValueError(
+                    f"{name} contains {sorted(stray)[:5]} outside decision_indices — a refinement of the "
+                    "decision rule on a bar that never ranks is a contradiction, not a no-op"
+                )
         for i in range(1, n):
             if self.dates[i] <= self.dates[i - 1]:
                 raise ValueError(
@@ -514,6 +550,36 @@ class StagedMember:
     verdicts: tuple[StrategySignal | None, ...]
     #: Ranking score per participating bar, keyed by that bar's DATE.
     scores: Mapping[date, float]
+    #: The member's refinements, converted to DATES so that a consumer that
+    #: re-slices series (``segmented_member``) merges them without the
+    #: index-remapping every index-keyed field owes at a reslice — the silent,
+    #: type-checking trap the 08-14 S-8 session committed to memory. ``None``
+    #: preserves the member's ``None`` (= unrefined).
+    admissible_dates: frozenset[date] | None = None
+    mandatory_dates: frozenset[date] | None = None
+
+
+def resolve_participating_bar(
+    *,
+    when: date,
+    index: int,
+    kind: SignalKind,
+    selected: bool,
+    admissible_dates: frozenset[date] | None,
+    mandatory_dates: frozenset[date] | None,
+) -> StrategySignal:
+    """THE one resolution rule for a staged bar that survived every refusal.
+
+    ⚠ Three resolvers rank cross-sections independently — ``evaluate_cross_
+    sectional`` here, the scan's ``_resolve_cross_section``, and the
+    backtest's ``_signals_for`` — and each used to inline ``fired iff
+    selected``. With admissibility and mandates in the rule, three inlined
+    copies is three chances for one of them to drift; they all call this.
+    """
+    admissible = admissible_dates is None or when in admissible_dates
+    mandatory = mandatory_dates is not None and when in mandatory_dates
+    fired = mandatory or (selected and admissible)
+    return StrategySignal(verdict="fired" if fired else "not_fired", signal_index=index, kind=kind)
 
 
 def stage_cross_sectional_member(member: CrossSectionalMember, *, kind: SignalKind = "entry") -> StagedMember:
@@ -553,7 +619,20 @@ def stage_cross_sectional_member(member: CrossSectionalMember, *, kind: SignalKi
         assert value is not None
         verdicts.append(None)
         scores[member.dates[index]] = value
-    return StagedMember(verdicts=tuple(verdicts), scores=scores)
+    return StagedMember(
+        verdicts=tuple(verdicts),
+        scores=scores,
+        admissible_dates=(
+            None
+            if member.admissible_indices is None
+            else frozenset(member.dates[index] for index in member.admissible_indices)
+        ),
+        mandatory_dates=(
+            None
+            if member.mandatory_indices is None
+            else frozenset(member.dates[index] for index in member.mandatory_indices)
+        ),
+    )
 
 
 #: Given a date and the scores of everyone ranking on it, the winners.
@@ -626,9 +705,16 @@ def evaluate_cross_sectional(
                 signals.append(
                     StrategySignal(verdict="not_evaluable", signal_index=index, kind=kind, reason="thin_cross_section")
                 )
-            elif key in winners_by_date[when]:
-                signals.append(StrategySignal(verdict="fired", signal_index=index, kind=kind))
             else:
-                signals.append(StrategySignal(verdict="not_fired", signal_index=index, kind=kind))
+                signals.append(
+                    resolve_participating_bar(
+                        when=when,
+                        index=index,
+                        kind=kind,
+                        selected=key in winners_by_date[when],
+                        admissible_dates=member_staged.admissible_dates,
+                        mandatory_dates=member_staged.mandatory_dates,
+                    )
+                )
         resolved[key] = signals
     return resolved

--- a/app/services/strategy_segmented_evaluation.py
+++ b/app/services/strategy_segmented_evaluation.py
@@ -12,6 +12,7 @@ from app.services.price_segments import series_segment_bounds
 from app.services.strategy_manifest import StrategyEntry
 from app.services.strategy_registry import (
     NotEvaluableReason,
+    SignalKind,
     StagedMember,
     StrategySignal,
     stage_cross_sectional_member,
@@ -77,21 +78,50 @@ def segmented_member(
     universe: Universe,
     masked_reason: NotEvaluableReason,
     unresolved_breaks: Sequence[date],
+    regime: RegimeSeries,
+    leg: SignalKind = "entry",
 ) -> StagedMember:
-    """Stage one ranked member with fresh state inside each scale segment."""
-    if entry.member is None:
-        raise ValueError(f"{entry.strategy_id} has no cross-sectional member function")
+    """Stage one ranked member with fresh state inside each scale segment.
+
+    ``leg`` selects which member function stages — ``"entry"`` is
+    ``entry.member``, ``"exit"`` is ``entry.exit_leg.member`` — and is also
+    the ``kind`` stamped on every verdict, so a leg cannot be staged under
+    the other leg's name. The regime is SLICED with the segment, exactly as
+    ``segmented_signals`` does and for its stated reason.
+
+    ⚠ ``admissible_dates`` / ``mandatory_dates`` merge by UNION across
+    segments — they are DATE-keyed on ``StagedMember`` precisely so this
+    merge needs no index remapping. ``None`` (unrefined) survives only when
+    EVERY segment returned ``None``; the same member function produces the
+    same shape per segment, so a mix is a bug and raises.
+    """
+    if leg == "entry":
+        member_stager = entry.member
+    elif entry.exit_leg is not None:
+        member_stager = entry.exit_leg.member
+    else:
+        member_stager = None
+    if member_stager is None:
+        raise ValueError(f"{entry.strategy_id} has no cross-sectional member function for the {leg!r} leg")
+    if len(regime) != len(series):
+        raise ValueError(f"regime has {len(regime)} bars against {len(series)} price bars; they must align")
     verdicts: list[StrategySignal | None] = []
     scores: dict[date, float] = {}
+    admissible: set[date] | None = None
+    mandatory: set[date] | None = None
+    segments = 0
     for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
+        segments += 1
         segment = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
         staged = stage_cross_sectional_member(
-            entry.member(
+            member_stager(
                 segment,
                 panel_decision_dates=panel_decision_dates,
                 universe=universe,
                 masked_reason=masked_reason,
-            )
+                regime=regime.segment(start, end),
+            ),
+            kind=leg,
         )
         verdicts.extend(
             None
@@ -108,9 +138,27 @@ def segmented_member(
         if overlap:  # pragma: no cover - BarSeries dates and segments are disjoint
             raise RuntimeError(f"{entry.strategy_id} produced duplicate segmented score dates {sorted(overlap)}")
         scores.update(staged.scores)
+        for label, merged, this_segment in (
+            ("admissible_dates", admissible, staged.admissible_dates),
+            ("mandatory_dates", mandatory, staged.mandatory_dates),
+        ):
+            if segments > 1 and (merged is None) != (this_segment is None):
+                raise RuntimeError(
+                    f"{entry.strategy_id} {leg} leg produced {label}={'None' if this_segment is None else 'a set'} "
+                    "in one segment and the opposite in another — one member function must be one shape"
+                )
+        if staged.admissible_dates is not None:
+            admissible = (admissible or set()) | staged.admissible_dates
+        if staged.mandatory_dates is not None:
+            mandatory = (mandatory or set()) | staged.mandatory_dates
     if len(verdicts) != len(series):
         raise RuntimeError(f"{entry.strategy_id} staged {len(verdicts)} segmented bars for {len(series)} inputs")
-    return StagedMember(verdicts=tuple(verdicts), scores=scores)
+    return StagedMember(
+        verdicts=tuple(verdicts),
+        scores=scores,
+        admissible_dates=None if admissible is None else frozenset(admissible),
+        mandatory_dates=None if mandatory is None else frozenset(mandatory),
+    )
 
 
 __all__ = ["segmented_member", "segmented_signals"]

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -68,6 +68,7 @@ from app.services.strategy_registry import (
     StrategyIdentity,
     StrategySignal,
     Verdict,
+    resolve_participating_bar,
 )
 from app.services.strategy_segmented_evaluation import segmented_member, segmented_signals
 
@@ -403,6 +404,9 @@ class _PendingMember:
     decided: dict[date, StrategySignal]
     #: Window dates at which this member ranks.
     participating: frozenset[date]
+    #: The member's refinements (S-10), date-keyed — ``None`` = unrefined.
+    admissible_dates: frozenset[date] | None
+    mandatory_dates: frozenset[date] | None
 
 
 def run_signal_scan(
@@ -523,23 +527,34 @@ def run_signal_scan(
             per_strategy=tuple(results),
         )
 
-    panel_dates: frozenset[date] | None = None
     cross_sectional = [plan for plan in plans if plan.entry.strategy_class == "cross_sectional"]
+    panel_dates_by_plan: dict[str, frozenset[date]] = {}
     if cross_sectional:
         # ⚠ The union calendar spans every LOADABLE instrument, not only the
         # frontier-eligible ones: a name that stopped trading last year still
         # contributed the sessions on which the panel rebalanced.
+        #
+        # ⚠ PER PLAN, not shared from plans[0] — S-2 and S-10 read the same
+        # union calendar through different rules (S-10 drops weekend rows
+        # first), and one strategy's calendar imposed on another would move
+        # every rebalance verdict silently.
         calendar = load_union_calendar(conn, sorted(spans))
-        panel_dates = cross_sectional[0].entry.decision_calendar(calendar)
-        if panel_dates is None:  # pragma: no cover — the manifest guarantees one
-            raise RuntimeError(
-                f"{cross_sectional[0].entry.strategy_id} is cross_sectional but returned no decision calendar"
-            )
+        for plan in cross_sectional:
+            plan_dates = plan.entry.decision_calendar(calendar)
+            if plan_dates is None:  # pragma: no cover — the manifest guarantees one
+                raise RuntimeError(f"{plan.entry.strategy_id} is cross_sectional but returned no decision calendar")
+            panel_dates_by_plan[plan.entry.strategy_id] = plan_dates
 
     rows: dict[str, list[LedgerRow]] = {plan.entry.strategy_id: [] for plan in plans}
     expected: dict[str, int] = {plan.entry.strategy_id: 0 for plan in plans}
-    pending: dict[str, dict[int, _PendingMember]] = {plan.entry.strategy_id: {} for plan in cross_sectional}
-    scores: dict[str, dict[date, dict[int, float]]] = {plan.entry.strategy_id: {} for plan in cross_sectional}
+    #: Cross-sectional staging state, PER LEG — S-10's exit leg ranks its own
+    #: (floor-free) panel, so the two legs' scores must never share a dict.
+    pending: dict[tuple[str, SignalKind], dict[int, _PendingMember]] = {
+        (plan.entry.strategy_id, leg): {} for plan in cross_sectional for leg in _legs(plan.entry)
+    }
+    scores: dict[tuple[str, SignalKind], dict[date, dict[int, float]]] = {
+        (plan.entry.strategy_id, leg): {} for plan in cross_sectional for leg in _legs(plan.entry)
+    }
     moved_mid_scan = 0
     evaluated = 0
 
@@ -583,25 +598,29 @@ def run_signal_scan(
                     regime_provider=regime_provider,
                 )
             else:
-                assert panel_dates is not None
-                _stage_cross_sectional(
-                    plan,
-                    series,
-                    instrument_id,
-                    window,
-                    panel_dates=panel_dates,
-                    pending=pending[plan.entry.strategy_id],
-                    scores=scores[plan.entry.strategy_id],
-                    unresolved_breaks=unresolved_breaks.get(instrument_id, ()),
-                )
+                for leg in _legs(plan.entry):
+                    _stage_cross_sectional(
+                        plan,
+                        series,
+                        instrument_id,
+                        window,
+                        panel_dates=panel_dates_by_plan[plan.entry.strategy_id],
+                        leg=leg,
+                        pending=pending[(plan.entry.strategy_id, leg)],
+                        scores=scores[(plan.entry.strategy_id, leg)],
+                        unresolved_breaks=unresolved_breaks.get(instrument_id, ()),
+                        regime_provider=regime_provider,
+                    )
 
     for plan in cross_sectional:
-        _resolve_cross_section(
-            plan,
-            pending=pending[plan.entry.strategy_id],
-            scores=scores[plan.entry.strategy_id],
-            out=rows[plan.entry.strategy_id],
-        )
+        for leg in _legs(plan.entry):
+            _resolve_cross_section(
+                plan,
+                leg=leg,
+                pending=pending[(plan.entry.strategy_id, leg)],
+                scores=scores[(plan.entry.strategy_id, leg)],
+                out=rows[plan.entry.strategy_id],
+            )
 
     for plan in plans:
         strategy_id = plan.entry.strategy_id
@@ -672,6 +691,11 @@ def _scan_per_series(
     out.extend(resolve_fills(windowed, series=series, identity=plan.identity, instrument_id=instrument_id))
 
 
+def _legs(entry: StrategyEntry) -> tuple[SignalKind, ...]:
+    """The ranked legs a cross-sectional strategy stages — S-2 one, S-10 two."""
+    return ("entry", "exit") if entry.exit_leg is not None else ("entry",)
+
+
 def _stage_cross_sectional(
     plan: _Plan,
     series: BarSeries,
@@ -679,9 +703,11 @@ def _stage_cross_sectional(
     window: range,
     *,
     panel_dates: frozenset[date],
+    leg: SignalKind,
     pending: dict[int, _PendingMember],
     scores: dict[date, dict[int, float]],
     unresolved_breaks: Sequence[date] = (),
+    regime_provider: MarketRegimeProvider,
 ) -> None:
     """Everything decidable about one member without seeing the others.
 
@@ -698,6 +724,8 @@ def _stage_cross_sectional(
         universe=SCAN_UNIVERSE,
         masked_reason=MASKED_REASON,
         unresolved_breaks=unresolved_breaks,
+        regime=regime_provider.for_dates(series.dates),
+        leg=leg,
     )
 
     start = window.start
@@ -726,12 +754,15 @@ def _stage_cross_sectional(
         window_dates=window_dates,
         decided=decided,
         participating=frozenset(participating),
+        admissible_dates=staged.admissible_dates,
+        mandatory_dates=staged.mandatory_dates,
     )
 
 
 def _resolve_cross_section(
     plan: _Plan,
     *,
+    leg: SignalKind,
     pending: Mapping[int, _PendingMember],
     scores: Mapping[date, Mapping[int, float]],
     out: list[LedgerRow],
@@ -749,19 +780,24 @@ def _resolve_cross_section(
     date-aware one needs no signature change — and passing the wrong date would
     be silent until one arrives.
     """
-    assert plan.entry.select is not None and plan.entry.min_participants is not None
+    if leg == "entry":
+        select, min_participants = plan.entry.select, plan.entry.min_participants
+    else:
+        assert plan.entry.exit_leg is not None
+        select, min_participants = plan.entry.exit_leg.select, plan.entry.exit_leg.min_participants
+    assert select is not None and min_participants is not None
     winners: dict[date, frozenset[int]] = {}
     thin: set[date] = set()
     for when in sorted(scores):
         at_date = scores[when]
-        if len(at_date) < plan.entry.min_participants:
+        if len(at_date) < min_participants:
             thin.add(when)
             continue
-        selected = frozenset(plan.entry.select(when, at_date))
+        selected = frozenset(select(when, at_date))
         unknown = selected - at_date.keys()
         if unknown:
             raise ValueError(
-                f"{plan.entry.strategy_id} select returned {sorted(unknown)} on {when}, which did not "
+                f"{plan.entry.strategy_id} {leg} select returned {sorted(unknown)} on {when}, which did not "
                 "participate in that cross-section — every winner must be one of the members offered"
             )
         winners[when] = selected
@@ -785,13 +821,21 @@ def _resolve_cross_section(
                     StrategySignal(
                         verdict="not_evaluable",
                         signal_index=offset,
-                        kind="entry",
+                        kind=leg,
                         reason="thin_cross_section",
                     )
                 )
                 continue
-            fired = instrument_id in winners[when]
-            signals.append(StrategySignal(verdict="fired" if fired else "not_fired", signal_index=offset, kind="entry"))
+            signals.append(
+                resolve_participating_bar(
+                    when=when,
+                    index=offset,
+                    kind=leg,
+                    selected=instrument_id in winners[when],
+                    admissible_dates=member.admissible_dates,
+                    mandatory_dates=member.mandatory_dates,
+                )
+            )
         out.extend(resolve_fills(signals, series=member.series, identity=plan.identity, instrument_id=instrument_id))
 
 

--- a/docs/proposals/ta/2026-08-14-s10-implementation-plan.md
+++ b/docs/proposals/ta/2026-08-14-s10-implementation-plan.md
@@ -1,0 +1,184 @@
+# S-10 relative-strength leader — implementation plan
+
+Parent spec: `2026-08-14-strategy-set-s5-s10.md` §S-10. Refs #2437.
+
+## Gate evidence (measured first, per the spec's own order)
+
+`scripts/verify_2437_s10_turnover.py` on the full validated universe (6,413 of
+6,774 loaded), production `MarketRegimeProvider`, NMV one-sided monthly
+turnover, 42 active months:
+
+| exit-cadence reading | steady-state mean | verdict |
+| --- | ---: | --- |
+| both exit legs at rebalance only | **36.2%/month** | inside the ~50% bar |
+| 50-SMA exit checked daily | **83.7%/month** | disqualified |
+
+**Consequence pinned into the design: S-10's exit legs are evaluated at
+rebalance dates ONLY.** The daily reading is not a viable variant; the cadence
+is a module constant hashed into the identity.
+
+## The rule (spec-literal)
+
+- Setup: regime ∈ {bull_quiet}; universe ranked by 63-bar return.
+- Signal: enter the top decile that ALSO closes above its own 50-SMA; rebalance
+  monthly. Reading pinned: the decile is cut on the FULL ranking, then the SMA
+  condition filters the winners (no backfill) — the panel denominator is the
+  whole rankable cross-section. The turnover measurement used exactly this.
+- Exit: leaves the top three deciles, or closes below 50-SMA — at rebalance.
+
+## Contract gaps and how each is closed
+
+S-2 is the only cross-sectional precedent and it is one-legged (its exit is the
+entry's complement; S-10's is not — band 3×N//10 ⊋ decile N//10, plus an SMA
+condition selection cannot see).
+
+1. **`CrossSectionalMember` gains two optional index sets**
+   (`strategy_registry.py`), both defaulting to `None` = today's behaviour:
+   - `admissible_indices` — participating bars allowed to fire when selected.
+     Selected-but-inadmissible → `not_fired`; the score STILL enters the panel
+     (denominator preserved — this is what makes reading A expressible).
+     Entry leg: bars with `close > sma50` and regime `bull_quiet`.
+   - `mandatory_indices` — participating bars that fire regardless of
+     selection. Exit leg: bars with `close < sma50`.
+   - Resolution rule everywhere a staged bar is decided:
+     `fired iff (selected AND admissible) OR mandatory`.
+   - `StagedMember` carries these as **date-keyed** sets so
+     `segmented_member`'s per-segment merge needs no index remapping (the
+     silent reslice trap from the 08-14 S-8 session).
+   - Three resolvers honour it: `evaluate_cross_sectional` (registry),
+     `_resolve_cross_section` (scan), and the backtest's cross-section pass.
+
+2. **Cross-sectional exit leg** (`strategy_manifest.py`): `StrategyEntry`
+   gains `exit_member: MemberStager | None` + `exit_select:
+   CrossSectionalSelect | None` — cross_sectional only, both-or-neither,
+   `"exit" ∈ signal_kinds` iff present, enforced in `__post_init__`.
+   `stage_cross_sectional_member(kind="exit")` already exists; the position
+   layer already pairs C1 `signal_pair` exits — no position-layer change,
+   S-7's precedent.
+
+3. **Regime for cross-sectional members**: `MemberStager` protocol gains
+   `regime: RegimeSeries`, uniformly — the same absorb-in-adapters move
+   `PerSeriesSignals` made for S-5..S-9. S-2's adapter ignores it.
+   `segmented_member` slices it per segment via `RegimeSeries.segment` (as
+   `segmented_signals` already does) and gains a `leg` selector for the exit
+   member. S-10's ENTRY member declares the regime as an input
+   (`missing_market_context` refusal on unclassifiable rebalance bars); the
+   EXIT member deliberately does NOT — a missing benchmark session must never
+   refuse the exit verdict for an open position (S-7 precedent).
+
+4. **Scan** (`strategy_signal_scan.py`): `panel_dates` becomes per-plan (S-10's
+   calendar differs from S-2's — below); `pending`/`scores` become per-leg;
+   `_resolve_cross_section` runs per leg with the leg's select and kind, and
+   its hardcoded `kind="entry"` refusals take the leg's kind.
+
+5. **Backtest** (`backtest_run.py`): the cross-section pass runs per leg for a
+   two-legged entry; exit verdicts join the same fill/outcome path S-1/S-3
+   exits use. `ExitRegime`: `signal_pair=True` only (no levels, no max-hold,
+   no calendar close — the exit leg IS the calendar, firing only on rebalance
+   bars).
+
+## The S-10 module (`app/services/strategies/s10_relative_strength_leader.py`)
+
+Frozen constants, S-2's shape, all hashed via params + source hash:
+
+- `LOOKBACK_BARS=63`, `ENTRY_DECILE=10`, `EXIT_BAND_DECILES=3`, `SMA_BARS=50`.
+- `MIN_CLOSE=1.0` — S-2's §9 Q3 rule, same argument verbatim (a ranked
+  strategy's top decile is where tick-quantised penny names concentrate).
+  Entry eligibility only; **no price floor on the exit leg** — a held name
+  that fell under $1 must still be exitable.
+- `MIN_CROSS_SECTION=100` — by construction, from the measurement's
+  `THIN_PANEL`: a decile BAND retention rule evaluated against a sliver panel
+  would liquidate a book built on thousands of names. (S-2's 10 protects a
+  one-shot decile cut; a retention band needs the panel to resemble the one
+  the book was built from.)
+- `s10_rebalance_dates(calendar)` — weekday-filtered (Sat/Sun dropped) union
+  calendar, then S-2's first-bar-of-new-month rule. By construction:
+  `price_daily` carries weekend rows for ~11 instruments, and the unfiltered
+  rule hands entire months' rebalances to those dates (measured; noted on
+  #2437 as an S-2 production quirk too).
+- Entry member: score = `close(t)/close(t-63) - 1` (positive-close guards,
+  S-2's); inputs = close + score + regime; decision = rebalance bars with
+  `close >= MIN_CLOSE`; admissible = `close > sma50` AND `bull_quiet`.
+- Entry select: top `N // 10`, S-2's frozen ordering (score desc, id asc).
+- Exit member: same score; inputs = close + score (NO regime); decision =
+  every rebalance bar; mandatory = `close < sma50`.
+- Exit select: the complement — `ordered[3 * N // 10 :]` (leaves the band).
+
+## Tests
+
+- Registry: admissible/mandatory unit tests (selected-but-inadmissible →
+  not_fired with score still ranking others; mandatory fires unselected;
+  None = unchanged — S-2 regression pinned).
+- S-10 module: score windows/refusals, both selects' cuts and tie-breaks,
+  regime gating incl. missing_market_context on the entry leg only, SMA
+  strictness (equality holds, never enters, never exits).
+- Manifest: registration invariants (existing sweeps) + two-leg validation.
+- Scan: two-leg cross-sectional staging on a small fixture.
+
+## Codex ckpt-1 resolutions (2026-08-14)
+
+Accepted and folded into the design above:
+
+- **SMA is a DECLARED input on both legs** — a masked/short window refuses the
+  bar (`not_evaluable`), never silently passes.
+- **The exit leg is evaluable only when the bar is rankable** (score + SMA +
+  close all present) — stated, not hidden: an unrankable rebalance bar for a
+  held name refuses visibly and the position carries to the next evaluable
+  rebalance. The below-SMA exit does not logically need the rank, but a
+  second evaluability regime for one condition would put two contracts inside
+  one leg; the refusal counts are censused.
+- **Precedence pinned and tested**: `no_fill_bar` → unevaluable input →
+  non-decision `not_fired` → `thin_cross_section` → mandatory → selected ∧
+  admissible. Mandatory does NOT beat a refusal or a thin panel.
+- **Regime mechanism**: `StrategyInput(series=regime, reason=
+  "missing_market_context")` — S-7's exact pattern (`s7_trend_pullback.py`
+  line ~240); `EvaluableSeries` is a Protocol precisely so `RegimeSeries`
+  declares (#2437). No new representation needed.
+- **`exit_leg` is one optional object** (`member`, `select`,
+  `min_participants`), not parallel fields.
+- **`min_participants = 1000` on both legs** — encodes panel resemblance; the
+  observed junk dates (11-row Sundays, a 243-row corpus-hole Friday) all
+  refuse, every observed real panel (2,084–5,747) passes.
+- **Entry "rankable" includes the $1 floor** (S-2 §9 Q3, adjusted-price floor
+  caveat included by reference); the exit panel is floor-free. Both
+  denominators are therefore different and that is a stated choice, now
+  MEASURED: v4 of the gate ran the exact shipped semantics — floored entry
+  panel, floor-free exit panel, 1000 thin floor — steady-state mean
+  **36.5%/month** monthly-pinned (daily 83.0%). Verdict unchanged.
+- **Semantics pinned**: score(t) = `close(t)/close(t-63) − 1` (63 intervals,
+  64 observations — S-2's interval convention); SMA = trailing 50 closes
+  including t, all 50 present or the bar refuses; comparisons are strict
+  float inequalities, no tolerance (a tolerance is an extra parameter).
+- **Implementation order**: registry oracle + tests first, then module, then
+  manifest, then scan/backtest, with a three-resolver equivalence test
+  (registry `evaluate_cross_sectional` vs scan `_resolve_cross_section` vs
+  the backtest resolution) on one shared fixture.
+- **Census**: per-leg verdict/reason distribution, thin-date counts, and a
+  mandatory-parity check (every below-SMA decision bar that was evaluable
+  fired an exit).
+
+Rebutted:
+
+- *"Exit cadence is parameter selection on measured data"* — the cadence is
+  selected by the spec's OWN pre-backtest disqualifier on a COST property,
+  not by a return outcome; Novy-Marx/Velikov's screen exists to be applied
+  exactly this way. It is frozen in the params and hashed.
+- *"Identity too weak — registry semantics not hashed"* —
+  `StrategyIdentity.version` includes `"registry": _module_hash()`
+  (`strategy_registry.py` line ~266); registry changes move every version.
+  Consequence stated instead: this PR bumps ALL strategy versions (accepted
+  over-invalidation, precedent #2719) and the next scan rewrites the fleet.
+- *"42 months is a sample"* — it is the entire regime-classifiable population
+  on `price_daily` (SPY starts 2022-05-10; the 200-SMA + 126-bar warm-up
+  reaches 2023-02-27). The 361 skipped instruments hold fewer than 64 bars
+  and can never rank; both counts are reported, not hidden.
+- *"Walk-forward / promotion evidence absent"* — queue items 6–8 (#2437 R4
+  order, #2720, #2721), deliberately not this PR. Nothing here claims
+  promotability; S-10 registers `harness_validation` like all nine.
+
+## Definition-of-done evidence (PR)
+
+Full-population census (per-leg verdict/reason distribution + fired counts +
+distinct instruments, per year), the turnover gate table above (v4 = shipped
+semantics), lint/typecheck/tests, Codex ckpt-2 (behavioural rung — data
+semantics throughout).

--- a/docs/proposals/ta/2026-08-14-s10-implementation-plan.md
+++ b/docs/proposals/ta/2026-08-14-s10-implementation-plan.md
@@ -86,11 +86,12 @@ Frozen constants, S-2's shape, all hashed via params + source hash:
   strategy's top decile is where tick-quantised penny names concentrate).
   Entry eligibility only; **no price floor on the exit leg** — a held name
   that fell under $1 must still be exitable.
-- `MIN_CROSS_SECTION=100` — by construction, from the measurement's
+- `MIN_CROSS_SECTION=1000` — by construction, from the measurement's
   `THIN_PANEL`: a decile BAND retention rule evaluated against a sliver panel
   would liquidate a book built on thousands of names. (S-2's 10 protects a
   one-shot decile cut; a retention band needs the panel to resemble the one
-  the book was built from.)
+  the book was built from. Raised from a first draft's 100 at Codex ckpt-1 —
+  see the resolutions section below.)
 - `s10_rebalance_dates(calendar)` — weekday-filtered (Sat/Sun dropped) union
   calendar, then S-2's first-bar-of-new-month rule. By construction:
   `price_daily` carries weekend rows for ~11 instruments, and the unfiltered

--- a/scripts/verify_2394_signal_scan_cost.py
+++ b/scripts/verify_2394_signal_scan_cost.py
@@ -444,7 +444,13 @@ def cost() -> bool:
     s2_participants = 0
     s2_rows = 0
     for instrument_id, series in loaded.items():
-        member = s2.member(series, panel_decision_dates=panel_dates, universe=UNIVERSE, masked_reason=MASKED_REASON)
+        member = s2.member(
+            series,
+            panel_decision_dates=panel_dates,
+            universe=UNIVERSE,
+            masked_reason=MASKED_REASON,
+            regime=unconstrained_regime(len(series)),
+        )
         if instrument_id not in at_frontier:
             continue
         index = len(series) - 2

--- a/scripts/verify_2394_strategy_manifest.py
+++ b/scripts/verify_2394_strategy_manifest.py
@@ -214,7 +214,13 @@ def equivalence() -> bool:
             assert s2.member is not None
             dates = s2.decision_calendar(series.dates)
             assert dates is not None
-            got_member = s2.member(series, panel_decision_dates=dates, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            got_member = s2.member(
+                series,
+                panel_decision_dates=dates,
+                universe=UNIVERSE,
+                masked_reason=MASKED_REASON,
+                regime=unconstrained_regime(len(series)),
+            )
             want_member = s2_member(series, panel_rebalance_dates=dates, universe=UNIVERSE, close_reason=MASKED_REASON)
             if (
                 got_member.dates != want_member.dates

--- a/scripts/verify_2437_s10_census.py
+++ b/scripts/verify_2437_s10_census.py
@@ -1,0 +1,182 @@
+"""S-10 full-population census — both legs over the validated universe (#2437).
+
+What it measures, per leg, on the same loader/masking/regime/segmentation the
+production scan uses (streamed via ``segmented_member``, resolved via the
+shared ``resolve_participating_bar`` — the census cannot drift from the scan
+because they call the same functions):
+
+- verdict/reason distribution over every bar of every loadable instrument;
+- fired counts per year + distinct instruments;
+- decision-date panel sizes and thin dates;
+- **mandatory parity**: every below-SMA decision bar that survived refusal and
+  thinness MUST have fired an exit — counted, not assumed (Codex ckpt-1).
+
+Usage
+-----
+    uv run python -m scripts.verify_2437_s10_census --out /tmp/s10_census.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import date
+
+import psycopg
+
+from app.config import settings
+from app.services.market_regime_provider import MarketRegimeProvider
+from app.services.price_masked_bars import load_masked_bars
+from app.services.price_segments import load_unresolved_breaks
+from app.services.strategies.s10_relative_strength_leader import (
+    MIN_CROSS_SECTION,
+    s10_entry_select,
+    s10_exit_select,
+    s10_rebalance_dates,
+)
+from app.services.strategies.validated_universe import load_validated_universe
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_registry import SignalKind, StagedMember, resolve_participating_bar
+from app.services.strategy_segmented_evaluation import segmented_member
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
+
+S10 = "s10-relative-strength-leader"
+SELECTS = {"entry": s10_entry_select, "exit": s10_exit_select}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    entry = STRATEGY_MANIFEST[S10]
+    legs: tuple[SignalKind, ...] = ("entry", "exit")
+
+    with psycopg.connect(settings.database_url) as conn:
+        universe = sorted(load_validated_universe(conn))
+        provider = MarketRegimeProvider.load(conn)
+        breaks = load_unresolved_breaks(conn, universe)
+
+        calendar: set[date] = set()
+        loaded: dict[int, object] = {}
+        skipped_short = 0
+        for instrument_id in universe:
+            series = load_masked_bars(conn, instrument_id).series
+            if len(series) < 2:
+                skipped_short += 1
+                continue
+            loaded[instrument_id] = series
+            calendar.update(series.dates)
+
+    panel_dates = s10_rebalance_dates(calendar)
+
+    staged_by_leg: dict[SignalKind, dict[int, StagedMember]] = {leg: {} for leg in legs}
+    dates_by_member: dict[int, tuple[date, ...]] = {}
+    scores_by_leg: dict[SignalKind, dict[date, dict[int, float]]] = {leg: {} for leg in legs}
+    for instrument_id, series in loaded.items():
+        dates_by_member[instrument_id] = series.dates  # type: ignore[attr-defined]
+        regime = provider.for_dates(series.dates)  # type: ignore[attr-defined]
+        for leg in legs:
+            staged = segmented_member(
+                entry,
+                series,  # type: ignore[arg-type]
+                panel_decision_dates=panel_dates,
+                universe=SCAN_UNIVERSE,
+                masked_reason="quarantined_bar",
+                unresolved_breaks=tuple(breaks.get(instrument_id, ())),
+                regime=regime,
+                leg=leg,
+            )
+            staged_by_leg[leg][instrument_id] = staged
+            for when, value in staged.scores.items():
+                scores_by_leg[leg].setdefault(when, {})[instrument_id] = value
+
+    result: dict[str, object] = {
+        "population": {
+            "universe": len(universe),
+            "loaded": len(loaded),
+            "skipped_short": skipped_short,
+            "rebalance_dates": len(panel_dates),
+            "min_cross_section": MIN_CROSS_SECTION,
+        }
+    }
+    for leg in legs:
+        winners: dict[date, frozenset[int]] = {}
+        thin: set[date] = set()
+        panel_sizes: dict[str, int] = {}
+        for when in sorted(scores_by_leg[leg]):
+            at_date = scores_by_leg[leg][when]
+            panel_sizes[when.isoformat()] = len(at_date)
+            if len(at_date) < MIN_CROSS_SECTION:
+                thin.add(when)
+                continue
+            selected = frozenset(SELECTS[leg](when, at_date))
+            unknown = selected - at_date.keys()
+            if unknown:
+                raise RuntimeError(f"{leg} select named non-participants {sorted(unknown)[:5]} on {when}")
+            winners[when] = selected
+
+        verdicts: Counter[str] = Counter()
+        fired_by_year: Counter[int] = Counter()
+        fired_instruments: set[int] = set()
+        mandatory_opportunities = mandatory_fired = 0
+        for instrument_id, staged in staged_by_leg[leg].items():
+            member_dates = dates_by_member[instrument_id]
+            for index, staged_verdict in enumerate(staged.verdicts):
+                if staged_verdict is not None:
+                    key = staged_verdict.verdict
+                    if staged_verdict.reason is not None:
+                        key = f"{key}/{staged_verdict.reason}"
+                    verdicts[key] += 1
+                    continue
+                when = member_dates[index]
+                if when in thin:
+                    verdicts["not_evaluable/thin_cross_section"] += 1
+                    continue
+                signal = resolve_participating_bar(
+                    when=when,
+                    index=index,
+                    kind=leg,
+                    selected=instrument_id in winners[when],
+                    admissible_dates=staged.admissible_dates,
+                    mandatory_dates=staged.mandatory_dates,
+                )
+                verdicts[signal.verdict] += 1
+                is_mandatory = staged.mandatory_dates is not None and when in staged.mandatory_dates
+                if is_mandatory:
+                    mandatory_opportunities += 1
+                    if signal.verdict == "fired":
+                        mandatory_fired += 1
+                if signal.verdict == "fired":
+                    fired_by_year[when.year] += 1
+                    fired_instruments.add(instrument_id)
+
+        result[leg] = {
+            "verdicts": dict(verdicts.most_common()),
+            "fired_by_year": {str(year): count for year, count in sorted(fired_by_year.items())},
+            "distinct_instruments_fired": len(fired_instruments),
+            "thin_dates": sorted(when.isoformat() for when in thin),
+            "panel_sizes": panel_sizes,
+            "mandatory_opportunities": mandatory_opportunities,
+            "mandatory_fired": mandatory_fired,
+        }
+        if mandatory_opportunities != mandatory_fired:
+            raise RuntimeError(
+                f"{leg}: {mandatory_opportunities} mandatory opportunities but {mandatory_fired} fired — "
+                "the below-SMA exit is being suppressed somewhere"
+            )
+
+    with open(args.out, "w") as handle:
+        json.dump(result, handle, indent=2)
+    for leg in legs:
+        stats = result[leg]
+        print(f"{leg}: fired_by_year={stats['fired_by_year']} distinct={stats['distinct_instruments_fired']}")  # type: ignore[index]
+        print(f"{leg}: verdicts={stats['verdicts']}")  # type: ignore[index]
+    print(f"population={result['population']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_2437_s10_turnover.py
+++ b/scripts/verify_2437_s10_turnover.py
@@ -1,0 +1,335 @@
+"""S-10 turnover measurement — the gate that runs BEFORE any S-10 code exists.
+
+Parent spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §S-10:
+
+    ⚠ Turnover check FIRST (Novy-Marx/Velikov: >50%/month rarely survives
+    costs). Monthly rebalance on deciles is near that bound — if measured
+    turnover exceeds it, S-10 is disqualified before any backtest, exactly as
+    S-1 was at 56x/yr.
+
+THE RULE BEING MEASURED, SPEC-LITERAL
+-------------------------------------
+- Setup: regime in {bull_quiet}; universe ranked by 63-bar return.
+- Signal: enter the top decile that ALSO closes above its own 50-SMA;
+  rebalance monthly.
+- Exit: leaves the top three deciles, or closes below 50-SMA.
+
+The exit BAND is load-bearing for this measurement: "enter top decile, hold
+while in top three" is a hysteresis rule whose entire purpose is to damp
+turnover, so measuring naive top-decile membership would over-reject the
+strategy the spec actually wrote.
+
+FROZEN BY CONSTRUCTION (no published formulation exists for any of these —
+stated per the source-rule discipline, exactly as S-2's decile cut had to be):
+
+- 63-bar return = ``close(t) / close(t-63) - 1`` on the instrument's OWN bar
+  indices (per-series windows, S-2's reading);
+- 50-SMA = trailing mean of the last 50 closes including t;
+- top decile = first ``N // 10`` of the panel ordered by score descending,
+  instrument id ascending (S-2's tie-break, verbatim);
+- top three deciles = first ``3 * N // 10`` of the same ordering;
+- a held name with NO bar on a rebalance date is CARRIED, not exited — no
+  trade can occur on a bar that does not exist, and the first draft of this
+  script that read absence as a forced exit measured the calendar, not the
+  strategy (see THIN DATES below). Carried counts are reported;
+- the rebalance calendar is the union of bar dates carrying at least
+  ``THIN_PANEL`` participating instruments, with the first-bar-of-new-month
+  rule applied AFTER that cut. ``price_daily`` holds weekend/holiday rows for
+  a handful of instruments (~11 on a typical Sunday), and an unfiltered union
+  calendar hands the month's one rebalance to such a date — a decile cut on
+  11 names when the typical cross-section is 2,000-5,700 is a calendar hole,
+  not the strategy, and because the FIRST qualifying bar takes the month, the
+  real first trading day then never rebalances at all. (⚠ S-2's production
+  ``rebalance_dates`` reads the unfiltered union calendar and rebalances on
+  those dates whenever ≥10 members trade — observed panels of 243 on
+  2023-12-01. Noted on #2437 rather than fixed here; this script measures
+  S-10.) ``THIN_PANEL = 100`` is by construction and the cut is reported;
+- entry needs ``close > sma50`` strictly; exit needs ``close < sma50``
+  strictly; equality holds an existing position and admits no new one.
+
+TWO ARMS, BECAUSE THE SPEC LEAVES THE EXIT CADENCE OPEN
+-------------------------------------------------------
+"Rebalance monthly" pins the entry cadence; whether the 50-SMA exit is checked
+monthly (at rebalance) or daily is a reading. Deciles only exist when the panel
+is ranked, so the decile-band exit is monthly in both arms.
+
+- ``monthly`` arm: both exit legs evaluated at rebalance dates only —
+  the turnover floor.
+- ``daily-sma`` arm: the 50-SMA exit checked every bar the holding trades,
+  decile band still monthly — the turnover ceiling of the two readings.
+
+If the floor already exceeds the bar, S-10 is dead under every reading. If the
+floor passes and the ceiling fails, the implementation must pin the monthly
+reading and say so.
+
+TURNOVER DEFINITION
+-------------------
+Equal-weight, Novy-Marx/Velikov-style one-sided monthly turnover:
+``(buys + sells) / 2 / mean(holdings_before, holdings_after)`` per rebalance
+interval, averaged over intervals where the portfolio is non-empty. The bar is
+~50%/month. Raw buy/sell/hold counts are reported alongside so the summary
+statistic cannot hide the distribution.
+
+POPULATION AND WINDOW
+---------------------
+The §4.0 validated universe on ``price_daily`` through ``load_masked_bars`` —
+the same loader, masking and regime provider the live scan uses, so the
+measurement is of the strategy the scan would actually run. ``price_daily``
+reaches back to 2022-05 and the SPY regime is classifiable from 2023-02-27
+(the 200-SMA + 126-bar BandWidth warm-up), so entries exist only from the
+first bull_quiet rebalance after that. ⚠ survivor_only population, and that
+CUTS WITH the gate here: today's survivors under-count forced exits
+(delistings), so measured turnover is a floor in that one respect — a FAIL on
+this population is final; a marginal pass is re-examined at backtest time on
+the research corpus.
+
+Usage
+-----
+    uv run python scripts/verify_2437_s10_turnover.py --out /tmp/s10_turnover.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+
+import numpy as np
+import psycopg
+
+from app.config import settings
+from app.services.market_regime import Regime
+from app.services.market_regime_provider import MarketRegimeProvider
+from app.services.price_masked_bars import load_masked_bars
+from app.services.strategies.s2_cross_sectional_momentum import rebalance_dates
+from app.services.strategies.validated_universe import load_validated_universe
+
+LOOKBACK_BARS = 63
+SMA_BARS = 50
+ENTRY_DECILE = 10  # top N//10
+EXIT_BAND_DECILES = 3  # hold while within first 3*N//10
+
+#: Below this an instrument cannot produce a score anyway (63-bar return needs
+#: index 63; the 50-SMA needs 50). Reported, never silently applied.
+MIN_BARS = LOOKBACK_BARS + 1
+
+#: See the module docstring — a month boundary the market did not trade.
+#: Raised 100 → 1000 at Codex ckpt-1: 100 still admits a corpus-hole date
+#: (243 rows on 2023-12-01, a normal Friday most of the corpus is missing),
+#: and a retention band cut on a sliver of the book's formation panel is the
+#: calendar hole wearing a rank. Every real panel measured 2,084–5,747; 1000
+#: refuses every observed junk date and no observed real one.
+THIN_PANEL = 1000
+
+#: S-2's §9 Q3 adjusted-price floor, applied to the ENTRY panel only.
+MIN_CLOSE = 1.0
+
+
+@dataclass(frozen=True)
+class MemberDay:
+    score: float
+    close: float
+    sma: float
+
+
+def _member_days(
+    dates: tuple[date, ...], closes: list[float | None]
+) -> tuple[dict[date, MemberDay], dict[date, tuple[float | None, float | None]]]:
+    """Per-date panel contribution + per-date (close, sma) for daily exits.
+
+    A date is rankable only when close(t), close(t-63) and every close in the
+    trailing 50 window are present and positive — a masked bar anywhere in the
+    windows refuses the date rather than interpolating through it.
+    """
+    n = len(closes)
+    values = np.array([np.nan if c is None or c <= 0.0 else c for c in closes], dtype=np.float64)
+    finite = np.isfinite(values)
+    # Trailing 50-SMA where the whole window is finite.
+    sma = np.full(n, np.nan)
+    if n >= SMA_BARS:
+        kernel = np.ones(SMA_BARS) / SMA_BARS
+        means = np.convolve(np.where(finite, values, 0.0), kernel, mode="valid")
+        whole = np.convolve(finite.astype(np.float64), kernel, mode="valid") == 1.0
+        sma[SMA_BARS - 1 :] = np.where(whole, means, np.nan)
+    rankable: dict[date, MemberDay] = {}
+    daily: dict[date, tuple[float | None, float | None]] = {}
+    for i in range(n):
+        c = values[i] if finite[i] else None
+        s = sma[i] if np.isfinite(sma[i]) else None
+        daily[dates[i]] = (c, s)
+        if c is None or s is None or i < LOOKBACK_BARS:
+            continue
+        past = values[i - LOOKBACK_BARS]
+        if not np.isfinite(past):
+            continue
+        rankable[dates[i]] = MemberDay(score=float(c / past - 1.0), close=float(c), sma=float(s))
+    return rankable, daily
+
+
+def _rank(panel: dict[int, MemberDay]) -> tuple[frozenset[int], frozenset[int]]:
+    """(top decile of the ENTRY panel, top-3-decile band of the EXIT panel).
+
+    Implementation semantics, exactly as the module will ship them (Codex
+    ckpt-1 made the divergence explicit, so it is measured rather than argued):
+
+    - ENTRY panel = names with ``close >= MIN_CLOSE`` — S-2's §9 Q3 adjusted-
+      price floor; the decile denominator is the floored panel.
+    - EXIT panel = every rankable name, floor-free — a held name that fell
+      under $1 must still be exitable, and the retention band is cut on the
+      panel that contains it.
+    """
+    ordered = sorted(panel.items(), key=lambda item: (-item[1].score, item[0]))
+    entry_ordered = [(key, member) for key, member in ordered if member.close >= MIN_CLOSE]
+    top1 = frozenset(key for key, _ in entry_ordered[: len(entry_ordered) // ENTRY_DECILE])
+    top3 = frozenset(key for key, _ in ordered[: EXIT_BAND_DECILES * len(ordered) // ENTRY_DECILE])
+    return top1, top3
+
+
+def simulate(
+    panels: dict[date, dict[int, MemberDay]],
+    daily_by_member: dict[int, dict[date, tuple[float | None, float | None]]],
+    calendar: list[date],
+    regime_at: dict[date, Regime | None],
+    *,
+    daily_sma_exit: bool,
+) -> dict[str, object]:
+    rebalances = sorted(panels)
+    holdings: set[int] = set()
+    months: list[dict[str, object]] = []
+    for idx, when in enumerate(rebalances):
+        panel = panels[when]
+        before = len(holdings)
+        thin = len(panel) < THIN_PANEL
+        carried_absent = {h for h in holdings if h not in panel}
+        rule_exits: set[int] = set()
+        buys: set[int] = set()
+        if not thin:
+            top1, top3 = _rank(panel)
+            rule_exits = {h for h in holdings - carried_absent if h not in top3 or panel[h].close < panel[h].sma}
+            holdings -= rule_exits
+            if regime_at.get(when) is Regime.BULL_QUIET:
+                buys = {m for m in top1 if panel[m].close > panel[m].sma} - holdings
+                holdings |= buys
+        intramonth_exits: set[int] = set()
+        if daily_sma_exit:
+            until = rebalances[idx + 1] if idx + 1 < len(rebalances) else None
+            span = [d for d in calendar if d > when and (until is None or d < until)]
+            for day in span:
+                for h in list(holdings):
+                    close, sma_value = daily_by_member[h].get(day, (None, None))
+                    if close is not None and sma_value is not None and close < sma_value:
+                        holdings.discard(h)
+                        intramonth_exits.add(h)
+        sells = len(rule_exits) + len(intramonth_exits)
+        after = len(holdings)
+        avg = (before + after) / 2.0
+        months.append(
+            {
+                "date": when.isoformat(),
+                "regime": (current.value if (current := regime_at.get(when)) else None),
+                "panel": len(panel),
+                "thin_skipped": thin,
+                "before": before,
+                "buys": len(buys),
+                "rule_exits": len(rule_exits),
+                "carried_absent": len(carried_absent),
+                "intramonth_exits": len(intramonth_exits),
+                "after": after,
+                "turnover": ((len(buys) + sells) / 2.0 / avg) if avg > 0 else None,
+            }
+        )
+    active = [m for m in months if m["turnover"] is not None and not m["thin_skipped"]]
+    turnovers = [float(m["turnover"]) for m in active]  # type: ignore[arg-type]
+    # The first month a portfolio exists is a bootstrap (everything is a buy,
+    # turnover 1.0 by construction) — steady state excludes months that START
+    # empty, and is the figure comparable to the published ~50%/month bar.
+    steady = [float(m["turnover"]) for m in active if int(m["before"]) > 0]  # type: ignore[arg-type]
+    return {
+        "months": months,
+        "active_months": len(active),
+        "mean_monthly_turnover": (sum(turnovers) / len(turnovers)) if turnovers else None,
+        "median_monthly_turnover": (sorted(turnovers)[len(turnovers) // 2] if turnovers else None),
+        "max_monthly_turnover": max(turnovers) if turnovers else None,
+        "steady_months": len(steady),
+        "steady_mean_monthly_turnover": (sum(steady) / len(steady)) if steady else None,
+        "steady_max_monthly_turnover": max(steady) if steady else None,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="write the full JSON here")
+    args = parser.parse_args()
+
+    with psycopg.connect(settings.database_url) as conn:
+        universe = sorted(load_validated_universe(conn))
+        provider = MarketRegimeProvider.load(conn)
+        panels: dict[date, dict[int, MemberDay]] = {}
+        daily_by_member: dict[int, dict[date, tuple[float | None, float | None]]] = {}
+        calendar_set: set[date] = set()
+        loaded = skipped_short = 0
+        # First pass collects every instrument's dates so the rebalance calendar
+        # is the PANEL's union, not any single member's (S-2's reading).
+        series_by_member: dict[int, tuple[tuple[date, ...], list[float | None]]] = {}
+        for instrument_id in universe:
+            series = load_masked_bars(conn, instrument_id).series
+            if len(series) < MIN_BARS:
+                skipped_short += 1
+                continue
+            loaded += 1
+            series_by_member[instrument_id] = (series.dates, list(series.float_closes))
+            calendar_set.update(series.dates)
+
+    participation = Counter(when for dates, _ in series_by_member.values() for when in dates)
+    calendar = sorted(when for when in calendar_set if participation[when] >= THIN_PANEL)
+    thin_dates_cut = len(calendar_set) - len(calendar)
+    rebalance_set = rebalance_dates(calendar)
+    for instrument_id, (dates, closes) in series_by_member.items():
+        rankable, daily = _member_days(dates, closes)
+        daily_by_member[instrument_id] = daily
+        for when, member in rankable.items():
+            if when in rebalance_set:
+                panels.setdefault(when, {})[instrument_id] = member
+
+    ordered_rebalances = tuple(sorted(panels))
+    regime_series = provider.for_dates(ordered_rebalances)
+    regime_at = dict(zip(ordered_rebalances, regime_series.values, strict=True))
+
+    result = {
+        "population": {
+            "universe": len(series_by_member) + skipped_short,
+            "loaded": loaded,
+            "skipped_below_min_bars": skipped_short,
+            "min_bars": MIN_BARS,
+            "thin_dates_cut_from_calendar": thin_dates_cut,
+            "rebalance_dates": len(ordered_rebalances),
+            "bull_quiet_rebalances": sum(1 for r in regime_at.values() if r is Regime.BULL_QUIET),
+            "regime_distribution": {
+                (r.value if r else "unclassifiable"): sum(1 for v in regime_at.values() if v is r)
+                for r in set(regime_at.values())
+            },
+        },
+        "monthly": simulate(panels, daily_by_member, calendar, regime_at, daily_sma_exit=False),
+        "daily_sma": simulate(panels, daily_by_member, calendar, regime_at, daily_sma_exit=True),
+    }
+    with open(args.out, "w") as handle:
+        json.dump(result, handle, indent=2)
+
+    for arm in ("monthly", "daily_sma"):
+        stats = result[arm]
+        print(
+            f"{arm}: active_months={stats['active_months']} "
+            f"mean={stats['mean_monthly_turnover']} median={stats['median_monthly_turnover']} "
+            f"max={stats['max_monthly_turnover']} | steady_months={stats['steady_months']} "
+            f"steady_mean={stats['steady_mean_monthly_turnover']} "
+            f"steady_max={stats['steady_max_monthly_turnover']}"
+        )
+    print(f"population: {result['population']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_2437_s10_relative_strength.py
+++ b/tests/test_2437_s10_relative_strength.py
@@ -1,0 +1,470 @@
+"""S-10 relative-strength leader — module rules + the refinement contract (#2437).
+
+Spec: ``docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`` §S-10; plan +
+Codex ckpt-1 resolutions ``docs/proposals/ta/2026-08-14-s10-implementation-plan.md``.
+Modules under test: ``app/services/strategies/s10_relative_strength_leader.py``
+and the ``admissible_indices`` / ``mandatory_indices`` refinements added to
+``app/services/strategy_registry.py`` for it.
+
+The resolution rule under test, everywhere a staged bar survives every refusal:
+
+    fired iff mandatory OR (selected AND admissible)
+
+with precedence pinned: ``no_fill_bar`` → unevaluable input → non-decision
+``not_fired`` → ``thin_cross_section`` → the rule. Mandatory beats NEITHER a
+refusal NOR a thin panel.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services.indicator_series import BarSeries, IndicatorSeries
+from app.services.market_regime import Regime, RegimeSeries
+from app.services.strategies.s10_relative_strength_leader import (
+    LOOKBACK_BARS,
+    SMA_BARS,
+    return_series,
+    s10_entry_member,
+    s10_entry_select,
+    s10_exit_member,
+    s10_exit_select,
+    s10_rebalance_dates,
+)
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_registry import (
+    CrossSectionalMember,
+    StrategyInput,
+    evaluate_cross_sectional,
+    stage_cross_sectional_member,
+)
+from app.services.strategy_segmented_evaluation import segmented_member
+from app.services.technical_analysis import OHLCVRow
+
+UNIVERSE = "survivor_only"
+REASON = "quarantined_bar"
+S10 = "s10-relative-strength-leader"
+
+#: 100 consecutive calendar days from 2024-01-01. The first rebalance with the
+#: 63-interval score warm the whole panel is 2024-04-01 (index 91, a Monday).
+START = date(2024, 1, 1)
+N_BARS = 100
+DATES = tuple(START + timedelta(days=i) for i in range(N_BARS))
+DECISION = date(2024, 4, 1)
+DECISION_INDEX = DATES.index(DECISION)
+
+
+def _bars(closes: list[float] | list[float | None]) -> BarSeries:
+    rows: list[OHLCVRow] = [
+        {
+            "open": None if c is None else Decimal(str(round(c, 6))),
+            "high": None if c is None else Decimal(str(round(c + 1, 6))),
+            "low": None if c is None else Decimal(str(round(c - 1, 6))),
+            "close": None if c is None else Decimal(str(round(c, 6))),
+            "volume": 1_000,
+        }  # type: ignore[typeddict-item]
+        for c in closes
+    ]
+    return BarSeries(dates=DATES[: len(closes)], rows=tuple(rows))
+
+
+def _regime(value: Regime | None = Regime.BULL_QUIET, *, holes: tuple[int, ...] = ()) -> RegimeSeries:
+    values: list[Regime | None] = [value] * N_BARS
+    for index in holes:
+        values[index] = None
+    return RegimeSeries(values=tuple(values), not_evaluable_indices=holes)
+
+
+def _rising(final: float) -> list[float]:
+    """Linear 100 → 100*(1+final); close > trailing mean everywhere after warm-up."""
+    return [100.0 * (1.0 + final * i / (N_BARS - 1)) for i in range(N_BARS)]
+
+
+def _rising_then_falling(peak: float) -> list[float]:
+    """Strong rise to bar 79 then a fall — 63-bar return still high at the
+    decision bar, close < 50-SMA there. The selected-but-inadmissible shape."""
+    up = [100.0 * (1.0 + peak * i / 79) for i in range(80)]
+    top = up[-1]
+    down = [top * (1.0 - 0.012 * (i + 1)) for i in range(N_BARS - 80)]
+    return up + down
+
+
+def _plain_sma(closes: list[float], index: int) -> float:
+    """Independent check of the fixture's close-vs-SMA relation — NOT the
+    module's own sma_series, which would make the assertion circular."""
+    return sum(closes[index - SMA_BARS + 1 : index + 1]) / SMA_BARS
+
+
+class TestRebalanceCalendar:
+    def test_weekends_never_take_a_month(self) -> None:
+        """2024-06-01 is a Saturday; an unfiltered first-bar rule would hand
+        June's one rebalance to an 11-instrument junk date (measured on
+        #2437). The first WEEKDAY takes it instead."""
+        calendar = [date(2024, 5, 1) + timedelta(days=i) for i in range(45)]
+        picked = s10_rebalance_dates(calendar)
+        assert date(2024, 6, 3) in picked
+        assert date(2024, 6, 1) not in picked and date(2024, 6, 2) not in picked
+
+    def test_the_first_date_is_not_a_rebalance(self) -> None:
+        calendar = [date(2024, 5, 1) + timedelta(days=i) for i in range(10)]
+        assert date(2024, 5, 1) not in s10_rebalance_dates(calendar)
+
+    def test_the_manifest_calendar_is_this_rule(self) -> None:
+        calendar = [date(2024, 5, 1) + timedelta(days=i) for i in range(45)]
+        assert STRATEGY_MANIFEST[S10].decision_calendar(calendar) == s10_rebalance_dates(calendar)
+
+
+class TestReturnSeries:
+    def test_warmup_then_the_63_interval_ratio(self) -> None:
+        closes = _rising(0.5)
+        series = return_series(_bars(closes), universe=UNIVERSE)
+        assert series.values[LOOKBACK_BARS - 1] is None
+        got = series.values[LOOKBACK_BARS]
+        assert got is not None
+        assert got == pytest.approx(closes[LOOKBACK_BARS] / closes[0] - 1.0)
+
+    def test_a_masked_endpoint_refuses_rather_than_interpolates(self) -> None:
+        closes: list[float | None] = list(_rising(0.5))
+        closes[DECISION_INDEX - LOOKBACK_BARS] = None
+        series = return_series(_bars(closes), universe=UNIVERSE)
+        assert series.values[DECISION_INDEX] is None
+        assert DECISION_INDEX in series.not_evaluable_indices
+
+
+class TestSelects:
+    def test_entry_is_the_floor_decile_with_the_frozen_tie_break(self) -> None:
+        scores = {key: 1.0 for key in range(1, 21)}  # 20 members, all tied
+        winners = s10_entry_select(DECISION, scores)
+        assert winners == frozenset({1, 2})  # 20 // 10 = 2, ids ascending on the tie
+
+    def test_exit_is_the_complement_of_the_band(self) -> None:
+        scores = {key: float(100 - key) for key in range(1, 21)}  # 1 is best
+        leavers = s10_exit_select(DECISION, scores)
+        assert leavers == frozenset(range(7, 21))  # band = 3*20//10 = 6 → 1..6 stay
+
+    def test_a_sub_decile_panel_selects_nobody(self) -> None:
+        assert s10_entry_select(DECISION, {1: 1.0, 2: 2.0}) == frozenset()
+
+
+class TestEntryMember:
+    def test_sub_dollar_bars_are_not_decision_bars(self) -> None:
+        closes = [0.5 * (1.0 + 0.3 * i / (N_BARS - 1)) for i in range(N_BARS)]
+        member = s10_entry_member(
+            _bars(closes),
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            close_reason=REASON,
+            regime=_regime(),
+        )
+        assert member.decision_indices == frozenset()
+
+    def test_below_sma_or_wrong_regime_is_inadmissible(self) -> None:
+        falling = _rising_then_falling(0.8)
+        assert falling[DECISION_INDEX] < _plain_sma(falling, DECISION_INDEX)
+        member = s10_entry_member(
+            _bars(falling),
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            close_reason=REASON,
+            regime=_regime(),
+        )
+        assert member.decision_indices == frozenset({DECISION_INDEX})
+        assert member.admissible_indices == frozenset()
+
+        rising = _rising(0.5)
+        bear = s10_entry_member(
+            _bars(rising),
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            close_reason=REASON,
+            regime=_regime(Regime.BEAR_QUIET),
+        )
+        assert bear.admissible_indices == frozenset()
+
+    def test_a_benchmark_hole_refuses_as_missing_market_context(self) -> None:
+        member = s10_entry_member(
+            _bars(_rising(0.5)),
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            close_reason=REASON,
+            regime=_regime(holes=(DECISION_INDEX,)),
+        )
+        staged = stage_cross_sectional_member(member)
+        verdict = staged.verdicts[DECISION_INDEX]
+        assert verdict is not None
+        assert (verdict.verdict, verdict.reason) == ("not_evaluable", "missing_market_context")
+
+    def test_equality_with_the_sma_admits_nothing(self) -> None:
+        flat = [100.0] * N_BARS  # close == 50-SMA exactly, and 63-bar return 0
+        member = s10_entry_member(
+            _bars(flat),
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            close_reason=REASON,
+            regime=_regime(),
+        )
+        assert member.decision_indices == frozenset({DECISION_INDEX})
+        assert member.admissible_indices == frozenset()
+
+
+class TestExitMember:
+    def test_below_sma_is_mandatory_and_a_benchmark_hole_does_not_refuse(self) -> None:
+        """The exit leg declares NO regime — a missing benchmark session must
+        never refuse the exit verdict for an open position (S-7's rule)."""
+        falling = _rising_then_falling(0.8)
+        member = s10_exit_member(
+            _bars(falling),
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            close_reason=REASON,
+        )
+        assert member.mandatory_indices == frozenset({DECISION_INDEX})
+        staged = stage_cross_sectional_member(member, kind="exit")
+        assert staged.verdicts[DECISION_INDEX] is None  # participates; not refused
+
+    def test_equality_with_the_sma_is_not_an_exit(self) -> None:
+        flat = [100.0] * N_BARS
+        member = s10_exit_member(
+            _bars(flat),
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            close_reason=REASON,
+        )
+        assert member.mandatory_indices == frozenset()
+
+    def test_sub_dollar_names_still_rank_on_the_exit_panel(self) -> None:
+        closes = [0.5] * N_BARS
+        member = s10_exit_member(
+            _bars(closes),
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            close_reason=REASON,
+        )
+        assert member.decision_indices == frozenset({DECISION_INDEX})
+
+
+def _panel(regime_value: Regime = Regime.BULL_QUIET) -> dict[int, BarSeries]:
+    """20 members: 1 = best rising, 2 = second-best but below its SMA at the
+    decision bar, 3.. descending returns, 20 = worst."""
+    finals = {key: 0.6 - 0.03 * (key - 1) for key in range(1, 21)}
+    panel = {key: _bars(_rising(finals[key])) for key in range(1, 21) if key != 2}
+    panel[2] = _bars(_rising_then_falling(1.2))
+    return panel
+
+
+class TestPanelResolution:
+    """The rule matrix, end to end through ``evaluate_cross_sectional`` with
+    the S-10 members and selects. ``min_participants`` is 10 here rather than
+    the shipped 1000 — the floor is a refusal threshold, not part of the rule,
+    and the shipped value is exercised by the full-population census."""
+
+    def _run(self, regime_value: Regime = Regime.BULL_QUIET) -> tuple[dict, dict]:
+        panel = _panel()
+        regime = _regime(regime_value)
+        entries = evaluate_cross_sectional(
+            members={
+                key: s10_entry_member(
+                    series,
+                    panel_decision_dates=frozenset({DECISION}),
+                    universe=UNIVERSE,
+                    close_reason=REASON,
+                    regime=regime,
+                )
+                for key, series in panel.items()
+            },
+            select=s10_entry_select,
+            min_participants=10,
+            kind="entry",
+        )
+        exits = evaluate_cross_sectional(
+            members={
+                key: s10_exit_member(
+                    series,
+                    panel_decision_dates=frozenset({DECISION}),
+                    universe=UNIVERSE,
+                    close_reason=REASON,
+                )
+                for key, series in panel.items()
+            },
+            select=s10_exit_select,
+            min_participants=10,
+            kind="exit",
+        )
+        return entries, exits
+
+    def test_the_matrix_at_the_decision_bar(self) -> None:
+        member2_closes = _rising_then_falling(1.2)
+        member3_closes = _rising(0.6 - 0.03 * 2)
+        assert member2_closes[DECISION_INDEX] < _plain_sma(member2_closes, DECISION_INDEX)
+        # The fixture's load-bearing ordering: member 2's 63-bar return beats
+        # member 3's, so 2 is genuinely SELECTED and only the SMA blocks it.
+        member2_return = member2_closes[DECISION_INDEX] / member2_closes[DECISION_INDEX - LOOKBACK_BARS] - 1.0
+        member3_return = member3_closes[DECISION_INDEX] / member3_closes[DECISION_INDEX - LOOKBACK_BARS] - 1.0
+        assert member2_return > member3_return
+
+        entries, exits = self._run()
+        entry_at = {key: signals[DECISION_INDEX] for key, signals in entries.items()}
+        exit_at = {key: signals[DECISION_INDEX] for key, signals in exits.items()}
+
+        # k = 20 // 10 = 2: members 2 (highest 63-bar return) and 1 are selected.
+        # 1 fires; 2 is selected-but-below-SMA — not_fired WITHOUT backfilling 3.
+        assert entry_at[1].verdict == "fired"
+        assert entry_at[2].verdict == "not_fired"
+        assert entry_at[3].verdict == "not_fired"
+
+        # Exit band = 3 * 20 // 10 = 6. Member 2 is INSIDE the band and below
+        # its SMA → mandatory exit. Member 3 is inside and above → holds.
+        # Member 20 is outside the band → exits by selection.
+        assert exit_at[2].verdict == "fired"
+        assert exit_at[3].verdict == "not_fired"
+        assert exit_at[20].verdict == "fired"
+
+    def test_a_bear_regime_blocks_every_entry_and_no_exit(self) -> None:
+        entries, exits = self._run(Regime.BEAR_QUIET)
+        entry_verdicts = {signals[DECISION_INDEX].verdict for signals in entries.values()}
+        assert entry_verdicts == {"not_fired"}
+        assert exits[20][DECISION_INDEX].verdict == "fired"
+
+    def test_thin_panel_refuses_both_legs_mandatory_included(self) -> None:
+        """Mandatory does NOT beat ``thin_cross_section`` — the refusal comes
+        first, so a sliver panel cannot fire the below-SMA exit either."""
+        panel = {2: _panel()[2]}
+        exits = evaluate_cross_sectional(
+            members={
+                2: s10_exit_member(
+                    panel[2],
+                    panel_decision_dates=frozenset({DECISION}),
+                    universe=UNIVERSE,
+                    close_reason=REASON,
+                )
+            },
+            select=s10_exit_select,
+            min_participants=10,
+            kind="exit",
+        )
+        verdict = exits[2][DECISION_INDEX]
+        assert (verdict.verdict, verdict.reason) == ("not_evaluable", "thin_cross_section")
+
+
+class TestRefinementContract:
+    """The registry-level refinements, on synthetic members — including the
+    S-2 regression: both ``None`` is exactly the old behaviour."""
+
+    @staticmethod
+    def _member(
+        *,
+        admissible: frozenset[int] | None,
+        mandatory: frozenset[int] | None,
+    ) -> CrossSectionalMember:
+        dates = (date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3))
+        score = IndicatorSeries(values=(1.0, 2.0, 3.0), universe=UNIVERSE)
+        return CrossSectionalMember(
+            dates=dates,
+            inputs=(StrategyInput(series=score, reason=REASON),),
+            score=score,
+            decision_indices=frozenset({1}),
+            admissible_indices=admissible,
+            mandatory_indices=mandatory,
+        )
+
+    def test_none_refinements_are_the_old_rule(self) -> None:
+        member = self._member(admissible=None, mandatory=None)
+        selected = evaluate_cross_sectional(
+            members={7: member}, select=lambda when, scores: frozenset(scores), min_participants=1
+        )
+        assert selected[7][1].verdict == "fired"
+        unselected = evaluate_cross_sectional(
+            members={7: member}, select=lambda when, scores: frozenset(), min_participants=1
+        )
+        assert unselected[7][1].verdict == "not_fired"
+
+    def test_selected_but_inadmissible_is_not_fired(self) -> None:
+        member = self._member(admissible=frozenset(), mandatory=None)
+        out = evaluate_cross_sectional(
+            members={7: member}, select=lambda when, scores: frozenset(scores), min_participants=1
+        )
+        assert out[7][1].verdict == "not_fired"
+
+    def test_mandatory_fires_unselected(self) -> None:
+        member = self._member(admissible=None, mandatory=frozenset({1}))
+        out = evaluate_cross_sectional(members={7: member}, select=lambda when, scores: frozenset(), min_participants=1)
+        assert out[7][1].verdict == "fired"
+
+    def test_mandatory_wins_over_inadmissible(self) -> None:
+        """fired iff mandatory OR (selected AND admissible) — the OR is real."""
+        member = self._member(admissible=frozenset(), mandatory=frozenset({1}))
+        out = evaluate_cross_sectional(members={7: member}, select=lambda when, scores: frozenset(), min_participants=1)
+        assert out[7][1].verdict == "fired"
+
+    def test_a_refinement_outside_decision_indices_raises(self) -> None:
+        with pytest.raises(ValueError, match="outside decision_indices"):
+            self._member(admissible=frozenset({0}), mandatory=None)
+        with pytest.raises(ValueError, match="outside decision_indices"):
+            self._member(admissible=None, mandatory=frozenset({2}))
+
+    def test_an_inadmissible_score_still_ranks_the_others(self) -> None:
+        """The panel denominator is unchanged — that is the whole point."""
+        member = self._member(admissible=frozenset(), mandatory=None)
+        staged = stage_cross_sectional_member(member)
+        assert date(2024, 1, 2) in staged.scores
+
+
+class TestManifestAdaptersMatchTheDirectCalls:
+    """The staging the scan and backtest share (``segmented_member``) must be
+    the module's own members — verdicts, scores AND refinements. The
+    resolution itself cannot drift: all three resolvers call
+    ``resolve_participating_bar``, which is the single source of the rule."""
+
+    @pytest.mark.parametrize("leg", ["entry", "exit"])
+    def test_segmented_staging_equals_direct_staging(self, leg: str) -> None:
+        entry = STRATEGY_MANIFEST[S10]
+        series = _panel()[2]
+        regime = _regime()
+        via_runner = segmented_member(
+            entry,
+            series,
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            masked_reason=REASON,
+            unresolved_breaks=(),
+            regime=regime,
+            leg=leg,  # type: ignore[arg-type]
+        )
+        if leg == "entry":
+            direct = s10_entry_member(
+                series,
+                panel_decision_dates=frozenset({DECISION}),
+                universe=UNIVERSE,
+                close_reason=REASON,
+                regime=regime,
+            )
+        else:
+            direct = s10_exit_member(
+                series,
+                panel_decision_dates=frozenset({DECISION}),
+                universe=UNIVERSE,
+                close_reason=REASON,
+            )
+        expected = stage_cross_sectional_member(direct, kind=leg)  # type: ignore[arg-type]
+        assert via_runner.verdicts == expected.verdicts
+        assert via_runner.scores == expected.scores
+        assert via_runner.admissible_dates == expected.admissible_dates
+        assert via_runner.mandatory_dates == expected.mandatory_dates
+
+    def test_the_exit_leg_carries_exit_kind_throughout(self) -> None:
+        entry = STRATEGY_MANIFEST[S10]
+        staged = segmented_member(
+            entry,
+            _panel()[2],
+            panel_decision_dates=frozenset({DECISION}),
+            universe=UNIVERSE,
+            masked_reason=REASON,
+            unresolved_breaks=(),
+            regime=_regime(),
+            leg="exit",
+        )
+        kinds = {verdict.kind for verdict in staged.verdicts if verdict is not None}
+        assert kinds == {"exit"}

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -189,6 +189,7 @@ class TestRunnableStrategies:
         runnable, excluded = runnable_strategies()
         assert list(runnable) == [
             "s1-time-series-momentum",
+            "s10-relative-strength-leader",
             "s2-cross-sectional-momentum",
             "s3-mean-reversion-in-trend",
             "s4-volatility-compression-breakout",
@@ -1658,6 +1659,7 @@ class TestSeriesBreakBoundary:
             universe="survivor_only",
             masked_reason="quarantined_bar",
             unresolved_breaks=(),
+            regime=unconstrained_regime(len(series)),
         )
         segmented = segmented_member(
             entry,
@@ -1666,6 +1668,7 @@ class TestSeriesBreakBoundary:
             universe="survivor_only",
             masked_reason="quarantined_bar",
             unresolved_breaks=(dates[300],),
+            regime=unconstrained_regime(len(series)),
         )
         assert whole.verdicts[400] is None
         before_break = segmented.verdicts[299]

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -53,6 +53,7 @@ SPEC_S6 = "s6-resistance-breakout"
 SPEC_S7 = "s7-trend-pullback"
 SPEC_S8 = "s8-range-mean-reversion"
 SPEC_S9 = "s9-squeeze-expansion"
+SPEC_S10 = "s10-relative-strength-leader"
 
 #: Spec §3's table, verbatim, as ``(signal_pair, level_based, max_hold_bars,
 #: has_rebalance_dates)``. ⚠ Written out for the reason in the module docstring:
@@ -70,6 +71,11 @@ SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
     SPEC_S7: (True, True, 60, False),
     SPEC_S8: (False, True, 15, False),
     SPEC_S9: (False, True, 40, False),
+    #: ⚠ Signal-pair ONLY, despite having a calendar: S-10's retention is the
+    #: top-three-decile BAND its ranked exit leg carries, and C4's calendar
+    #: close is entry-set retention — declaring both would close
+    #: band-surviving positions a month early (module docstring).
+    SPEC_S10: (True, False, None, False),
 }
 
 #: The legs each strategy emits — §4: S-1 and S-3 have an exit rule, S-2 closes
@@ -84,6 +90,7 @@ SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
     SPEC_S7: frozenset({"entry", "exit"}),
     SPEC_S8: frozenset({"entry"}),
     SPEC_S9: frozenset({"entry"}),
+    SPEC_S10: frozenset({"entry", "exit"}),
 }
 
 SPEC_CLASSES: dict[str, str] = {
@@ -96,11 +103,12 @@ SPEC_CLASSES: dict[str, str] = {
     SPEC_S7: "per_series",
     SPEC_S8: "per_series",
     SPEC_S9: "per_series",
+    SPEC_S10: "cross_sectional",
 }
 
 SPEC_PURPOSES = {
     strategy_id: "harness_validation"
-    for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S7, SPEC_S8, SPEC_S9)
+    for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S7, SPEC_S8, SPEC_S9, SPEC_S10)
 }
 
 
@@ -175,7 +183,7 @@ class TestManifestIsComplete:
         forever. Pin that it is actually reading the modules it claims to — the
         prevention-log lesson from a probe that matched nothing."""
         declared = self._declared_strategy_ids()
-        assert len(declared) == 9, f"expected the nine catalogue modules, walked {sorted(declared)}"
+        assert len(declared) == 10, f"expected the ten catalogue modules, walked {sorted(declared)}"
         assert declared["s1_time_series_momentum.py"] == SPEC_S1
 
     def test_every_strategy_module_is_registered(self) -> None:
@@ -211,6 +219,7 @@ class TestManifestIsComplete:
             SPEC_S7,
             SPEC_S8,
             SPEC_S9,
+            SPEC_S10,
         }
 
 
@@ -354,7 +363,13 @@ class TestUniformInvocationEqualsTheDirectCall:
         series = _bars(_CLOSES)
         dates = entry.decision_calendar(series.dates)
         assert dates is not None
-        via_manifest = entry.member(series, panel_decision_dates=dates, universe=UNIVERSE, masked_reason=REASON)
+        via_manifest = entry.member(
+            series,
+            panel_decision_dates=dates,
+            universe=UNIVERSE,
+            masked_reason=REASON,
+            regime=unconstrained_regime(len(series)),
+        )
         expected = s2_member(series, panel_rebalance_dates=dates, universe=UNIVERSE, close_reason=REASON)
         assert via_manifest.dates == expected.dates
         assert via_manifest.decision_indices == expected.decision_indices

--- a/tests/test_strategy_signal_scan.py
+++ b/tests/test_strategy_signal_scan.py
@@ -270,13 +270,15 @@ class TestCrossSectionalResolution:
             window_dates=(date(2026, 1, 1),),
             decided={},
             participating=frozenset({date(2026, 1, 1)}),
+            admissible_dates=None,
+            mandatory_dates=None,
         )
 
     def test_winner_fills_at_the_next_bar_open(self) -> None:
         plan = self._plan()
         out: list[LedgerRow] = []
         scores = {date(2026, 1, 1): {instrument: float(instrument) for instrument in range(1, 21)}}
-        _resolve_cross_section(plan, pending={20: self._pending()}, scores=scores, out=out)
+        _resolve_cross_section(plan, leg="entry", pending={20: self._pending()}, scores=scores, out=out)
         assert len(out) == 1
         row = out[0]
         assert (row.verdict, row.signal_bar_date) == ("fired", date(2026, 1, 1))
@@ -294,7 +296,7 @@ class TestCrossSectionalResolution:
         plan = self._plan()
         out: list[LedgerRow] = []
         scores = {date(2026, 1, 1): {1: 1.0, 20: 2.0}}
-        _resolve_cross_section(plan, pending={20: self._pending()}, scores=scores, out=out)
+        _resolve_cross_section(plan, leg="entry", pending={20: self._pending()}, scores=scores, out=out)
         assert (out[0].verdict, out[0].not_evaluable_reason) == ("not_evaluable", "thin_cross_section")
         assert (out[0].fill_bar_date, out[0].fill_price) == (None, None)
 
@@ -310,9 +312,11 @@ class TestCrossSectionalResolution:
             window_dates=(date(2026, 1, 1),),
             decided={date(2026, 1, 1): StrategySignal(verdict="not_fired", signal_index=0)},
             participating=frozenset(),
+            admissible_dates=None,
+            mandatory_dates=None,
         )
         out: list[LedgerRow] = []
-        _resolve_cross_section(plan, pending={20: pending}, scores={}, out=out)
+        _resolve_cross_section(plan, leg="entry", pending={20: pending}, scores={}, out=out)
         assert (out[0].verdict, out[0].signal_bar_date) == ("not_fired", date(2026, 1, 1))
 
     def test_a_selector_naming_a_non_participant_raises(self) -> None:
@@ -339,4 +343,4 @@ class TestCrossSectionalResolution:
         )
         scores = {date(2026, 1, 1): {instrument: float(instrument) for instrument in range(1, 21)}}
         with pytest.raises(ValueError, match="did not participate"):
-            _resolve_cross_section(rogue, pending={20: self._pending()}, scores=scores, out=[])
+            _resolve_cross_section(rogue, leg="entry", pending={20: self._pending()}, scores=scores, out=[])


### PR DESCRIPTION
## What

S-10 relative-strength leader (`s10-relative-strength-leader`), the last strategy of the S-5..S-10 set. Cross-sectional, two ranked legs — the first strategy whose EXIT is a ranked leg rather than levels, a hold cap, or the entry's complement.

Rule (spec §S-10, `docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`): regime ∈ {bull_quiet}; universe ranked by 63-bar return; enter the top decile that ALSO closes above its own 50-SMA; rebalance monthly; exit on leaving the top three deciles or closing below the 50-SMA.

## The gate ran first, and it pinned a design decision

§S-10 orders the turnover measurement BEFORE any code (Novy-Marx/Velikov: >~50%/month rarely survives costs — the bar that killed S-1 at 56×/yr). Measured on the full validated universe with `scripts/verify_2437_s10_turnover.py` (v4 = the exact semantics this PR ships; evidence + month table posted on #2437):

| exit-cadence reading | steady-state one-sided turnover | verdict |
| --- | ---: | --- |
| both exit legs at rebalance only | **36.5%/month** | inside the bar |
| 50-SMA exit checked daily | **83.0%/month** | disqualified |

**Consequence: the exit cadence is monthly, frozen as `exit_cadence: "rebalance_only"` in the hashed params.** The daily reading is not a viable variant of this strategy.

## Contract additions (all inert for existing strategies; S-2 regression pinned in tests)

- `CrossSectionalMember.admissible_indices` / `mandatory_indices` + ONE shared resolver `resolve_participating_bar` (`fired iff mandatory OR (selected AND admissible)`, applied after every refusal) called by all three resolution sites — registry `evaluate_cross_sectional`, scan `_resolve_cross_section`, backtest `_signals_for`. This expresses "the top decile that ALSO closes above its SMA" without shrinking the panel denominator (no slot backfill), and "closes below 50-SMA" without needing the band.
- `StrategyEntry.exit_leg: CrossSectionalLeg` (member/select/min_participants as one object); `"exit" ∈ signal_kinds` iff present, enforced.
- `MemberStager` gains `regime` uniformly (adapters absorb; S-2 ignores it). S-10's entry member declares the regime input → benchmark holes refuse as `missing_market_context`; the exit member deliberately does NOT (S-7's rule: a missing benchmark never refuses an exit for an open position).
- `segmented_member` gains `regime` (sliced per segment, as `segmented_signals` does) + `leg`; `StagedMember` carries the refinements DATE-keyed so segment merges need no index remapping.
- Scan: panel dates computed PER PLAN (S-10's calendar drops Sat/Sun rows before the first-bar-of-month rule — `price_daily` carries weekend rows for ~11 instruments and an unfiltered union calendar hands whole months' rebalances to them; measured on #2437); staging/resolution per leg.
- Backtest: `_rank_cross_sections` ranks per leg — the legs' panels genuinely differ (entry carries S-2's §9 Q3 $1 floor; exit is floor-free so a held sub-$1 name stays exitable). Position layer: NO change — C1 `signal_pair` pairing consumes the exit fills; `rebalance_dates` deliberately stays None (C4 is entry-set retention, S-10's retention is the wider band).

## Codex

- **Ckpt-1** on the plan (`docs/proposals/ta/2026-08-14-s10-implementation-plan.md`): ~30 findings; the accepted ones reshaped the design (SMA became a declared input on both legs; exit-leg evaluability stated; precedence pinned + tested; leg object instead of parallel fields; `min_participants` 100→1000; entry-"rankable" defined to include the floor; v4 re-measurement with shipped semantics). Rebuttals with evidence are recorded in the plan doc — notably "identity too weak" is refuted by `"registry": _module_hash()` in the version payload.
- **Ckpt-2** on this diff: no findings ("consistently propagated through the manifest, registry, signal scan, segmented evaluation, and backtest paths").

## Full-population census (`scripts/verify_2437_s10_census.py`, dev DB, 6,573 of 6,774 loaded)

- **Entry: fired 10,038 on 3,082 distinct instruments** — 2023: 1,730 · 2024: 2,911 · 2025: 2,417 · 2026: 2,980. Zero before 2023 — the SPY regime ceiling (classifiable from 2023-02-27), correct by construction.
- **Exit: fired 105,524 on 6,269** — fires in every year and regime, correct for a ranked stateless exit (S-1/S-3's shape, 65-70% of the panel leaves the band monthly).
- **Mandatory parity holds**: every evaluable below-SMA rebalance bar fired an exit (the census RAISES otherwise).
- 44 real panels (1,212–5,726 members); 22 weekend/corpus-hole dates refused `thin_cross_section` on the exit side and `missing_market_context` on the entry side.
- Consistency: census entries/rebalance (~250) match the independent turnover simulation's buys/month.

## Consequences to know

- ⚠ The registry edit moves EVERY strategy version (`"registry": _module_hash()` in the identity payload — accepted over-invalidation, precedent #2719). The next scan rewrites the fleet under new versions.
- Jobs daemon: `dev_reload` picks up `app/**` on merge; the next scan cycle runs the ten-strategy manifest and S-10 appears in `/strategies`.

## Security model

No security surface: pure evaluation code over stored prices; no new endpoints, no auth paths, no broker interaction.

## Checks

- `ruff check` / `ruff format --check` / `pyright`: clean.
- Fast tier (`-m "not db"`) + smoke: green. `tests/test_strategy_signal_scan.py`, `tests/test_backtest_run.py`, `tests/test_strategy_manifest.py`, `tests/test_strategy_registry.py`, `tests/test_2437_s10_relative_strength.py` (24 new tests): green including db-marked portions locally.
- DoD 8-12 (ETL clauses): not an ingest/schema change — evaluation only; the census above is the operator-visible evidence, and the live `/strategies` figure lands with the next scan after merge.

Refs #2437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
