### PR TITLE
fix(#2721): Form 25 fetcher survives transport errors

### DIFF
--- a/scripts/build_2282_form25_register.py
+++ b/scripts/build_2282_form25_register.py
@@ -99,7 +99,16 @@ class _Fetcher:
         if wait > 0:
             time.sleep(wait)
         self._next_free = time.monotonic() + _MIN_INTERVAL_S
-        response = self._client.get(url)
+        # Transport failures (ReadTimeout, connection resets) surface as
+        # status 0 rather than an exception: every caller already handles a
+        # non-200, and over a ~14k-request multi-year run a single timeout
+        # must count as one failed fetch, not kill the year (measured: the
+        # first 2024 harvest died mid-run on httpx.ReadTimeout).
+        try:
+            response = self._client.get(url)
+        except httpx.HTTPError as exc:
+            logger.warning("%s: %s", url, type(exc).__name__)
+            return 0, ""
         return response.status_code, response.text
 
     def close(self) -> None:


### PR DESCRIPTION
One-function fix, found by running the 2024 harvest right after #2728 merged: `_Fetcher.get` let `httpx.ReadTimeout` (and any transport error) propagate, killing the whole year run on the first flaky request — the per-year failure gating #2728 added only ever saw HTTP status codes. Transport failures now surface as status 0 with a warning log; every caller already treats non-200 as a failed fetch, so a timeout becomes one countable failure that the existing retry pass and per-year gate handle.

No data semantics; narrow mechanical diff. Gates green (ruff/format/pyright/CLI tests).

## Security
No security surface.

Refs #2721.
