### PR TITLE
feature(#2721): Form 25 evidence without a suspension date + termination rule (steps 1-3)

### DIFF
--- a/.claude/skills/data-sources/research-price-corpus.md
+++ b/.claude/skills/data-sources/research-price-corpus.md
@@ -213,14 +213,31 @@ on March 02, 2023"* — and LIN trades now.
 truncates — at ingest or at read time. `link_form25_delistings` in
 `app/services/research_corpus_ingest.py`.
 
+**#2721 extended this to the EVIDENCE model (sql/353):** `delisting_source` +
+`delisting_provision` + `delisting_filed_date` now persist WITHOUT a suspension date —
+`(b)` states one on 0 of 105 cohort rows, so the date-paired schema held the
+exchange-failure class at zero coverage by construction. `delisting_date` is still never
+back-filled from `filed_date`, a bare date is still unrepresentable, and a DATED
+'sec_form25' row still must carry its provision. Measured on the 2023 register alone the
+re-link moved terminating-Intrader coverage 37 → 249 series, `(b)` 0 → 89. What a held
+position REALISES at a termination is `app/services/series_termination.py` (pure,
+versioned, UNWIRED until the `BACKTEST_UNIVERSE` parameterisation wires it): linked
+`(b)`/`(a)(4)` → last close × (1 − 0.55) (Shumway JF 1997 Table V −30% NYSE/AMEX;
+Shumway & Warther JF 1999 −55% Nasdaq; adverse anchor, venue unknown), `(a)(3)` → last
+close, unlinked → two-armed bounds.
+
 **What is actually detectable, and it is the OTHER half of the guard.** "First bar precedes
 the known listing date" was thought unimplementable because the schema holds no listing date.
 A proxy needs neither a listing date nor a threshold: a series whose first bar postdates a
 Form 25 on the same symbol cannot be the series of the security that filing removed. Four
 today — `ALPS` (filed 2023-07-27, first bar 2025-10-31), `ATCX` (2023-04-19 → 2026-01-09),
-`USX` (2023-07-03 → 2026-06-03), `DBD` (2023-06-20 → 2023-08-14). ⚠ It is reported, never
-acted on: `DBD` is Diebold Nixdorf relisting after Chapter 11, the SAME company. The honest
-output is "identity unverified" — which is the FIRST guard (label it), not the second.
+`USX` (2023-07-03 → 2026-06-03), `DBD` (2023-06-20 → 2023-08-14). ⚠ Since #2721 the
+linkage REFUSES to write evidence onto these (`classify_form25_match` →
+`identity_unverified`): the filing removed a security whose price history the series
+demonstrably is not, and under the evidence model an unrefused write would mark a live,
+running series as delisted. `DBD` is Diebold Nixdorf relisting after Chapter 11, the SAME
+company — which is exactly why the verdict is "identity unverified" (censused), never
+"different company" (asserted).
 
 ⚠ **No corpus series is currently known to be welded.** `REED` and `SRAX` span their `(b)`
 filings with no gap at all (last bar the day before, first bar the day of) — both moved to

--- a/app/services/research_corpus_ingest.py
+++ b/app/services/research_corpus_ingest.py
@@ -1118,10 +1118,13 @@ class DelistingLinkCensus:
     overlap_series: int = 0
     #: Series given a ``delisting_date``. Requires a stated suspension date.
     suspension_dates_written: int = 0
-    #: Overlapping series left NULL because the filing states no suspension
-    #: date. NOT back-filled from ``filed_date``: that is a different event and
-    #: mistruncates every series it touches (sec-edgar.md §2.6 trap 5).
-    no_suspension_date: int = 0
+    #: Series given source + provision + filed date but NO ``delisting_date``,
+    #: because the filing states no suspension date. The date is NOT
+    #: back-filled from ``filed_date``: that is a different event and
+    #: mistruncates every series it touches (sec-edgar.md §2.6 trap 5). Before
+    #: #2721 these wrote nothing at all, which held the exchange-failure
+    #: class ``(b)`` — 0 stated dates on 105 cohort rows — at zero coverage.
+    undated_evidence_written: int = 0
     #: Symbols whose cohort filings disagree on provision or suspension date.
     #: Left NULL rather than tie-broken — two different delisting events on one
     #: ticker is precisely the ambiguity the guard exists to surface.
@@ -1129,27 +1132,41 @@ class DelistingLinkCensus:
     #: Overlap by rule provision. `(b)` here with a zero write count is the
     #: measurement that kills provision-blind truncation.
     by_provision: dict[str, int] = field(default_factory=dict)
-    #: (symbol, earliest filing, first bar) where the series starts AFTER a
-    #: Form 25 on that symbol. Identity unverified — may be a later occupant
-    #: or the same issuer relisting.
+    #: (symbol, latest filing, first bar) where the series starts AFTER every
+    #: Form 25 on that symbol (the classifier's ``identity_unverified``
+    #: verdict — nothing is written). May be a later occupant or the same
+    #: issuer relisting. A series starting BETWEEN two filings is a conflict,
+    #: not an identity refusal, and appears under ``conflicting`` only.
     identity_unverified: list[tuple[str, date, date]] = field(default_factory=list)
     #: (symbol, earliest filing, last bar) where the series ends BEFORE the
     #: filing — a genuine termination, the shape the acceptance test expects
     #: and has never yet observed on this archive.
     terminating: list[tuple[str, date, date]] = field(default_factory=list)
+    #: Measured register span at link time — (filings, first filed, last
+    #: filed). Measured rather than written into the note below because the
+    #: 2013-2024 expansion (#2721) moves it, and a hardcoded "2023 only"
+    #: would go stale in the sentence a reader trusts most.
+    register_filings: int = 0
+    register_first_filed: date | None = None
+    register_last_filed: date | None = None
 
     @property
     def coverage_note(self) -> str:
+        span = (
+            f"{self.register_filings:,} filings, {self.register_first_filed} to {self.register_last_filed}"
+            if self.register_filings
+            else "EMPTY register"
+        )
         return (
-            "Form 25 coverage is 2023 ONLY (1,282 filings, 2023-01-03 to "
-            "2023-12-29) against a corpus spanning 1962-2026, and Form 25 is "
-            "US-only — there is no free authoritative equivalent for EU/UK/"
-            "Asia/MENA, where #2290's forward record is the only future "
-            "source. The cohort also excludes the 128 issuer-filed paragraph "
-            "(c) filings, which are delistings but carry no "
-            "descriptionClassSecurity and so cannot be verified as COMMON "
-            "EQUITY (sql/252's view comment). A series absent from this "
-            "linkage is therefore UNCHECKED, never 'checked and clean'."
+            f"Form 25 register coverage: {span} — measured at link time, "
+            "against a corpus spanning 1962-2026. Form 25 is US-only — there "
+            "is no free authoritative equivalent for EU/UK/Asia/MENA, where "
+            "#2290's forward record is the only future source. The cohort "
+            "also excludes issuer-filed paragraph (c) filings, which are "
+            "delistings but carry no descriptionClassSecurity and so cannot "
+            "be verified as COMMON EQUITY (sql/252's view comment). A series "
+            "absent from this linkage is therefore UNCHECKED, never 'checked "
+            "and clean'."
         )
 
 
@@ -1161,6 +1178,7 @@ class Form25Match:
     first_bar: date | None
     last_bar: date | None
     earliest_filed: date
+    latest_filed: date
     provision_variants: int
     provision: str | None
     suspension_variants: int
@@ -1168,26 +1186,59 @@ class Form25Match:
 
 
 def classify_form25_match(match: Form25Match) -> str:
-    """What to do with one match: ``write`` / ``conflict`` / ``no_suspension``.
+    """One match's verdict: ``write`` / ``conflict`` / ``identity_unverified``
+    / ``no_suspension``.
 
-    Pure so the policy is table-testable without a corpus. Three rules, and the
-    two refusals matter more than the write:
+    Pure so the policy is table-testable without a corpus. Four rules, and
+    the two refusals matter more than either write:
 
     ``conflict`` — the cohort's filings for this symbol disagree on the
     provision or on the suspension date. Two different delisting events on one
     ticker is exactly the ambiguity the guard exists to surface, so it is
     counted and left NULL rather than tie-broken. There is no source rule
     saying which of two filings wins, and inventing a precedence order
-    (latest-filed? the /A amendment?) would be a fabricated citation.
+    (latest-filed? the /A amendment?) would be a fabricated citation. The only
+    verdict that writes nothing at all.
 
-    ``no_suspension`` — the filing states no suspension date. NULL is the
-    correct value: ``filed_date`` is a DIFFERENT event (a Form 25 carries up to
-    three dates, sec-edgar.md §2.6 trap 5), and substituting it mistruncates
-    every series it touches. This is the common case, not the exception —
-    ``(b)`` supplies a suspension date on 0 of 105 cohort rows.
+    ``identity_unverified`` — the series STARTS after every Form 25 on its
+    symbol (``first_bar > latest_filed``), so it may be a later occupant of
+    the ticker (ALPS: filed 2023-07, first bar 2025-10) or the same issuer
+    relisting post-Chapter-11 (DBD). Either way the filings removed a security
+    whose price history this is demonstrably NOT, and writing the evidence
+    would mark a live, running series as delisted. Refused and censused. This
+    gate predates nothing: the dated writer always had the hole (it wrote
+    unconditionally) and it simply never fired — none of the four 2023
+    identity-unverified overlaps carries a stated suspension date. The
+    evidence write #2721 added would have fired on all four.
+
+    A series that STRADDLES the filings — starts after the earliest but not
+    after the latest — is a ``conflict``, not an identity refusal: the later
+    filing may well describe this series' security (a relist-then-delist
+    cycle), but the aggregate collapses the events, so the evidence cannot be
+    attributed to one of them without inventing a precedence order. Refusing
+    beats attributing: an unlinked terminating series degrades to the
+    termination rule's honest two-armed bounds, while a mis-attributed write
+    stamps a filed date that PRECEDES the series' own first bar. Zero cases
+    in the 2023 register (no resolved symbol carries two distinct filed
+    dates); the 2013-2024 expansion is what makes the branch reachable, and
+    it must exist BEFORE the data that exercises it (Codex ckpt-2 on #2721).
+
+    ``no_suspension`` — the filing states no suspension date. Since #2721 this
+    WRITES the evidence (source, provision, filed date) and leaves only
+    ``delisting_date`` NULL: ``filed_date`` is a DIFFERENT event (a Form 25
+    carries up to three dates, sec-edgar.md §2.6 trap 5), and substituting it
+    mistruncates every series it touches. This is the common case, not the
+    exception — ``(b)`` supplies a suspension date on 0 of 105 cohort rows,
+    which is why refusing to store the undated link held the exchange-failure
+    class at zero coverage.
     """
     if match.provision_variants > 1 or match.suspension_variants > 1:
         return "conflict"
+    if match.first_bar is not None:
+        if match.first_bar > match.latest_filed:
+            return "identity_unverified"
+        if match.first_bar > match.earliest_filed:
+            return "conflict"
     if match.suspension_date is None:
         return "no_suspension"
     return "write"
@@ -1207,6 +1258,12 @@ def link_form25_delistings(
     function has no evidence about them.
     """
     census = DelistingLinkCensus()
+
+    span = conn.execute("SELECT count(*), min(filed_date), max(filed_date) FROM sec_form25_register").fetchone()
+    if span is not None:
+        census.register_filings = int(span[0])
+        census.register_first_filed = span[1]
+        census.register_last_filed = span[2]
 
     # Scoped to the common-equity VIEW, never the raw register: a Form 25 is
     # per-SECURITY, so `sec_form25_register` contains bond and warrant
@@ -1261,13 +1318,15 @@ def link_form25_delistings(
         # fabricated conflict.
         provisions = {p for _f, p, _s in events if p is not None}
         suspensions = {s for _f, _p, s in events if s is not None}
+        filed_dates = [f for f, _p, _s in events]
         rows.append(
             (
                 series_id,
                 matched,
                 first_bar,
                 last_bar,
-                min(f for f, _p, _s in events),
+                min(filed_dates),
+                max(filed_dates),
                 len(provisions),
                 min(provisions, default=None),
                 len(suspensions),
@@ -1279,7 +1338,8 @@ def link_form25_delistings(
         """
         UPDATE research_price_series
            SET delisting_date = NULL, delisting_source = NULL,
-               delisting_provision = NULL, updated_at = now()
+               delisting_provision = NULL, delisting_filed_date = NULL,
+               updated_at = now()
          WHERE vendor = %s AND delisting_source = 'sec_form25'
         """,
         (vendor,),
@@ -1291,6 +1351,7 @@ def link_form25_delistings(
         first_bar,
         last_bar,
         earliest_filed,
+        latest_filed,
         provision_variants,
         provision,
         suspension_variants,
@@ -1301,6 +1362,7 @@ def link_form25_delistings(
             first_bar=first_bar,
             last_bar=last_bar,
             earliest_filed=earliest_filed,
+            latest_filed=latest_filed,
             provision_variants=provision_variants,
             provision=provision,
             suspension_variants=suspension_variants,
@@ -1315,47 +1377,67 @@ def link_form25_delistings(
         # suspension date is a conflict the classifier refuses to write, and
         # it would still have been filed under its provision — a census that
         # disagrees with the writer about what happened.
-        key = "conflicting" if action == "conflict" else provision
+        # `provision` is None where the filing carries no <ruleProvision>
+        # (the 25-NSE form omits it by design); label it rather than key on
+        # None, which would TypeError the census consumers' sorted() calls.
+        key = "conflicting" if action == "conflict" else (provision or "(unparsed)")
         census.by_provision[key] = census.by_provision.get(key, 0) + 1
 
-        # ``earliest_filed`` is min() over the symbol's cohort filings, and the
-        # min is deliberate rather than incidental. Both tests below are
-        # one-sided, so the earliest filing is the CONSERVATIVE bound: "the
-        # series begins after a Form 25 on this symbol" and "the series ends
-        # before any Form 25 on this symbol" are each true against min() for
-        # every filing, including when a conflicted symbol carries two events.
-        if first_bar is not None and first_bar > earliest_filed:
-            census.identity_unverified.append((symbol, earliest_filed, first_bar))
+        # The identity census keys on the CLASSIFIER's verdict — a straddling
+        # series (starts after the earliest filing, not after the latest) is a
+        # `conflict`, and reporting it under identity_unverified as well would
+        # file one series in two categories (Codex ckpt-2 on #2721). The
+        # terminating test keeps min() as its bound: "the series ends before
+        # any Form 25 on this symbol" is one-sided, and the earliest filing is
+        # the conservative side of it.
+        if action == "identity_unverified":
+            census.identity_unverified.append((symbol, latest_filed, first_bar))
         if last_bar is not None and last_bar < earliest_filed:
             census.terminating.append((symbol, earliest_filed, last_bar))
 
         if action == "conflict":
             census.conflicting.append(symbol)
             continue
-        if action == "no_suspension":
-            census.no_suspension_date += 1
+        if action == "identity_unverified":
+            # Recorded above. Nothing is written: the series starts after
+            # every filing, so the removed security's history is not this.
             continue
 
+        # Both remaining verdicts persist the EVIDENCE (source, provision,
+        # earliest filed date); they differ only in whether a suspension date
+        # exists to write. ``delisting_date`` is never fabricated from
+        # ``filed_date`` — for ``no_suspension`` it stays NULL, which sql/353
+        # made representable (source without date) precisely so the undated
+        # ``(b)`` links stop being dropped on the floor.
         conn.execute(
             """
             UPDATE research_price_series
                SET delisting_date = %s,
                    delisting_source = 'sec_form25',
                    delisting_provision = %s,
+                   delisting_filed_date = %s,
                    updated_at = now()
              WHERE series_id = %s
             """,
-            (suspension_date, provision, series_id),
+            (
+                suspension_date if action == "write" else None,
+                provision,
+                earliest_filed,
+                series_id,
+            ),
         )
-        census.suspension_dates_written += 1
+        if action == "write":
+            census.suspension_dates_written += 1
+        else:
+            census.undated_evidence_written += 1
 
     conn.commit()
     logger.info(
-        "form25 linkage: %d overlapping series, %d dated, %d with no stated "
-        "suspension date, %d conflicting, %d identity-unverified",
+        "form25 linkage: %d overlapping series, %d dated, %d undated evidence "
+        "(no stated suspension date), %d conflicting, %d identity-unverified",
         census.overlap_series,
         census.suspension_dates_written,
-        census.no_suspension_date,
+        census.undated_evidence_written,
         len(census.conflicting),
         len(census.identity_unverified),
     )

--- a/app/services/research_corpus_ingest.py
+++ b/app/services/research_corpus_ingest.py
@@ -1260,10 +1260,10 @@ def link_form25_delistings(
     census = DelistingLinkCensus()
 
     span = conn.execute("SELECT count(*), min(filed_date), max(filed_date) FROM sec_form25_register").fetchone()
-    if span is not None:
-        census.register_filings = int(span[0])
-        census.register_first_filed = span[1]
-        census.register_last_filed = span[2]
+    assert span is not None  # an aggregate always returns one row; typing guard only
+    census.register_filings = int(span[0])
+    census.register_first_filed = span[1]
+    census.register_last_filed = span[2]
 
     # Scoped to the common-equity VIEW, never the raw register: a Form 25 is
     # per-SECURITY, so `sec_form25_register` contains bond and warrant

--- a/app/services/series_termination.py
+++ b/app/services/series_termination.py
@@ -1,0 +1,228 @@
+"""#2721 — what a held position realises when its price series terminates.
+
+The survivorship treatment ITSELF: a backtest whose universe contains dead
+names must say what happens to a position whose series simply stops. Stamping
+``survivorship_free`` while this is undefined would claim handling that does
+not exist, which is why the ``universe_basis_not_survivorship_free`` refusal
+(#2698) cannot come down without this module.
+
+⚠⚠ SHIPS UNWIRED, ON PURPOSE. No execution path calls this module in #2721
+steps 1-2, and ``TERMINATION_RULE_VERSION`` is NOT hashed into any strategy
+identity yet. The hash joins the result-producing rule set at the SAME commit
+that first wires it (step 3, the ``BACKTEST_UNIVERSE`` parameterisation) —
+"inert because nothing calls it" is a stronger invariant than "inert because
+the current universe happens to contain no terminating series" (ckpt-1).
+
+Source rule (verified against the papers, 2026-08-15, on-issue evidence pass):
+
+* Shumway, *The Delisting Bias in CRSP Data*, Journal of Finance 52(1) 1997,
+  Table V p.336 — where CRSP is missing the delisting return for a
+  performance-related delist (NYSE/AMEX), the traced outcomes average **−30%**
+  (mean −29.9, median −31.3, 71% of value accounted; the worthless subset is
+  −100%).
+* Shumway & Warther, *The Delisting Bias in CRSP's Nasdaq Data and Its
+  Implications for the Size Effect*, Journal of Finance 54(6) 1999 — the
+  corresponding Nasdaq prescription is **−55%**.
+
+The corpus does not record the venue of a dead name, so the ADVERSE anchor of
+the two (−55%) is used for every failure-class termination — the same
+pessimistic-end construction as ``cost_model.UNKNOWN_NOMINAL_PRICE_BAND``
+(absence of evidence prices at the bad end of the measured range, never the
+good end).
+
+THE THREE-DATE TRAP (ckpt-1 amendment a). A Form 25 carries up to three dates
+— filing, suspension, removal-effective (sec-edgar.md §2.6 trap 5) — and this
+module deliberately keys on NONE of them. Termination fires at the series'
+**last bar**, and every realisation below is a fraction of the **last close**.
+The filing/suspension dates are linkage evidence (which class of termination
+this was), never a substitute clock: the last bar's relation to those dates
+varies by class ((b) filings trail the OTC death by months; (a)(3) filings
+often precede a continuing series) and substituting any of them for the last
+bar mistruncates or misprices the position.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Final
+
+from app.services.strategy_result import AmbiguityArm
+
+#: Shumway & Warther 1999's Nasdaq prescription, as a FRACTION LOST. Applied
+#: to the last close: realised = last_close * (1 - SHUMWAY_HAIRCUT). The
+#: NYSE/AMEX anchor is −30% (Shumway 1997 Table V); venue is unknown for our
+#: dead names, so the adverse anchor binds. Changing this constant is a NEW
+#: ``TERMINATION_RULE_VERSION`` by construction (it is hashed below).
+SHUMWAY_HAIRCUT: Final[float] = 0.55
+
+_RULE_SET_ID: Final[str] = "series-termination-v1"
+
+
+def _code_hash() -> str:
+    """Hash this module's source, per ``indicator_series._code_hash``'s idiom."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+#: ⚠ NOT yet part of any strategy identity — see the module docstring. Once
+#: step 3 wires termination into the backtest, this joins the result-producing
+#: rule set and every change to this file moves every strategy version.
+TERMINATION_RULE_VERSION: Final[str] = f"{_RULE_SET_ID}+{_code_hash()}"
+
+
+class TerminationClass(StrEnum):
+    """The closed set of termination treatments. One per evidence shape.
+
+    Deliberately more classes than treatments: ``EXCHANGE_FAILURE_A4`` and
+    ``EXCHANGE_FAILURE`` realise identically today, but "(a)(4) ≈ (b)" is
+    ASSERTED, not demonstrated (ckpt-1 amendment c) — the expanded register
+    is what verifies it, and collapsing the labels now would make the
+    verification unmeasurable later.
+    """
+
+    #: Linked Form 25, Rule 12d2-2(b) — exchange-initiated delisting for
+    #: non-compliance. The archetypal performance delist: haircut applies.
+    EXCHANGE_FAILURE = "exchange_failure"
+    #: Linked Form 25, Rule 12d2-2(a)(4). Treated as the failure class, kept
+    #: distinct so the expanded register can verify the equivalence.
+    EXCHANGE_FAILURE_A4 = "exchange_failure_a4"
+    #: Linked Form 25, Rule 12d2-2(a)(3) — the security now evidences other
+    #: securities by operation of law (merger, holdco reorg, redomicile).
+    #: The position converts at the last print; realise at last close.
+    OPERATION_OF_LAW = "operation_of_law"
+    #: Linked Form 25 whose <ruleProvision> could not be parsed (the 25-NSE
+    #: form omits it by design). Linked-but-unreadable is NOT unknown — the
+    #: security was removed — but its failure-vs-conversion split is, so it
+    #: takes the two-armed bounds (ckpt-1 amendment d).
+    LINKED_UNPARSED = "linked_unparsed_provision"
+    #: No Form 25 link, but the vendor symbol carries the ``Q`` bankruptcy
+    #: suffix — plausibly a post-petition OTC series that traded to its own
+    #: end, so the last close already embeds the collapse. Sound ONLY as a
+    #: labelled class, unverified per-name (ckpt-1 amendment f): realise at
+    #: last close, and the label is what keeps that assumption auditable.
+    Q_SUFFIX_OTC = "q_suffix_otc_unverified"
+    #: No usable evidence. Bankruptcy (−100%), acquisition (often a premium),
+    #: ticker change and archive gap all look identical — opposite signs for
+    #: a held position — so the honest answer is BOTH bounds, reusing the
+    #: §3.4 two-armed ambiguity machinery. Honest wide bounds beat a silent
+    #: guess.
+    UNKNOWN = "unknown_termination"
+
+
+#: The classes whose realisation depends on the ambiguity arm. Everything
+#: else realises the same value under either arm.
+TWO_ARMED_CLASSES: Final[frozenset[TerminationClass]] = frozenset(
+    {TerminationClass.LINKED_UNPARSED, TerminationClass.UNKNOWN}
+)
+
+
+class UnlinkedStratum(StrEnum):
+    """Why an UNKNOWN series has no Form 25 link — absence of linkage is not
+    random (ckpt-1 amendment e), and the census that stamps a result must
+    report this split, not one pooled "unlinked" count.
+    """
+
+    #: The register holds no Form 25 for any candidate spelling of the symbol
+    #: — genuinely outside the register's span/venue, or never delisted.
+    NO_FORM25 = "no_form25"
+    #: A Form 25 exists but its issuer never resolved to a ticker
+    #: (closed-end funds file N-CSR, not a cover-page-XBRL 10-K; some
+    #: foreign private issuers likewise).
+    UNRESOLVED_TICKER = "unresolved_ticker"
+    #: Issuer-filed paragraph (c) filings are EXCLUDED from the common-equity
+    #: cohort by design (no descriptionClassSecurity to verify the security
+    #: class). A series whose only Form 25 is a (c) is unlinked BY THAT
+    #: EXCLUSION, and broadening it needs its own labelled stratum, not a
+    #: silent widening (ckpt-1 amendment b).
+    EXCLUDED_ISSUER_FILED_C = "excluded_issuer_filed_c"
+    #: Two filing symbols resolved onto one archive series (RVLP + RVLPQ) —
+    #: two delisting events against one price history. The linkage refuses
+    #: to tie-break; the series stays unlinked and this stratum says why.
+    SYMBOL_COLLISION = "symbol_collision"
+    #: A Form 25 exists on the symbol but the series STARTS after it — a
+    #: later occupant of the ticker or an unverified relisting. The linkage's
+    #: identity gate refused the write (classify_form25_match).
+    IDENTITY_UNVERIFIED_REUSE = "identity_unverified_reuse"
+
+
+@dataclass(frozen=True)
+class TerminationEvidence:
+    """One terminating series' evidence, as the corpus stores it.
+
+    ``linked`` means ``delisting_source = 'sec_form25'`` on the series row;
+    ``provision`` is ``delisting_provision`` (may be NULL on a linked row —
+    sql/353); ``q_suffix`` is a property of the VENDOR SYMBOL, not of any
+    filing, and the caller must derive it with the SAME rule the linkage's
+    candidate ladder strips by (``research_corpus_ingest.
+    archive_symbol_candidates``: trailing ``Q`` with more than one letter) —
+    a second spelling of that rule here would drift from the first.
+    """
+
+    linked: bool
+    provision: str | None
+    q_suffix: bool
+
+
+def classify_termination(evidence: TerminationEvidence) -> TerminationClass:
+    """Map stored evidence to its termination class. Pure; total.
+
+    Precedence: a Form 25 link outranks the Q-suffix heuristic — the filing
+    is a regulator's statement about this security, the suffix a naming
+    convention about the symbol. The suffix only speaks where nothing
+    stronger does.
+    """
+    if evidence.linked:
+        if evidence.provision == "(b)":
+            return TerminationClass.EXCHANGE_FAILURE
+        if evidence.provision == "(a)(4)":
+            return TerminationClass.EXCHANGE_FAILURE_A4
+        if evidence.provision == "(a)(3)":
+            return TerminationClass.OPERATION_OF_LAW
+        return TerminationClass.LINKED_UNPARSED
+    if evidence.q_suffix:
+        return TerminationClass.Q_SUFFIX_OTC
+    return TerminationClass.UNKNOWN
+
+
+def terminal_value_fraction(
+    termination_class: TerminationClass,
+    arm: AmbiguityArm | None,
+) -> float:
+    """Fraction of the LAST CLOSE a held position realises at termination.
+
+    ``arm`` is required for the two-armed classes and ignored — deliberately,
+    so a caller can pass its running arm unconditionally — for the rest.
+
+    Raises on a two-armed class with no arm: silently picking a side there
+    would be exactly the unstated survivorship treatment this module exists
+    to abolish.
+    """
+    if termination_class in (
+        TerminationClass.EXCHANGE_FAILURE,
+        TerminationClass.EXCHANGE_FAILURE_A4,
+    ):
+        return 1.0 - SHUMWAY_HAIRCUT
+    if termination_class in (
+        TerminationClass.OPERATION_OF_LAW,
+        TerminationClass.Q_SUFFIX_OTC,
+    ):
+        return 1.0
+    # Two-armed: best case the last print was the story (conversion, quiet
+    # exit); worst case the name failed and the Shumway haircut binds.
+    if arm is None:
+        raise ValueError(f"{termination_class} requires an ambiguity arm; refusing to pick a side silently")
+    return 1.0 if arm == "best_case" else 1.0 - SHUMWAY_HAIRCUT
+
+
+__all__ = [
+    "SHUMWAY_HAIRCUT",
+    "TERMINATION_RULE_VERSION",
+    "TWO_ARMED_CLASSES",
+    "TerminationClass",
+    "TerminationEvidence",
+    "UnlinkedStratum",
+    "classify_termination",
+    "terminal_value_fraction",
+]

--- a/scripts/build_2282_form25_register.py
+++ b/scripts/build_2282_form25_register.py
@@ -7,10 +7,21 @@ Run from repo root:
     uv run python -m scripts.build_2282_form25_register --year 2023 --emit-fixture
     uv run python -m scripts.build_2282_form25_register --year 2023 --census
 
-⚠ Rate limited against the SHARED SEC budget. The jobs daemon issues SEC
-requests from the same 10 req/s allowance, so this uses the same Postgres GCRA
-gate rather than a local sleep — a local limiter would be correct in isolation
-and would still get us blocked.
+Multi-year expansion (#2721) runs strictly sequentially, one year at a time,
+gating each year on its harvest failure count before touching the next:
+
+    uv run python -m scripts.build_2282_form25_register --years 2013-2024 \
+        --harvest --resolve-symbols --census
+
+⚠ Rate limited against the SHARED SEC budget: SEC's published limit is
+10 req/s and the jobs daemon draws from the same allowance. This script does
+NOT use the app's Postgres GCRA gate — that gate lives behind the app's
+connection pool and this is a one-shot script outside the app lifespan.
+Instead ``_Fetcher`` enforces a local 0.2 s floor (5 req/s), a deliberate
+PARTITION of the budget: this run takes half and leaves the other half to the
+daemon, so the two clocks interleave safely without sharing state. (An
+earlier version of this header claimed the GCRA gate was used — it never was;
+ckpt-1 on #2721 caught the contradiction with ``_Fetcher``'s own docstring.)
 
 Expected shape for 2023, from #2284's spike and reproduced here:
 
@@ -30,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import logging
 import sys
 import time
@@ -154,44 +166,80 @@ def harvest(conn: psycopg.Connection[tuple], fetcher: _Fetcher, year: int) -> in
     """
     rows = _index_rows(fetcher, year)
     started = time.time()
-    failures = 0
 
-    for i, row in enumerate(rows.values(), start=1):
-        status, body = fetcher.get(_submission_url(row))
-        if status != 200:
-            logger.warning("%s: status %d", row.accession_number, status)
-            failures += 1
-            continue
-        filing = parse_submission(row, body)
-        conn.execute(
-            _UPSERT,
-            (
-                filing.accession_number,
-                filing.form,
-                filing.filed_date,
-                filing.exchange_cik,
-                filing.exchange_name,
-                filing.issuer_cik,
-                filing.issuer_name,
-                filing.file_number,
-                filing.description_class_security,
-                filing.rule_provision,
-                filing.provision_class,
-                filing.security_class,
-                filing.signature_date,
-                filing.suspension_date,
-            ),
+    def _fetch_and_store(batch: dict[str, Form25IndexRow]) -> list[Form25IndexRow]:
+        failed: list[Form25IndexRow] = []
+        for i, row in enumerate(batch.values(), start=1):
+            status, body = fetcher.get(_submission_url(row))
+            if status != 200:
+                logger.warning("%s: status %d", row.accession_number, status)
+                failed.append(row)
+                continue
+            filing = parse_submission(row, body)
+            conn.execute(
+                _UPSERT,
+                (
+                    filing.accession_number,
+                    filing.form,
+                    filing.filed_date,
+                    filing.exchange_cik,
+                    filing.exchange_name,
+                    filing.issuer_cik,
+                    filing.issuer_name,
+                    filing.file_number,
+                    filing.description_class_security,
+                    filing.rule_provision,
+                    filing.provision_class,
+                    filing.security_class,
+                    filing.signature_date,
+                    filing.suspension_date,
+                ),
+            )
+            if i % 100 == 0:
+                conn.commit()
+                logger.info("  %d/%d filings (%.0fs)", i, len(batch), time.time() - started)
+        conn.commit()
+        return failed
+
+    failed = _fetch_and_store(rows)
+    if failed:
+        # One retry pass after a pause — transient 429/5xx are the common
+        # case at this volume. Anything that fails twice is a real failure
+        # and the YEAR is incomplete: the caller must gate on the return
+        # value, not shrug (ckpt-1 on #2721 — `main` used to discard it, so
+        # a partial year read as complete).
+        logger.warning("%d filing fetch(es) failed; retrying once in 30s", len(failed))
+        time.sleep(30)
+        failed = _fetch_and_store({r.accession_number: r for r in failed})
+    if failed:
+        logger.error(
+            "%d filing(s) failed twice — year %d is INCOMPLETE: %s",
+            len(failed),
+            year,
+            ", ".join(r.accession_number for r in failed[:10]),
         )
-        if i % 100 == 0:
-            conn.commit()
-            logger.info("  %d/%d filings (%.0fs)", i, len(rows), time.time() - started)
-    conn.commit()
-    if failures:
-        logger.warning("%d filing fetch(es) failed", failures)
-    return failures
+    return len(failed)
 
 
 _SUBMISSIONS = "https://data.sec.gov/submissions/CIK{cik}.json"
+
+
+def _cover_page_candidates(columnar: dict[str, list[str]], before: date) -> list[tuple[str, str, str]]:
+    """(filing_date, accession, primary_doc) for cover-page forms at/before the delisting."""
+    candidates: list[tuple[str, str, str]] = []
+    for form, filing_date, accession, primary in zip(
+        columnar.get("form", []),
+        columnar.get("filingDate", []),
+        columnar.get("accessionNumber", []),
+        columnar.get("primaryDocument", []),
+        strict=False,
+    ):
+        if form not in COVER_PAGE_FORMS or not primary:
+            continue
+        if filing_date > before.isoformat():
+            continue
+        candidates.append((filing_date, accession, primary))
+    return candidates
 
 
 def _resolve_symbol(fetcher: _Fetcher, cik: str, before: date) -> tuple[str, str] | None:
@@ -202,27 +250,30 @@ def _resolve_symbol(fetcher: _Fetcher, cik: str, before: date) -> tuple[str, str
     company APIs serve numeric facts only). So walk the filing history for the
     newest cover-page form filed at or before the delisting and read
     ``dei:TradingSymbol`` off its primary document.
+
+    ``filings.recent`` is capped at ~1000 filings / ≥1 year; older history
+    lives in the ``filings.files[]`` pages (sec-edgar.md: "Always check
+    ``files`` and recurse"). For old delisting years the miss is BIASED, not
+    random: an issuer that failed stops filing (its cover pages stay in
+    ``recent`` forever), while an ``(a)(3)`` survivor keeps filing and pushes
+    its pre-delisting cover pages out — resolution would skew along exactly
+    the failure-vs-acquisition axis the census z-tests (Codex ckpt-2, #2721).
     """
     status, body = fetcher.get(_SUBMISSIONS.format(cik=cik))
     if status != 200:
         return None
-    import json
-
-    payload = json.loads(body)
-    recent = payload.get("filings", {}).get("recent", {})
-    candidates: list[tuple[str, str, str]] = []
-    for form, filing_date, accession, primary in zip(
-        recent.get("form", []),
-        recent.get("filingDate", []),
-        recent.get("accessionNumber", []),
-        recent.get("primaryDocument", []),
-        strict=False,
-    ):
-        if form not in COVER_PAGE_FORMS or not primary:
-            continue
-        if filing_date > before.isoformat():
-            continue
-        candidates.append((filing_date, accession, primary))
+    filings = json.loads(body).get("filings", {})
+    candidates = _cover_page_candidates(filings.get("recent", {}), before)
+    if not candidates:
+        for page in filings.get("files", []):
+            name = page.get("name")
+            # Pages carry their span; skip any that begins after the delisting.
+            if not name or page.get("filingFrom", "9999") > before.isoformat():
+                continue
+            page_status, page_body = fetcher.get(f"https://data.sec.gov/submissions/{name}")
+            if page_status != 200:
+                continue
+            candidates.extend(_cover_page_candidates(json.loads(page_body), before))
 
     for _, accession, primary in sorted(candidates, reverse=True)[:5]:
         url = f"{_ARCHIVES}/edgar/data/{int(cik)}/{accession.replace('-', '')}/{primary}"
@@ -474,9 +525,33 @@ def census(conn: psycopg.Connection[tuple], year: int) -> None:
     )
 
 
+def parse_years(spec: str) -> list[int]:
+    """``2013-2024`` -> [2013, ..., 2024]. Pure so the CLI contract is testable."""
+    start_s, _, end_s = spec.partition("-")
+    start, end = int(start_s), int(end_s or start_s)
+    if end < start:
+        raise ValueError(f"years range is backwards: {spec}")
+    return list(range(start, end + 1))
+
+
+#: The year whose cohort the committed acceptance fixture was frozen from.
+#: `--emit-fixture` for any other year against the DEFAULT path would silently
+#: overwrite the vendor acceptance test (ckpt-1 on #2721) — a different year's
+#: cohort is a different test, and it gets an explicit `--fixture-path`.
+_FIXTURE_YEAR = 2023
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--year", type=int, default=2023)
+    parser.add_argument(
+        "--years",
+        type=str,
+        default=None,
+        help="Inclusive range, e.g. 2013-2024. Runs the selected actions per "
+        "year, strictly sequentially, aborting if a year's harvest is "
+        "incomplete after retry. Excludes --emit-fixture.",
+    )
     parser.add_argument("--harvest", action="store_true")
     parser.add_argument("--reclassify", action="store_true")
     parser.add_argument("--resolve-symbols", action="store_true")
@@ -489,19 +564,37 @@ def main(argv: list[str] | None = None) -> int:
     if not any((args.harvest, args.reclassify, args.resolve_symbols, args.emit_fixture, args.census)):
         parser.error("pick at least one action")
 
+    years = parse_years(args.years) if args.years else [args.year]
+    if args.emit_fixture:
+        if args.years:
+            parser.error("--emit-fixture is single-year; it is an acceptance fixture, not a log")
+        if args.year != _FIXTURE_YEAR and args.fixture_path == _FIXTURE:
+            parser.error(
+                f"--emit-fixture --year {args.year} would overwrite the frozen "
+                f"{_FIXTURE_YEAR} acceptance fixture at {_FIXTURE}; pass an "
+                "explicit --fixture-path"
+            )
+
     fetcher = _Fetcher()
     try:
         with psycopg.connect(settings.database_url) as conn:
-            if args.harvest:
-                harvest(conn, fetcher, args.year)
-            if args.reclassify:
-                reclassify(conn, args.year)
-            if args.resolve_symbols:
-                resolve_symbols(conn, fetcher, args.year)
-            if args.emit_fixture:
-                emit_fixture(conn, args.year, args.fixture_path)
-            if args.census:
-                census(conn, args.year)
+            for year in years:
+                if args.harvest:
+                    failures = harvest(conn, fetcher, year)
+                    if failures:
+                        # The year is incomplete; its census would understate
+                        # and its resolution would run against a partial
+                        # cohort. Stop rather than continue on bad data.
+                        logger.error("aborting at year %d: %d unfetched filings", year, failures)
+                        return 1
+                if args.reclassify:
+                    reclassify(conn, year)
+                if args.resolve_symbols:
+                    resolve_symbols(conn, fetcher, year)
+                if args.emit_fixture:
+                    emit_fixture(conn, year, args.fixture_path)
+                if args.census:
+                    census(conn, year)
     finally:
         fetcher.close()
     return 0

--- a/scripts/build_2282_form25_register.py
+++ b/scripts/build_2282_form25_register.py
@@ -264,11 +264,21 @@ def _resolve_symbol(fetcher: _Fetcher, cik: str, before: date) -> tuple[str, str
         return None
     filings = json.loads(body).get("filings", {})
     candidates = _cover_page_candidates(filings.get("recent", {}), before)
-    if not candidates:
+    # ``recent`` holds the NEWEST filings, so any candidate it yields outranks
+    # everything in the (strictly older) ``files[]`` pages for the
+    # newest-at-or-before-the-delisting scan below. The pages matter when
+    # ``recent`` yields fewer than the scan's five-candidate capacity — zero
+    # because the issuer kept filing past the cap, or too few to survive a
+    # fetch/parse failure on the top pick.
+    if len(candidates) < 5:
         for page in filings.get("files", []):
             name = page.get("name")
-            # Pages carry their span; skip any that begins after the delisting.
-            if not name or page.get("filingFrom", "9999") > before.isoformat():
+            if not name:
+                continue
+            # Pages carry their span; skip any that BEGINS after the
+            # delisting. A page missing ``filingFrom`` is unknown-but-
+            # possibly-relevant and is fetched, not skipped.
+            if page.get("filingFrom", "") > before.isoformat():
                 continue
             page_status, page_body = fetcher.get(f"https://data.sec.gov/submissions/{name}")
             if page_status != 200:

--- a/scripts/build_2282_form25_register.py
+++ b/scripts/build_2282_form25_register.py
@@ -543,7 +543,9 @@ _FIXTURE_YEAR = 2023
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--year", type=int, default=2023)
+    # Default applied after parsing (not here) so that passing BOTH --year and
+    # --years is detectable as the contradiction it is.
+    parser.add_argument("--year", type=int, default=None)
     parser.add_argument(
         "--years",
         type=str,
@@ -564,13 +566,21 @@ def main(argv: list[str] | None = None) -> int:
     if not any((args.harvest, args.reclassify, args.resolve_symbols, args.emit_fixture, args.census)):
         parser.error("pick at least one action")
 
-    years = parse_years(args.years) if args.years else [args.year]
+    if args.year is not None and args.years:
+        parser.error("--year and --years contradict; pass one")
+    if args.years:
+        try:
+            years = parse_years(args.years)
+        except ValueError as exc:
+            parser.error(f"--years: {exc}")
+    else:
+        years = [args.year if args.year is not None else _FIXTURE_YEAR]
     if args.emit_fixture:
         if args.years:
             parser.error("--emit-fixture is single-year; it is an acceptance fixture, not a log")
-        if args.year != _FIXTURE_YEAR and args.fixture_path == _FIXTURE:
+        if years != [_FIXTURE_YEAR] and args.fixture_path == _FIXTURE:
             parser.error(
-                f"--emit-fixture --year {args.year} would overwrite the frozen "
+                f"--emit-fixture --year {years[0]} would overwrite the frozen "
                 f"{_FIXTURE_YEAR} acceptance fixture at {_FIXTURE}; pass an "
                 "explicit --fixture-path"
             )

--- a/scripts/build_2282_form25_register.py
+++ b/scripts/build_2282_form25_register.py
@@ -263,39 +263,52 @@ def _resolve_symbol(fetcher: _Fetcher, cik: str, before: date) -> tuple[str, str
     if status != 200:
         return None
     filings = json.loads(body).get("filings", {})
-    candidates = _cover_page_candidates(filings.get("recent", {}), before)
+
+    tried: set[str] = set()
+
+    def _scan(candidates: list[tuple[str, str, str]]) -> tuple[str, str] | None:
+        """Try the newest five UNTRIED candidates; None if all fail."""
+        untried = [c for c in sorted(candidates, reverse=True) if c[1] not in tried]
+        for _, accession, primary in untried[:5]:
+            tried.add(accession)
+            doc_status, document = fetcher.get(
+                f"{_ARCHIVES}/edgar/data/{int(cik)}/{accession.replace('-', '')}/{primary}"
+            )
+            if doc_status != 200:
+                continue
+            match = TRADING_SYMBOL_RE.search(document)
+            if match:
+                symbol = clean_trading_symbol(match.group(1))
+                if symbol:
+                    return symbol, accession
+        return None
+
     # ``recent`` holds the NEWEST filings, so any candidate it yields outranks
     # everything in the (strictly older) ``files[]`` pages for the
-    # newest-at-or-before-the-delisting scan below. The pages matter when
-    # ``recent`` yields fewer than the scan's five-candidate capacity — zero
-    # because the issuer kept filing past the cap, or too few to survive a
-    # fetch/parse failure on the top pick.
-    if len(candidates) < 5:
-        for page in filings.get("files", []):
-            name = page.get("name")
-            if not name:
-                continue
-            # Pages carry their span; skip any that BEGINS after the
-            # delisting. A page missing ``filingFrom`` is unknown-but-
-            # possibly-relevant and is fetched, not skipped.
-            if page.get("filingFrom", "") > before.isoformat():
-                continue
-            page_status, page_body = fetcher.get(f"https://data.sec.gov/submissions/{name}")
-            if page_status != 200:
-                continue
-            candidates.extend(_cover_page_candidates(json.loads(page_body), before))
+    # newest-at-or-before-the-delisting objective. Scan those first; the
+    # pages are fetched only if that scan RESOLVES NOTHING — whether because
+    # ``recent`` had no candidate at or before the cutoff, or because every
+    # attempted one failed to fetch/parse (a pre-loop count cannot see the
+    # second case — review round 3).
+    candidates = _cover_page_candidates(filings.get("recent", {}), before)
+    resolved = _scan(candidates)
+    if resolved is not None:
+        return resolved
 
-    for _, accession, primary in sorted(candidates, reverse=True)[:5]:
-        url = f"{_ARCHIVES}/edgar/data/{int(cik)}/{accession.replace('-', '')}/{primary}"
-        status, document = fetcher.get(url)
-        if status != 200:
+    for page in filings.get("files", []):
+        name = page.get("name")
+        if not name:
             continue
-        match = TRADING_SYMBOL_RE.search(document)
-        if match:
-            symbol = clean_trading_symbol(match.group(1))
-            if symbol:
-                return symbol, accession
-    return None
+        # Pages carry their span; skip any that BEGINS after the delisting.
+        # A page missing ``filingFrom`` is unknown-but-possibly-relevant and
+        # is fetched, not skipped.
+        if page.get("filingFrom", "") > before.isoformat():
+            continue
+        page_status, page_body = fetcher.get(f"https://data.sec.gov/submissions/{name}")
+        if page_status != 200:
+            continue
+        candidates.extend(_cover_page_candidates(json.loads(page_body), before))
+    return _scan(candidates)
 
 
 def resolve_symbols(conn: psycopg.Connection[tuple], fetcher: _Fetcher, year: int) -> int:

--- a/scripts/ingest_2282_research_archive.py
+++ b/scripts/ingest_2282_research_archive.py
@@ -135,7 +135,7 @@ def link_delistings(conn: psycopg.Connection[tuple]) -> int:
     print("\n=== #2297 Form 25 delisting linkage ===")
     print(f"  overlapping series      : {census.overlap_series:,}")
     print(f"  suspension dates written: {census.suspension_dates_written:,}")
-    print(f"  no suspension date (NULL, not back-filled): {census.no_suspension_date:,}")
+    print(f"  undated evidence written (date NULL, not back-filled): {census.undated_evidence_written:,}")
     print(f"  conflicting symbols     : {census.conflicting or 'none'}")
     print("  overlap by rule provision:")
     for provision, n in sorted(census.by_provision.items()):

--- a/scripts/ingest_2597_intrader_archive.py
+++ b/scripts/ingest_2597_intrader_archive.py
@@ -105,7 +105,7 @@ def link_delistings(conn: psycopg.Connection[tuple]) -> int:
     print("\n=== #2597 Form 25 delisting linkage (Intrader) ===")
     print(f"  overlapping series      : {census.overlap_series:,}")
     print(f"  suspension dates written: {census.suspension_dates_written:,}")
-    print(f"  no suspension date (NULL, not back-filled): {census.no_suspension_date:,}")
+    print(f"  undated evidence written (date NULL, not back-filled): {census.undated_evidence_written:,}")
     print(f"  conflicting symbols     : {census.conflicting or 'none'}")
     print("  overlap by rule provision:")
     for provision, count in sorted(census.by_provision.items()):

--- a/sql/353_form25_evidence_without_suspension_date.sql
+++ b/sql/353_form25_evidence_without_suspension_date.sql
@@ -1,0 +1,145 @@
+-- 353_form25_evidence_without_suspension_date.sql
+--
+-- #2721 step 1 — let Form 25 evidence persist WITHOUT a suspension date.
+--
+--
+-- THE STRUCTURAL GAP THIS CLOSES
+-- ---------------------------------------------------------------------------
+-- sql/249 CHECK-paired `delisting_date` with `delisting_source` in BOTH
+-- directions, and sql/253 biconditionally paired `delisting_provision` with
+-- `delisting_source = 'sec_form25'`. Together those two constraints make
+-- "linked to a Form 25 that states no suspension date" UNREPRESENTABLE: no
+-- date -> no source -> no provision. Measured on the 2023 register
+-- (#2721, 2026-08-15): `(b)` — exchange-initiated delisting for
+-- non-compliance, the one provision where a held position's termination
+-- treatment matters most — states a suspension date on 0 of 105 cohort rows
+-- (the date lives in the EX-99 exhibit and exchanges attach a stub,
+-- sec-edgar.md §2.6 trap 5). So every one of the 88 `(b)` symbols present in
+-- the Intrader corpus linked to NOTHING, while all 39 written links are
+-- `(a)(3)` — the merger/reorg provision where a continuous series is usually
+-- correct. The schema itself enforced exactly the wrong asymmetry.
+--
+-- What changes and what does not:
+--
+--   * `delisting_source` + `delisting_provision` may now exist with
+--     `delisting_date` NULL — "a Form 25 removed this security; the filing
+--     states no suspension date". The date is NEVER back-filled from
+--     `filed_date`: that is a different event (a Form 25 carries up to three
+--     dates) and substituting it mistruncates every series it touches.
+--   * A bare `delisting_date` (date without source) stays impossible.
+--   * A DATED 'sec_form25' row without a provision stays impossible —
+--     sql/253's loaded-gun argument is about truncating on a date whose
+--     provision you cannot read, and that guard is kept verbatim.
+--   * `delisting_provision` may now be NULL on an undated 'sec_form25' row.
+--     The 2023 cohort happens to contain zero NULL-provision rows
+--     (`SELECT coalesce(rule_provision,'(NULL)'), count(*) FROM
+--     sec_form25_common_equity_delistings GROUP BY 1` -> (a)(3) 212, (b) 105)
+--     but the 25-NSE form carries no <ruleProvision> element by design
+--     (app/services/sec_form25_register.py::classify_provision), so the
+--     2013-2024 expansion can produce them. "Linked, provision unparsed" is a
+--     real evidence state and gets its own class downstream, not a fabricated
+--     paragraph.
+--
+-- `delisting_filed_date` is added because the earliest linked filing date is
+-- evidence in its own right (the series ended BEFORE any Form 25 on the
+-- symbol = a genuine termination), and sql/253's "read it by joining
+-- resolved_symbol = vendor_symbol" no longer works: #2597 replaced that join
+-- with the Q-suffix candidate ladder in Python, so SQL readers cannot
+-- reproduce the resolution.
+
+ALTER TABLE research_price_series
+    ADD COLUMN IF NOT EXISTS delisting_filed_date DATE;
+
+-- Was biconditional (date IS NULL) = (source IS NULL). What remains:
+--   1. a date with no source is still a fabrication;
+--   2. the undated-evidence state is opened for 'sec_form25' ONLY — the other
+--      sources (#2290's forward record, vendor flags) have no filing to be
+--      evidence OF, so an undated row under them would be the old integrity
+--      hole reopened under a different name (Codex ckpt-2 on #2721).
+ALTER TABLE research_price_series
+    DROP CONSTRAINT IF EXISTS research_price_series_delisting_evidenced;
+ALTER TABLE research_price_series
+    ADD CONSTRAINT research_price_series_delisting_evidenced
+        CHECK (
+            (delisting_date IS NULL OR delisting_source IS NOT NULL)
+            AND (delisting_source IS NULL
+                OR delisting_source = 'sec_form25'
+                OR delisting_date IS NOT NULL)
+        );
+
+-- Was biconditional (source = 'sec_form25') = (provision IS NOT NULL).
+-- Split into the two directions that are still true:
+--   1. a provision only ever comes from a Form 25 (#2290's forward record and
+--      vendor flags have no Rule 12d2-2 paragraph);
+--   2. a DATED Form 25 row must carry its provision — nobody may truncate on
+--      a date whose provision class they cannot read (sql/253's argument).
+-- An UNDATED 'sec_form25' row with a NULL provision is now legal: linked,
+-- provision unparsed.
+ALTER TABLE research_price_series
+    DROP CONSTRAINT IF EXISTS research_price_series_provision_from_form25;
+ALTER TABLE research_price_series
+    ADD CONSTRAINT research_price_series_provision_from_form25
+        CHECK (
+            (delisting_provision IS NULL
+                OR delisting_source IS NOT DISTINCT FROM 'sec_form25')
+            AND (delisting_date IS NULL
+                OR delisting_source IS DISTINCT FROM 'sec_form25'
+                OR delisting_provision IS NOT NULL)
+        );
+
+-- The filed date is Form 25 evidence and nothing else supplies one. One-way
+-- (not biconditional) so the constraint holds over the 37 pre-existing
+-- 'sec_form25' rows between this migration and the re-link that back-fills
+-- them; the linkage writes it on every row it touches.
+ALTER TABLE research_price_series
+    DROP CONSTRAINT IF EXISTS research_price_series_filed_date_from_form25;
+ALTER TABLE research_price_series
+    ADD CONSTRAINT research_price_series_filed_date_from_form25
+        CHECK (delisting_filed_date IS NULL
+               OR delisting_source IS NOT DISTINCT FROM 'sec_form25');
+
+COMMENT ON COLUMN research_price_series.delisting_filed_date IS
+    'Earliest filed_date across the Form 25 filings linked to this series '
+    '(min() over the symbol''s cohort filings — the conservative bound). '
+    'Present whenever delisting_source = ''sec_form25''. NOT a suspension '
+    'date and never a truncation point: a Form 25 carries up to three dates '
+    'and the filing date is the one that is always stated, not the one that '
+    'ends trading.';
+
+COMMENT ON COLUMN research_price_series.delisting_source IS
+    'Source of the delisting EVIDENCE on this row, not merely of '
+    'delisting_date. ''sec_form25'' rows may carry a NULL delisting_date: '
+    '(b) exchange-initiated filings state a suspension date on 0 of 105 '
+    '2023 cohort rows (sec-edgar.md §2.6 trap 5), and refusing to store the '
+    'link because the date is unstated is how the exchange-failure class — '
+    'the one a termination rule needs most — stayed at zero coverage '
+    '(#2721).';
+
+-- The census view counted `count(s.delisting_date)` as "series with a
+-- delisting record". Under the evidence model that undercounts: an undated
+-- (b) link IS a delisting record. Count the source instead; the dated subset
+-- stays visible as its own column.
+CREATE OR REPLACE VIEW research_corpus_census AS
+SELECT
+    COALESCE(e.asset_class, CASE WHEN s.instrument_id IS NULL
+                                 THEN '(unresolved)' ELSE '(unmapped)' END)
+                                                       AS asset_class,
+    s.vendor,
+    count(*)                                           AS series,
+    count(s.instrument_id)                             AS resolved_series,
+    min(s.first_bar)                                   AS earliest_first_bar,
+    max(s.last_bar)                                    AS latest_last_bar,
+    sum(s.bar_count)                                   AS bars,
+    count(*) FILTER (WHERE s.bar_count IS NULL)        AS series_without_bars,
+    count(s.delisting_source)                          AS series_with_delisting,
+    count(s.delisting_date)                            AS series_with_delisting_date
+FROM research_price_series s
+LEFT JOIN instruments i ON i.instrument_id = s.instrument_id
+LEFT JOIN exchanges   e ON e.exchange_id = i.exchange
+GROUP BY 1, 2;
+
+COMMENT ON VIEW research_corpus_census IS
+    'Per asset-class corpus coverage: series, resolved series, first/last bar, '
+    'bar count, series carrying a delisting record (any Form 25 evidence, '
+    'dated or not — see 353) plus the dated subset. The (unresolved) row is '
+    'the eToro-listing-bias measurement and is reported, never filtered out.';

--- a/tests/test_build_form25_register_cli.py
+++ b/tests/test_build_form25_register_cli.py
@@ -1,0 +1,38 @@
+"""#2721 — the Form 25 register builder's multi-year CLI contract.
+
+Only the pure/parse layer: every guard here fires in ``main`` before any DB
+connection or network call, so these run in the fast tier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.build_2282_form25_register import main, parse_years
+
+
+def test_years_range_is_inclusive_both_ends() -> None:
+    assert parse_years("2013-2024") == list(range(2013, 2025))
+
+
+def test_single_year_spec_is_one_year() -> None:
+    assert parse_years("2019") == [2019]
+
+
+def test_backwards_range_is_refused() -> None:
+    with pytest.raises(ValueError):
+        parse_years("2024-2013")
+
+
+def test_emit_fixture_for_another_year_cannot_overwrite_the_frozen_fixture() -> None:
+    # tests/fixtures/form25_2023_cohort.csv is the vendor acceptance test for
+    # any future price source. `--emit-fixture --year 2013` on the default
+    # path would silently replace it with a different year's cohort — a
+    # different test wearing the same filename.
+    with pytest.raises(SystemExit):
+        main(["--emit-fixture", "--year", "2013"])
+
+
+def test_emit_fixture_is_single_year_only() -> None:
+    with pytest.raises(SystemExit):
+        main(["--emit-fixture", "--years", "2013-2024"])

--- a/tests/test_build_form25_register_cli.py
+++ b/tests/test_build_form25_register_cli.py
@@ -36,3 +36,13 @@ def test_emit_fixture_for_another_year_cannot_overwrite_the_frozen_fixture() -> 
 def test_emit_fixture_is_single_year_only() -> None:
     with pytest.raises(SystemExit):
         main(["--emit-fixture", "--years", "2013-2024"])
+
+
+def test_year_and_years_together_are_refused() -> None:
+    with pytest.raises(SystemExit):
+        main(["--census", "--year", "2019", "--years", "2013-2024"])
+
+
+def test_malformed_years_is_an_argparse_error_not_a_traceback() -> None:
+    with pytest.raises(SystemExit):
+        main(["--census", "--years", "20x3-2024"])

--- a/tests/test_research_corpus_ingest.py
+++ b/tests/test_research_corpus_ingest.py
@@ -109,12 +109,14 @@ def test_same_instrument_listed_twice_is_not_a_collision() -> None:
 # #2297 — Form 25 delisting-link policy
 # ---------------------------------------------------------------------------
 #
-# The three cases below are the whole policy, and TWO OF THEM ARE REFUSALS.
-# That ratio is the finding: measured on the full 2023 register, `(b)` — the
-# provision where truncating a series is unambiguously right — states a
-# suspension date on 0 of 105 cohort rows, so `no_suspension` is the normal
-# outcome and `write` is the exception. A test suite that only exercised the
-# happy path would describe a guard that does not exist.
+# The three verdicts below are the whole policy. Measured on the full 2023
+# register, `(b)` — the provision where truncating a series is unambiguously
+# right — states a suspension date on 0 of 105 cohort rows, so
+# `no_suspension` is the normal outcome and `write` is the exception. Since
+# #2721 `no_suspension` persists the EVIDENCE (source, provision, filed date)
+# and withholds only `delisting_date`; `conflict` remains a full refusal. A
+# test suite that only exercised the happy path would describe a guard that
+# does not exist.
 
 
 def _match(**overrides: object) -> Form25Match:
@@ -130,6 +132,7 @@ def _match(**overrides: object) -> Form25Match:
         "first_bar": date(1992, 6, 17),
         "last_bar": date(2026, 7, 7),
         "earliest_filed": date(2023, 3, 2),
+        "latest_filed": date(2023, 3, 2),
         "provision_variants": 1,
         "provision": "(a)(3)",
         "suspension_variants": 1,
@@ -149,7 +152,9 @@ def test_stated_suspension_date_is_written() -> None:
 
 def test_absent_suspension_date_is_never_backfilled_from_filed_date() -> None:
     # The filing date is RIGHT THERE on the match and is a different event.
-    # Substituting it is the failure mode sql/249's CHECK pair exists to stop.
+    # Substituting it is the failure mode sql/353's constraints exist to stop:
+    # the writer maps `no_suspension` to an evidence write whose
+    # delisting_date is NULL, never to a date borrowed from the filing.
     match = _match(suspension_date=None)
     assert match.earliest_filed is not None
     assert classify_form25_match(match) == "no_suspension"
@@ -167,6 +172,53 @@ def test_conflict_outranks_the_missing_date_branch() -> None:
     # filing them as ordinary missing dates. Probed by swapping the branches —
     # this assertion fails, the other four still pass.
     assert classify_form25_match(_match(provision_variants=2, suspension_date=None)) == "conflict"
+
+
+def test_series_starting_after_the_filing_is_refused() -> None:
+    # ALPS: Form 25 filed 2023-07-27, series first bar 2025-10-31 — a later
+    # occupant of the ticker (or a post-Ch11 relisting, DBD). The filing
+    # removed a security whose history this demonstrably is not; writing
+    # evidence here marks a live series as delisted.
+    match = _match(first_bar=date(2025, 10, 31), suspension_date=None)
+    assert classify_form25_match(match) == "identity_unverified"
+
+
+def test_series_straddling_two_filings_is_a_conflict_not_an_identity_refusal() -> None:
+    # A relist-then-delist cycle: filings 2015 and 2023, series starts 2018.
+    # The 2023 filing may describe THIS series' security, so this is not
+    # "starts after every filing" — but the aggregate collapses the two
+    # events, so the evidence cannot be attributed without inventing a
+    # precedence order. Refused as ambiguity. Zero such symbols in the 2023
+    # register (no resolved symbol carries two distinct filed dates); the
+    # 2013-2024 expansion is what makes this branch reachable.
+    match = _match(
+        first_bar=date(2018, 1, 5),
+        earliest_filed=date(2015, 3, 2),
+        latest_filed=date(2023, 3, 2),
+        suspension_date=None,
+    )
+    assert classify_form25_match(match) == "conflict"
+
+
+def test_identity_gate_also_blocks_dated_writes() -> None:
+    # The dated writer always had this hole (it wrote unconditionally) and it
+    # never fired — none of 2023's four identity-unverified overlaps states a
+    # suspension date. The gate closes it for both write shapes.
+    assert classify_form25_match(_match(first_bar=date(2025, 10, 31))) == "identity_unverified"
+
+
+def test_conflict_outranks_the_identity_gate() -> None:
+    # Disagreeing filings are a stronger refusal: two events on one ticker is
+    # ambiguity about WHICH filing the bar test should even run against.
+    match = _match(first_bar=date(2025, 10, 31), provision_variants=2)
+    assert classify_form25_match(match) == "conflict"
+
+
+def test_unknown_first_bar_is_not_refused() -> None:
+    # A bar-less series cannot fail a bar test; it stays at the pre-existing
+    # policy (evidence written) rather than being refused on missing data.
+    match = _match(first_bar=None, suspension_date=None)
+    assert classify_form25_match(match) == "no_suspension"
 
 
 def test_provision_does_not_change_the_write_decision() -> None:

--- a/tests/test_series_termination.py
+++ b/tests/test_series_termination.py
@@ -1,0 +1,109 @@
+"""#2721 — the termination rule's class table and realisation fractions.
+
+The module ships UNWIRED (no execution path calls it until step 3 wires the
+``BACKTEST_UNIVERSE`` parameterisation), so these tests ARE its whole
+behavioural surface for now.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.series_termination import (
+    SHUMWAY_HAIRCUT,
+    TERMINATION_RULE_VERSION,
+    TWO_ARMED_CLASSES,
+    TerminationClass,
+    TerminationEvidence,
+    classify_termination,
+    terminal_value_fraction,
+)
+
+
+def _evidence(**overrides: object) -> TerminationEvidence:
+    base: dict[str, object] = {"linked": True, "provision": "(b)", "q_suffix": False}
+    base.update(overrides)
+    return TerminationEvidence(**base)  # type: ignore[arg-type]
+
+
+# --- the class table -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("evidence", "expected"),
+    [
+        (_evidence(provision="(b)"), TerminationClass.EXCHANGE_FAILURE),
+        (_evidence(provision="(a)(4)"), TerminationClass.EXCHANGE_FAILURE_A4),
+        (_evidence(provision="(a)(3)"), TerminationClass.OPERATION_OF_LAW),
+        (_evidence(provision=None), TerminationClass.LINKED_UNPARSED),
+        (
+            _evidence(linked=False, provision=None, q_suffix=True),
+            TerminationClass.Q_SUFFIX_OTC,
+        ),
+        (_evidence(linked=False, provision=None), TerminationClass.UNKNOWN),
+    ],
+)
+def test_class_table(evidence: TerminationEvidence, expected: TerminationClass) -> None:
+    assert classify_termination(evidence) == expected
+
+
+def test_a4_is_a_distinct_label_from_b() -> None:
+    # "(a)(4) ≈ (b)" is asserted, not demonstrated (ckpt-1). The two realise
+    # identically TODAY, but collapsing the labels would make the
+    # expanded-register verification unmeasurable.
+    a4 = classify_termination(_evidence(provision="(a)(4)"))
+    b = classify_termination(_evidence(provision="(b)"))
+    assert a4 != b
+    assert terminal_value_fraction(a4, None) == terminal_value_fraction(b, None)
+
+
+def test_form25_link_outranks_the_q_suffix() -> None:
+    # The filing is a regulator's statement about this security; the suffix
+    # is a naming convention. A linked (a)(3) that happens to carry a Q must
+    # realise as the conversion, not as the OTC heuristic.
+    evidence = _evidence(provision="(a)(3)", q_suffix=True)
+    assert classify_termination(evidence) == TerminationClass.OPERATION_OF_LAW
+
+
+# --- realisation fractions -------------------------------------------------
+
+
+def test_failure_classes_take_the_adverse_shumway_anchor() -> None:
+    # Venue is unknown for dead names, so the Nasdaq −55% (Shumway & Warther
+    # 1999) binds, not the NYSE/AMEX −30% (Shumway 1997 Table V) — the same
+    # pessimistic-end construction as UNKNOWN_NOMINAL_PRICE_BAND.
+    assert terminal_value_fraction(TerminationClass.EXCHANGE_FAILURE, None) == pytest.approx(0.45)
+    assert SHUMWAY_HAIRCUT == pytest.approx(0.55)
+
+
+def test_conversion_and_qsuffix_realise_at_last_close() -> None:
+    assert terminal_value_fraction(TerminationClass.OPERATION_OF_LAW, None) == 1.0
+    assert terminal_value_fraction(TerminationClass.Q_SUFFIX_OTC, None) == 1.0
+
+
+@pytest.mark.parametrize("termination_class", sorted(TWO_ARMED_CLASSES))
+def test_two_armed_classes_span_the_bounds(termination_class: TerminationClass) -> None:
+    best = terminal_value_fraction(termination_class, "best_case")
+    worst = terminal_value_fraction(termination_class, "worst_case")
+    assert best == 1.0
+    assert worst == pytest.approx(1.0 - SHUMWAY_HAIRCUT)
+
+
+@pytest.mark.parametrize("termination_class", sorted(TWO_ARMED_CLASSES))
+def test_two_armed_classes_refuse_a_missing_arm(termination_class: TerminationClass) -> None:
+    # Silently picking a side is exactly the unstated survivorship treatment
+    # this module exists to abolish.
+    with pytest.raises(ValueError):
+        terminal_value_fraction(termination_class, None)
+
+
+def test_single_valued_classes_ignore_the_arm() -> None:
+    # A caller may pass its running arm unconditionally.
+    assert terminal_value_fraction(TerminationClass.OPERATION_OF_LAW, "worst_case") == 1.0
+    assert terminal_value_fraction(TerminationClass.EXCHANGE_FAILURE, "best_case") == pytest.approx(0.45)
+
+
+def test_version_carries_rule_set_id_and_code_hash() -> None:
+    rule_set, _, code_hash = TERMINATION_RULE_VERSION.partition("+")
+    assert rule_set == "series-termination-v1"
+    assert len(code_hash) == 12


### PR DESCRIPTION
## What

Gate 2 of 2 between firing strategies and funded paper trades (`survivorship_free`). Implements the reviewed handoff on #2721 (evidence pass + Codex ckpt-1 already on the issue), in its stated order.

**Step 1 — persist suspension-date-less Form 25 evidence.** `sql/353` + `link_form25_delistings`. The old schema CHECK-paired `delisting_date` with `delisting_source` (sql/249) and biconditionally paired provision with source (sql/253), which made "linked to a Form 25 that states no suspension date" unrepresentable — and `(b)`, exchange-initiated failure, states one on **0 of 105** cohort rows (the date lives in the EX-99 exhibit; exchanges attach a stub). The exchange-failure class — the one a termination rule needs most — was held at zero coverage by the schema itself. Now: `delisting_source` + `delisting_provision` + new `delisting_filed_date` persist with `delisting_date` NULL, for `sec_form25` ONLY. A bare date stays impossible; a dated Form 25 row still must carry its provision; `filed_date` is never written into `delisting_date`.

**Identity gate (found by running the measurement).** The evidence write would have fired on 4 series whose first bar postdates every Form 25 on their symbol (ALPS filed 2023-07 / first bar 2025-10 — a later ticker occupant; DBD — post-Ch11 relisting). New classifier verdict `identity_unverified` refuses these; a series straddling two filings (relist-then-delist cycle, unattributable aggregate) is a `conflict`. Zero straddle cases in the 2023 register (measured: no resolved symbol carries two distinct filed dates); the branch exists before the 2013-2024 expansion makes it reachable.

**Step 2 — register builder hardened for 2013-2024.** Per-year failure gating + one retry pass (a partial year no longer reads as complete — `main` used to discard the failure count); `--years 2013-2024` strictly-sequential mode; hard guard against `--emit-fixture` overwriting the frozen 2023 acceptance fixture; `filings.files[]` pagination in `_resolve_symbol` (sec-edgar.md's own "always recurse" rule — the miss is biased along the failure-vs-acquisition axis, because failures stop filing and stay in `recent` while (a)(3) survivors push their pre-delisting cover pages out); stale GCRA header claim corrected (the local 0.2 s floor is a deliberate half-budget partition).

**Step 3 — `app/services/series_termination.py`, pure, versioned, UNWIRED.** No execution path calls it; `TERMINATION_RULE_VERSION` joins strategy identity only at the commit that wires it (the `BACKTEST_UNIVERSE` parameterisation, next stage). Class table per the ckpt-1-amended design: linked `(b)`/`(a)(4)` → last close × (1−0.55); `(a)(3)` → last close; linked-unparsed + unknown → two-armed bounds; Q-suffix a labelled last-close class; `(a)(4)` kept a distinct label so the expanded register can verify the asserted ≈`(b)` equivalence; `UnlinkedStratum` enum for the census split.

**Source rule:** Shumway, JF 52(1) 1997, Table V p.336 (−30% NYSE/AMEX missing performance-delist returns); Shumway & Warther, JF 54(6) 1999 (−55% Nasdaq). Venue unknown for dead names → adverse anchor, same pessimistic-end construction as `UNKNOWN_NOMINAL_PRICE_BAND`. Rule 12d2-2 provision semantics per sec-edgar.md §2.6.

## Verification (dev DB, full population, 2026-08-15)

- Migration applied; re-link run for BOTH vendors (this is the backfill — it is done, not queued):
  - Intrader: 258 overlap → 37 dated + 221 undated evidence, 0 conflicts, 0 identity-unverified. **(b) 0 → 90 series.**
  - HF archive: 17 overlap → 2 dated + 11 undated, 4 identity-unverified refused.
- A/B: dated arm unchanged (39 rows before and after — same 39 series, same dates); the gain side is undated-evidence-only; distinct-series metric.
- Terminating Intrader cohort (last_bar < 2024-09-01, n=12,468): evidence coverage **37 → 249**, of which (b) **0 → 89**.
- Resolver regression after the pagination change: 2 stored cohort issuers re-resolved to identical symbols (ESTE, CTG).
- `research_corpus_census` view now counts any evidence as `series_with_delisting` and exposes `series_with_delisting_date` as the dated subset.

Not run here: the 2013-2024 harvest itself (hours against the shared SEC budget; the hardened builder is what this PR ships — the run is the post-merge step and its per-year resolution rate is measured, not extrapolated from 2023's 91/105).

## Review

Codex ckpt-2 ran three rounds on this diff: R1 found the non-Form-25 constraint weakening (fixed: undated state scoped to `sec_form25`) and the earliest-vs-latest filing identity comparison (fixed: `latest_filed` + straddle-as-conflict); R2 found the census/classifier disagreement on straddles (fixed: census keys on the verdict); R3 clean.

Skill updated in-PR: `.claude/skills/data-sources/research-price-corpus.md` (evidence model, identity-gate behaviour).

## Security

No security surface: research-corpus schema + one-shot scripts; no auth, no user input, parameterised SQL throughout.

Refs #2721. Refs #2437. Refs #2698.
