### PR TITLE
docs: market-technician skill family — evidence-tagged chart-reading discipline

### DIFF
--- a/.claude/skills/data-sources/market-structure.md
+++ b/.claude/skills/data-sources/market-structure.md
@@ -9,7 +9,10 @@ confirmation.
 
 It exists because these terms carry two meanings: the one in a trading book, and the one our
 code computes. Speccing against the first while the second ships is how an invented
-formulation gets past review. `.claude/CLAUDE.md` already carries the precedent — a spec cut
+formulation gets past review. (The trading-book meaning itself — each concept's published
+source and honest evidence status, plus the chart-read protocol — is owned by
+`.claude/skills/market-technician/SKILL.md`; this file owns the mapping to OUR code and the
+measurement traps.) `.claude/CLAUDE.md` already carries the precedent — a spec cut
 the volatility regime at 20th/80th percentile BandWidth; Bollinger's published rule is the
 lowest/highest in **126 trading days**. Caught by Codex, not by any gate.
 

--- a/.claude/skills/market-technician/SKILL.md
+++ b/.claude/skills/market-technician/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: market-technician
+description: Professional chart-reading discipline — layered chart-read protocol (regime, trend, structure, volatility, volume, candles → falsifiable call), evidence-tagged TA domain knowledge (PUBLISHED/MEASURED/CONVENTION/REFUTED), and the refuted-on-our-data list. Read before producing any chart read, citing any TA formulation, or reviewing TA-flavoured specs. Routes to sub-skills per layer; defers to quant/strategy-evidence on tradability and to ta-analyst on our stored encoding.
+---
+
+# market-technician
+
+## When to use
+
+Producing or reviewing a read of a chart; citing any technical-analysis formulation, threshold or pattern; writing or reviewing a spec that consumes TA concepts. This family owns **"what does this chart say"**. It does NOT own "is this tradable" (→ `.claude/skills/quant/strategy-evidence.md`, whose turnover/cost/significance bars and promotion gates bind unchanged) and it does NOT own "what does our stored indicator mean here" (→ `.claude/skills/ta-analyst/SKILL.md`). Capital decisions stay behind strategy-evidence's bars and the promotion gates — nothing in this family funds anything.
+
+## The provenance tag system — untagged claims are defects
+
+Every factual claim in this family carries exactly one tag:
+
+| tag | means | example |
+| --- | --- | --- |
+| **PUBLISHED** | a citable formulation — author, work, chapter/page — as the author stated it, not folklore-drifted paraphrase | Bollinger's Squeeze = BandWidth lowest in six months (*Bollinger on Bollinger Bands* ch. 21) |
+| **MEASURED** | verified on our data or in cited empirical literature, with the command/citation that reproduces it | the published Squeeze fires ~17× less than S-4's percentile cut (commit `82915ee5`) |
+| **CONVENTION** | practitioner folklore with no published basis — kept where it is load-bearing market psychology, labelled so nobody cites it as evidence | round numbers; "1.5–2× volume confirms"; the 20/50/200 triplet itself |
+| **REFUTED** | killed by the literature or our own backtests — kept prominently, because a technician who does not know what fails is a hazard | fib levels (placebo-beaten here + null in the best published test) |
+
+Rules: verify citations at write time, never from memory (#2279 is the precedent — an invented "20th/80th percentile" rule shipped into a spec where Bollinger's published six-month rule existed). Where no published formulation exists, say so and fix the rule by construction in a version hash (`price_levels.py` is the model). A drifted paraphrase of a real source is worse than a CONVENTION tag — it launders folklore with a citation.
+
+## Step-0 vet of the existing TA surface (2026-08-14)
+
+Recorded per the session brief; fixes applied where one-line:
+
+1. **The academic canon already lives in `quant/strategy-evidence.md`** — §2.12 (LMW 2000 pattern-testing recipe), "the four papers" (Osler 2003 → BLL 1992 → STW 1999 → LMW 2000), the maths-grounding table, Park & Irwin 2007 context, and the Wyckoff computability audit. This family POINTS there and does not duplicate; one precision upgrade from this session's verification: STW's result is "BLL's best rule survives the snooping correction in-sample but is dead in the 10-year out-of-sample window and on S&P futures" — sharper than "no profitable rule", same conclusion.
+2. **`ta-analyst/SKILL.md` is our encoding, not domain knowledge** — correct scope, current, and already carries the current-state vs strategy-platform boundary. Gap fixed by cross-link: it predates `market_regime.py` / `price_levels.py` (both 2026-08-14) and this family; pointers added there in this PR.
+3. **The code precedent pair is load-bearing**: `app/services/market_regime.py` (both legs PUBLISHED: 200-SMA trend + Bollinger ch. 21 Squeeze/Bulge) vs `app/services/price_levels.py` (no published formulation exists for level clustering — says so, frozen by construction). The two files are deliberately different in provenance and this family agrees with both.
+4. **One resolved citation debt**: `indicator_series.bollinger_series` flags population-σ as "a citation still owed". Verified 2026-08-14 from Bollinger's own site ("we use the population calculation for standard deviation") — recorded in [volatility-and-bands](volatility-and-bands.md); the module is identity-hashed, so the docstring is left untouched.
+5. **S5-S10 proposal spot-checks hold**: S-6's 1.2× volume multiple was recorded as convention and verification confirms no published source for ANY specific multiplier except O'Neil's 40–50%-above-average (~1.4–1.5×); S-7's "RSI rarely reaches 30 in an uptrend" and S-8's ADX<20 are convention, correctly frozen; the ADX-25 "Wilder threshold" is *plausibly* his but verifiably attaches to his CSI market-selection rule, not per-chart ADX ([trend-and-averages](trend-and-averages.md)).
+6. **`data-sources/market-structure.md` was found late in the vet and is the closest neighbour** — it owns the concept → published source → OUR implementation map (`indicator_series.py` / `price_structure.py`), the measurement traps (shared-print, unfillable-window, micro-cap means, back-adjusted stratification) and the trial budget. Division of labour: market-structure answers "what does our code compute and how do I measure it without lying to myself"; this family answers "how does a technician read a chart, and what is each concept's honest evidence status". Cross-links added; no contradictions found between it and this family (same #2260/#2279 verdicts, same 0.5-not-fib warning, same by-construction rule).
+
+## The layered chart-read protocol
+
+Fixed order, each layer conditioning the next — full contract + worked example in [chart-read-protocol](chart-read-protocol.md):
+
+1. Regime & higher-timeframe context → 2. Trend vs MAs → 3. Structure (levels, touch counts) → 4. Volatility state → 5. Volume character → 6. Candle context at the decision point → 7. **The call**: bias · entry zone · invalidation price · targets · horizon · what flips it.
+
+**A read with no invalidation level is not a read.** Stand-aside is a first-class call.
+
+## Sub-skills
+
+| file | owns |
+| --- | --- |
+| [trend-and-averages](trend-and-averages.md) | 20/50/200 horizons, slope vs price-relative, golden/death cross, pullback-to-MA, EMA provenance, ADX |
+| [volatility-and-bands](volatility-and-bands.md) | Bollinger construction (population σ), %b/BandWidth, six-month Squeeze/Bulge, band walks, ATR as the distance unit, Keltner, TTM contrast |
+| [volume](volume.md) | effort vs result, confirmation folklore, climax/dry-up, OBV, VWAP (execution benchmark) + anchored VWAP, NULL-volume caveat |
+| [price-structure](price-structure.md) | level mechanism (Osler), role reversal, pivots + confirmation lag, trendlines' honest status, gaps taxonomy, false breaks/springs, measured moves |
+| [fibonacci](fibonacci.md) | the mechanics as practiced + the evidence status (null + placebo-refuted here); exists to prevent fib-mysticism |
+| [candles](candles.md) | anatomy as intrabar narrative, Nison's actual criteria, the negative empirical record, candles as confirmation-only |
+| [market-dynamics](market-dynamics.md) | regimes, impulse/correction, breakout→retest, reversion after extension, relative strength, gap dynamics, short-side asymmetries, failure modes |
+| [chart-read-protocol](chart-read-protocol.md) | the synthesis: the seven-step read + a MEASURED worked example (AAPL 2026-08-13) |
+
+## Refuted on our data — read before proposing anything TA-shaped
+
+Pointers, not re-derivations; each verdict lives with its evidence:
+
+- **RSI<30 "76.8% win" did not reproduce.** Causal Wilder recompute on the full population: 51.846% vs 50.585% baseline on `price_daily` (n=311,332 triggers); BELOW baseline on the 25.7M-bar research corpus. The original figure was never reproduced; attribution by elimination points at look-ahead. (#2260; also `data-sources/market-structure.md`'s RSI row)
+- **S-1…S-4: 0 of 20 hold-out years beat buy-and-hold** (4 strategies × 5 years, 2022–2026); on the primary holdout all four trail buy-and-hold by 44–147 pts with S-1 at 91.75× annual turnover — the turnover bar (`strategy-evidence` §2.1) predicted the ranking ex ante. (`docs/proposals/ta/2026-08-12-s1-s4-primary-holdout-result.md`)
+- **Fake fib/support levels BEAT real ones.** Placebo fib 29/44/71 > real 38.2/50/61.8; fake support > real pivot-low support; both real variants below the no-level baseline. Univariate feature testing was itself the broken instrument (day/year clusters disagreeing in sign). (2026-08-09, `docs/proposals/ta/2026-08-09-plan-of-attack.md`; [fibonacci](fibonacci.md))
+- **S-4's invented bottom-quartile ATR cut fired ~17× more than Bollinger's published Squeeze on the same leg** — 1,667 signals vs 26 on the same 71 instruments (measured 2026-08-14, commit `82915ee5`). An invented percentile admits ordinary bars; a published extreme is rare by construction.
+- **Gap-down fade: dead since 2020** (t 1.39 in 2020+, vs t 5.73 pooled — the pooled number was the illusion). **≥12%-drop continuation short: positive per-trade, lost 13.76–47.72% on all 8 finite-capital sizing arms** (#2481). Both closed; do not resurrect. ([market-dynamics](market-dynamics.md))
+
+## Cross-links
+
+Tradability, costs, significance, family viability: `.claude/skills/quant/strategy-evidence.md` (MANDATORY before proposing any strategy — this family never overrides it). Concept → our implementation + measurement traps: `.claude/skills/data-sources/market-structure.md` (MANDATORY before speccing any indicator/level/pattern). Our stored indicators and their encoded ramps: `.claude/skills/ta-analyst/SKILL.md`. Platform code this family must agree with: `app/services/market_regime.py`, `app/services/price_levels.py`, `app/services/price_structure.py`. Strategy set consuming these concepts: `docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`.

--- a/.claude/skills/market-technician/candles.md
+++ b/.claude/skills/market-technician/candles.md
@@ -1,0 +1,59 @@
+# market-technician / candles
+
+## When to use
+
+Reading individual bars and candlestick patterns — anatomy, the major Nison patterns, inside/outside bars — at a decision point on a chart.
+
+Provenance tags per the [hub](SKILL.md): **PUBLISHED** / **MEASURED** / **CONVENTION** / **REFUTED**.
+
+⚠ **The frame comes first:** in every located developed-market test with a proper null (below), candlestick patterns alone showed no value on daily bars. They are kept in this family as a **confirmation layer** — the intrabar narrative at a level or decision point — never as standalone signals. A read that leads with a candle name has the hierarchy inverted; the [chart-read-protocol](chart-read-protocol.md) puts candle context sixth of seven, deliberately.
+
+## Anatomy — the bar as intrabar narrative
+
+**CONVENTION** (auction-logic reading — coherent, untested as such): a candle compresses one session's auction: body = where the session settled relative to where it opened; wicks = excursions that FAILED to hold. That is the entire content, and it is real content at the right place:
+
+- Long lower wick at support = sellers pushed, buyers absorbed, close reclaimed — rejection.
+- Long body closing near its extreme = one-sided conviction, little fade.
+- Small body, long both-side wicks (high-wave/doji family) = auction unresolved; indecision, meaningful mainly after a directional run.
+- Body-to-range ratio is the quick quantitative handle (**CONVENTION** thresholds; e.g. Nison's hammer wants the lower shadow ≥ 2× the body).
+
+The same anatomy is regime-sensitive: a doji inside a quiet range is nothing; the same doji after eight expanding trend bars is the first no-supply/no-demand print.
+
+## The major patterns (Nison), defined precisely
+
+**PUBLISHED:** Steve Nison, *Japanese Candlestick Charting Techniques* (1991; 2nd ed. 2001) — the book that brought candlesticks West. Definitional details matter because retail paraphrase drifts:
+
+| pattern | Nison's criteria | note |
+| --- | --- | --- |
+| engulfing | second **real body** totally engulfs the prior real body; opposite colours; requires a definable prior trend | **bodies only** — "ideally the body should engulf the shadows as well, but this is not a requirement" |
+| hammer | after a downtrend: small body at the TOP of the range, lower shadow ≥ 2× body, little/no upper shadow | body colour not critical |
+| shooting star | after an uptrend: small body at the BOTTOM, upper shadow ≥ 2× body, little/no lower shadow | inverse of hammer |
+| doji | open ≈ close ("many technicians are flexible here") | indecision, weight after a trend leg |
+| morning / evening star | long trend-direction candle → small body gapping away (colour unimportant) → third candle closing deep into the first body | three-bar; the middle bar is the stall |
+| harami | small real body contained inside the prior bar's unusually large real body | "a state of truce"; = inside bar with body emphasis |
+
+Inside/outside bars are the Western-terminology cousins (range containment / range engulfment, wicks included) — **CONVENTION**, same auction logic: contraction then resolution.
+
+## What testing shows
+
+**MEASURED (literature)** — every located developed-market test with a proper null is negative (2026-08-14 sweep; scope is what was located, not the whole literature):
+
+- Marshall, Young & Rose, "Candlestick technical trading strategies: Can they create value for investors?", *J. Banking & Finance* 30 (2006), 2303–2323: 35 DJIA stocks 1992–2002, 28 candle rules, bootstrapped OHLC null — **no value**; actual-series profitability weaker than the bootstrap ~75% of the time.
+- Marshall, Young & Cahan, "Are candlestick technical trading strategies profitable in the Japanese equity market?", *RQFA* 31 (2008), 191–207: top-100 TSE stocks 1975–2004 — **no value in candlesticks' home market**, in any sub-period or regime.
+- Fock, Klein & Zwergel, "Performance of Candlestick Analysis on Intraday Futures Data", *J. Derivatives* 13(1) (2005), 28–40: 5-min DAX/Bund futures, 19 patterns — no predictive power.
+- Horton, "Stars, crows, and doji: The use of candlesticks in stock selection", *QREF* (2009): 349 stocks — "not recommended".
+- The located positives cluster in Taiwanese studies (Goo, Chen & Chang 2007; Lu, Shiu & Liu 2012) using holding-period optimization the negative papers control against.
+
+So: **as standalone signals, refuted where tested carefully.** What the tests do NOT cover is the way this family uses them — as the last-layer read *conditional on structure* (a hammer AT a tested support inside an uptrend regime). That conditional use is **CONVENTION**: coherent with the Osler/auction mechanism, and untested — which is a different status from validated, and must be said that way. LMW 2000 (`strategy-evidence` §2.12) is the template if anyone wants to test it: algorithmic definition → conditional-vs-unconditional distribution → random-entry null.
+
+## Reading candles at the decision point — the checklist form
+
+1. Only read candles AFTER regime, trend, structure, volatility and volume (protocol order) — a candle modifies a thesis, it never creates one.
+2. At the level: rejection wick, absorption body, or drive-through? Does the intrabar story agree with the structural story?
+3. Pattern names only when Nison's actual criteria are met (bodies vs wicks; the trend prerequisite) — a green bar near support is not "a hammer".
+4. Confirmation bar: Nison treats confirmation as pattern-specific (explicit for some patterns, e.g. the hanging man; optional for others). Waiting for next-session follow-through before acting is this family's discipline — **CONVENTION**, not his universal rule.
+5. Tag honestly: any candle-based statement in a read is CONVENTION unless it cites the table above (PUBLISHED for the definition, never for efficacy).
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md). Test recipe for any pattern claim: `strategy-evidence` §2.12. Structure context candles confirm: [price-structure](price-structure.md). Volume agreement at the bar: [volume.md](volume.md).

--- a/.claude/skills/market-technician/chart-read-protocol.md
+++ b/.claude/skills/market-technician/chart-read-protocol.md
@@ -1,0 +1,79 @@
+# market-technician / chart-read-protocol
+
+## When to use
+
+Producing a read of an actual chart (or series of charts) — the synthesis step. The sub-skills teach the layers; this file fixes the order and the output contract.
+
+## The contract
+
+A read is **falsifiable or it is not a read**. Every read ends with a call that names the price at which it is wrong. "Looks bullish" with no invalidation is decoration; the protocol exists to make that unwritable.
+
+Fixed order — each layer conditions the next, which is why the order is not negotiable:
+
+1. **Regime & higher-timeframe context** — benchmark regime (`market_regime`), the instrument's primary trend, where price sits in its 52-week range. ([market-dynamics](market-dynamics.md))
+2. **Trend state vs MAs** — 20/50/200: price side, slopes, stacking, extension from the 200-day in ATRs. ([trend-and-averages](trend-and-averages.md))
+3. **Structure** — confirmed levels above and below with touch counts and recency; role-reversal candidates; confluence; open gaps. ([price-structure](price-structure.md))
+4. **Volatility state** — BandWidth vs its own 126-bar extremes (Squeeze/Bulge/neither), ATR% of price, band walk vs range. ([volatility-and-bands](volatility-and-bands.md))
+5. **Volume character** — trend legs vs corrective legs, dry-up/expansion/climax, divergence. NULL-volume check first. ([volume.md](volume.md))
+6. **Candle context at the decision point** — rejection/absorption/drive at the level; Nison criteria or no pattern name. ([candles.md](candles.md))
+7. **The call** — ALL of: bias (long / short / stand aside) · entry zone · **invalidation price** (the level that proves the read wrong) · target(s) as reference geometry · horizon in bars · what would flip the bias early.
+
+Rules on the call:
+
+- Stand-aside is a full-status call and often the right one; it still names what would make the chart readable.
+- The invalidation is structural (a level that, broken, kills the thesis), never a P&L number, and it is written before any position exists so it cannot drift ([market-dynamics](market-dynamics.md), "narrative persistence").
+- Targets are attention-point geometry (~51% honesty problem — [price-structure](price-structure.md)), stated as references, not expectancy.
+- Tag claims inline: a read that leans on a CONVENTION (round number, volume multiplier) says so.
+- ⚠ This protocol produces a READ, not a trade. Tradability — costs, turnover, sample discipline — is `strategy-evidence`'s bar; capital is behind the promotion gates. The hub says this once and it binds here.
+
+## Worked example — AAPL, 2026-08-13 (MEASURED)
+
+Every number below is computed from our stored bars via the repo's own pure functions. Reproduce (dev DB):
+
+```python
+# uv run python - <<'EOF'  (from the repo root)
+import numpy as np, psycopg
+from app.config import settings
+from app.services.indicator_series import atr_series, bollinger_series, rsi_series, sma_series
+from app.services.market_regime import SQUEEZE_LOOKBACK_BARS, bandwidth, classify_regimes, is_squeeze
+from app.services.price_levels import LevelScan
+from app.services.price_masked_bars import load_masked_bars
+
+with psycopg.connect(settings.database_url) as conn:
+    aapl = load_masked_bars(conn, 1001).series   # instruments.symbol = 'AAPL'
+    spy = load_masked_bars(conn, 3000).series    # instruments.symbol = 'SPY'
+# then: sma_series/rsi_series/atr_series/bollinger_series(aapl, universe="survivor_only", ...),
+# bandwidth + is_squeeze on the Bollinger components, LevelScan.build(...).at(atr=..., index=-1),
+# classify_regimes on SPY's closes/bands.
+```
+
+Measured 2026-08-14 (1,050 bars, last bar 2026-08-13, close **304.76**):
+
+| layer | measurement | reading |
+| --- | --- | --- |
+| 1 regime | SPY 777.50 > its 200-SMA 705.16, no Bulge → **`bull_quiet`**; AAPL at 70% of its 52w range (224.63–339.78); 63-bar return +1.5% vs SPY +5.2% → **relative laggard, −3.7 pts** | market supportive; this name is not leading it |
+| 2 trend | close **below** SMA20 318.92 (5-bar slope −3.73) and **below** SMA50 308.51 (slope −0.46), **above** SMA200 280.20; extension +2.9 ATR above the 200-day | primary uptrend intact; intermediate corrective leg in progress, 20-day rolling over |
+| 3 structure | live levels (≥3 touches, ≤120 bars): all BELOW price — R 280.67 (5 touches, last 2026-02-26), R 258.52 (5), S 264.65 (3), S 244.07 (4). ⚠ Level *kind* is the pivot type (swing highs → "resistance"), so an old resistance now below price is exactly the role-reversal candidate of [price-structure](price-structure.md). **No live level overhead** → upside references are the falling SMA20 and the 52w high 339.78. Key confluence: old resistance 280.67 ≈ SMA200 280.20 → role-reversal support zone ~**280–281** | one structural floor, two references above, nothing tested overhead |
+| 4 volatility | BandWidth 0.1548 vs 126-bar range [0.0527, 0.2188] → neither Squeeze nor Bulge; ATR 8.60 = 2.82% of close; %b 0.21 | mid-volatility corrective drift, not a compression setup and not an expansion climax |
+| 5 volume | last bar 30.7M vs 20-bar avg 37.8M → **0.81×**, contracting through the pullback | dry-up on the corrective leg — constructive under effort-vs-result (no urgent supply) |
+| 6 candle | last bar closed mid-range, no Nison pattern criteria met at a decision level (price is between references) | nothing to read at this bar — which is itself information: no decision point yet |
+| 7 call | below | |
+
+**The call (2026-08-13 close):**
+
+- **Bias:** constructive-neutral — a pullback inside a primary uptrend, in a supportive regime, on contracting volume; but a relative laggard below its falling 20-day, so no long trigger yet. **Stand aside, long-watch.**
+- **Entry zone (if triggered):** either (a) a tested hold of the **280–281** confluence (SMA200 + role-reversal level) — rejection/absorption per [candles](candles.md), or (b) a reclaim of the 20-day SMA (~319, falling) on ≥1.4–1.5× volume (O'Neil's published threshold; the only citable one).
+- **Invalidation:** a daily **close below ~280** — that breaks the 200-day AND the only live role-reversal support in one move; below it the read is wrong, structure is 264.65 then 258.52, and no long thesis survives.
+- **Targets (reference geometry, not expectancy):** 318.92 (falling 20-day) → 339.78 (52w high). Overhead is untested — targets here are attention points only.
+- **Horizon:** 20–40 bars — price sits ~1.6 ATR below the falling 20-day and ~2.8 ATR above the 280 confluence; ATR here supplies the distance scale (per [volatility-and-bands](volatility-and-bands.md)), not a forecast — the horizon is a review deadline, and an unresolved read at 40 bars expires rather than extends.
+- **Flips the bias:** bearish — volume *expansion* on down bars (supply arriving; kills the dry-up read) before any level breaks; bullish — relative-strength turn vs SPY plus the volume-confirmed 20-day reclaim.
+
+Note what the protocol did: the same facts support no "signal" — every popular one-liner ("above the 200!", "oversold soon!") dissolves into a stand-aside with two triggers, one invalidation, and a stated horizon. That is the product.
+
+## Multi-chart sequences
+
+Reading a series of charts (one instrument over time, or a watchlist): run the protocol per chart, then rank by (a) proximity to a decision point (step 3/6) and (b) regime fit (step 1). A chart mid-range between references is unrankable by construction — park it. Never average two charts' reads into one; each read carries its own invalidation or it is not carried.
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md). Every layer's depth: the sub-skill linked at each step. Tradability of anything a read suggests: `.claude/skills/quant/strategy-evidence.md`.

--- a/.claude/skills/market-technician/fibonacci.md
+++ b/.claude/skills/market-technician/fibonacci.md
@@ -1,0 +1,41 @@
+# market-technician / fibonacci
+
+## When to use
+
+Anyone proposes, cites, or asks about Fibonacci retracements/extensions. This file exists to prevent fib-mysticism, not to teach it — read the evidence section before using a fib level anywhere.
+
+Provenance tags per the [hub](SKILL.md): **PUBLISHED** / **MEASURED** / **CONVENTION** / **REFUTED**.
+
+## The mechanics, as practiced
+
+**CONVENTION** (platform convention; no canonical published source rule fixes the level set):
+
+- Anchor a swing high and swing low (already discretionary — two readers, two anchors; and per [price-structure](price-structure.md), a swing is only confirmed N bars late).
+- Retracements at 23.6 / 38.2 / 50 / 61.8 (some platforms add 78.6 = √0.618) percent of the leg, drawn as horizontal lines.
+- Extensions (127.2 / 161.8 / 261.8) project beyond the origin for targets.
+- The ratios come from adjacent-term limits of the Fibonacci sequence (0.618 = 1/φ, 0.382 = 1 − 0.618, 0.236 = 0.382 × 0.618).
+
+⚠ **50% is not a Fibonacci ratio.** It comes from Dow Theory's halfway-retracement observation (and Gann's independent 50% rule), grafted onto the fib tool. StockCharts states it plainly: "The 50% retracement is not based on a Fibonacci number." A tool whose most-used level is not from its own namesake sequence is telling you what it actually is: a set of round-fraction attention points.
+
+## The evidence status — honest and short
+
+- **MEASURED (literature, best test = null):** Tsinaslanidis, Guijarro & Voukelatos, "Automatic identification and evaluation of Fibonacci retracements", *Expert Systems with Applications* 187 (2022), 115893 — algorithmic fib zones across three equity markets: bounce behaviour on Fibonacci and non-Fibonacci zones was **statistically indistinguishable**. Bounce probability rose with zone *width* — mechanically, wider zones catch more bounces, which the authors offer as an explanation for the tool's popularity without profitability.
+- **MIXED (weak positives):** Bhattacharya & Kumar (*Annals of Economics and Finance*, 2006) and scattered small-market studies report favorable rates, in venues below the replication literature's tier. No top-journal support was located (2026-08-14 sweep).
+- ⚠⚠ **REFUTED (ours, 2026-08-09, #2437):** in our own backtest, **placebo fib levels at 29/44/71% BEAT the real 38.2/50/61.8%**, fake support beat real pivot-low support, and both *real* variants sat below the no-level baseline. A placebo arm that gets the identical measurement is conclusive about the levels carrying no specific information — whatever bounce statistics fib levels show, arbitrary nearby fractions show as much or more. Support + Fibonacci as entry conditions are on the closed-do-not-reopen list (`docs/proposals/ta/2026-08-09-plan-of-attack.md`, merged via PR #2444).
+
+## What is left after the evidence
+
+The honest ceiling: fib levels work — at most — as **self-fulfilling attention points**. Enough participants draw the same lines from the same obvious swings that orders cluster near them, the same mechanism (Osler; round numbers) that makes any widely-watched reference behave level-like. Two things follow:
+
+1. Nothing is special about the *ratios*. Our placebo result is precisely what the attention-point account predicts: the crowd's coordination, where it exists at all, is approximate — and a level's power comes from being watched, not from φ.
+2. A fib level with confluence (an old structural level, a round number, an MA at the same zone) reduces to the OTHER references — read those directly ([price-structure](price-structure.md)); the fib line adds narrative, not information.
+
+## Rules for this repo
+
+- Never cite a fib level as evidence for anything, in a spec, thesis, or read. If a chart-read mentions one, it must carry the CONVENTION tag and stand only where confluence with real structure exists.
+- Never build a strategy leg on fib levels — placebo-refuted here, null in the best published test, closed on #2437. A proposal that reaches for them must first explain what would distinguish it from the 2026-08-09 placebo arm.
+- Extensions-as-targets follow measured-move logic and inherit its honesty problem (~51% by the friendliest practitioner count — [price-structure](price-structure.md)): reference geometry, not expectancy.
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md) (refuted list). Mechanism for why *any* watched line can behave level-like: [price-structure](price-structure.md) (Osler 2003). Our implementation (`price_structure.fib_levels`, `FIB_RATIOS = (0.236, 0.382, 0.5, 0.618, 0.786)`, inheriting the swing-confirmation lag): `.claude/skills/data-sources/market-structure.md` — which carries the same 0.5-is-not-fib warning. The transferable lesson from the 2026-08-09 result is the placebo-arm technique itself: any level-shaped claim needs a fake-twin control that receives the identical measurement.

--- a/.claude/skills/market-technician/market-dynamics.md
+++ b/.claude/skills/market-technician/market-dynamics.md
@@ -1,0 +1,70 @@
+# market-technician / market-dynamics
+
+## When to use
+
+Reasoning about how price actually moves — regimes, impulse/correction rhythm, breakout→retest, reversion after extension, relative strength, gap behaviour, short-side mechanics, and the standard ways reads fail.
+
+Provenance tags per the [hub](SKILL.md): **PUBLISHED** / **MEASURED** / **CONVENTION** / **REFUTED**.
+
+## Regimes — trend, range, transition
+
+**CONVENTION** (the trend/range/transition framing is practitioner canon, not a measured taxonomy): markets are read as alternating between trending and ranging states, and the tools in this family are regime-conditional — Bollinger's own rules read band tags opposite ways by regime ([volatility-and-bands](volatility-and-bands.md)), S-6 excludes breakouts from the volatile regime by design, and S-8 only fires where ADX says no trend exists. So regime is the FIRST read, not a footnote — and in our platform it is an **input**: `app/services/market_regime.py` classifies every bar as `bull/bear × quiet/volatile` from two frozen legs with stated provenance (SPY vs 200-SMA — the conventional long-horizon reference with a published test trail; Bollinger's published Bulge). ⚠ Note the encoded classifier has NO "range" state — range-reading goes through ADX (S-8's `ADX(14) < 20`, a frozen convention) or structure, not the regime enum. Strategies declare permitted regimes, and firing outside the declared domain is the defect (S5-S10 §0).
+
+**MEASURED (why this is structural here):** S-1…S-4 were each judged on one pooled statistic over the whole span — the wrong instrument for a non-stationary series. Concrete instance: the gap fade was t 5.73 pooled 1962–2026 and t 1.39 in 2020+ (negative pre-2001). Pooled numbers flatter dead effects; report per-regime and per-era, and treat the recent window as the deciding one.
+
+⚠ An unclassifiable bar (warm-up, or a benchmark hole) is `None`/`not_evaluable`, never "neutral" — a strategy gated on regime refuses to fire on it. Fail-closed applies to reads too: "regime unknown" is a legitimate line in a chart read.
+
+## Impulse and correction
+
+**CONVENTION** (Dow-descended structure, codified by Wyckoff/Elliott traditions in incompatible ways — the common testable core is below):
+
+- Trends move in alternating impulse legs (directional, expanding range/volume) and corrective legs (contra-directional, contracting range/volume). The volume asymmetry is the effort-vs-result read ([volume.md](volume.md)).
+- A correction that keeps making progress on rising volume is not a correction — relabel it before it relabels you.
+- Structure metric: confirmed higher-highs/higher-lows ([price-structure](price-structure.md)) — the slowest and most robust trend definition; MAs proxy it faster and dirtier.
+
+## Breakout → retest
+
+**CONVENTION** (mechanism-coherent: Osler's stop clustering beyond levels, plus trapped-inventory role reversal): a valid break converts the level; the pullback to it from the far side ("retest") is where the role reversal is confirmed or refuted. Waiting for the retest trades missed fast moves for cheaper invalidation — a stop just back inside the level is small, and S-6 encodes exactly that (`stop = level − 1 × ATR`, "back inside the range = failed break"). ⚠ Not every break retests; there is no published retest frequency worth quoting, and any number you see for it is folklore.
+
+## Mean reversion after extension
+
+- **PUBLISHED (where reversion is real):** short-horizon reversal is a documented effect family — and the most cost-constrained one (Frazzini/Israel/Moskowitz line, via `strategy-evidence` §2.5: the family's paper profits die to real trading costs fastest). De Bondt/Thaler long-horizon reversal lives in cheap/small names (§2.8a) — where we cannot trade.
+- **CONVENTION (the chart version):** "price stretched N× ATR from its 20-MA snaps back" — no canonical published formulation; distance-from-mean as bad entry geometry is the defensible read (chasing an extended move buys someone else's exit), an expectancy claim is not.
+- **MEASURED (ours, long side):** unconditional 10-day drift after big drops was ~44 bps against a ~50 bps round trip — the long-side short-horizon game is played inside the spread (2026-08-09). RSI(2)-style reversion setups pass through `strategy-evidence`'s cost bar before anything else.
+
+## Relative strength vs the index
+
+**PUBLISHED (family):** cross-sectional momentum — ranking by trailing return — is the best-documented anomaly family and the one the cost literature calls most scalable in liquid names (`strategy-evidence` §§2.1–2.2, and our own measurement found it strongest in expensive names). The chart-read version: compare the instrument's 63-bar return to the benchmark's; an instrument making relative highs while the index chops is under accumulation in the only sense that is measurable. Wyckoff's ninth buying test ("stock stronger than the market") is this quantity. ⚠ On our data, total-return-relative claims need the comparator rules in `strategy-evidence` §"Recent-regime and storage contract"; price-only relative strength is computable everywhere.
+
+## Gap dynamics
+
+Gap taxonomy and its after-the-fact nature: [price-structure](price-structure.md). Dynamics worth carrying here:
+
+- A gap is the visible print of overnight order imbalance — the auction reopening away from equilibrium. Gaps through levels void the level's geometry (the stop cluster beyond it fills at the open, not at the level).
+- **MEASURED (ours):** stops do not bound gap risk — 141 of 1,402 short-side stops filled at an open beyond the stop level; worst single trade −87% *with* a 20% stop (2026-08-09). Position size, not stop placement, is the only control that survives a gap.
+- **REFUTED (ours):** the gap-down fade as a strategy — dead since 2020 on our own era-split. Closed on #2437; do not resurrect.
+
+## Short-side mechanics — the asymmetries
+
+The short side is not the long side mirrored; four asymmetries, all load-bearing:
+
+1. **Unbounded loss.** A long risks its stake; a short's loss has no ceiling. A mean return is not a sufficient basis for a short strategy — the tail and the delisting attribution decide (risk posture, `.claude/CLAUDE.md`).
+2. **Carry.** On eToro a short is a **CFD** — a contract with the broker, no ownership. Easy-to-borrow costs spread only; **hard-to-borrow (>10%/yr) accrues a daily fee at 21:00 GMT (22:00 during daylight saving, per eToro's fee page), tripled at weekends** — and a name that just fell hard is the archetypal hard-to-borrow candidate, so a drop-triggered short cannot reuse the long cost model.
+3. **Availability.** Shorting is gated by share availability, volatility halts, and region — the signal firing does not mean the trade exists.
+4. **Crowd geometry inverts.** Short squeezes are the stop-run mechanism with the signs flipped and leverage of forced buying behind it; support/resistance reads carry over, but the violent tail is on the adverse side.
+
+**MEASURED (ours, the arc in one line):** the ≥12% one-day-drop continuation short survived its per-trade checks (t 4.83, net +49 bps at a 30%/yr borrow) and then **lost 13.76–47.72% on all 8 sizing arms once capital was finite** (#2481, 2026-08-12) — per-trade expectancy and an equity curve are different objects, and ~6 concurrent firings/day with −87% tails is how a positive mean becomes a negative account. ⛔ Closed; do not resurrect. (Full record: `docs/proposals/ta/2026-08-09-plan-of-attack.md` + #2481.)
+
+## Common failure modes — name them to catch them
+
+| failure | what it looks like | the counter |
+| --- | --- | --- |
+| chasing | entering N ATRs from the mean because the move "is confirmed" | extension check (protocol step 2/4); the confirmation you waited for is the entry geometry you gave up |
+| fighting regime | fading a band walk; buying breakouts in a Bulge | regime first; S-6 excludes `bull_volatile` for exactly this |
+| averaging into an invalidated setup | the invalidation level broke, so the read is dead — adding is a new (worse) thesis wearing the old one's name | the read dies AT its invalidation; re-underwrite from scratch or walk |
+| narrative persistence | keeping the bias and moving the invalidation | invalidation is written down at read time (protocol step 7) precisely so it cannot move |
+| pooled-statistic comfort | "it worked over 20 years" | era-split + regime-split before excitement (S-1…S-4 lesson) |
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md). Regime encoding: `app/services/market_regime.py`. Cost/turnover bars and family evidence: `.claude/skills/quant/strategy-evidence.md`. Short-side closed results: `docs/proposals/ta/2026-08-09-plan-of-attack.md`, #2481.

--- a/.claude/skills/market-technician/price-structure.md
+++ b/.claude/skills/market-technician/price-structure.md
@@ -1,0 +1,73 @@
+# market-technician / price-structure
+
+## When to use
+
+Reading support/resistance, swing pivots, trendlines/channels, gaps, false breaks and measured moves — or reviewing anything that consumes a level.
+
+Provenance tags per the [hub](SKILL.md): **PUBLISHED** / **MEASURED** / **CONVENTION** / **REFUTED**.
+
+## Why levels exist at all — the mechanism, before any drawing
+
+**PUBLISHED (the strongest pro-TA evidence in the literature):** Osler, "Currency Orders and Exchange Rate Dynamics", *JF* 58(5) (2003) — actual dealer order-book data: take-profit orders cluster **at** round numbers (trends reverse at levels), stop-loss orders cluster **just beyond** them (breaks accelerate once a level goes). Mechanistic, not statistical — the order book actually contains the clustering. ⚠ Caveat that travels with it: the order data is **FX**; for equities, stop clustering is asserted convention with no located peer-reviewed demonstration (stops sit broker-side, off-book). `strategy-evidence` "four papers" carries the full arc.
+
+Two consequences worth internalizing:
+
+- A level is an **attention point**, not a physical floor. It works to the extent orders anchor there — which is also why round numbers matter (**CONVENTION**, load-bearing psychology) and why our own placebo test could beat "real" levels with fake ones (see [fibonacci](fibonacci.md) and the hub's refuted list).
+- The interesting events are AT the level: rejection, absorption, or break-and-go. The level itself predicts nothing; the reaction is the information.
+
+## Support/resistance formation and role reversal
+
+**PUBLISHED:** Edwards & Magee, *Technical Analysis of Stock Trends* (1st ed. 1948; ch. 13 "Support and Resistance" in the modern editions): "these critical price levels constantly switch their roles from Support to Resistance and from Resistance to Support… A former Top, once it has been surpassed, becomes a bottom zone in a subsequent downtrend." The classic rationale is trapped inventory: buyers of the old top who suffered through a decline sell "at break-even" on the retest — a positioning story consistent with Osler's order data.
+
+Reading rules (E&M-derived, **CONVENTION** at the edges):
+
+- More touches + more volume transacted at a zone = more significant (**CONVENTION**, E&M-derived). The counter-consideration is an inference from Osler's mechanism, equally **CONVENTION**: each successful defense plausibly *consumes* the resting orders that made it work, so a level defended four times is both more widely watched AND possibly more depleted on the fifth approach. Hold both; neither is measured.
+- Zones, not lines. Draw the level as a band scaled to the instrument's volatility — our `price_levels.py` clusters pivots within **0.5 × the caller-supplied ATR** (scan convention: ATR(14) at the decision bar — the module warns a later ATR is a leak), exactly this idea, frozen by construction.
+- Recency decays relevance (`MAX_TOUCH_AGE_BARS = 120` in our encoding — a by-construction constant, not a finding).
+
+## Swing pivots
+
+A swing high is a bar whose high stands above its neighbours for N bars either side (fractal definition). ⚠ Tie handling differs between our two implementations and is load-bearing: `price_structure.detect_swings` uses strict comparison (a plateau yields NO pivot); `price_levels.swing_pivots` calls the FIRST of two equal highs the pivot (`argmax == half_window` plus `>=`). ⚠⚠ **Either way a pivot is only knowable N bars after it happens** — `price_levels.PivotSet` confirms at `index + half_window`, and reading a pivot at its own bar is look-ahead ("today is a swing high" cannot be known today). Any chart narrative that says "price bounced at the swing low" is written with hindsight unless the bounce postdates the pivot's confirmation.
+
+**CONVENTION:** N itself (ours: 5) is a choice. Larger N → fewer, more significant pivots. Higher-highs/higher-lows sequences built from confirmed pivots are the structural definition of trend — more robust than any MA read, and slower.
+
+## Trendlines and channels
+
+**PUBLISHED (as practitioner canon):** Murphy, *Technical Analysis of the Financial Markets* (1999), ch. 4: two points draw a *tentative* trendline, the third touch validates it; the fan principle (successive redrawn lines, third break = reversal). E&M treat trendline breaks as significant with volume.
+
+⚠ Honest status: trendlines resist algorithmic definition — which extremes to connect is discretionary, and two competent readers draw different lines. Lo/Mamaysky/Wang solved this for patterns with kernel smoothing; nobody has a canonical published trendline algorithm. That is why our platform ships **horizontal levels** and not trendlines — two frozen constructions: `price_structure.cluster_levels` (research corpus, `price-structure-v1`) and `price_levels.LevelScan` (S5-S10, `price-levels-v1`) — horizontal clustering has a freezable construction; sloped lines multiply free parameters. Treat trendline reads as narrative aids, levels as the testable structure.
+
+## Gaps taxonomy
+
+**PUBLISHED:** Edwards & Magee ch. 12 (codifying earlier 1930s work — Schabacker precedes them):
+
+| gap | where it appears | classic read |
+| --- | --- | --- |
+| common | inside congestion | noise; fills routinely |
+| breakaway | leaving a base/pattern | begins a move; should NOT fill soon; volume matters |
+| runaway ("measuring") | mid-move | continuation; midpoint → project the first leg again |
+| exhaustion | end of a move | last gasp; filled quickly, then reversal |
+
+⚠ The taxonomy is diagnostic **after the fact** — breakaway vs exhaustion is decided by what follows (does it fill?), so at the bar itself the classification is a hypothesis. "Gaps always fill" is **CONVENTION** and false as stated — common gaps usually fill, breakaway gaps by definition should not. **MEASURED (ours):** the gap-down fade tested here was dead in the modern era — t 5.73 pooled over 1962–2026 but t 1.39 in 2020+, negative pre-2001 (2026-08-09, #2437) — a lesson in era-splitting, and in what "measured" means: pooled statistics on a non-stationary series flatter dead effects.
+
+## False breaks and stop runs
+
+**CONVENTION (Wyckoff course tradition — no citable original text located):** the **Spring** — price dips below a well-defined support near the end of accumulation and quickly reverses back above; the **Upthrust** mirrors it above resistance. The mechanism is Osler's: stops cluster beyond levels, a probe fills them, and absence of follow-through strands the breakout traders. The read: a failed break is *information about the other side* — a spring back above support after a stop run is a stronger long context than a clean defense, because the supply below has been consumed.
+
+Operational reading (**CONVENTION**): the E&M 3%-close filter and the "wait for the retest" habit both exist to separate break from probe. Every "confirmation" filter trades false positives for lateness; pick one, freeze it, and never narrate it as evidence.
+
+## Measured moves
+
+**PUBLISHED:** E&M's "measuring implications" — e.g. head-and-shoulders target = head-to-neckline distance projected from the break; runaway-gap midpoint projection; flag "measured move" = repeat the pole. **MEASURED (practitioner, on the rule's honesty):** Bulkowski's *Encyclopedia of Chart Patterns* — a practitioner compilation, not peer-reviewed, "perfect trade" accounting, no costs — puts H&S targets hit at ~**51%**. By the friendliest available count, the measuring rule is a coin flip; use targets as *reference geometry* (where the crowd projects to — an attention point), never as an expectancy claim.
+
+## Reading structure — the checklist form
+
+1. Confirmed pivots only (respect the N-bar confirmation lag).
+2. Levels above and below current price, each with touch count + last-touch recency; ATR-scaled zones, not lines.
+3. Role-reversal candidates: old tops below price (support), old bottoms above (resistance), confluence with MAs ([trend-and-averages](trend-and-averages.md)).
+4. Open gaps in range: which taxonomy hypothesis, and what would confirm/kill it.
+5. Recent break attempts: clean, confirmed, or sprung? Who is trapped where?
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md). Our frozen constructions: `app/services/price_levels.py` and `app/services/price_structure.py` (both by-construction — no published formulation exists for level clustering; the modules say so; do not invent a citation). Concept→implementation map + the break-and-retest primitives: `.claude/skills/data-sources/market-structure.md`. Pattern-testing recipe (algorithmic definition → conditional distribution → random-entry null): `strategy-evidence` §2.12. Wyckoff computability table: `strategy-evidence` §2.12 "The three the operator named".

--- a/.claude/skills/market-technician/trend-and-averages.md
+++ b/.claude/skills/market-technician/trend-and-averages.md
@@ -1,0 +1,73 @@
+# market-technician / trend-and-averages
+
+## When to use
+
+Reading trend state from moving averages — the 20/50/200 horizons, slope vs price-relative reads, golden/death cross, MA confluence, pullback-to-MA behaviour, ADX trend strength — or reviewing anything that consumes them.
+
+Provenance tags per the [hub](SKILL.md): **PUBLISHED** / **MEASURED** / **CONVENTION** / **REFUTED**.
+
+## What each horizon proxies
+
+**CONVENTION** — the 20/50/200 triplet is folklore, not a result; no published derivation exists for the specific periods. What each usefully proxies:
+
+| MA | proxies | typical reading |
+| --- | --- | --- |
+| 20-day | ~one month of positioning; the swing-trader's reference | short-term trend + the pullback magnet in fast trends |
+| 50-day | ~one quarter; the intermediate trend | institutions' conventional "in an uptrend" line |
+| 200-day | ~one year; the primary trend | the regime line — the one horizon with published tests (below) |
+
+Two separate reads per MA (**CONVENTION**, the practitioner distinction — kept because collapsing them loses information):
+
+- **Price-relative**: close above/below the MA. Binary, immediate, whipsaw-prone near the line.
+- **Slope**: the MA rising or falling. Slower, but a rising 200-day with price briefly below it is a different fact from a falling one — direction of the average carries the trend claim; price-relative carries the timing claim.
+
+Stacking (20 > 50 > 200, all rising) is the **CONVENTION** definition of an established uptrend; inverted stacking mirrors it. Confluence — price meeting two references at one zone (e.g. the 200-day sitting on an old level) — strengthens a read for the mechanistic reason in [price-structure](price-structure.md): more eyes and orders anchored at one price.
+
+## The 200-day — the one MA with a published evidence trail
+
+- **PUBLISHED (origin):** Joseph Granville, *A Strategy of Daily Stock Market Timing for Maximum Profit* (1960) — eight rules around the 200-day MA. William Gordon, *The Stock Market Indicators* (1968) measured it on the Dow back to the late 1800s. (Not "William Gorman" — that attribution found no support.)
+- **PUBLISHED (test):** Meb Faber, "A Quantitative Approach to Tactical Asset Allocation", *Journal of Wealth Management* (Spring 2007; SSRN 962461) — monthly close vs **10-month SMA** ("corresponds closest to the 200-day"), S&P 500 1901–2012: compounded 10.18% vs 9.32% buy-and-hold, **max drawdown 83.66% → 42.24%**, invested ~70% of the time. His own framing: the gain is risk management, not return — *average* returns are nearly identical (11.22% vs 11.26%).
+- **PUBLISHED (costed test):** Jeremy Siegel, *Stocks for the Long Run* (5th ed.), DJIA 1886–2012, ±1% band around the 200-day: **after all transaction costs, timing falls short of buy-and-hold on absolute return** (~8.11% net vs 9.39%) but wins risk-adjusted; "a large number of small losses" in trendless markets, offset by sidestepping 1929/1987/2008.
+
+The honest summary: the 200-day is a **volatility/drawdown filter with roughly break-even raw return**, not an alpha source. Read it as regime context — which is exactly how `app/services/market_regime.py` uses it (SPY vs 200-SMA as the trend leg, a stated-as-conventional reference, not tuned).
+
+## Golden cross / death cross
+
+- **CONVENTION (origin):** no identifiable first publisher — searches including the Japanese literature (ゴールデンクロス) found no documented coinage. It is a modern name for a 50/200 relation, not a published system.
+- **MEASURED (literature, mixed):** full-sample S&P 500 tests (QuantifiedStrategies, ~33 signals since 1960): ~79% of trades positive, average ~+16%/signal — and still **trails buy-and-hold on raw return**, winning only on drawdown (~33% vs ~56%) and risk-adjustment. The favourable framing depends entirely on risk-adjustment; a study of crossover signals vs passive found no statistically significant advantage.
+- ⚠ Our derived signal `sma_50_200_regime` ("golden"/"death") is the CURRENT 50-vs-200 **relation**, not a crossover **event** — `ta-analyst` is explicit. A "golden" state can persist for years; do not narrate it as a fresh signal.
+
+**PUBLISHED (the crossover family's academic arc)** — lives in `.claude/skills/quant/strategy-evidence.md` ("the four papers"): Brock/Lakonishok/LeBaron (*JF* 1992) tested 26 rules — ten MA pairs including (1,200), (2,200), (5,150), ±1% bands — and found them significant against four nulls; Sullivan/Timmermann/White (*JF* 1999) applied the Reality Check over the full 7,846-rule universe: BLL's best rule survives the snooping correction **in-sample** but is dead in the 10-year out-of-sample window and on S&P futures. Read the precise form: not "the test was wrong", but "the edge did not survive its own publication window".
+
+## Pullback-to-MA
+
+- **CONVENTION with one practitioner print source:** no academic formulation or peer-reviewed test of "price pulls back to the 20/50-EMA in a trend" exists. The citable practitioner formulation is Connors & Raschke, *Street Smarts* (1995) — the "Holy Grail" setup: ADX(14) > 30, first pullback to the 20-EMA, entry above the touch bar's high, stop below the swing low. Quote it as a practitioner recipe, never as evidence.
+- **MEASURED (adjacent, negative):** AQR's buy-the-dip study (196 implementations, 60 years) — >60% of implementations worse risk-adjusted than passive; only 8% statistically significant. That tests drawdown-depth dips, not MA touches, but it is the nearest controlled relative and it cautions against assuming bought weakness pays.
+- The readable content: in a trending market the pullback-to-MA is where trend-followers add — so the MA touch is an *attention point* (same self-fulfilling mechanism as levels), and the tradable question is whether the trend resumes, answered by the resumption bar + volume, not by the touch itself.
+
+## EMA — what it is and where the formula comes from
+
+**PUBLISHED:** exponential smoothing from operations research (Holt 1957; R.G. Brown 1959); the familiar multiplier **2/(N+1)** is the average-age equivalence commonly traced to Brown's *Smoothing, Forecasting and Prediction of Discrete Time Series* (1963) — the attribution is via Siligardos (*Technical Analysis of Stocks & Commodities*, March 2013), not a page-verified quote — chosen so an EMA's average data age matches an N-period SMA's. First charted stock application: P.N. Haurlan (JPL engineer), *Measuring Trend Values* (1968). EMA vs SMA is a lag/smoothness trade, not an accuracy claim; our stored `ema_12/26` exist to feed MACD's published periods.
+
+## ADX — trend strength (Wilder 1978)
+
+**PUBLISHED** (J. Welles Wilder Jr., *New Concepts in Technical Trading Systems*, 1978 — the same book as RSI and ATR):
+
+- +DM = today's high − yesterday's high, counted only if it exceeds the down-move and is positive; −DM mirrors. Only the larger of the two counts on a bar.
+- ±DI = 100 × Wilder-smoothed(±DM) / Wilder-smoothed(TR). DX = 100 × |+DI − −DI| / (+DI + −DI). ADX = Wilder-smoothed DX, period 14.
+- ⚠ **Wilder's smoothing is the recursive `(prev × (n−1) + current) / n`**, causal — never an SMA approximation. Substituting a different smoother silently changes every value (#2260 is the RSI version of that lesson).
+- ADX is **directionless** — it measures trend *strength* either way; direction comes from which DI is on top.
+
+**CONVENTION (the threshold):** "ADX > 25 = trending / < 20 = no trend" is quoted everywhere as Wilder's, but the verifiable book-shaped rule attaches 25/20 to his **Commodity Selection Index** (a market-selection rule using ADXR), not to ADX as a per-chart gate. Plausibly his, not verifiably his sentence — tag any ADX cut as convention-with-a-published-ancestor and freeze it by construction if it gates anything (S-8 froze `ADX(14) < 20` exactly this way).
+
+## Reading trend state — the checklist form
+
+1. 200-day: price side + slope → primary regime (and check the benchmark's regime too — [market-dynamics](market-dynamics.md)).
+2. Stacking: 20/50/200 order + slopes → established trend, transition, or disorder.
+3. Distance from the 200-day in ATRs → extension (a read far from the mean has worse entry geometry regardless of trend).
+4. ADX if computed → is there a trend to respect at all, either direction.
+5. A crossover just fired? It is a *description of the last N bars*, already visible in 1–3 — never additive evidence on top of them.
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md). Tradability of any MA rule: `.claude/skills/quant/strategy-evidence.md` (BLL/STW arc, turnover bar). Repo encoding: `.claude/skills/ta-analyst/SKILL.md` (`sma_20/50/200`, `derive_trend_signals`, the momentum-blend ramps). Regime consumer: `app/services/market_regime.py`.

--- a/.claude/skills/market-technician/volatility-and-bands.md
+++ b/.claude/skills/market-technician/volatility-and-bands.md
@@ -1,0 +1,72 @@
+# market-technician / volatility-and-bands
+
+## When to use
+
+Reading volatility state on a chart — Bollinger Bands, BandWidth, Squeeze/Bulge, ATR-denominated distances, band walks vs reversion, Keltner contrast — or reviewing any code/spec that consumes them.
+
+Provenance tags per the [hub](SKILL.md): **PUBLISHED** / **MEASURED** / **CONVENTION** / **REFUTED**.
+
+## Bollinger Bands — the published construction
+
+**PUBLISHED** (John Bollinger, *Bollinger on Bollinger Bands*, 2001; rules verbatim on bollingerbands.com/bollinger-band-rules, verified 2026-08-14):
+
+- Middle band = 20-period SMA; bands at ±2 standard deviations. His defaults, unchanged "35 years".
+- **POPULATION standard deviation** (divide by N, not N−1) — his own site states "the population calculation for standard deviation". Our `indicator_series.bollinger_series` matches; its docstring flags this citation as "still owed" — it is now verified, but the module is identity-hashed, so the resolution is recorded here rather than edited into the file.
+- **Rule 11 — the multiplier moves with the period:** 2.0 at 20 periods, 2.1 at 50, 1.9 at 10. Changing the window without changing the multiplier is not "the same indicator, longer".
+- **%b** = (price − lower) / (upper − lower). ≥1 means closed above the upper band; ≤0 below the lower; 0.5 is the middle band.
+- **BandWidth** = (upper − lower) / middle. Normalised by the middle band so it is comparable across price levels — the raw spread is not.
+- **Rule 14 — his own statistical disclaimer:** "Make no statistical assumptions based on the use of the standard deviation calculation… The distribution of security prices is non-normal." The bands are an adaptive envelope, not a confidence interval; "price should be inside the bands 95% of the time" is a misreading Bollinger himself rejects (secondary reproductions of his rationale put actual containment at 20/2.0 around 88–89% — a figure not independently verified here; the load-bearing point is Rule 14 itself).
+
+## The Squeeze and the Bulge — six-month EXTREMES, not percentiles
+
+**PUBLISHED** (*Bollinger on Bollinger Bands* ch. 21; Bollinger's own screener defines it verbatim: "Squeeze means a stock's BandWidth is at its narrowest (lowest) in 6 months", "Bulge… widest (highest) in 6 months"):
+
+- **Squeeze** = BandWidth at its lowest reading in six months (126 trading days). Volatility is cyclical — contraction precedes expansion; the Squeeze marks the setup, not the direction.
+- **Bulge** = BandWidth at its highest in six months — the mirror extreme, and the `volatile` flag in our regime classifier. **CONVENTION** on top of it: reading a Bulge as volatility exhaustion near trend ends is the common practitioner gloss, not part of the verified definition.
+- ⚠ **REFUTED locally:** a 20th/80th-percentile BandWidth cut was invented for exactly this purpose on #2279 and caught at review. A distributional quantile and a six-month extreme disagree precisely in the quiet regimes the Squeeze exists to find. `app/services/market_regime.py` encodes the published rule (`SQUEEZE_LOOKBACK_BARS = 126`) and names the failed invention in its docstring.
+- **MEASURED:** the published Squeeze is ~17× more selective than S-4's invented bottom-quartile ATR cut on the same 71 instruments — 26 signals from 21 names vs 1,667 (commit `82915ee5`, 2026-08-14). A genuine six-month extreme *should* be rare; a percentile cut admits ordinary bars by construction.
+- ⚠ Distinct construct: the **TTM Squeeze** (John Carter, *Mastering the Trade*, 2005) is Bollinger Bands entirely inside Keltner Channels — a cross-indicator containment rule with no lookback window. Different rule, different author; do not conflate with Bollinger's ch. 21 rule.
+
+## Band walks vs reversion — the misread that costs most
+
+**PUBLISHED** (Bollinger's own rules 6–8, verbatim):
+
+- Rule 6: "Tags of the bands are just that, tags not signals. A tag of the upper Bollinger Band is NOT in-and-of-itself a sell signal."
+- Rule 7: "In trending markets price can, and does, walk up the upper Bollinger Band and down the lower Bollinger Band."
+- Rule 8: "Closes outside the Bollinger Bands are initially continuation signals, not reversal signals."
+
+So the same event — price at the upper band — reads opposite ways by regime: in a trend it is strength (a band walk); in a range it is extension. Deciding which regime you are in comes FIRST (see [market-dynamics](market-dynamics.md)); the band tag alone decides nothing. Our scoring encodes both readings deliberately: Bollinger position scores as trend *strength* in the momentum blend while RSI/stoch score exhaustion — `ta-analyst` says "do not 'fix' one to match the other".
+
+**MEASURED (literature):** academic tests of the naive band rules (Lento, Gradojevic & Wright 2007; Lento & Gradojevic 2011; Lento 2009 — US/Canadian indices + FX, then eight Asia-Pacific markets) find the touch-and-fade rule loses to buy-and-hold after costs, and in the markets they tested the *contrarian* application (fading the naive signal) was the profitable side. That is the same content as Rules 6–8: the naive reading is the wrong reading.
+
+## ATR — the unit of instrument-relative distance
+
+**PUBLISHED** (J. Welles Wilder Jr., *New Concepts in Technical Trading Systems*, 1978 — same book as RSI, ADX, Parabolic SAR):
+
+- True Range = max(high − low, |high − prev close|, |low − prev close|). The prev-close arms exist so gaps count as range.
+- ATR = Wilder-smoothed TR (recursive `(prev × (n−1) + current) / n`, causal), default 14. NOT a simple average — #2260 is what a non-causal smoother substitution costs.
+
+Use ATR as the *denominator* for distances: "within 0.5 ATR of the level", "stop 2 ATR below entry". A $400 stock and a $4 stock have no shared notion of "close"; percent gets it wrong in opposite directions at the two ends (this is why `price_levels.py` clusters in ATR units).
+
+**Stop multiples — provenance is messier than folklore admits:**
+
+- **PUBLISHED:** Wilder's own Volatility System used a constant of **2.8–3.1 × ATR(7)**. The Chandelier Exit (Charles Le Beau, popularized in Elder's *Come Into My Trading Room*, 2002) hangs **3 × ATR** off a 22-day extreme.
+- **CONVENTION:** the popular "2 × ATR stop" has no identifiable published origin — it is the retail short-horizon variant of the 3× convention. Our own `entry_timing` stop (entry − 2.0 × ATR(14), floored) is this convention, encoded and frozen; treat it as by-construction, not cited.
+- **MEASURED (ours):** no stop level catches a gap — the 2026-08-09 short-side backtest filled 141 of 1,402 stops at an open beyond the level; worst trade −87% *with* a 20% stop. An ATR stop bounds intent, not outcome.
+
+## Keltner Channels — the contrast
+
+**PUBLISHED** (Chester W. Keltner, *How to Make Money in Commodities*, 1960 — "Ten-Day Moving Average Trading Rule"): centre = 10-day SMA of typical price (H+L+C)/3; offset = 10-day SMA of the daily range. No ATR, no multiplier — the modern form (EMA ± k × ATR, typically 20-EMA ± 2 × ATR(10)) is a later revision attributed to Linda Bradford Raschke (1980s); the attribution is consistent across secondary sources but no primary Raschke citation was found — treat the modern parameters as **CONVENTION** with a published ancestor.
+
+Why the contrast matters (mechanical property of the formulas, not a claim about markets): a rolling σ re-prices a large move immediately and quadratically, an averaged range linearly — so Bollinger bands expand faster after a shock than a Keltner envelope on the same bars. That difference is exactly what the TTM Squeeze exploits — σ compressing inside the ATR envelope.
+
+## Reading volatility state — the checklist form
+
+1. BandWidth now, vs its own 126-bar min/max → Squeeze / Bulge / neither. (Six-month extreme, never a percentile.)
+2. ATR as % of close → the instrument's recent average true range; the distance SCALE for every level/stop you quote, not a forecast of movement.
+3. Price vs bands: %b + whether recent closes hug one band (walk) or oscillate between them (range).
+4. Squeeze resolving? Direction comes from the breakout leg and regime, never from the Squeeze itself.
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md). Regime consumption of BandWidth: `app/services/market_regime.py` (published-rule precedent). Tradability of any band-based rule: `.claude/skills/quant/strategy-evidence.md` (the Lento-line results above are reads, not strategies). Repo encoding of bands/ATR on `price_daily`: `.claude/skills/ta-analyst/SKILL.md`.

--- a/.claude/skills/market-technician/volume.md
+++ b/.claude/skills/market-technician/volume.md
@@ -1,0 +1,65 @@
+# market-technician / volume
+
+## When to use
+
+Reading volume against price — confirmation vs contradiction, effort vs result, climax/exhaustion, dry-up, OBV, VWAP and anchored VWAP — or reviewing anything that consumes a volume signal.
+
+Provenance tags per the [hub](SKILL.md): **PUBLISHED** / **MEASURED** / **CONVENTION** / **REFUTED**.
+
+⚠ **Data caveat first:** a large share of our LIVE bars carry NULL volume — measured 2026-08-14: `select count(*), count(*) filter (where volume is null) from price_daily` → 6,766,612 / 1,899,147 (**28.07%** of `price_daily`, the eToro-fed live table; the #2437 S-6 session measured 26.13% on its validated-universe subset). The RESEARCH corpus is different: `research_price_daily` volume was measured present on all 25,818,944 rows (`data-sources/market-structure.md`) — name the table before quoting either figure. Any volume read must state what it does on a NULL bar — in `price_levels.py`, a wholly-absent volume array falls back to an unweighted cluster mean, while a per-bar NaN contributes zero through `nansum`/`nancumsum`; a volume-confirmation gate must refuse, not pass.
+
+## Effort vs result — the organizing idea
+
+**PUBLISHED (as modern codification):** Wyckoff's "law of effort versus result" — volume is effort, price movement is result; convergence confirms the move, divergence warns of a change. The three-laws codification is the Pruden/Bogomazov school's statement of the 1930s Wyckoff course; no verbatim 1931 text was located, so cite it as the Wyckoff *tradition*, not a page.
+
+The quantity underneath is real and computable: high volume + small |return| (absorption) maps to **low Amihud illiquidity**; low volume + big move to high Amihud — and Amihud (2002) *is* published, priced, and measured on our corpus. `strategy-evidence` §2.11–2.12 carries the derivation of this inversion. Test the observable, not the story about "composite operators".
+
+Practical reads (all **CONVENTION** as specific rules, coherent under effort-vs-result):
+
+- Advance on rising volume, pullback on falling volume → participation confirms the trend.
+- New price high on clearly lower volume than the prior high → effort divergence; a warning, not a signal.
+- Huge volume, narrow range, no progress → absorption: someone is on the other side of the crowd. Direction resolves on the NEXT bars, not this one.
+
+## Confirmation multipliers — the folklore, labelled
+
+- **PUBLISHED (the only book-sourced threshold):** William O'Neil, *How to Make Money in Stocks* — breakout volume "at least 40% to 50% above normal" (part of the S — Supply and Demand — criterion in CANSLIM), i.e. ~1.4–1.5×.
+- **PUBLISHED (qualitative only):** Edwards & Magee require "a conspicuous burst of activity" on a valid breakout — their only *number* is a **3% price** penetration, not a volume multiple.
+- **CONVENTION:** the popular 1.2× / 1.5× / 2× 20-bar-average cuts have no published source; retail convention clusters at 1.5–2×. Our S-6 froze **1.2×** and recorded it as convention at the time — correctly tagged, and note it sits *below* even the folklore cluster; if a future version moves it, O'Neil's 1.4–1.5× is the only citable anchor.
+- ⚠ A "confirmed" breakout is still a breakout — [price-structure](price-structure.md) covers false breaks; volume shifts the odds, it does not close the false-break case.
+
+## Climax, exhaustion, dry-up
+
+- **PUBLISHED (Wyckoff tradition):** the Selling Climax — "widening spread and selling pressure… climaxes and heavy or panicky selling by the public is being absorbed by larger professional interests at or near a bottom"; extreme volume, close well off the low. Mirror: Buying Climax. A climax is identified by what follows (the Automatic Rally / Secondary Test), not on the bar itself.
+- **PUBLISHED (O'Neil):** volume dry-up on pullbacks and in the late stage of a base is constructive — "when a stock pulls back in price, you want to see volume dry up, indicating no significant selling pressure" — then expansion on the breakout. Practitioner rule, IBD-published.
+- **MEASURED (adjacent academic):** Gervais, Kaniel & Mingelgrin, "The High-Volume Return Premium", *JF* 56(3) (2001) — unusually high-volume days are followed by appreciation over the next month (low volume by the reverse); follow-up work (Kaniel, Li & Starks) reports the effect internationally. Note the direction: a volume *shock* is bullish on average in their samples — which cuts against reading every volume spike as distribution.
+- **PUBLISHED (theory):** Blume, Easley & O'Hara, "Market Statistics and Technical Analysis: The Role of Volume", *JF* 49 (1994) — volume carries information about signal *precision* that price alone cannot reveal; conditioning on both is rational. This legitimizes volume-reading as a class; it validates no specific rule. Karpoff's survey (*JFQA* 1987) adds the stylized facts: volume correlates with |return|, and in equities with the signed return (heavier on up-moves).
+
+## OBV
+
+**PUBLISHED:** Joseph Granville, *New Key to Stock Market Profits* (1963). Up close → add the bar's volume to the running total; down close → subtract; unchanged → nothing. The claim is that OBV divergence leads price ("volume precedes price").
+
+**MEASURED (literature, thin):** the one located academic test (Tsang & Chong, *Economics Bulletin* 2009) finds OBV-based rules beat buy-and-hold in Greater China samples but "in general cannot beat the buy-and-hold strategy in the US and European markets". Lower-tier venue, mixed geography — treat OBV as a divergence lens, not an evidence-backed signal.
+
+## VWAP — what it actually is
+
+**PUBLISHED:** VWAP = Σ(price × volume) / Σ(volume) over **a session**. Its origin is not chartist at all: it is the institutional **execution benchmark** — Berkowitz, Logue & Noser, "The Total Cost of Transactions on the NYSE", *JF* 43 (1988) formalized measuring execution cost against the day's volume-weighted price (practitioner use from ~1984, Abel Noser). **CONVENTION** (mechanism rationale, untested here): desks benchmarked against VWAP must trade near it, and that flow is the usual explanation for the line's intraday gravity.
+
+Consequences for reading:
+
+- VWAP is a **session-anchored intraday** quantity. It resets at the open. "VWAP on a daily chart" has no canonical published definition — vendor "rolling VWAP" over N daily bars is a derived convention, not the benchmark quantity. Do not cite daily-chart VWAP as if it were the institutional line.
+- Intraday uses (**CONVENTION**, coherent with the mechanism): above VWAP = buyers in control of the session; institutional buyers working orders tend to defend it; reversion to VWAP is the natural magnet in balanced sessions.
+- ⚠ Our `price_intraday` is a build gap, not a data gap (`etoro-api` skill: `get_intraday_candles` exists, 1000 bars/request). Until intraday bars are stored, no *session* VWAP is computable here — flag any spec that pretends otherwise.
+
+**Anchored VWAP** — **PUBLISHED (practitioner):** Brian Shannon, *Maximum Trading Gains with Anchored VWAP* (2023; a CMT Association presentation of the same material exists). Same formula, anchor chosen at an event — earnings, IPO, a swing extreme — answering "what is the average holder since X in at?". Above the anchor-VWAP, the average post-event buyer is in profit; below, trapped. A positioning lens, not a signal; the anchor choice is discretionary and two readers with different anchors get different lines. We DO ship this on daily bars: `price_structure.anchored_vwap` (HLC3 typical price — a stated daily-bar convention, not a standard; and `usable_from_index` guards the swing-anchor look-ahead — an anchor chosen after seeing the outcome is the trap, per `data-sources/market-structure.md`).
+
+## Reading volume character — the checklist form
+
+1. NULL check: does this instrument's series carry volume at all? (26.13% of bars do not.)
+2. Trend legs vs corrective legs: which side carries the volume?
+3. At the decision point: expansion (participation), contraction (dry-up), or extreme (possible climax — wait for the response bars)?
+4. Divergence: is the latest push to a new extreme made on less effort than the prior push?
+5. If intraday context exists (it does not yet, here): position vs session VWAP / relevant anchored VWAP.
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md). Amihud/effort-result inversion + Wyckoff Nine Tests computability: `.claude/skills/quant/strategy-evidence.md` §2.11–2.12. Concept→implementation map (incl. the anchored-VWAP anchor trap, and "no volume-flow indicators shipped" status): `.claude/skills/data-sources/market-structure.md`. Level strength uses volume share: `app/services/price_levels.py`. Intraday capability facts: `.claude/skills/data-sources/etoro-api.md`.

--- a/.claude/skills/quant/strategy-evidence.md
+++ b/.claude/skills/quant/strategy-evidence.md
@@ -16,6 +16,9 @@ prior is how a session spends a week on a family the evidence killed in 2016.
 
 ⚠ Companion to `data-sources/market-structure.md`, which owns *indicator
 formulations*. This file owns *whether a strategy family is worth building*.
+A third companion, `market-technician/SKILL.md`, owns *how to read a chart*
+(the layered read protocol + per-concept evidence status, every claim tagged
+PUBLISHED/MEASURED/CONVENTION/REFUTED); it defers to this file on tradability.
 
 ⚠ Storage companion: `quant/data-capability.md` §7. Every logical signal must
 reach the durable daily census, but only fired signals are durable detail;

--- a/.claude/skills/ta-analyst/SKILL.md
+++ b/.claude/skills/ta-analyst/SKILL.md
@@ -16,6 +16,13 @@ Also read it before citing any TA figure in an operator-facing surface or
 prompt — the interpretation rules below are the encoded ones, not textbook
 defaults.
 
+⚠ Domain chart-reading knowledge (what a formulation means, its published
+source and honest evidence status, the layered chart-read protocol) lives in
+`.claude/skills/market-technician/SKILL.md` — this file stays OUR encoding
+only. The platform's regime + level modules (`app/services/market_regime.py`,
+`app/services/price_levels.py`, both 2026-08-14, S5-S10 §1–§2) postdate this
+skill and belong to the strategy platform side of the boundary below.
+
 ## ⚠ Scope boundary — this skill is CURRENT-STATE TA only
 
 Everything below describes TA as it works **today**: indicators computed on the


### PR DESCRIPTION
## What

New skill family `.claude/skills/market-technician/` — the professional chart-reading discipline, replacing "day-trader style" framing. One hub + eight sub-skills. Every factual claim carries exactly one provenance tag — **PUBLISHED** (citation verified at write time) / **MEASURED** (with the reproducing command or study) / **CONVENTION** (folklore, labelled) / **REFUTED** (kept prominently) — untagged claims are defects by the family's own rule.

- `SKILL.md` — hub: tag system, layered read protocol, refuted-on-our-data list, step-0 vet findings, routing.
- `trend-and-averages.md` · `volatility-and-bands.md` · `volume.md` · `price-structure.md` · `fibonacci.md` · `candles.md` · `market-dynamics.md` — the layers.
- `chart-read-protocol.md` — the synthesis: fixed 7-step order ending in a falsifiable call (bias / entry / **invalidation price** / targets / horizon / flip conditions), plus a **MEASURED worked example** (below).

Cross-link edits (both directions, division of labour stated in each): `ta-analyst/SKILL.md`, `quant/strategy-evidence.md`, `data-sources/market-structure.md`. No code touched.

## Why

The TA surface had our encoding (`ta-analyst`), tradability bars (`strategy-evidence`) and the code map (`market-structure`), but no domain skill teaching how to READ a chart with honest evidence status per concept. #2279 (invented percentile Squeeze) is the class of error this closes: citations verified during writing, never recited from memory.

## Citation verification (session research, 4 parallel sweeps)

Highlights: Bollinger's own site confirms **population σ** (resolves the "citation still owed" flag in `indicator_series.bollinger_series` — recorded in the skill, module untouched because it is identity-hashed) and the six-month Squeeze/Bulge; the "ADX > 25" threshold verifiably attaches to Wilder's **CSI** market-selection rule, not per-chart ADX (tagged convention); the **golden cross has no identifiable published origin**; O'Neil's 40–50%-above-average is the only book-published breakout-volume threshold (the 1.2×/1.5×/2× cuts have none); "2×ATR stop" has no published origin (Wilder's own Volatility System used 2.8–3.1×); Tsinaslanidis et al. (*ESWA* 2022) is the best fib test and is a null — pairing our own 2026-08-09 placebo refutation.

## Worked example (Definition-of-done clause 3)

AAPL, 1,050 bars to 2026-08-13, computed from dev `price_daily` via `load_masked_bars` + `indicator_series` + `price_levels.LevelScan` + `market_regime.classify_regimes` (reproduce recipe inline in the skill). Full seven-step read ends in a falsifiable call: stand-aside/long-watch; invalidation = daily close below ~280 (SMA200 280.20 ≈ old resistance 280.67 confluence); two entry triggers; 20–40 bar horizon. Fresh measurement this session: `price_daily` NULL-volume share = 28.07% (query in `volume.md`, distinguished from the all-volume research corpus).

## Review

Codex checkpoint-1 pass ran over the staged family; ~25 findings triaged and fixed before this push (drifted quote → "statistically indistinguishable"; Bulge-exhaustion over-claim tagged CONVENTION; code-behaviour mismatches on `price_levels` tie-rule/ATR-supply/volume-weight corrected; unresolvable memory wiki-links replaced with in-repo `docs/proposals/ta/2026-08-09-plan-of-attack.md`; over-broad quantifiers scoped to "located studies, 2026-08-14 sweep").

## Security model

Not applicable — documentation-only diff, no code, no endpoints, no data paths.

Refs #2437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
