### PR TITLE
feature(#2437): backtest regime benchmark from the research corpus — spy_chain_v1

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -1444,17 +1444,16 @@ def evaluate_arm(
     already refused.
     """
     # ⚠ ONE benchmark classification per arm pass, built before the instrument
-    # loop. See `_signals_for` for the material limitation: `price_daily` SPY
-    # starts 2022-05-10 while this axis reaches 1962, so every earlier bar
-    # carries `None` and a regime-gated strategy cannot fire there.
+    # loop. Sourced from the RESEARCH corpus (`spy_chain_v1` — see
+    # `MarketRegimeProvider.load_research`), the same source universe the bars
+    # come from, so the regime reaches 1993-11-11 rather than `price_daily`'s
+    # 2023-02 ceiling. Bars before SPY's 1993 inception still carry `None`; see
+    # `_signals_for`.
     #
-    # ⚠ INJECTABLE, defaulting to a read from `conn`. Two callers need to supply
-    # their own: a harness with no real connection, and — when it exists — a
-    # provider sourced from the RESEARCH corpus, which is what actually closes
-    # the pre-2022 gap above. A parameter now costs nothing and is the seam that
-    # fix will use.
+    # ⚠ INJECTABLE, defaulting to the research read from `conn`, for a harness
+    # with no real connection.
     if regime_provider is None:
-        regime_provider = MarketRegimeProvider.load(conn)
+        regime_provider = MarketRegimeProvider.load_research(conn)
     started = time.monotonic()
     if return_basis not in {LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS}:
         raise ValueError(f"unknown return basis {return_basis!r}")
@@ -1732,17 +1731,16 @@ def evaluate_level_arms(
     measurements cannot influence one another after that common evidence.
     """
     # ⚠ ONE benchmark classification per arm pass, built before the instrument
-    # loop. See `_signals_for` for the material limitation: `price_daily` SPY
-    # starts 2022-05-10 while this axis reaches 1962, so every earlier bar
-    # carries `None` and a regime-gated strategy cannot fire there.
+    # loop. Sourced from the RESEARCH corpus (`spy_chain_v1` — see
+    # `MarketRegimeProvider.load_research`), the same source universe the bars
+    # come from, so the regime reaches 1993-11-11 rather than `price_daily`'s
+    # 2023-02 ceiling. Bars before SPY's 1993 inception still carry `None`; see
+    # `_signals_for`.
     #
-    # ⚠ INJECTABLE, defaulting to a read from `conn`. Two callers need to supply
-    # their own: a harness with no real connection, and — when it exists — a
-    # provider sourced from the RESEARCH corpus, which is what actually closes
-    # the pre-2022 gap above. A parameter now costs nothing and is the seam that
-    # fix will use.
+    # ⚠ INJECTABLE, defaulting to the research read from `conn`, for a harness
+    # with no real connection.
     if regime_provider is None:
-        regime_provider = MarketRegimeProvider.load(conn)
+        regime_provider = MarketRegimeProvider.load_research(conn)
     started = time.monotonic()
     if return_basis not in {LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS}:
         raise ValueError(f"unknown return basis {return_basis!r}")
@@ -1955,17 +1953,15 @@ def _signals_for(
 ) -> list[StrategySignal]:
     """One instrument's whole-series verdicts, per-series or cross-sectional.
 
-    ⚠⚠ THE REGIME COMES FROM ``price_daily``, WHICH STARTS 2022-05-10, WHILE THIS
-    BACKTEST'S AXIS REACHES BACK TO 1962. Every bar before the benchmark's first
-    is ``None``, so a regime-gated strategy (S-5…S-10) CANNOT FIRE on the long
-    span and its pre-2022 result is an empty sample rather than a bad one.
-
-    Stated here rather than worked around because the workaround would be worse:
-    defaulting the missing years to a permissive regime would fabricate market
-    conditions for six decades. Closing this needs a benchmark series in the
-    RESEARCH corpus — the same source the bars come from — which is a separate
-    piece of work. Until then, judge S-5…S-10 on the window where the regime
-    exists, which is what §0 of the spec asks for anyway.
+    ⚠ THE REGIME NOW COMES FROM THE RESEARCH CORPUS (``spy_chain_v1``, see
+    ``MarketRegimeProvider.load_research``) — the same source universe as the
+    bars — and is classifiable 1993-11-11 → the corpus end. The residual bound
+    is SPY's own 1993-01-22 inception: bars before it carry ``None``, so a
+    regime-gated strategy (S-5…S-10) still cannot fire 1962–1992 and that span
+    is an empty sample rather than a bad one. Defaulting those decades to a
+    permissive regime would fabricate market conditions; a pre-1993 regime
+    would need a different benchmark (the S&P 500 index itself) and a new
+    ``spy_chain`` version.
     """
     if entry.signals is not None:
         return segmented_signals(

--- a/app/services/market_regime_provider.py
+++ b/app/services/market_regime_provider.py
@@ -6,6 +6,13 @@ benchmark from the database and aligns the result to an instrument's own bar
 dates. The split is deliberate, so a regime edit that changes verdicts moves the
 hash while a change to *how the benchmark is fetched* does not.
 
+⚠ One refinement to that split (#2437 walk-forward prerequisite): the fetch
+*mechanics* stay outside the hash, but the source *semantics* — which closes
+feed the classifier in each context — are identity-bearing, carried by this
+module's ``RULE_SET_VERSION`` through ``strategy_registry.INPUT_RULE_SETS``.
+``load`` (live scan, ``price_daily``) and ``load_research`` (backtest,
+``spy_chain_v1`` over the research corpus) are the two declared sources.
+
 ⚠⚠ ALIGNED BY DATE, NEVER BY POSITION. An instrument and the benchmark do not
 share a bar count — different listing dates, different halts, different holidays
 on a non-US venue. Zipping two arrays positionally would pair an instrument's
@@ -22,6 +29,8 @@ it would be most wrong exactly when the market is closed for an unusual reason.
 
 from __future__ import annotations
 
+import math
+from collections.abc import Sequence
 from datetime import date
 from typing import Any, Final
 
@@ -43,6 +52,61 @@ from app.services.market_regime import (
 #: by a LIKE or a prefix match, because a resolver that returns both would pick
 #: one arbitrarily and the regime would change identity between runs.
 BENCHMARK_SYMBOL: Final[str] = "SPY"
+
+#: The benchmark SOURCE rules, hashed into every strategy identity via
+#: ``strategy_registry.INPUT_RULE_SETS`` (#2333's mechanism).
+#:
+#: ⚠ A DECLARED STRING, NOT A MODULE HASH — deliberately unlike
+#: ``REGIME_RULE_VERSION``. This module's header freezes the design that fetch
+#: *mechanics* stay outside the hash; what joins the hash is the source
+#: *semantics*: which closes feed the classifier in each context. Changing
+#: either source rule (the live table, or any frozen chain constant below) bumps
+#: this string by hand; an edit to how the rows are fetched does not.
+#:
+#: Why the source is identity-bearing at all: switching the backtest benchmark
+#: from ``price_daily`` (first SPY bar 2022-05-10) to the research chain flips
+#: every pre-2023 bar of a regime-gated strategy from ``not_evaluable`` to a
+#: real verdict. Same signals table, same strategy code, different verdicts —
+#: the exact "changed input under an unchanged version" defect
+#: ``INPUT_RULE_SETS`` exists to make visible.
+RULE_SET_VERSION: Final[str] = "benchmark-source-v1:live=price_daily_spy;research=spy_chain_v1"
+
+# --- The research chain (``spy_chain_v1``), all constants frozen together. ---
+# Two segments, ONE seam. There is no published formulation for splicing two
+# vendor series into a benchmark, so the construction is fixed BY CONSTRUCTION
+# (the repo rule for that case) and every constant below is part of
+# ``RULE_SET_VERSION``'s ``spy_chain_v1`` — moving any of them is a new chain
+# version, never a redefinition.
+
+#: Primary segment: the eToro comparator snapshot. Chosen because it is
+#: numerically identical to the live scan's benchmark — ``close IS DISTINCT
+#: FROM`` returns 0 rows against ``price_daily`` SPY across all 1,018 shared
+#: dates — so the backtest's recent-window regime IS the live regime.
+CHAIN_PRIMARY: Final[tuple[str, str]] = ("etoro/etoro-comparators-2026-07-08-v1", "SPY")
+#: What the primary's ``adjustment_basis`` must be. Provenance drift under an
+#: unchanged vendor name (a re-ingested series on a different basis) is refused,
+#: not absorbed.
+CHAIN_PRIMARY_BASIS: Final[str] = "split_adjusted"
+
+#: Fallback segment: the Intrader archive's SPY, used strictly BEFORE the seam.
+#: ``unadjusted`` vs the primary's ``split_adjusted`` is not a step source: SPY
+#: has no split history, which the 585-date overlap agreement (max |diff| $1.76,
+#: ~0.3% — vendor close-mark difference) itself evidences.
+CHAIN_FALLBACK: Final[tuple[str, str]] = ("icyDenev/Intrader", "SPY")
+CHAIN_FALLBACK_BASIS: Final[str] = "unadjusted"
+
+#: ⚠ THE SEAM IS FROZEN, NOT DERIVED. It equals the primary's first bar at
+#: freeze time; deriving it from live coverage would let a corpus refresh that
+#: extends either series silently move the seam and redefine ``spy_chain_v1``
+#: under an unchanged version. ``load_research`` asserts the primary actually
+#: has a bar on this date and refuses otherwise.
+CHAIN_SEAM: Final[date] = date(2022, 5, 10)
+
+#: The fallback's last bar must fall within this many calendar days before the
+#: seam. 7 = the maximum intra-series gap measured on BOTH segments' full
+#: population (a holiday week); a larger gap means the fallback segment eroded
+#: and the chain would classify across a hole it believes is continuous.
+CHAIN_MAX_SEAM_GAP_DAYS: Final[int] = 7
 
 
 class BenchmarkUnavailableError(RuntimeError):
@@ -77,6 +141,49 @@ def _bollinger(closes: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         upper[i] = mean + BOLLINGER_NUM_STD * sigma
         lower[i] = mean - BOLLINGER_NUM_STD * sigma
     return upper, middle, lower
+
+
+def _chain_closes(
+    primary: Sequence[tuple[date, float]],
+    fallback: Sequence[tuple[date, float]],
+    *,
+    seam: date = CHAIN_SEAM,
+    max_seam_gap_days: int = CHAIN_MAX_SEAM_GAP_DAYS,
+) -> list[tuple[date, float]]:
+    """``spy_chain_v1``'s merge — pure, so the construction is testable without a DB.
+
+    ⚠ ONE SEAM ONLY. The fallback contributes strictly-before-seam bars and the
+    primary contributes on-or-after-seam bars; a hole in the primary after the
+    seam STAYS A HOLE even when the fallback has that date. Per-date
+    interleaving would flip vendors mid-SMA-window on every vendor hole and
+    turn the one declared seam into unbounded micro-seams.
+
+    Refusals (``BenchmarkUnavailableError``) rather than degradation, matching
+    ``load``'s contract: a silently short chain would classify a different span
+    than ``RULE_SET_VERSION`` declares.
+    """
+    trimmed_fallback = [(day, close) for day, close in fallback if day < seam]
+    trimmed_primary = [(day, close) for day, close in primary if day >= seam]
+    if not trimmed_primary or trimmed_primary[0][0] != seam:
+        raise BenchmarkUnavailableError(
+            f"chain primary has no bar on the frozen seam {seam} — the series no longer "
+            "matches the coverage spy_chain_v1 was frozen against"
+        )
+    if not trimmed_fallback:
+        raise BenchmarkUnavailableError(f"chain fallback has no bars before the seam {seam}")
+    gap = (seam - trimmed_fallback[-1][0]).days
+    if gap > max_seam_gap_days:
+        raise BenchmarkUnavailableError(
+            f"chain fallback's last bar {trimmed_fallback[-1][0]} is {gap} calendar days before "
+            f"the seam {seam} (limit {max_seam_gap_days}) — the fallback segment has eroded"
+        )
+    chained = trimmed_fallback + trimmed_primary
+    for index, (day, close) in enumerate(chained):
+        if index and day <= chained[index - 1][0]:
+            raise BenchmarkUnavailableError(f"chain dates are not strictly increasing at {day}")
+        if not math.isfinite(close) or close <= 0:
+            raise BenchmarkUnavailableError(f"chain close on {day} is {close!r} — not a positive finite price")
+    return chained
 
 
 class MarketRegimeProvider:
@@ -123,15 +230,89 @@ class MarketRegimeProvider:
                 f"(first few: {duplicated}); more than one instrument matches this symbol, "
                 "so the regime series is ambiguous — pin the instrument_id rather than the symbol"
             )
-        closes = np.array([float(row[1]) for row in rows])
+        return cls._classify(dates, [float(row[1]) for row in rows], label=repr(symbol))
+
+    @classmethod
+    def _classify(cls, dates: Sequence[date], close_values: Sequence[float], *, label: str) -> MarketRegimeProvider:
+        """The one classification path, shared by both constructors.
+
+        ⚠ Shared deliberately: if ``load`` and ``load_research`` each owned a
+        Bollinger + ``classify_regimes`` call, the two could drift apart and the
+        live scan and the backtest would disagree about what the market was
+        doing on a date both can classify — the exact property the chain's
+        strict-extension check (0 disagreements on all 819 live-classifiable
+        dates) exists to preserve.
+        """
+        closes = np.array(close_values)
         upper, middle, lower = _bollinger(closes)
         series = classify_regimes(closes=closes, band_upper=upper, band_middle=middle, band_lower=lower)
         if all(value is None for value in series.values):
             raise BenchmarkUnavailableError(
-                f"benchmark {symbol!r} has {len(rows)} bars but none are classifiable; "
+                f"benchmark {label} has {len(close_values)} bars but none are classifiable; "
                 "the 200-SMA and a full 126-bar BandWidth window need ~326 bars"
             )
         return cls(regime_by_date=dict(zip(dates, series.values, strict=True)))
+
+    @classmethod
+    def load_research(cls, conn: psycopg.Connection[Any]) -> MarketRegimeProvider:
+        """The BACKTEST's benchmark: ``spy_chain_v1`` over the research corpus.
+
+        The live scan keeps ``load`` (``price_daily``); this constructor exists
+        because the backtest's bars come from the research corpus and its axis
+        reaches decades before ``price_daily``'s first SPY bar (2022-05-10) —
+        the benchmark must come from the same source universe as the bars it
+        contextualises (`backtest_run._signals_for`'s own prescription).
+
+        ⚠ Quarantine treatment, declared: reads ``research_price_daily.close``
+        without consulting ``research_bar_quarantine``. The regime is market
+        context, not a return computation, so the quarantine's ``return_usable``
+        / ``range_usable`` verdicts do not define "close usable". Verified on
+        the full population at freeze time: the only flagged rows on either
+        pinned series are 5 archive-tail ``provisional`` marks on the fallback
+        (2024-09-23→27, empty rule list, both flags true) — all AFTER the seam,
+        so the chain never reads them.
+
+        ⚠ Both segment reads happen on the one connection passed in, inside its
+        current transaction, so the two queries observe one corpus snapshot.
+        """
+        segments: dict[str, list[tuple[date, float]]] = {}
+        for role, (vendor, vendor_symbol), expected_basis in (
+            ("primary", CHAIN_PRIMARY, CHAIN_PRIMARY_BASIS),
+            ("fallback", CHAIN_FALLBACK, CHAIN_FALLBACK_BASIS),
+        ):
+            series_rows = conn.execute(
+                """
+                SELECT series_id, adjustment_basis
+                FROM research_price_series
+                WHERE vendor = %s AND vendor_symbol = %s
+                """,
+                (vendor, vendor_symbol),
+            ).fetchall()
+            # ``(vendor, vendor_symbol)`` is DB-unique, so >1 cannot happen today;
+            # kept because this refusal message beats a downstream shape error.
+            if len(series_rows) != 1:
+                raise BenchmarkUnavailableError(
+                    f"chain {role} pin {(vendor, vendor_symbol)!r} resolved to {len(series_rows)} series; "
+                    "spy_chain_v1 requires exactly one"
+                )
+            series_id, basis = series_rows[0]
+            if basis != expected_basis:
+                raise BenchmarkUnavailableError(
+                    f"chain {role} {(vendor, vendor_symbol)!r} has adjustment_basis {basis!r}, "
+                    f"expected {expected_basis!r} — provenance drifted under an unchanged vendor name"
+                )
+            bar_rows = conn.execute(
+                """
+                SELECT bar_date, close
+                FROM research_price_daily
+                WHERE series_id = %s AND close IS NOT NULL
+                ORDER BY bar_date
+                """,
+                (series_id,),
+            ).fetchall()
+            segments[role] = [(row[0], float(row[1])) for row in bar_rows]
+        chained = _chain_closes(segments["primary"], segments["fallback"])
+        return cls._classify([day for day, _ in chained], [close for _, close in chained], label="spy_chain_v1")
 
     def for_dates(self, dates: tuple[date, ...]) -> RegimeSeries:
         """The regime on each of ``dates``, ``None`` where the benchmark has no bar.
@@ -162,6 +343,13 @@ class MarketRegimeProvider:
 
 __all__ = [
     "BENCHMARK_SYMBOL",
+    "CHAIN_FALLBACK",
+    "CHAIN_FALLBACK_BASIS",
+    "CHAIN_MAX_SEAM_GAP_DAYS",
+    "CHAIN_PRIMARY",
+    "CHAIN_PRIMARY_BASIS",
+    "CHAIN_SEAM",
+    "RULE_SET_VERSION",
     "BenchmarkUnavailableError",
     "MarketRegimeProvider",
 ]

--- a/app/services/strategy_registry.py
+++ b/app/services/strategy_registry.py
@@ -43,6 +43,7 @@ from typing import Literal, Protocol, get_args
 
 from app.services.indicator_series import RULE_SET_VERSION as INDICATOR_SERIES_RULE_SET_VERSION
 from app.services.indicator_series import IndicatorSeries, MultiIndicatorSeries, Universe
+from app.services.market_regime_provider import RULE_SET_VERSION as BENCHMARK_SOURCE_RULE_SET_VERSION
 
 STRATEGY_SET_ID = "strategy-registry-v1"
 
@@ -84,6 +85,16 @@ def _module_hash() -> str:
 INPUT_RULE_SETS: Mapping[str, str] = MappingProxyType(
     {
         "indicator_series": INDICATOR_SERIES_RULE_SET_VERSION,
+        # ⚠ Not import-detectable by ``TestInputRuleSetsAreComplete``'s walk —
+        # strategies receive the regime as a constructed ``RegimeSeries``, they
+        # never import the provider — so this entry is maintained by hand and
+        # pinned by ``test_the_stored_mapping_is_the_hashed_one``. It names the
+        # benchmark SOURCE rules (live ``price_daily`` vs the backtest's
+        # ``spy_chain_v1`` research chain): switching the backtest source flips
+        # every pre-2023 bar of a regime-gated strategy from ``not_evaluable``
+        # to a real verdict, which is a changed input under an unchanged
+        # strategy_version unless it is hashed here.
+        "market_regime_provider": BENCHMARK_SOURCE_RULE_SET_VERSION,
     }
 )
 

--- a/docs/proposals/ta/2026-08-14-backtest-regime-benchmark-research-corpus.md
+++ b/docs/proposals/ta/2026-08-14-backtest-regime-benchmark-research-corpus.md
@@ -1,0 +1,153 @@
+# Backtest regime benchmark from the research corpus — the chained SPY series
+
+Narrows the gap `backtest_run.py::_signals_for` documents: the regime comes from
+`price_daily` (first SPY bar 2022-05-10) while the backtest axis reaches 1962, so every
+regime-gated strategy (S-5…S-10) is `not_evaluable` before ~2023-02 and §0's "per-year
+and per-regime, never pooled-only" blocks cannot be produced over more than ~3.4 years.
+The docstring names the fix: *"a benchmark series in the RESEARCH corpus — the same
+source the bars come from."* This document is that piece of work. Refs #2437.
+
+⚠ **Narrows, not closes**: SPY's inception is 1993-01-22, so 1962–1992 stays
+`not_evaluable` under any SPY-based rule. Classifying pre-1993 conditions would need a
+different benchmark (the S&P 500 index itself) and is out of scope — the regime rule
+(§1 of the S-5…S-10 spec) is defined on SPY.
+
+## Source rule
+
+There is no published formulation for splicing two vendor series into one benchmark.
+Per the repo rule for that case, the construction is fixed **by construction** and
+frozen in a version id — stated, not cited.
+
+**The chain (`spy_chain_v1`), two segments, one seam, all constants frozen:**
+
+| segment | series (pinned by `(vendor, vendor_symbol)`) | span used |
+| --- | --- | --- |
+| primary | `('etoro/etoro-comparators-2026-07-08-v1', 'SPY')` | every bar **on or after the frozen seam** (2022-05-10 → 2026-07-08 today) |
+| fallback | `('icyDenev/Intrader', 'SPY')` | every bar **strictly before the seam** (1993-01-29 → 2022-05-09 today) |
+
+- **The seam is a frozen constant, `date(2022, 5, 10)`** — the primary's first bar at
+  freeze time — not derived from live coverage. A corpus refresh that extends either
+  series cannot silently move the seam or redefine the chain (the loader *asserts* the
+  primary has a bar exactly on the seam and refuses otherwise).
+- One seam only. Per-date interleaving is rejected: a hole in one vendor would flip
+  vendors mid-window and create unbounded micro-seams. A hole in the primary after the
+  seam is **left as a hole**, never backfilled from the fallback.
+- The primary is the eToro comparator because it is **numerically identical to the live
+  scan's benchmark**: `close IS DISTINCT FROM` returns **0 rows** across all 1,018
+  dates shared with `price_daily` SPY (full population, exact comparison). The
+  backtest's recent-window regime therefore *is* the live regime.
+- The fallback (`unadjusted`, `yahoo_derivative`) and the primary (`split_adjusted`,
+  `etoro`) disagree by ~0.1–0.3% on their 585-date overlap (max $1.76, avg $0.66, full
+  population — different vendor close marks; SPY has no split history, which the
+  overlap agreement itself evidences). The seam step is therefore real and
+  **declared**: SMA-200 / BandWidth windows crossing 2022-05-10 mix the two marks. No
+  rescaling — a splice factor would be an invented transformation of source data. The
+  loader logs the seam step; no runtime tolerance gate, because any threshold would be
+  an invented constant — the one-time full-overlap measurement above is the evidence.
+- **Quarantine treatment, declared:** the chain reads `research_price_daily.close`
+  without consulting `research_bar_quarantine`. The regime is market context, not a
+  return computation; the quarantine's `return_usable` / `range_usable` verdicts do not
+  define "close usable". Verified on the full population: the only flagged rows on
+  either pinned series are 5 archive-tail `provisional` marks on the fallback
+  (2024-09-23→27, empty rule list, both usability flags true) — all **after** the seam
+  and therefore never read by the chain.
+
+### Runtime invariants (the loader refuses rather than degrades)
+
+1. Each pin resolves to exactly one series — `(vendor, vendor_symbol)` is DB-unique,
+   so this is belt-and-braces, kept because the refusal message is better than a
+   downstream shape error.
+2. Resolved metadata matches the frozen expectation: primary
+   `adjustment_basis = 'split_adjusted'`, fallback `= 'unadjusted'` — provenance drift
+   under an unchanged vendor name is refused.
+3. Primary has a bar exactly on the seam; fallback is non-empty and its last bar is
+   within **7 calendar days** before the seam (7 = the max intra-series gap measured on
+   both segments, i.e. a holiday week; a larger gap means a segment eroded).
+4. Chained dates strictly increasing and unique (guaranteed by construction; asserted
+   anyway).
+5. Every close finite and > 0.
+6. Both segment reads happen on one connection in one transaction snapshot.
+
+All refusals raise `BenchmarkUnavailableError` — same contract as `load`: a scan that
+silently produced an all-`None` regime would render an outage as a quiet market.
+
+## Identity treatment
+
+The pure classifier (`market_regime`, `REGIME_RULE_VERSION`) is untouched. What changes
+is **which closes feed it in the backtest**, and that changes verdicts — pre-2023 bars
+flip from `not_evaluable` to real verdicts — so it must move identity, or old and new
+result rows silently mix under one `result_version` (the exact defect
+`INPUT_RULE_SETS` / #2333 exists for).
+
+- `market_regime_provider` gains a declared frozen constant
+  `RULE_SET_VERSION = "benchmark-source-v1:live=price_daily_spy;research=spy_chain_v1"`
+  naming **both** source rules. A declared string, not a module hash — the provider's
+  own header freezes the design that fetch *mechanics* stay outside the hash; the
+  source *semantics* now join it. Changing either source rule bumps the string. The
+  chain's frozen constants (pins, seam, basis expectations) live beside it; the string
+  and the constants are one frozen block, and tests pin both so they cannot drift
+  apart silently.
+- `strategy_registry.INPUT_RULE_SETS` gains
+  `"market_regime_provider": RULE_SET_VERSION`. Consequences, both accepted:
+  **every strategy_version moves**, including S-1…S-4 which never read the regime —
+  that is the registry's own documented trade ("a strategy reading none of these still
+  moves with them... visibly stale instead of silently mixed"), taken knowingly three
+  times before, and the fleet is already scheduled to rewrite on the next scan after
+  S-10's registry move; and **a live-source bump also invalidates backtest rows** —
+  same over-invalidation direction, same acceptance.
+- No `ResultIdentity` schema change: `strategy_version` is already an identity member,
+  so stored backtest rows cannot collide with re-runs. The chain version is recorded
+  indirectly, exactly as every indicator rule set already is.
+- No content checksum of the bar population is added: the corpus is frozen by settled
+  policy, the primary carries `comparator_snapshot_id`, and the seam + metadata
+  asserts catch the mutations that would matter to the chain.
+
+## Mechanics
+
+- `MarketRegimeProvider.load_research(conn)` — new constructor. The date/close merge is
+  a **pure function** (`_chain_closes`) so the construction is unit-testable without a
+  database; `load_research` is fetch + invariants + the same classification path as
+  `load` (shared helper, so the two constructors cannot classify differently).
+- `backtest_run.py`'s two arm passes switch `MarketRegimeProvider.load(conn)` →
+  `load_research(conn)`. The live scan keeps `load` (price_daily) unchanged.
+- The `_signals_for` ⚠⚠ docstring block recording the 2022 ceiling is rewritten to
+  record the chain and the 1993 bound.
+
+## Tests
+
+- Update `test_strategy_registry.py`'s exact-mapping pin (line ~247) to the two-entry
+  mapping; keep the tamper-proof and completeness walks green.
+- New unit tests on the pure chain: fallback trimmed strictly before the seam; primary
+  hole after the seam stays a hole with a fallback bar available on that date; refusals
+  for missing seam bar / empty fallback / fallback short of the seam window /
+  non-finite close / duplicate date.
+- A constants pin: the frozen seam, pins and `RULE_SET_VERSION` string asserted
+  together, so an implementation edit cannot drift from the declared rule silently.
+- No new DB-tier test: the loader's SQL is two straight reads; dev-verify is the
+  full-population dry run recorded below, re-run against the merged code before the
+  backtest re-run.
+
+## Full-population verification (already run, dev DB)
+
+- Chained series: 8,391 bars, 1993-01-29 → 2026-07-08, seam 2022-05-10, dates unique
+  and ordered, both segments gap-free (max 7 calendar days).
+- Classifiable: 8,192 days, 1993-11-11 → 2026-07-08 — 34 calendar years. All four
+  regimes populated: bull_quiet 5,977, bear_quiet 1,910, bear_volatile 155,
+  bull_volatile 150.
+- **Strict-extension check: 0 disagreements** between the chained classification and
+  the live provider on all 819 dates the live provider can classify.
+
+## What this does NOT do
+
+- It does not run the walk-forward (queue item 6) — it makes item 6's per-year /
+  per-regime blocks producible. The backtest re-run is a follow-up invocation, not
+  part of this diff.
+- It does not touch the live scan's benchmark, `price_daily`, or any promotion gate.
+- It does not modify the frozen corpus — read-only consumer.
+- It does not resample, rescale or fill either vendor's closes.
+- It does not classify 1962–1992 (SPY inception bound, above).
+
+## Security model
+
+No security surface: read-only queries against two research tables already read by the
+same job, no user input, no new endpoint.

--- a/tests/test_market_regime_benchmark_chain.py
+++ b/tests/test_market_regime_benchmark_chain.py
@@ -1,0 +1,117 @@
+"""``spy_chain_v1`` — the backtest's chained SPY benchmark (#2437 walk-forward prereq).
+
+Covers the PURE half (``_chain_closes``) plus the frozen-constants pin. The
+fetch half (``load_research``) is two straight reads whose invariants
+(single-series pin, adjustment-basis match) are exercised against the dev DB by
+the full-population dry run recorded in the proposal doc, not by a DB-tier test
+— per the lean-test rule.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.services.market_regime_provider import (
+    CHAIN_FALLBACK,
+    CHAIN_FALLBACK_BASIS,
+    CHAIN_MAX_SEAM_GAP_DAYS,
+    CHAIN_PRIMARY,
+    CHAIN_PRIMARY_BASIS,
+    CHAIN_SEAM,
+    RULE_SET_VERSION,
+    BenchmarkUnavailableError,
+    _chain_closes,
+)
+
+SEAM = date(2022, 5, 10)
+
+
+def _bars(*days_closes: tuple[date, float]) -> list[tuple[date, float]]:
+    return list(days_closes)
+
+
+class TestTheFrozenConstantsCannotDriftSilently:
+    """The declared version string and the constants it describes are one
+    frozen block — an implementation edit that moves a constant without bumping
+    the string is exactly the silent redefinition the spec forbids."""
+
+    def test_the_frozen_block(self) -> None:
+        assert RULE_SET_VERSION == "benchmark-source-v1:live=price_daily_spy;research=spy_chain_v1"
+        assert CHAIN_PRIMARY == ("etoro/etoro-comparators-2026-07-08-v1", "SPY")
+        assert CHAIN_PRIMARY_BASIS == "split_adjusted"
+        assert CHAIN_FALLBACK == ("icyDenev/Intrader", "SPY")
+        assert CHAIN_FALLBACK_BASIS == "unadjusted"
+        assert CHAIN_SEAM == SEAM
+        assert CHAIN_MAX_SEAM_GAP_DAYS == 7
+
+
+class TestTheChainHasOneSeam:
+    def test_fallback_contributes_strictly_before_the_seam(self) -> None:
+        primary = _bars((SEAM, 400.0), (SEAM + timedelta(days=1), 401.0))
+        fallback = _bars(
+            (SEAM - timedelta(days=3), 300.0),
+            # A fallback bar ON the seam and one after it — both must be dropped,
+            # not merged: the primary owns the seam onward.
+            (SEAM, 999.0),
+            (SEAM + timedelta(days=1), 999.0),
+        )
+        chained = _chain_closes(primary, fallback, seam=SEAM)
+        assert chained == [
+            (SEAM - timedelta(days=3), 300.0),
+            (SEAM, 400.0),
+            (SEAM + timedelta(days=1), 401.0),
+        ]
+
+    def test_a_primary_hole_after_the_seam_stays_a_hole(self) -> None:
+        """⚠ The central invariant: no per-date interleaving. A vendor hole must
+        NOT flip the chain back to the fallback mid-window."""
+        hole = SEAM + timedelta(days=1)
+        primary = _bars((SEAM, 400.0), (SEAM + timedelta(days=2), 402.0))  # no bar on ``hole``
+        fallback = _bars((SEAM - timedelta(days=1), 300.0), (hole, 999.0))
+        chained = _chain_closes(primary, fallback, seam=SEAM)
+        assert hole not in [day for day, _ in chained]
+
+    def test_primary_bars_before_the_seam_are_dropped(self) -> None:
+        primary = _bars((SEAM - timedelta(days=1), 999.0), (SEAM, 400.0))
+        fallback = _bars((SEAM - timedelta(days=1), 300.0))
+        chained = _chain_closes(primary, fallback, seam=SEAM)
+        assert chained == [(SEAM - timedelta(days=1), 300.0), (SEAM, 400.0)]
+
+
+class TestTheChainRefusesRatherThanDegrades:
+    def test_no_primary_bar_on_the_seam(self) -> None:
+        primary = _bars((SEAM + timedelta(days=1), 400.0))
+        fallback = _bars((SEAM - timedelta(days=1), 300.0))
+        with pytest.raises(BenchmarkUnavailableError, match="no bar on the frozen seam"):
+            _chain_closes(primary, fallback, seam=SEAM)
+
+    def test_empty_fallback(self) -> None:
+        primary = _bars((SEAM, 400.0))
+        with pytest.raises(BenchmarkUnavailableError, match="no bars before the seam"):
+            _chain_closes(primary, [], seam=SEAM)
+
+    def test_fallback_short_of_the_seam_window(self) -> None:
+        primary = _bars((SEAM, 400.0))
+        fallback = _bars((SEAM - timedelta(days=CHAIN_MAX_SEAM_GAP_DAYS + 1), 300.0))
+        with pytest.raises(BenchmarkUnavailableError, match="eroded"):
+            _chain_closes(primary, fallback, seam=SEAM)
+
+    def test_a_holiday_week_gap_is_accepted(self) -> None:
+        primary = _bars((SEAM, 400.0))
+        fallback = _bars((SEAM - timedelta(days=CHAIN_MAX_SEAM_GAP_DAYS), 300.0))
+        assert len(_chain_closes(primary, fallback, seam=SEAM)) == 2
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), 0.0, -5.0])
+    def test_a_non_positive_or_non_finite_close_is_refused(self, bad: float) -> None:
+        primary = _bars((SEAM, 400.0), (SEAM + timedelta(days=1), bad))
+        fallback = _bars((SEAM - timedelta(days=1), 300.0))
+        with pytest.raises(BenchmarkUnavailableError, match="not a positive finite price"):
+            _chain_closes(primary, fallback, seam=SEAM)
+
+    def test_a_duplicate_date_is_refused(self) -> None:
+        primary = _bars((SEAM, 400.0), (SEAM, 400.5))
+        fallback = _bars((SEAM - timedelta(days=1), 300.0))
+        with pytest.raises(BenchmarkUnavailableError, match="strictly increasing"):
+            _chain_closes(primary, fallback, seam=SEAM)

--- a/tests/test_signal_ledger.py
+++ b/tests/test_signal_ledger.py
@@ -20,6 +20,7 @@ import pytest
 
 from app.services.indicator_series import RULE_SET_VERSION as INDICATOR_SERIES_RULE_SET_VERSION
 from app.services.indicator_series import BarSeries
+from app.services.market_regime_provider import RULE_SET_VERSION as BENCHMARK_SOURCE_RULE_SET_VERSION
 from app.services.signal_ledger import LedgerRow, resolve_fills
 from app.services.strategy_registry import StrategyIdentity, StrategySignal
 from app.services.technical_analysis import OHLCVRow
@@ -252,7 +253,10 @@ class TestBatchIntegrity:
         object is what stops the column disagreeing with the hash beside it."""
         rows = resolve_fills([_fired_at(0)], series=_series(_CONSECUTIVE), identity=_IDENTITY, instrument_id=7)
         assert rows[0].input_rule_set_versions == _IDENTITY.input_rule_set_versions
-        assert dict(rows[0].input_rule_set_versions) == {"indicator_series": INDICATOR_SERIES_RULE_SET_VERSION}
+        assert dict(rows[0].input_rule_set_versions) == {
+            "indicator_series": INDICATOR_SERIES_RULE_SET_VERSION,
+            "market_regime_provider": BENCHMARK_SOURCE_RULE_SET_VERSION,
+        }
 
 
 class TestLedgerRowRejects:

--- a/tests/test_strategy_registry.py
+++ b/tests/test_strategy_registry.py
@@ -21,6 +21,7 @@ from app.services.indicator_series import (
     IndicatorSeries,
     sma_series,
 )
+from app.services.market_regime_provider import RULE_SET_VERSION as BENCHMARK_SOURCE_RULE_SET_VERSION
 from app.services.strategy_registry import (
     INPUT_RULE_SETS,
     NOT_EVALUABLE_REASONS,
@@ -244,7 +245,10 @@ class TestIdentityCoversMoreThanSource:
         """The writer stores ``identity.input_rule_set_versions`` and the hash
         is built from the same object, so a disagreement is not expressible."""
         assert self._identity().input_rule_set_versions is strategy_registry.INPUT_RULE_SETS
-        assert dict(INPUT_RULE_SETS) == {"indicator_series": INDICATOR_SERIES_RULE_SET_VERSION}
+        assert dict(INPUT_RULE_SETS) == {
+            "indicator_series": INDICATOR_SERIES_RULE_SET_VERSION,
+            "market_regime_provider": BENCHMARK_SOURCE_RULE_SET_VERSION,
+        }
 
     def test_the_registry_constant_is_read_only(self) -> None:
         """A plain dict would let any importer mutate the identity of every


### PR DESCRIPTION
## What

The regime fed to backtests came from `price_daily` (first SPY bar 2022-05-10) while the backtest axis reaches 1962, so every regime-gated strategy (S-5..S-10) was `not_evaluable` before ~2023-02 and §0's "per-year and per-regime, never pooled-only" blocks could not be produced over more than ~3.4 years. `backtest_run.py::_signals_for`'s own docstring named the fix: a benchmark series in the RESEARCH corpus, the same source the bars come from. This PR is that piece of work — the named prerequisite for queue item 6 (walk-forward validation).

Spec: `docs/proposals/ta/2026-08-14-backtest-regime-benchmark-research-corpus.md` (in this diff; Codex ckpt-1 ran with 50 findings, all incorporated or rebutted in the revised spec).

## How

- **`spy_chain_v1`** — a frozen two-segment chained SPY close series, one seam:
  - primary `('etoro/etoro-comparators-2026-07-08-v1', 'SPY')` from the **frozen seam `2022-05-10`** (a declared constant, not derived from live coverage — a corpus refresh cannot silently move it). Chosen because it is numerically identical to the live scan's benchmark: `close IS DISTINCT FROM` returns 0 rows vs `price_daily` SPY across all 1,018 shared dates.
  - fallback `('icyDenev/Intrader', 'SPY')` strictly before the seam (1993-01-29 →). The ~0.3% vendor close-mark step at the seam is declared, not rescaled.
  - Loader refuses rather than degrades: pin resolution, `adjustment_basis` provenance match, seam-bar-present, fallback-reach, strictly-increasing dates, finite positive closes. Quarantine treatment declared (the only flagged rows on either series are 5 post-seam archive-tail provisional marks, never read).
- **Identity**: `market_regime_provider.RULE_SET_VERSION` (declared string naming both source rules) joins `strategy_registry.INPUT_RULE_SETS`, so every `strategy_version` moves — the registry's own documented over-invalidation trade, and the fleet was already scheduled to rewrite after S-10's registry move. Stored backtest rows cannot collide with re-runs (`strategy_version` is a `ResultIdentity` member). No schema change.
- **Both backtest arm passes** default to `load_research(conn)`; the live scan keeps `load` (`price_daily`) unchanged. Pure classifier untouched; classification path shared by both constructors so they cannot drift.

## Verification (dev DB, full population)

- Chained series: 8,391 bars, 1993-01-29 → 2026-07-08, seam 2022-05-10; both segments gap-free (max 7 calendar days).
- `load_research` classifies **8,192 days, 1993-11-11 → 2026-07-08** (34 calendar years): bull_quiet 5,977 / bear_quiet 1,910 / bear_volatile 155 / bull_volatile 150.
- **Strict-extension check: 0 disagreements** vs the live provider on all 819 dates the live provider can classify.
- 1962–1992 stays `not_evaluable` — SPY's own 1993-01-22 inception; recorded in the rewritten `_signals_for` docstring.

## Gates

- ruff / format / pyright / fast tier / smoke: green locally.
- db tier for touched modules (`test_backtest_run.py`, `test_2437_missing_market_context.py`, `test_2420_criterion6_zero_spread_guard.py`, `test_backtest_run_lock_scope.py`): green.
- Codex ckpt-2 (`codex exec review --base origin/main`, all files staged): no findings.
- No backtest re-run in this PR — that is queue item 6's invocation, deliberately separate.

## Security model

No security surface: read-only queries against two research tables already read by the same job, no user input, no new endpoint.

Refs #2437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
