### PR TITLE
feature(#2720): carry + FX structural closure — the second cost model

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -1248,6 +1248,27 @@ def load_corpus(
             f"{EVALUATION_WINDOW_START} -> {EVALUATION_WINDOW_END}"
         )
     universe = load_validated_universe(conn)
+    # ⚠ THE PER-RUN FX GATE (#2720). The cost model's ``fx_unmodelled = False``
+    # stamp rests on "no conversion event occurs", whose universe half is a
+    # MUTABLE table property — #2605's script asserts it full-population, but a
+    # later ``sync_universe`` could break it without moving the frozen
+    # ``COST_MODEL_ID``. So the run that stamps the flag re-asserts it on its
+    # own evaluated set, against the instrument's OWN quote currency rather
+    # than the ``exchanges.currency`` proxy, and refuses loudly rather than
+    # stamping a claim it did not check. NULL is a violation, not a pass.
+    non_usd = conn.execute(
+        "SELECT instrument_id, currency FROM instruments "
+        "WHERE instrument_id = ANY(%(ids)s) AND (currency IS NULL OR upper(currency) <> 'USD')",
+        {"ids": list(universe)},
+    ).fetchall()
+    if non_usd:
+        sample = ", ".join(f"{int(row[0])}={row[1]!r}" for row in non_usd[:5])
+        raise RuntimeError(
+            f"{len(non_usd)} validated-universe instruments are not USD-quoted ({sample}…) — the cost model "
+            f"({COST_MODEL_ID}) closes FX as structurally zero for an all-USD lane, so stamping "
+            "fx_unmodelled=false over a non-USD instrument would clear a promotion refusal the run did not "
+            "earn. Fix the universe or ship a cost model that prices conversion."
+        )
     bounds = {"ids": list(universe), "start": window.start, "end": window.end}
     axis = tuple(row[0] for row in conn.execute(_AXIS_SQL, bounds).fetchall())
     pairs = [(int(row[0]), int(row[1])) for row in conn.execute(_SERIES_SQL, {"ids": list(universe)}).fetchall()]

--- a/app/services/cost_model.py
+++ b/app/services/cost_model.py
@@ -31,8 +31,14 @@ return is computed from those adjusted prices, never by subtracting a cost from
 ``gross_return_pct``"* — ``sql/256`` names that column GROSS precisely so
 nothing averages it as performance.
 
-NOT charged: carry (eToro's overnight/weekend CFD fee) and FX. Both are
-``None``, not zero — see ``CARRY_BPS``.
+Carry and FX are STRUCTURALLY ZERO for the one lane this model prices —
+long, x1, ``real`` settlement, USD order, USD account, USD-quoted universe —
+because eToro's own product rule says no overnight/weekend fee exists on a
+non-leveraged underlying-asset BUY and no currency conversion event occurs on
+an all-USD path. See ``CARRY_CLOSURE`` / ``FX_CLOSURE``: a closure state, never
+a ``Decimal("0")`` pretending to be a measurement (#2720). Any OTHER lane —
+short, leveraged, CFD-resolved, non-USD — is UNPRICED, not free. Dividends and
+corporate-action cash remain outside the model as before: trade costs only.
 
 For an **as-traded** entry price the band is keyed on that entry and fixed for
 the life of the position. A split-adjusted research price cannot select a
@@ -54,7 +60,13 @@ from typing import Literal, get_args
 #: admits only quotes captured inside a real NYSE session, resolved from
 #: ``market_calendar`` rather than from a UTC-hour literal (see
 #: ``SESSION_RULE``).
-COST_MODEL_ID = "static-p75-insession-v2+split-adjusted-max"
+#:
+#: ⚠ v3 (#2720): carry and FX closed as structural zero for the declared lane,
+#: which the id now names. The band table, session rule and calibration figures
+#: are UNCHANGED from v2 — what changed is what the model claims about carry
+#: and FX, and the module rule (a change to what is charged is a new model)
+#: applies to a claim exactly as it does to a number.
+COST_MODEL_ID = "static-p75-insession-v3+split-adjusted-max+carry-fx-structural-zero-long-x1-real-usd"
 
 #: Whether a price can honestly select a nominal-price spread band.  The
 #: research corpus is split-adjusted, not as-traded; treating those two as the
@@ -90,10 +102,10 @@ SESSION_RULE = "NYSE regular session 09:30–16:00 ET (13:00 ET on a half day), 
 CALIBRATION_POPULATION = "§4.0 validated universe (app.services.strategies.validated_universe)"
 CALIBRATION_QUOTES_IN_SESSION = 1_159
 
-#: ⚠ FIVE LIMITS, EVERY ONE STILL LIVE — §5.1's four, with its fourth split in
-#: two by #2363 because carry and FX close on different evidence and one of them
-#: will be live while the other is not. They are constants rather than prose so
-#: stage 5c can put them on the result row.
+#: ⚠ SIX LIMITS, EVERY ONE STILL LIVE — §5.1's four, with its fourth split in
+#: two by #2363, and 4/5 REWRITTEN plus 6 ADDED by #2720 when carry and FX
+#: closed as structural zero for the declared lane. They are constants rather
+#: than prose so stage 5c can put them on the result row.
 #:
 #: 1. The sample is one hour of the day — 1,149 of the 1,159 in-session captures
 #:    sit at UTC hour 19 (15:00–15:59 ET), the session's final and most liquid
@@ -102,10 +114,11 @@ CALIBRATION_QUOTES_IN_SESSION = 1_159
 #:    universe, and the ``<$5`` band rests on 76 of them.
 #: 3. Those captures land on 9 distinct NY dates in one summer. Nothing here
 #:    observes a volatile regime.
-#: 4. Carry is NULL, not zero.
-#: 5. FX is NULL, not zero — and it is a SEPARATE limit, not a clause of 4:
-#:    carry closes on a per-order product eligibility proving underlying-at-x1,
-#:    FX on the funding account's currency and a measured conversion markup.
+#: 4. Carry is structurally zero FOR THE DECLARED LANE ONLY; any other lane is
+#:    unpriced, not free.
+#: 5. FX is structurally zero for the same lane, and the account-currency half
+#:    of it is measured on ONE account (the configured demo account).
+#: 6. Real-settlement fills are ASSUMED, not observed, in the backtest.
 #:
 #: ⚠ Every figure in this tuple is printed by ``--calibrate``. It is written
 #: down because 5c has to put it on a result row, and a hand-written statistic
@@ -116,92 +129,178 @@ CALIBRATION_LIMITS: tuple[str, ...] = (
     "one hour of the day — 1,149 of 1,159 in-session captures are at UTC hour 19 (15:00-15:59 ET)",
     "a sample — 1,159 in-session quotes against a 6,735-instrument universe; the <$5 band rests on 76",
     "9 distinct NY capture dates in one summer; no volatile regime is observed",
-    "carry is unmodelled (CARRY_BPS is None, not zero)",
-    "FX is unmodelled (FX_BPS is None, not zero)",
+    "carry is structurally zero for the declared lane ONLY (long x1 real-settlement USD); any other lane"
+    " — short, leveraged, CFD-resolved, non-USD — is UNPRICED, not free",
+    "FX is structurally zero for the same lane; the account currency is measured on the configured demo"
+    " account (account_equity_evidence), not proven for any other account",
+    "the backtest ASSUMES real-settlement fills: eToro resolves some non-leveraged buys as CFDs,"
+    " historical resolution is unobservable, and the order path closes this only forward"
+    " (settlementType is an assertion the platform rejects on mismatch)",
 )
 
-#: ⚠⚠ NULL, NOT ZERO, AND THE DIFFERENCE IS THE #2286 SHAPE — *"a value that is
-#: present and wrong beats a value that is absent and refused"*.
-#:
-#: Criterion 2 requires eToro's overnight/weekend CFD fee and FX conversion, and
-#: says their magnitude *"is not established here"*. The eToro portal is
-#: unreachable from this environment, so it is not established here either.
-#: Zero is a measurement nobody made. #2277 carries the standing re-check.
-#:
-#: ⚠ FX is NULL for a second, independent reason: §4.0 restricts the universe to
-#: ``us_equity``, which quotes in USD — but *"quotes in USD"* and *"needs no
-#: conversion"* coincide only if the ACCOUNT currency is USD, and that has not
-#: been verified.
-CARRY_BPS: Decimal | None = None
-FX_BPS: Decimal | None = None
+#: How a cost component is closed. ⚠ A CLOSED vocabulary, guarded at import:
+#: an unknown value would read as "not unmodelled" to the markers below and
+#: clear a promotion refusal while modelling nothing — #2286's shape arriving
+#: through a typo. A future measured nonzero fee (a CFD lane, a non-USD
+#: account) adds a "charged" member TOGETHER WITH the arithmetic that adds it
+#: to a price and a new ``COST_MODEL_ID`` — there is deliberately no dormant
+#: scalar to set (#2720 deleted ``CARRY_BPS`` / ``FX_BPS`` rather than zeroing
+#: them).
+CostComponentClosure = Literal["unmodelled", "structural_zero"]
+COST_COMPONENT_CLOSURES: frozenset[str] = frozenset(get_args(CostComponentClosure))
 
 
-#: ⚠ DERIVED, never hand-written. When carry is finally measured, setting
-#: ``CARRY_BPS`` flips this by itself — a hand-written ``True`` would have to be
-#: remembered, and §5.1 makes this marker the thing the promotion gate refuses
-#: on: *"statistics are computed and published with an explicit
-#: ``carry_unmodelled`` marker; they are not promotable"*.
+@dataclass(frozen=True)
+class CostLane:
+    """The ONE execution lane this model prices. INTRINSICALLY SINGLE-LANE.
+
+    ⚠ There is exactly one instance (``STRUCTURAL_ZERO_LANE``) and the model id
+    names it, so there is no per-component lane to diverge and no
+    lane-conditional marker state: a consumer outside the lane needs a
+    DIFFERENT cost model, which the identity hash makes a different strategy
+    version. The lane is pinned to the live order writer by test
+    (``tests/test_cost_model.py`` — the executor payload states its literals
+    independently; neither side imports the other's constant).
+    """
+
+    direction: str
+    leverage: int
+    settlement: str
+    order_currency: str
+    account_currency: str
+
+
+#: Matches, field for field, what ``EtoroBrokerProvider.place_demo_strategy_order``
+#: puts on the wire (``transaction: buy`` ⇔ long, ``leverage: 1``,
+#: ``settlementType: real``, ``orderCurrency: usd``) and what
+#: ``BrokerStrategyOrder`` refuses at type level (``settlement_type`` is
+#: ``Literal["real"]``). Held together by test, not by import.
+STRUCTURAL_ZERO_LANE = CostLane(
+    direction="long",
+    leverage=1,
+    settlement="real",
+    order_currency="USD",
+    account_currency="USD",
+)
+
+#: ⚠ The evidence a structural-zero claim stands on, DATED, one tuple per
+#: component because they close on unrelated facts (#2363). Leg 3 of the carry
+#: tuple is deliberately labelled consistent-only: an all-zero component has an
+#: undecodable unit (`.claude/skills/data-sources/etoro-api.md`), so it can
+#: fail to falsify the rule but can never be the rule.
+CARRY_EVIDENCE: tuple[str, ...] = (
+    "etoro.com/trading/fees — 'Overnight fee: Free' for non-leveraged stock/ETF BUYs; overnight/weekend"
+    " financing is a CFD property ('Short-selling orders and leveraged positions on stocks are executed as"
+    " CFDs and incur CFD spreads and overnight fees') (verified 2026-08-14)",
+    "api-portal.etoro.com create-an-order (OpenAPI v1.342.0) — settlementType 'is an assertion, not a"
+    " selector … a mismatch is rejected during execution'; the strategy order writer pins"
+    " settlementType='real', so an order in this lane holds the underlying or is rejected"
+    " (verified 2026-08-14)",
+    "what-if cost census — overnightFee 0.0 on every real-settlement buy observation (n=28);"
+    " CONSISTENT-ONLY, unit undecodable (skill §band-census, 2026-08-12/13)",
+)
+FX_EVIDENCE: tuple[str, ...] = (
+    "account_currency_id = 1 (USD) measured on account_equity_evidence for the configured demo account"
+    " (#2698, 2026-08-14)",
+    "validated universe uniformly USD-quoted — asserted full-population by"
+    " scripts/measure_2605_universe_scope.py (#2605) and re-asserted per run at the stamping site",
+    "order payload pins orderCurrency='usd'; DEPLOYMENT_CURRENCY='USD' enforced at the sql/290 + sql/338"
+    " CHECKs and the executor eligibility/cost currency checks (strategy_base_currency)",
+)
+
+#: ⚠⚠ STRUCTURAL ZERO IS A CLOSURE STATE, NEVER A ``Decimal("0")`` — *"a value
+#: that is present and wrong beats a value that is absent and refused"*
+#: (#2286). For the declared lane no overnight/weekend fee EXISTS (the position
+#: is the underlying, not a financing contract) and no conversion event OCCURS
+#: (USD in, USD held, USD out), so there is no amount to measure and writing
+#: zero would claim a measurement nobody made. #2277's standing re-check
+#: closes with this; the evidence tuples above are its record.
+CARRY_CLOSURE: CostComponentClosure = "structural_zero"
+FX_CLOSURE: CostComponentClosure = "structural_zero"
+
+
+#: ⚠ DERIVED, never hand-written — §5.1 makes these markers the thing the
+#: promotion gate refuses on: *"statistics are computed and published with an
+#: explicit ``carry_unmodelled`` marker; they are not promotable"*.
 #:
-#: ⚠⚠ #2363 NARROWED THIS. It used to be ``CARRY_BPS is None or FX_BPS is
-#: None`` — one flag for two components, so a stored ``True`` could not say
-#: which was missing and neither half could be banked when its evidence
-#: arrived. Promotion still requires BOTH clear; the split is diagnostic, not a
-#: relaxation.
-def unmodelled_markers(carry_bps: Decimal | None, fx_bps: Decimal | None) -> tuple[bool, bool]:
-    """``(carry_unmodelled, fx_unmodelled)`` — EACH FROM ITS OWN AMOUNT ONLY.
+#: ⚠⚠ #2363 NARROWED THIS to one flag per component; #2720 moved the inputs
+#: from bps amounts to closure states. Promotion semantics are unchanged: a
+#: ``True`` marker still hard-refuses via ``structural_promotion_refusals``.
+def unmodelled_markers(carry_closure: str, fx_closure: str) -> tuple[bool, bool]:
+    """``(carry_unmodelled, fx_unmodelled)`` — EACH FROM ITS OWN CLOSURE ONLY.
 
     ⚠⚠ A FUNCTION RATHER THAN TWO INLINE EXPRESSIONS, AND THE REASON IS A FAILED
-    REVERT-PROBE. Re-coupling the carry marker to FX — restoring the pre-#2363
-    ``CARRY_BPS is None or FX_BPS is None`` — changed the value of no test,
-    because both amounts are ``None`` today and the coupled and uncoupled
-    expressions are indistinguishable while that holds. The de-coupling this
-    ticket exists to deliver was therefore unguarded at the point it lives.
+    REVERT-PROBE (#2363): a re-coupled expression was indistinguishable while
+    both inputs held the same value. Taking the closures as ARGUMENTS keeps the
+    de-coupling observable — the test drives all four combinations.
 
-    Taking the amounts as ARGUMENTS is what makes it observable: the test drives
-    all four combinations, so a marker that consults the other component's
-    amount fails immediately rather than in whichever quarter one of them is
-    finally measured.
+    ⚠ An UNKNOWN closure value RAISES rather than defaulting: ``value ==
+    "unmodelled"`` alone would read a typo as "modelled", which clears a
+    promotion refusal while modelling nothing. Validation reads both arguments;
+    each MARKER still derives from its own argument only.
     """
-    return carry_bps is None, fx_bps is None
+    for name, value in (("carry", carry_closure), ("fx", fx_closure)):
+        if value not in COST_COMPONENT_CLOSURES:
+            raise ValueError(
+                f"unknown {name} closure {value!r}; must be one of {sorted(COST_COMPONENT_CLOSURES)} — "
+                "an unknown closure must never read as 'modelled'"
+            )
+    return carry_closure == "unmodelled", fx_closure == "unmodelled"
 
 
 #: The FX half is separate evidence, a separate owner and a separate arrival
 #: date — see the module docstring and #2363.
-CARRY_UNMODELLED, FX_UNMODELLED = unmodelled_markers(CARRY_BPS, FX_BPS)
+CARRY_UNMODELLED, FX_UNMODELLED = unmodelled_markers(CARRY_CLOSURE, FX_CLOSURE)
 
 
-def _check_unmodelled_components_are_not_charged() -> None:
-    """Neither component may carry an amount until something CHARGES it.
+def _check_closures() -> None:
+    """A structural-zero closure must carry its lane and its evidence.
 
-    ⚠⚠ THIS IS THE HOLE #2363's CODEX PASS FOUND, AND IT IS NOT HYPOTHETICAL.
-    ``CARRY_BPS`` and ``FX_BPS`` are referenced nowhere except the two flags
-    above, ``__all__``, and a test asserting they are ``None`` — no price, no
-    return and no equity mark has ever added either of them. So setting one to a
-    measured number would clear its promotion refusal *without charging the
-    cost*, and every result under that model would become promotable while
-    modelling exactly what it modelled the day before. That is #2286's shape
-    ("a value that is present and wrong beats a value that is absent and
-    refused") aimed straight at the gate.
+    Replaces ``_check_unmodelled_components_are_not_charged`` (#2363→#2720):
+    the bps scalars are deleted, so the clause naming them went with them —
+    which is the ticket's own step 4, performed by removing the subject rather
+    than waiving the guard. What still needs guarding at import:
 
-    The guard is at IMPORT for the reason ``_check_bands_are_total`` is: this is
-    an edit somebody makes to the literal above, so the check belongs beside the
-    literal rather than in a test file they may not run.
+    - the closure VALUES are in the vocabulary (an unknown value would clear a
+      refusal — the markers raise too, but this fires beside the literal, in
+      the import of whoever edited it);
+    - a ``structural_zero`` claim carries non-empty, dated evidence — a claim
+      with no record is ceremony;
+    - the single lane is unleveraged and long: leverage above x1 is a CFD and a
+      short accrues financing by construction (risk posture,
+      ``.claude/CLAUDE.md``), so EITHER edit needs a new model, not this one
+      relabelled.
 
-    ⚠ Removing this guard is part of the work of charging a component, not a
-    prerequisite to be waived: charge it in the position arithmetic, ship a new
-    ``COST_MODEL_ID`` (the module rule — a change to what is charged is a new
-    model, not a silent improvement), then delete the clause that names it here.
+    The guard is at IMPORT for the reason ``_check_bands_are_total`` is: these
+    are edits somebody makes to the literals above, so the check belongs beside
+    the literals rather than in a test file they may not run.
     """
-    charged_nowhere = [name for name, value in (("CARRY_BPS", CARRY_BPS), ("FX_BPS", FX_BPS)) if value is not None]
-    if charged_nowhere:
+    for name, closure, evidence in (
+        ("CARRY_CLOSURE", CARRY_CLOSURE, CARRY_EVIDENCE),
+        ("FX_CLOSURE", FX_CLOSURE, FX_EVIDENCE),
+    ):
+        if closure not in COST_COMPONENT_CLOSURES:
+            raise ValueError(
+                f"{name} = {closure!r} is not in the closure vocabulary {sorted(COST_COMPONENT_CLOSURES)} — "
+                "an unknown closure would read as 'not unmodelled' and clear a promotion refusal while "
+                "modelling nothing new (#2286's shape). Fix the literal or widen the vocabulary together "
+                "with the arithmetic and a new COST_MODEL_ID."
+            )
+        if closure == "structural_zero" and not evidence:
+            raise ValueError(
+                f"{name} claims structural_zero with no evidence — a structural claim with no dated record "
+                "is not a closure, it is the flag-clearing shortcut the promotion gate exists to refuse."
+            )
+    if STRUCTURAL_ZERO_LANE.leverage != 1 or STRUCTURAL_ZERO_LANE.direction != "long":
         raise ValueError(
-            f"{', '.join(charged_nowhere)} is set but nothing in this module adds it to a price — clearing the "
-            "promotion refusal without charging the cost would promote every result under this model while "
-            "modelling nothing new. Charge it in the position arithmetic and ship a new COST_MODEL_ID first."
+            f"the structural-zero lane must be long and unleveraged, got direction="
+            f"{STRUCTURAL_ZERO_LANE.direction!r} leverage={STRUCTURAL_ZERO_LANE.leverage} — a short is a CFD "
+            "and leverage above x1 is a CFD, both accrue financing by construction; that lane needs a NEW "
+            "cost model, never this one relabelled."
         )
 
 
-_check_unmodelled_components_are_not_charged()
+_check_closures()
 
 
 @dataclass(frozen=True)
@@ -405,11 +504,17 @@ __all__ = [
     "CALIBRATION_POPULATION",
     "CALIBRATION_QUOTES_IN_SESSION",
     "CALIBRATION_RUN_DATE",
-    "CARRY_BPS",
+    "CARRY_CLOSURE",
+    "CARRY_EVIDENCE",
     "CARRY_UNMODELLED",
+    "COST_COMPONENT_CLOSURES",
     "COST_MODEL_ID",
-    "FX_BPS",
+    "CostComponentClosure",
+    "CostLane",
+    "FX_CLOSURE",
+    "FX_EVIDENCE",
     "FX_UNMODELLED",
+    "STRUCTURAL_ZERO_LANE",
     "PRICE_BASES",
     "SESSION_RULE",
     "PriceBand",

--- a/app/services/position_costing.py
+++ b/app/services/position_costing.py
@@ -175,6 +175,14 @@ def cost_position(position: Position, *, price_basis: PriceBasis) -> CostedPosit
     ``price_basis`` is mandatory: nominal prices select their calibrated band;
     split-adjusted research prices cannot and receive the maximum band. The
     selected ``h`` goes to both sides and never re-keys during the position.
+
+    ⚠ LONG-ONLY BY ITS OWN ARITHMETIC, and that is the backtest half of the
+    cost model's declared lane (#2720): the entry is charged as ``buy_price``
+    and the exit as ``sell_price``, so a short — whose entry is a sale — cannot
+    pass through here meaningfully. The model's carry/FX structural-zero
+    closure holds for exactly this lane (``cost_model.STRUCTURAL_ZERO_LANE``);
+    a short is a CFD, accrues financing by construction, and needs a NEW cost
+    model plus its own costing arithmetic, never this function reused.
     """
     band = cost_band_for(position.entry_fill_price, price_basis=price_basis)
     half_spread = band.half_spread

--- a/app/services/result_ledger.py
+++ b/app/services/result_ledger.py
@@ -57,6 +57,7 @@ from typing import Final, Literal, NoReturn, cast, get_args
 import psycopg
 from psycopg.conninfo import conninfo_to_dict, make_conninfo
 
+from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, FX_UNMODELLED
 from app.services.deflated_sharpe import DeflatedSharpeResult
 from app.services.prereg_contract import (
     ForwardShadowFloor,
@@ -68,6 +69,7 @@ from app.services.prereg_contract import (
     supersession_refusals,
 )
 from app.services.random_entry_cohort import SyntheticControl
+from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_result import (
     PromotionRefusal,
     ResultIdentity,
@@ -1122,6 +1124,32 @@ def freeze_preregistration(conn: psycopg.Connection[tuple], declaration: PreregD
         raise PreregDeclarationRefused(
             declaration.strategy_id, declaration.strategy_version, tuple(str(code) for code in refusals)
         )
+    # ⚠ FREEZE-TIME ONLY, deliberately not in ``PreregDeclaration.__post_init__``:
+    # that class is also the read-back of stored rows, and rows frozen under an
+    # earlier cost model legitimately declare stamps today's constants do not
+    # produce. A NEW freeze of a MANIFEST strategy has no such licence — its
+    # runs go through ``backtest_run``, which stamps the ``cost_model`` module
+    # constants on every row, so a declaration that cannot match burns an
+    # immutable trial (sql/333 bars UPDATE and DELETE; sql/337 chains cost a
+    # supersession). Added by #2720, whose closure flipped both constants to
+    # False.
+    #
+    # ⚠ SCOPED TO THE MANIFEST on purpose: a bespoke contract trial (the #2582
+    # schedule-13D catalyst charges its own flat 50 bps and models no carry)
+    # OWNS its stamps — declaring ``True`` there is the honest state, not a
+    # stale copy of this module's, and refusing it would force a false
+    # "modelled" claim onto a run that charges no carry.
+    if declaration.strategy_id in STRATEGY_MANIFEST:
+        current = (CARRY_UNMODELLED, FX_UNMODELLED)
+        declared = (declaration.declared_carry_unmodelled, declaration.declared_fx_unmodelled)
+        if declared != current:
+            raise ValueError(
+                f"declaration for {declaration.strategy_id}@{declaration.strategy_version} declares "
+                f"(carry_unmodelled, fx_unmodelled) = {declared}, but the current cost model "
+                f"({COST_MODEL_ID}) stamps {current} on every manifest-strategy row — freezing it would "
+                "burn an immutable trial on stamps its run cannot produce. Re-derive the declaration "
+                "from the current cost_model constants."
+            )
     _lock_trial(conn, declaration.strategy_id, declaration.strategy_version)
     row = conn.execute(
         _FREEZE_DECLARATION,

--- a/app/services/strategy_result.py
+++ b/app/services/strategy_result.py
@@ -251,6 +251,8 @@ PromotionRefusal = Literal[
     #: absent; what the split buys is that an operator can act on the one that
     #: is actually blocking, and that whichever evidence lands first can be
     #: banked. Same argument as the `synthetic_control_*` trio below.
+    #: (#2720 closed both for the declared lane — new rows stamp false — but
+    #: the codes stay: every pre-#2720 row still carries true and refuses here.)
     "carry_unmodelled",
     "fx_unmodelled",
     "no_instruments_evaluated",

--- a/docs/proposals/ta/2026-08-14-carry-fx-structural-closure.md
+++ b/docs/proposals/ta/2026-08-14-carry-fx-structural-closure.md
@@ -1,0 +1,224 @@
+# Carry + FX structural closure — the second cost model (#2720)
+
+Parent: `docs/proposals/ta/2026-08-07-bounded-backtester.md` §5.1 (criterion 2's
+carry/FX requirement), #2698 root cause 2, #2277 (standing carry re-check),
+#2363 (the marker split this closes both halves of). Refs #2437.
+
+Codex ckpt-1 ran 2026-08-14 (50 findings); the design below is the post-ckpt-1
+revision. The decisive finding — "structural zero is stamped globally while lane
+membership is per-position" — is resolved by making the model **intrinsically
+single-lane** with the assumption declared as a limit on every result row, plus
+two mechanical gates (per-run USD assertion, freeze-time declaration
+validation).
+
+## What this closes, in one sentence
+
+`carry_unmodelled` and `fx_unmodelled` become `false` on rows produced under a
+new `COST_MODEL_ID`, because for the one execution lane this system trades —
+**long, x1, `real` settlement, USD order, USD demo account, USD-quoted
+universe** — eToro's own product rule says no overnight/weekend fee exists and
+no currency conversion event occurs. The closure is **structural zero for a
+declared lane**, not a measured bps written as `Decimal("0")`.
+
+## Source rule
+
+Per `.claude/skills/data-sources/etoro-api.md` (live-portal verification,
+WebFetch, never memory). All legs re-verified 2026-08-14:
+
+1. **eToro fees page (`etoro.com/trading/fees`, fetched 2026-08-14):** Stocks
+   and ETFs — *"Overnight fee: Free"* for non-leveraged BUY positions;
+   *"Short-selling orders and leveraged positions on stocks are executed as
+   CFDs and incur CFD spreads and overnight fees."* Overnight/weekend financing
+   is a CFD property; a non-leveraged BUY holds the underlying.
+   ⚠ The page's own trap: *"some non-leveraged BUY positions in stocks are also
+   executed as CFDs"* — closed for the ORDER PATH by leg 2, and declared as a
+   backtest LIMIT below (the backtest cannot observe historical settlement
+   resolution).
+2. **API portal `trading--demo/create-an-order` (OpenAPI v1.342.0, fetched
+   2026-08-14):** `settlementType` *"when supplied it is an assertion, not a
+   selector: it must equal the settlement type the platform resolves, and a
+   mismatch is rejected during execution."* Our strategy order writer pins
+   `"settlementType": "real"` in the payload
+   (`app/providers/implementations/etoro_broker.py:356`), so an order in this
+   lane either holds the underlying or is REJECTED — it can never silently
+   execute as a CFD.
+3. **What-if cost endpoint (measured, skill §band-census, n=28 across the
+   2026-08-12/13 censuses):** `overnightFee` reads `0.0` on every
+   `real`-settlement buy observation. ⚠ CONSISTENT WITH the rule and NOT the
+   evidence for it — an all-zero component has an undecodable unit (the skill
+   says so in bold). The rule is leg 1 + leg 2; this leg only fails to falsify.
+4. **FX — three measured facts, one per denomination site:**
+   - account: `account_currency_id = 1` (USD), measured on
+     `account_equity_evidence` for the configured DEMO account (#2698). The
+     claim is scoped to that account — see limits.
+   - universe: uniformly USD-quoted, asserted by
+     `scripts/measure_2605_universe_scope.py` (settled decision #2605) — and,
+     new in this change, re-asserted PER RUN at the stamping site (below),
+     because a frozen model id cannot police a mutable universe table.
+   - order: `"orderCurrency": "usd"` pinned in the same payload as leg 2, and
+     `strategy_base_currency.DEPLOYMENT_CURRENCY = "USD"` enforced at the DB
+     CHECKs (sql/290, sql/338) and the executor eligibility + cost-currency
+     checks (`strategy_paper_executor.py:555/:593`).
+   USD in, USD held, USD out: no conversion event exists to charge.
+
+## Design
+
+### 1. `cost_model.py` — closure vocabulary replaces the bps scalars
+
+```python
+CostComponentClosure = Literal["unmodelled", "structural_zero"]
+
+CARRY_CLOSURE: CostComponentClosure = "structural_zero"
+FX_CLOSURE: CostComponentClosure = "structural_zero"
+
+@dataclass(frozen=True)
+class CostLane:
+    direction: str        # "long"
+    leverage: int         # 1
+    settlement: str       # "real"
+    order_currency: str   # "USD"
+    account_currency: str # "USD"
+
+STRUCTURAL_ZERO_LANE = CostLane("long", 1, "real", "USD", "USD")
+```
+
+- **The model is intrinsically single-lane.** There is exactly ONE lane object;
+  both closures are closures *of this model*, whose id names the lane. There is
+  no per-component lane to diverge (ckpt-1 #22), and no lane-conditional marker
+  state (#23/#24): a consumer outside the lane needs a different cost model,
+  which the identity hash makes a different strategy version.
+- `CARRY_BPS` / `FX_BPS` are DELETED, not set to zero. A future measured
+  nonzero fee (a CFD lane, a non-USD account) reintroduces a charged amount
+  together with the arithmetic that adds it and a new model id — the #2286
+  shape stays impossible because there is no dormant scalar to set.
+- `unmodelled_markers(carry_closure, fx_closure)` keeps its #2363 contract:
+  each marker from its own argument ONLY (`closure == "unmodelled"`), test
+  drives all four combinations.
+- Import guard `_check_unmodelled_components_are_not_charged` is REPLACED by
+  `_check_closures()`: closure values in vocabulary; any `structural_zero`
+  requires THE single frozen lane and a non-empty, dated evidence tuple (each
+  entry `"<source> — <fact> (verified YYYY-MM-DD)"`). Ticket step 4 (remove the
+  clause naming the charged component) is subsumed: the clause's subject no
+  longer exists.
+- `CALIBRATION_LIMITS` — items 4/5 rewritten and one added, so every result row
+  keeps carrying the honest limits:
+  4. carry is structurally zero FOR THE DECLARED LANE ONLY (long x1 real USD);
+     any other lane — short, leveraged, CFD, non-USD — is UNPRICED, not free;
+  5. FX is structurally zero for the same lane; account currency is measured on
+     the configured demo account, not proven for any other account;
+  6. the backtest ASSUMES real-settlement fills: eToro resolves some
+     non-leveraged buys as CFDs, historical resolution is unobservable, and the
+     order path closes this only forward (settlementType is an assertion the
+     platform rejects on mismatch).
+- New id:
+  `COST_MODEL_ID = "static-p75-insession-v3+split-adjusted-max+carry-fx-structural-zero-long-x1-real-usd"`.
+  Band table, session rule, calibration figures: UNCHANGED. Charged remains
+  trade costs only — dividends and corporate-action cash are outside this model
+  as before.
+
+### 2. The charge (ticket step 2) — lane enforcement, not a zero added to a price
+
+For a structural-zero component the charged amount is identically zero for
+in-lane positions, so adding `+ 0` to `buy_price` would be theatre. What is
+real:
+
+- **Per-run FX gate at the stamping site.** `backtest_run`'s universe/corpus
+  load asserts `instruments.currency = 'USD'` for every evaluated instrument
+  and REFUSES THE RUN on violation — the instrument's own quote currency, not
+  the `exchanges.currency` proxy, checked at run time rather than trusted from
+  a frozen id (ckpt-1 #29/#30).
+- **Freeze-time declaration validation.** `freeze_preregistration` validates
+  `declared_carry_unmodelled == cost_model.CARRY_UNMODELLED` (and FX) before
+  any write: a declaration is a prediction of what its run will stamp, and
+  freezing one that cannot match burns an immutable trial (ckpt-1
+  #40/#42/#45). ⚠ SCOPED TO `STRATEGY_MANIFEST` ids — a bespoke contract trial
+  (#2582's 13D catalyst charges its own flat 50 bps, models no carry) OWNS its
+  stamps and honestly declares `True`; and NOT in
+  `PreregDeclaration.__post_init__`, which is also the read-back of stored
+  rows frozen under the earlier model.
+- **Lane pinned to the executor by non-tautological test.** Capture the body
+  built by `EtoroBrokerProvider.place_demo_strategy_order` via a fake transport
+  and assert `settlementType/leverage/transaction/orderCurrency` equal the lane
+  fields — each side states its literals independently (the "#2240 phase 5c"
+  tautology entry, `docs/review-prevention-log.md`). A future short/leveraged/
+  non-USD executor change fails THIS test, naming the cost model as the thing
+  that must move with it. Plus lane `account_currency ==
+  strategy_base_currency.DEPLOYMENT_CURRENCY` (literal vs literal).
+- `position_costing.cost_position` is long-only BY ITS OWN ARITHMETIC (entry
+  charged as `buy_price`, exit as `sell_price`) — stated in its docstring as
+  the backtest half of the lane. The research ledgers that do price shorts
+  (`pead_outcomes`, `insider_purchase_outcomes`) consume ONLY the spread
+  functions and stamp no cost-model identity and no carry/fx flags (verified
+  2026-08-14, grep); the insider preregistration script hard-codes its
+  unmodelled stamps and a test pins that it keeps them (ckpt-1 #12/#50).
+
+### 3. What flows downstream, without edits
+
+- `backtest_run.py:2340` stamps `CARRY_UNMODELLED`/`FX_UNMODELLED` per row —
+  both now `False`. No stamping-code change.
+- `structural_promotion_refusals` UNCHANGED; `STRUCTURAL_REFUSAL_POLICY_VERSION`
+  NOT bumped: the rule ("refuse if the row says unmodelled") did not change;
+  the stamps rows will carry did. (Ckpt-1 #38 agrees; #39's counterpoint is
+  answered by the id move: audits distinguish the regimes by `cost_model_id`,
+  which is on every row and in every strategy version.)
+- New `COST_MODEL_ID` → `StrategyIdentity` hash → **every strategy version
+  moves** (third move of 2026-08-14). Pending fleet-ledger rewrite covers it.
+
+### 4. Deletion-break inventory (all updated in this PR)
+
+- `scripts/verify_2240_cost_model.py:80` — imports/prints both bps constants.
+- `tests/test_cost_model.py:25` — imports them; mutation/import-guard probes
+  tied to their source text.
+- `scripts/probe_2240_cost_model.py:246` — literal source substitutions against
+  their declarations.
+- `sql/262_strategy_results.sql`, `sql/335_strategy_result_fx_unmodelled.sql` —
+  column COMMENTs define the flags via `CARRY_BPS is None`; corrected via a
+  small idempotent `COMMENT ON` migration (never by editing applied files).
+- Any doc/docstring describing the standing model through `CARRY_BPS is None`
+  (grep at implementation time).
+
+## What this deliberately does NOT do
+
+1. Does NOT price any short, leveraged, CFD or non-USD lane — UNPRICED (a
+   refusal), not free. A short is a CFD and accrues financing by construction
+   (risk-posture note, `.claude/CLAUDE.md`); its cost model is new work.
+2. Does NOT make any stored row promotable: existing rows keep their immutable
+   `carry_unmodelled = true` stamps, and `universe_basis = 'survivor_only'`
+   still hard-refuses everything until #2721.
+3. Does NOT bump `STRUCTURAL_REFUSAL_POLICY_VERSION`, does NOT touch existing
+   declarations. Declarations frozen pre-merge under old strategy_versions stay
+   consistent with rows produced under old code; post-merge runs need fresh
+   declarations under the moved versions, which the new freeze-time validation
+   forces to declare both flags `False` (#2599 gate itself unchanged).
+   ⚠ Coordination: the sibling session working #2437 item 6 is declaring
+   S-5..S-10 trials — a warning comment goes on #2437 BEFORE this merges.
+4. Does NOT re-run any backtest and does NOT write any DB row (the migration
+   updates COMMENT metadata only).
+5. Does NOT claim settlement-resolution proof for historical fills or for the
+   full instrument population — declared as limit 6 and closed forward by the
+   order path (ckpt-1 #2/#3/#25/#26/#27: accepted as limits, not solved).
+
+## Full-population verification
+
+- FX universe leg: `measure_2605_universe_scope.py` asserts USD-uniformity over
+  the ENTIRE validated universe at run time; additionally the new per-run gate
+  re-asserts it on every backtest's own evaluated set. Both recorded in the PR
+  evidence table.
+- Lane pin: the executor payload is one construction site
+  (`etoro_broker.py:352-364`), grep-verified; `BrokerStrategyOrder` refuses
+  `settlement_type != "real"` at type level (`app/providers/broker.py:152`).
+
+## Ckpt-1 findings NOT actioned, with reasons
+
+- #46 (prove every registered strategy long-only): no direction field exists to
+  introspect; long-only is the §3 fill contract (every entry is a buy), and the
+  costing arithmetic enforces it at the only place a position is priced.
+- #19 (out-of-tree `__all__` consumers): none exist; single-repo codebase.
+- #13 (reconcile live what-if cost basis with the backtest model): the executor
+  order-time cost validation is a separate, unchanged contract.
+- #35 (`orderCurrency` semantics): supplementary to the primary FX facts
+  (instrument quotes USD + account USD); not load-bearing.
+- #36 (dividends/corporate-action cash): outside the model's charged scope
+  before and after this change — stated in §1.
+- #47 (per-instrument real-arm eligibility over the whole universe): subsumed
+  by limit 6; unobservable historically, enforced forward per order.

--- a/scripts/probe_2240_cost_model.py
+++ b/scripts/probe_2240_cost_model.py
@@ -107,8 +107,9 @@ PROBES: list[tuple[str, Path, str, list[tuple[str, str]], str]] = [
         MODEL_TESTS,
         [
             (
-                'COST_MODEL_ID = "static-p75-insession-v2+split-adjusted-max"',
-                'COST_MODEL_ID = "static-p75-v3"',
+                'COST_MODEL_ID = "static-p75-insession-v3+split-adjusted-max'
+                '+carry-fx-structural-zero-long-x1-real-usd"',
+                'COST_MODEL_ID = "static-p75-v4"',
             )
         ],
         "test_the_cost_model_id_is_the_frozen_one",
@@ -215,49 +216,42 @@ PROBES: list[tuple[str, Path, str, list[tuple[str, str]], str]] = [
         "test_a_half_spread_at_or_above_one_is_rejected",
     ),
     (
-        # ⚠ #2286's shape, injected: a value that is PRESENT and wrong. Setting
-        # carry to zero also flips CARRY_UNMODELLED, which is what the promotion
-        # gate refuses on — so this one defect quietly promotes every result.
-        # ⚠⚠ A COMPOUND COUNTERFACTUAL, AND THE NAME SAYS SO (#2695, after Codex
-        # called the first wording — "not a weakening" — wrong at mutation
-        # level). #2363 added `_check_unmodelled_components_are_not_charged()` at
-        # MODULE level after this probe was written, so setting `CARRY_BPS` to
-        # zero now raises during import: conftest never loads and pytest exits 4,
-        # which the harness rightly declines to read as CAUGHT because no test
-        # evaluated anything.
-        #
-        # In PRODUCTION the defect is caught at import, and that is the real
-        # defence. This probe therefore no longer reverts one shipped defect — it
-        # removes an independent guard AND injects the value, to answer the
-        # narrower question the harness can still answer: do the two shipped-state
-        # assertions observe zero carry once the stronger guard is out of the way.
-        # ⚠ The guard's own REFUSAL is proved directly by
-        # `test_a_component_may_not_carry_an_amount_that_nothing_charges`; the
-        # presence of its module-level INVOCATION is not, and that gap is
-        # recorded in WHAT IS NOT PROBED above.
-        #
-        # ⚠ Found by running the harness, not by the anchor audit — the anchor was
-        # intact the whole time. That is #2695's third decay class.
-        "the shipped-state carry assertions blind to zero carry (import guard removed to reach them)",
+        # ⚠⚠ #2286's shape in its #2720 form: an unknown closure value would read
+        # as "modelled" and clear a promotion refusal while modelling nothing.
+        # Two independent gates hold it — the marker function's own validation
+        # (which the derivation line runs at import) and `_check_closures()` —
+        # so this probes the MARKER validation: with the loop deleted, an
+        # unknown closure derives (False, False) silently.
+        "the marker vocabulary validation deleted (an unknown closure reads as modelled)",
         MODEL,
         MODEL_TESTS,
         [
-            ("\n_check_unmodelled_components_are_not_charged()\n", "\n"),
-            ("CARRY_BPS: Decimal | None = None", 'CARRY_BPS: Decimal | None = Decimal("0")'),
+            (
+                '    for name, value in (("carry", carry_closure), ("fx", fx_closure)):\n'
+                "        if value not in COST_COMPONENT_CLOSURES:\n"
+                "            raise ValueError(\n"
+                '                f"unknown {name} closure {value!r}; must be one of '
+                '{sorted(COST_COMPONENT_CLOSURES)} — "\n'
+                "                \"an unknown closure must never read as 'modelled'\"\n"
+                "            )\n",
+                "",
+            )
         ],
-        "test_carry_is_none or test_the_unmodelled_marker_is_set",
+        "test_an_unknown_closure_is_refused_by_the_markers",
     ),
     (
         # ⚠⚠ THE INVOCATION ITSELF, probeable since #2699. Deleting this one line
         # leaves the guard defined, imported and directly testable — and never run.
-        # A guard that no longer runs is the #2437 R4 shape arriving through a
-        # missing CALL rather than a missing branch, and it was invisible for the
-        # ordinary reason: every test reached the function by calling it.
-        "the module-level call to the false-promotion tripwire deleted",
+        # ⚠ #2720: the markers validate the closure VOCABULARY independently, so
+        # the observable loss when this call goes is the LANE and EVIDENCE half —
+        # a short/leveraged lane or an evidence-free structural claim imports
+        # silently. The selectors are the subprocess tests that mutate exactly
+        # those literals and expect the import to fail.
+        "the module-level call to the closure guard deleted",
         MODEL,
         MODEL_TESTS,
-        [("\n_check_unmodelled_components_are_not_charged()\n", "\n")],
-        "test_setting_carry_bps_fails_the_import_itself or test_setting_fx_bps_fails_the_import_itself",
+        [("\n_check_closures()\n", "\n")],
+        "test_a_short_lane_fails_the_import_itself or test_empty_carry_evidence_fails_the_import_itself",
     ),
     (
         # ⚠ The SAME asymmetry, found while closing #2699 rather than stated by it:

--- a/scripts/verify_2240_cost_model.py
+++ b/scripts/verify_2240_cost_model.py
@@ -77,12 +77,13 @@ from app.services.cost_model import (
     BANDS,
     CALIBRATION_QUOTES_IN_SESSION,
     CALIBRATION_RUN_DATE,
-    CARRY_BPS,
+    CARRY_CLOSURE,
     CARRY_UNMODELLED,
     COST_MODEL_ID,
-    FX_BPS,
+    FX_CLOSURE,
     FX_UNMODELLED,
     SESSION_RULE,
+    STRUCTURAL_ZERO_LANE,
     UNKNOWN_NOMINAL_PRICE_BAND,
     _check_bands_are_total,
     band_for,
@@ -317,8 +318,9 @@ def calibrate() -> int:
     _report_bounding_statistics(by_band, top_hour=top_hour, top_count=top_count)
 
     print(
-        f"\n  carry_bps {CARRY_BPS}   fx_bps {FX_BPS}   "
-        f"carry_unmodelled {CARRY_UNMODELLED}   fx_unmodelled {FX_UNMODELLED}"
+        f"\n  carry_closure {CARRY_CLOSURE}   fx_closure {FX_CLOSURE}   "
+        f"carry_unmodelled {CARRY_UNMODELLED}   fx_unmodelled {FX_UNMODELLED}   "
+        f"lane {STRUCTURAL_ZERO_LANE}"
     )
     print(f"  problems: {len(problems)}")
     for problem in problems:

--- a/sql/352_carry_fx_structural_closure_comments.sql
+++ b/sql/352_carry_fx_structural_closure_comments.sql
@@ -21,6 +21,14 @@ COMMENT ON COLUMN strategy_results.carry_unmodelled IS
     're-derived: rows computed under an earlier model stay unpromotable. The '
     'promotion gate refuses on it (§5.1).';
 
+COMMENT ON COLUMN strategy_results.fx_unmodelled IS
+    'True when the run''s cost model left FX unmodelled '
+    '(cost_model.FX_CLOSURE = unmodelled). False from #2720''s v3 model on: FX '
+    'is STRUCTURALLY ZERO for the all-USD lane — no conversion event occurs. '
+    '⚠ This column carried NO comment before #2720 (sql/335 commented only the '
+    'store table); added here for symmetry. Stamped AS AT COMPUTE TIME and '
+    'never re-derived.';
+
 COMMENT ON COLUMN strategy_results_store.carry_unmodelled IS
     'True when the run''s cost model left carry unmodelled '
     '(cost_model.CARRY_CLOSURE = unmodelled). False from #2720''s v3 model on: '

--- a/sql/352_carry_fx_structural_closure_comments.sql
+++ b/sql/352_carry_fx_structural_closure_comments.sql
@@ -1,0 +1,41 @@
+-- 352_carry_fx_structural_closure_comments.sql
+--
+-- #2720: carry + FX closed as structural zero for the declared lane; the
+-- second cost model (static-p75-insession-v3+…+carry-fx-structural-zero-long-
+-- x1-real-usd). COMMENT-ONLY — no schema or data change. The prior comments
+-- defined the flags via cost_model.CARRY_BPS / FX_BPS, which #2720 DELETED
+-- (never zeroed), so left standing they would describe constants that do not
+-- exist. Spec: docs/proposals/ta/2026-08-14-carry-fx-structural-closure.md.
+--
+-- ⚠ Applied migrations are never edited; comment drift is corrected by a new
+-- idempotent migration, which COMMENT ON is by construction.
+
+BEGIN;
+
+COMMENT ON COLUMN strategy_results.carry_unmodelled IS
+    'True when the run''s cost model left carry unmodelled '
+    '(cost_model.CARRY_CLOSURE = unmodelled). False from #2720''s v3 model on: '
+    'carry is STRUCTURALLY ZERO for the declared lane (long x1 real-settlement '
+    'USD — the position is the underlying, no financing leg exists); any other '
+    'lane is unpriced, not free. ⚠ Stamped AS AT COMPUTE TIME and never '
+    're-derived: rows computed under an earlier model stay unpromotable. The '
+    'promotion gate refuses on it (§5.1).';
+
+COMMENT ON COLUMN strategy_results_store.carry_unmodelled IS
+    'True when the run''s cost model left carry unmodelled '
+    '(cost_model.CARRY_CLOSURE = unmodelled). False from #2720''s v3 model on: '
+    'carry is STRUCTURALLY ZERO for the declared lane (long x1 real-settlement '
+    'USD). ⚠ NARROWED by #2363 (FX has its own column; promotion requires BOTH '
+    'false). ⚠ Stamped AS AT COMPUTE TIME and never re-derived.';
+
+COMMENT ON COLUMN strategy_results_store.fx_unmodelled IS
+    'True when the run''s cost model left FX unmodelled '
+    '(cost_model.FX_CLOSURE = unmodelled). False from #2720''s v3 model on: FX '
+    'is STRUCTURALLY ZERO for the all-USD lane (USD account measured on '
+    'account_equity_evidence, USD-quoted universe re-asserted per run in '
+    'load_corpus, USD orders) — no conversion event occurs. ⚠ Stamped AS AT '
+    'COMPUTE TIME and never re-derived, for the reason carry_unmodelled is: a '
+    'gate reading today''s module constant would silently promote a row that '
+    'never charged it.';
+
+COMMIT;

--- a/tests/test_2720_freeze_stamp_validation.py
+++ b/tests/test_2720_freeze_stamp_validation.py
@@ -1,0 +1,121 @@
+"""#2720 — freeze-time validation of declared cost stamps, as pure logic.
+
+A frozen declaration is a PREDICTION of the stamps its run will produce. For a
+MANIFEST strategy the run is ``backtest_run``, which stamps the ``cost_model``
+module constants — so a mismatching declaration must be refused AT FREEZE, the
+only time refusing is cheap (``sql/333`` makes the row immutable). A bespoke
+contract trial (the #2582 schedule-13D catalyst charges its own flat 50 bps)
+OWNS its stamps and is exempt.
+
+Deliberately NOT in ``PreregDeclaration.__post_init__``: that class is also the
+read-back of stored rows, and rows frozen under an earlier cost model
+legitimately declare stamps today's constants do not produce.
+
+⚠ DB-free by design: the validation fires before ``freeze_preregistration``
+touches its connection, which is what these tests lean on.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest import mock
+
+import pytest
+
+from app.services.cost_model import CARRY_UNMODELLED, FX_UNMODELLED
+from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
+from app.services.result_ledger import freeze_preregistration
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION
+
+#: A real manifest id — the check is scoped to the manifest, so the fixture
+#: must sit inside it for the refusal arm to be reachable.
+_MANIFEST_ID = "s1-time-series-momentum"
+
+
+def _declaration(**overrides: object) -> PreregDeclaration:
+    base: dict[str, object] = {
+        "strategy_id": _MANIFEST_ID,
+        "strategy_version": "strategy-registry-v1+abc123",
+        "contract_version": "test-contract-v1",
+        "prereg_purpose": "falsification_only",
+        "structural_refusal_policy_version": STRUCTURAL_REFUSAL_POLICY_VERSION,
+        "declared_universe_basis": "survivor_only",
+        "declared_carry_unmodelled": CARRY_UNMODELLED,
+        "declared_fx_unmodelled": FX_UNMODELLED,
+        "expected_structural_refusals": ("universe_basis_not_survivorship_free",),
+        "forward_shadow": ForwardShadowFloor(
+            min_independent_decision_dates=40,
+            min_calendar_weeks=12,
+            derivation="planning power calculation, candidate contract §statistics",
+        ),
+        "declared_by": "tests/test_2720_freeze_stamp_validation.py",
+    }
+    base.update(overrides)
+    return PreregDeclaration(**base)  # type: ignore[arg-type]
+
+
+_STALE = {
+    "declared_carry_unmodelled": True,
+    "declared_fx_unmodelled": True,
+    "expected_structural_refusals": (
+        "universe_basis_not_survivorship_free",
+        "carry_unmodelled",
+        "fx_unmodelled",
+    ),
+}
+
+
+def test_the_premises_hold() -> None:
+    """Stated so a failure names #2720 (or a manifest rename) rather than a
+    mysterious coherence mismatch in the fixtures below."""
+    assert (CARRY_UNMODELLED, FX_UNMODELLED) == (False, False)
+    assert _MANIFEST_ID in STRATEGY_MANIFEST
+
+
+def test_a_manifest_declaration_of_stale_stamps_is_refused_before_any_write() -> None:
+    """Declaring ``True`` under a model that stamps ``False`` would burn an
+    immutable trial (sql/333 bars UPDATE and DELETE). ⚠ ``conn=None`` is the
+    proof the refusal happens before the connection is touched."""
+    with pytest.raises(ValueError, match="stamps its run cannot produce"):
+        freeze_preregistration(cast(Any, None), _declaration(**_STALE))
+
+
+@pytest.mark.parametrize("field", ["declared_carry_unmodelled", "declared_fx_unmodelled"])
+def test_one_stale_stamp_is_enough(field: str) -> None:
+    """Either half alone mis-predicts the run; the pair is checked whole.
+
+    ⚠ ``expected_structural_refusals`` is kept CONSISTENT with the mutated
+    stamp, so ``declaration_refusals`` passes and the stamp check is the ONLY
+    thing refusing — otherwise this would re-test coherence, not #2720."""
+    refusal = "carry_unmodelled" if field == "declared_carry_unmodelled" else "fx_unmodelled"
+    stale = _declaration(
+        **{field: True},
+        expected_structural_refusals=("universe_basis_not_survivorship_free", refusal),
+    )
+    with pytest.raises(ValueError, match="stamps its run cannot produce"):
+        freeze_preregistration(cast(Any, None), stale)
+
+
+def test_a_current_stamp_declaration_reaches_the_lock() -> None:
+    """The pass side: matching stamps proceed past the check to the trial lock
+    (the first connection touch), where a sentinel proves the order."""
+    sentinel = RuntimeError("reached-the-lock")
+    conn = mock.MagicMock()
+    conn.execute.side_effect = sentinel
+    with pytest.raises(RuntimeError, match="reached-the-lock"):
+        freeze_preregistration(cast(Any, conn), _declaration())
+
+
+def test_a_bespoke_trial_keeps_owning_its_stamps() -> None:
+    """⚠ THE SCOPE, not a loophole: a non-manifest contract trial (#2582's
+    schedule-13D catalyst charges its own flat 50 bps and models no carry)
+    honestly declares ``True`` — refusing it would force a false "modelled"
+    claim onto a run that charges no carry. It must reach the lock."""
+    sentinel = RuntimeError("reached-the-lock")
+    conn = mock.MagicMock()
+    conn.execute.side_effect = sentinel
+    bespoke = _declaration(strategy_id="c4-bespoke-contract-trial", **_STALE)
+    assert bespoke.strategy_id not in STRATEGY_MANIFEST
+    with pytest.raises(RuntimeError, match="reached-the-lock"):
+        freeze_preregistration(cast(Any, conn), bespoke)

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -628,6 +628,46 @@ class TestDemoStrategyOrder:
         assert result.broker_order_ref == "13902598"
         assert result.reference_id == request_id
 
+    def test_the_order_payload_is_the_cost_model_lane(self) -> None:
+        """⚠ #2720: the cost model's carry/FX structural-zero closure holds for
+        exactly the lane this writer trades, and this is the wire that holds
+        the two together. NOT a tautology (the "#2240 phase 5c" prevention
+        entry): the payload side is built from the writer's own literals, the
+        lane side from ``cost_model``'s — neither imports the other. A future
+        short / leveraged / non-USD writer change fails HERE, naming the cost
+        model as the thing that must move with it.
+        """
+        from app.services.cost_model import STRUCTURAL_ZERO_LANE
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "token": "066faaee-e1e9-49d2-a568-c6e1cc336ad8",
+            "orderId": 13902598,
+            "referenceId": "1c94300c-90aa-4303-9d00-dec376d74efb",
+        }
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.post.return_value = mock_resp
+            broker.place_demo_strategy_order(
+                BrokerStrategyOrder(
+                    instrument_id=1001,
+                    amount=Decimal("100"),
+                    settlement_type="real",
+                    stop_loss_rate=Decimal("90"),
+                    take_profit_rate=Decimal("120"),
+                ),
+                request_id=UUID("1c94300c-90aa-4303-9d00-dec376d74efb"),
+            )
+            body = broker._http_write.post.call_args.kwargs["json"]
+
+        # `transaction: buy` opening a position IS the long direction — the
+        # only open transactions are buy (long) and sellShort (short).
+        assert (body["transaction"], STRUCTURAL_ZERO_LANE.direction) == ("buy", "long")
+        assert body["action"] == "open"
+        assert body["leverage"] == STRUCTURAL_ZERO_LANE.leverage
+        assert body["settlementType"] == STRUCTURAL_ZERO_LANE.settlement
+        assert body["orderCurrency"] == STRUCTURAL_ZERO_LANE.order_currency.lower()
+
     def test_real_credentials_cannot_select_a_strategy_writer(self) -> None:
         with EtoroBrokerProvider(api_key="k", user_key="u", env="real") as broker:
             try:

--- a/tests/test_cost_model.py
+++ b/tests/test_cost_model.py
@@ -22,12 +22,16 @@ import pytest
 from app.services import cost_model
 from app.services.cost_model import (
     BANDS,
-    CARRY_BPS,
+    CARRY_CLOSURE,
+    CARRY_EVIDENCE,
     CARRY_UNMODELLED,
+    COST_COMPONENT_CLOSURES,
     COST_MODEL_ID,
-    FX_BPS,
+    FX_CLOSURE,
+    FX_EVIDENCE,
     FX_UNMODELLED,
     PRICE_BASES,
+    STRUCTURAL_ZERO_LANE,
     UNKNOWN_NOMINAL_PRICE_BAND,
     PriceBand,
     _check_bands_are_total,
@@ -54,7 +58,17 @@ SPEC_BANDS: tuple[tuple[str, str | None, str | None, str, int], ...] = (
     (">=$100", "100", None, "0.322", 210),
 )
 
-SPEC_COST_MODEL_ID = "static-p75-insession-v2+split-adjusted-max"
+SPEC_COST_MODEL_ID = "static-p75-insession-v3+split-adjusted-max+carry-fx-structural-zero-long-x1-real-usd"
+
+#: ⚠ THE LANE, RESTATED AS LITERALS AND NOT IMPORTED — the same second-copy
+#: rule as ``SPEC_BANDS``. These are also, field for field, the literals
+#: ``EtoroBrokerProvider.place_demo_strategy_order`` puts on the wire
+#: (``transaction: buy`` ⇔ long, ``leverage: 1``, ``settlementType: "real"``,
+#: ``orderCurrency: "usd"``) — ``tests/test_broker_provider.py``'s
+#: ``test_the_order_payload_is_the_cost_model_lane`` captures that payload
+#: independently, so an executor change that leaves the lane fails there and a
+#: lane change that leaves the executor fails here.
+SPEC_LANE = ("long", 1, "real", "USD", "USD")
 
 
 class TestTheFrozenTable:
@@ -248,84 +262,115 @@ class TestTheArithmetic:
             sell_price(Decimal("100"), half_spread=Decimal("1"))
 
 
-class TestCarryIsNullNotZero:
-    """§5.1: *"Writing zero would be the #2286 shape: a value that is present
-    and wrong beats a value that is absent and refused."*"""
+class TestTheStructuralClosure:
+    """#2720: carry and FX close as STRUCTURAL ZERO for the declared lane —
+    a closure state, never a ``Decimal("0")`` pretending to be a measurement
+    (#2286's shape)."""
 
-    def test_carry_is_none(self) -> None:
-        assert CARRY_BPS is None
+    def test_both_closures_are_structural_zero(self) -> None:
+        assert CARRY_CLOSURE == "structural_zero"
+        assert FX_CLOSURE == "structural_zero"
 
-    def test_fx_is_none(self) -> None:
-        assert FX_BPS is None
+    def test_the_closure_vocabulary_is_closed(self) -> None:
+        assert COST_COMPONENT_CLOSURES == {"unmodelled", "structural_zero"}
 
-    def test_the_unmodelled_marker_is_set(self) -> None:
-        """⚠ The marker the promotion gate refuses on (§6 clause 4). It is
-        DERIVED from the two constants above, so measuring carry flips it
-        without anybody remembering to."""
-        assert CARRY_UNMODELLED is True
+    def test_the_markers_are_cleared(self) -> None:
+        """⚠ The markers the promotion gate refuses on (§6 clause 4). DERIVED
+        from the closures, so the closure IS the single source — a hand-written
+        ``False`` would have to be remembered."""
+        assert CARRY_UNMODELLED is False
+        assert FX_UNMODELLED is False
 
-    def test_the_fx_marker_is_set_and_is_its_own_flag(self) -> None:
-        """#2363 — FX has its own marker rather than riding on carry's.
+    def test_the_lane_is_the_frozen_one(self) -> None:
+        """The second copy, as literals — a lane edit (short, leveraged,
+        non-USD) must fail a test and force a human to decide whether the
+        ``cost_model_id`` should have moved with it. It should: either edit is
+        a NEW model by the module rule."""
+        lane = STRUCTURAL_ZERO_LANE
+        assert (
+            lane.direction,
+            lane.leverage,
+            lane.settlement,
+            lane.order_currency,
+            lane.account_currency,
+        ) == SPEC_LANE
 
-        ⚠ Both are asserted TRUE here and that is the current state, not the
-        invariant. The invariant is that they are INDEPENDENT, which this file
-        cannot show because both are derived at import; it is shown by
-        ``test_prereg_declaration_gate``'s four-state parametrisation over
-        ``structural_promotion_refusals``, which is the function the gate and
-        the preregistration freeze both call.
-        """
-        assert FX_UNMODELLED is True
+    def test_the_lane_account_currency_matches_the_deployment_currency(self) -> None:
+        """Literal vs literal — ``strategy_base_currency`` states USD in its own
+        constant (enforced at the sql/290 + sql/338 CHECKs and the executor
+        currency checks); the lane states it independently. Divergence means
+        one of the two contracts moved without the other."""
+        from app.services.strategy_base_currency import DEPLOYMENT_CURRENCY
+
+        assert STRUCTURAL_ZERO_LANE.account_currency == DEPLOYMENT_CURRENCY
+        assert STRUCTURAL_ZERO_LANE.order_currency == DEPLOYMENT_CURRENCY
+
+    def test_the_evidence_is_present_and_dated(self) -> None:
+        """A structural claim with no dated record is ceremony (§ckpt-1 #21)."""
+        for evidence in (CARRY_EVIDENCE, FX_EVIDENCE):
+            assert evidence
+            assert any("2026-08-14" in item or "#2698" in item or "#2605" in item for item in evidence)
 
     @pytest.mark.parametrize(
-        "carry_bps,fx_bps,expected",
+        "carry_closure,fx_closure,expected",
         [
-            (None, None, (True, True)),
-            (Decimal("1.5"), None, (False, True)),
-            (None, Decimal("2.5"), (True, False)),
-            (Decimal("1.5"), Decimal("2.5"), (False, False)),
+            ("unmodelled", "unmodelled", (True, True)),
+            ("structural_zero", "unmodelled", (False, True)),
+            ("unmodelled", "structural_zero", (True, False)),
+            ("structural_zero", "structural_zero", (False, False)),
         ],
     )
-    def test_each_marker_reads_only_its_own_amount(
-        self, carry_bps: Decimal | None, fx_bps: Decimal | None, expected: tuple[bool, bool]
+    def test_each_marker_reads_only_its_own_closure(
+        self, carry_closure: str, fx_closure: str, expected: tuple[bool, bool]
     ) -> None:
-        """⚠⚠ THE DE-COUPLING ITSELF, which was unguarded until a revert-probe
-        said so: restoring the pre-#2363 ``CARRY_BPS is None or FX_BPS is None``
-        broke no test, because both amounts are ``None`` today and the two
-        expressions cannot be told apart while that holds. The two mixed rows
-        below are the ones that matter — under the coupled rule each would
-        return ``(True, ...)``.
-        """
-        assert cost_model.unmodelled_markers(carry_bps, fx_bps) == expected
+        """⚠⚠ THE #2363 DE-COUPLING, preserved across #2720's input change: the
+        two mixed rows are the ones that matter — under a re-coupled rule each
+        would return ``(True, ...)``."""
+        assert cost_model.unmodelled_markers(carry_closure, fx_closure) == expected
 
-    def test_a_component_may_not_carry_an_amount_that_nothing_charges(self) -> None:
-        """⚠⚠ THE FALSE-PROMOTION TRIPWIRE (#2363, found by Codex checkpoint 1).
+    @pytest.mark.parametrize("bad", ["charged", "zero", "", "STRUCTURAL_ZERO"])
+    def test_an_unknown_closure_is_refused_by_the_markers(self, bad: str) -> None:
+        """⚠⚠ THE FALSE-PROMOTION TRIPWIRE'S NEW SHAPE. ``== "unmodelled"``
+        alone would read a typo as "modelled" — clearing a promotion refusal
+        while modelling nothing. Unknown values must RAISE, never default."""
+        with pytest.raises(ValueError, match="unknown carry closure"):
+            cost_model.unmodelled_markers(bad, "unmodelled")
+        with pytest.raises(ValueError, match="unknown fx closure"):
+            cost_model.unmodelled_markers("unmodelled", bad)
 
-        ``CARRY_BPS`` and ``FX_BPS`` are added to no price anywhere — verified
-        by grep, not assumed — so setting one to a measured number would clear
-        its promotion refusal WITHOUT charging the cost, making every result
-        under this model promotable while modelling exactly what it modelled
-        before. The guard runs at import; this asserts it actually refuses,
-        because a guard nobody has seen fail is a comment.
-        """
-        with pytest.raises(ValueError, match="nothing in this module adds it to a price"):
-            with mock.patch.object(cost_model, "CARRY_BPS", Decimal("0.5")):
-                cost_model._check_unmodelled_components_are_not_charged()
+    def test_the_closure_guard_refuses_an_unknown_value(self) -> None:
+        with pytest.raises(ValueError, match="not in the closure vocabulary"):
+            with mock.patch.object(cost_model, "CARRY_CLOSURE", "charged"):
+                cost_model._check_closures()
 
-    def test_the_tripwire_names_every_component_that_is_set(self) -> None:
-        """Both, not just the first — an operator fixing one must see the other."""
-        with pytest.raises(ValueError, match="CARRY_BPS, FX_BPS") as excinfo:
-            with (
-                mock.patch.object(cost_model, "CARRY_BPS", Decimal("0.5")),
-                mock.patch.object(cost_model, "FX_BPS", Decimal("0.25")),
+    def test_the_closure_guard_requires_evidence(self) -> None:
+        """A structural_zero with an empty evidence tuple is the flag-clearing
+        shortcut wearing a new name; the guard refuses it beside the literal."""
+        with pytest.raises(ValueError, match="no evidence"):
+            with mock.patch.object(cost_model, "FX_EVIDENCE", ()):
+                cost_model._check_closures()
+
+    def test_the_closure_guard_refuses_a_short_or_leveraged_lane(self) -> None:
+        """⚠ Risk posture (`.claude/CLAUDE.md`): a short is a CFD and accrues
+        financing by construction; leverage above x1 the same. Either lane
+        needs a NEW cost model, never this one relabelled."""
+        with pytest.raises(ValueError, match="must be long and unleveraged"):
+            with mock.patch.object(
+                cost_model, "STRUCTURAL_ZERO_LANE", cost_model.CostLane("short", 1, "cfd", "USD", "USD")
             ):
-                cost_model._check_unmodelled_components_are_not_charged()
-        assert "new COST_MODEL_ID" in str(excinfo.value)
+                cost_model._check_closures()
+        with pytest.raises(ValueError, match="must be long and unleveraged"):
+            with mock.patch.object(
+                cost_model, "STRUCTURAL_ZERO_LANE", cost_model.CostLane("long", 2, "cfd", "USD", "USD")
+            ):
+                cost_model._check_closures()
 
 
 class TestTheImportTimeGuardsActuallyRun:
     """⚠⚠ Both module-level guards were UNPROVEN until #2699.
 
-    ``_check_unmodelled_components_are_not_charged`` and ``_check_bands_are_total``
+    ``_check_closures`` (#2720; previously ``_check_unmodelled_components_are_not_charged``)
+    and ``_check_bands_are_total``
     each end their definition with a module-level call, and each docstring says why:
     the thing they guard is *an edit somebody makes to the literal above*, so the
     check belongs beside the literal rather than in a test file that person may never
@@ -379,29 +424,49 @@ class TestTheImportTimeGuardsActuallyRun:
 
         assert result.returncode == 0, result.stderr
 
-    def test_setting_carry_bps_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
+    def test_an_unknown_closure_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
         """Not merely `the function raises when called` -- THE MODULE WILL NOT LOAD.
 
-        This is the difference the tripwire trades on: someone who measures carry and
-        sets the literal is stopped by their next import, whether or not they run
-        ``tests/test_cost_model.py``.
+        Someone who widens a closure literal without widening the vocabulary
+        (and the arithmetic, and the model id) is stopped by their next import,
+        whether or not they run ``tests/test_cost_model.py``. The marker
+        derivation fires first (it sits before ``_check_closures()``), so the
+        message asserted is its.
         """
         result = self._run_with_substitution(
-            tmp_path, "CARRY_BPS: Decimal | None = None", 'CARRY_BPS: Decimal | None = Decimal("1.5")'
+            tmp_path,
+            'CARRY_CLOSURE: CostComponentClosure = "structural_zero"',
+            'CARRY_CLOSURE: CostComponentClosure = "charged"',
         )
 
         assert result.returncode != 0
-        assert "nothing in this module adds it to a price" in result.stderr
-        assert "new COST_MODEL_ID" in result.stderr
+        assert "unknown carry closure" in result.stderr
 
-    def test_setting_fx_bps_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
-        """FX shares the guard and had the identical gap (#2699 scope note)."""
+    def test_a_short_lane_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
+        """⚠⚠ THE LANE HALF OF THE GUARD, reachable only through the module-level
+        ``_check_closures()`` call — the markers cannot see the lane, so deleting
+        that invocation would let a short/leveraged lane import silently. This
+        subprocess is what the probe harness's guard-deletion probe selects.
+        """
         result = self._run_with_substitution(
-            tmp_path, "FX_BPS: Decimal | None = None", 'FX_BPS: Decimal | None = Decimal("0.25")'
+            tmp_path,
+            '    direction="long",\n    leverage=1,',
+            '    direction="short",\n    leverage=1,',
         )
 
         assert result.returncode != 0
-        assert "FX_BPS is set" in result.stderr
+        assert "must be long and unleveraged" in result.stderr
+
+    def test_empty_carry_evidence_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
+        """The evidence half, same reasoning: only the module-level call sees it."""
+        result = self._run_with_substitution(
+            tmp_path,
+            "CARRY_EVIDENCE: tuple[str, ...] = (",
+            "CARRY_EVIDENCE: tuple[str, ...] = ()\n_UNUSED_EVIDENCE = (",
+        )
+
+        assert result.returncode != 0
+        assert "no evidence" in result.stderr
 
     def test_a_gap_in_the_band_table_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
         """``_check_bands_are_total`` had the same asymmetry, for the same reason.

--- a/tests/test_prereg_declaration_gate.py
+++ b/tests/test_prereg_declaration_gate.py
@@ -37,7 +37,13 @@ _INELIGIBLE = ("universe_basis_not_survivorship_free", "carry_unmodelled", "fx_u
 
 
 def _declaration(**overrides: object) -> PreregDeclaration:
-    """A coherent falsification declaration over today's actual stamps."""
+    """A coherent falsification declaration over the PRE-#2720 stamps.
+
+    ⚠ Still a valid fixture: ``declaration_refusals`` judges internal coherence
+    and stored rows of this shape must keep loading. A NEW freeze of this shape
+    for a MANIFEST strategy is refused by ``freeze_preregistration``'s stamp
+    check — ``tests/test_2720_freeze_stamp_validation.py`` owns that side
+    ("S-1" here is not a manifest id, so these fixtures stay freezable)."""
     base: dict[str, object] = {
         "strategy_id": "S-1",
         "strategy_version": "strategy-registry-v1+abc123",

--- a/tests/test_residual_confluence_candidate.py
+++ b/tests/test_residual_confluence_candidate.py
@@ -52,8 +52,11 @@ def _inputs() -> dict[str, object]:
 
 def test_definition_is_complete_stable_and_contains_no_measured_result() -> None:
     payload = definition_json()
-    assert definition_hash() == "32dae77ea948d553589b98f42feb117f3efee25871e37c21aa0b3741a60e97d1"
-    assert CANDIDATE_VERSION == "residual-confluence-v1+32dae77ea948"
+    # ⚠ Moved by #2720 (cost_model_id is a definition input; the carry/FX
+    # structural closure is a new model, so the candidate version moves with
+    # it — that is the pin doing its job, not collateral).
+    assert definition_hash() == "6173442ec8ed4c8518b9e8f9baea9e3aaf5d92b2cb2f58f7fce776e9c800ccc8"
+    assert CANDIDATE_VERSION == "residual-confluence-v1+6173442ec8ed"
     assert DEFINITION.market_vol_long_lookback == 252
     assert DEFINITION.model_features == MODEL_FEATURE_NAMES
     assert "expectancy" not in payload


### PR DESCRIPTION
Closes #2720. Refs #2437. Refs #2698. Refs #2277.

Spec: `docs/proposals/ta/2026-08-14-carry-fx-structural-closure.md` (in this PR; Codex ckpt-1 ran with 50 findings, the decisive one — "structural zero is stamped globally while lane membership is per-position" — resolved by the intrinsically-single-lane design + two mechanical gates below).

## What

Gate 1 of 2 between firing strategies and funded paper trades. `carry_unmodelled` and `fx_unmodelled` stamp **false** on rows produced under a new `COST_MODEL_ID`, because for the one lane this system trades — long, x1, `real` settlement, USD order, USD demo account, USD-quoted universe — eToro's own product rule says no overnight/weekend fee exists and no conversion event occurs. The closure is a **state** (`structural_zero`), never a `Decimal("0")` pretending to be a measurement: `CARRY_BPS`/`FX_BPS` are DELETED, so there is no dormant scalar whose setting could clear a refusal (#2286's shape).

## Source rule (live-portal, per `data-sources/etoro-api.md`, all fetched 2026-08-14)

- **`etoro.com/trading/fees`**: stocks/ETFs *"Overnight fee: Free"* for non-leveraged BUYs; *"Short-selling orders and leveraged positions … are executed as CFDs and incur CFD spreads and overnight fees."* The page's own trap — *"some non-leveraged BUY positions in stocks are also executed as CFDs"* — is closed for the order path by:
- **portal `create-an-order` (OpenAPI v1.342.0)**: `settlementType` *"is an assertion, not a selector … a mismatch is rejected during execution"*; our writer pins `"settlementType": "real"` (`etoro_broker.py:356`). An order in this lane holds the underlying or is rejected.
- What-if census `overnightFee` 0.0 on all 28 real-settlement observations is recorded as **consistent-only** (all-zero unit undecodable — skill's own bold warning), never as the evidence.
- **FX**: `account_currency_id = 1` measured on `account_equity_evidence` (#2698); universe USD-uniform (#2605, full population); `orderCurrency: "usd"` + `DEPLOYMENT_CURRENCY` CHECKs.

## The charge = lane enforcement (adding `+ 0` to a price would be theatre)

1. **Per-run FX gate** — `load_corpus` asserts `instruments.currency = 'USD'` over every evaluated instrument (the instrument's own quote currency, not the `exchanges` proxy) and refuses the run; a frozen id cannot police a mutable table.
2. **Freeze-time stamp validation** — `freeze_preregistration` refuses a manifest-strategy declaration whose declared stamps mismatch the module constants (an immutable trial burned otherwise; sql/333). ⚠ Scoped to `STRATEGY_MANIFEST`: the #2582 13D bespoke trial charges its own flat 50 bps and honestly declares `True` — test pins both sides.
3. **Lane pinned to the wire** — `test_the_order_payload_is_the_cost_model_lane` compares the captured order body to the lane, literal vs literal (non-tautological per the "#2240 phase 5c" prevention entry); `cost_position` documented long-only-by-arithmetic; import guard refuses a short/leveraged lane or an evidence-free structural claim.

## What this does NOT do

- Does NOT price any short/leveraged/CFD/non-USD lane — UNPRICED (limits 4-6 on every result row), not free. A short is a CFD and needs a new model (risk posture).
- Does NOT make any stored row promotable (immutable stamps; `survivor_only` still hard-refuses everything until #2721).
- Does NOT bump `STRUCTURAL_REFUSAL_POLICY_VERSION` (the refusal rule is unchanged) and does NOT re-run any backtest.
- The migration (sql/352) is COMMENT-only.

## Identity move

New `COST_MODEL_ID` → **every strategy version moves** (third move of 2026-08-14). `residual-confluence` candidate version moved with it (test pin updated deliberately). Post-merge declarations must be re-derived under the moved versions — the freeze-time check now forces this instead of letting a stale one burn a trial. Coordination note posted on #2437 for the sibling item-6 session before merge.

## Evidence

| check | result |
| --- | --- |
| full fast tier + smoke | green (exit 0) |
| touched db tier (result_ledger, backtest_run, strategy_result, c4/2634/2616 gates, control plane) | green (exit 0) |
| ruff / format / pyright | green |
| probe harness `probe_2240_cost_model.py` (re-anchored, 2 probes redesigned) | **19/19 CAUGHT**, restored suite PASS |
| anchor audit | 288 anchors / 16 harnesses OK |
| `measure_2605_universe_scope.py` (full population) | 6,774 validated instruments, all USD; both asserted properties hold |
| `load_corpus` against dev DB (new gate live) | passes; universe 6,774 |
| Codex ckpt-1 (spec) | 50 findings; resolutions + not-actioned list recorded in the spec |
| Codex ckpt-2 (diff) | "No actionable correctness defects were identified" |

## Security model

No security surface: no auth/authz change, no new input boundary, no broker mutation path touched (the one broker test uses a mocked transport).
