### PR TITLE
docs(#2437): quant-methods sub-skill + market-technician-derived candidates — measured on our own panel

### DIFF
--- a/.claude/skills/market-technician/SKILL.md
+++ b/.claude/skills/market-technician/SKILL.md
@@ -53,6 +53,7 @@ Fixed order, each layer conditioning the next — full contract + worked example
 | [candles](candles.md) | anatomy as intrabar narrative, Nison's actual criteria, the negative empirical record, candles as confirmation-only |
 | [market-dynamics](market-dynamics.md) | regimes, impulse/correction, breakout→retest, reversion after extension, relative strength, gap dynamics, short-side asymmetries, failure modes |
 | [chart-read-protocol](chart-read-protocol.md) | the synthesis: the seven-step read + a MEASURED worked example (AAPL 2026-08-13) |
+| [quant-methods](quant-methods.md) | the systematic mathematics: spread estimators from bars (Roll/Corwin-Schultz/Abdi-Ranaldo, with our measured level-vs-ranking verdict), range volatility (Parkinson/GK/RS/Yang-Zhang), forecast vol (EWMA/GARCH), sizing (Kelly/Thorp, vol targeting), trend strength (Clenow, Kaufman ER, Hurst/Lo negative) — constants verified against author sources |
 
 ## Refuted on our data — read before proposing anything TA-shaped
 

--- a/.claude/skills/market-technician/quant-methods.md
+++ b/.claude/skills/market-technician/quant-methods.md
@@ -1,0 +1,71 @@
+# market-technician / quant-methods
+
+## When to use
+
+Choosing or reviewing the mathematics that turns bars into systematic measurements — spread/liquidity estimators, range-based and forecast volatility, position-sizing formulas, trend-strength metrics. Read before implementing any of these or citing their constants.
+
+Provenance tags per the [hub](SKILL.md): **PUBLISHED** / **MEASURED** / **CONVENTION** / **REFUTED**.
+
+⚠⚠ **MEASURED (verification sweep, 2026-08-15): the constants in this file are exactly where citations drift.** Two live mis-transcriptions were found in reputable secondaries during that sweep: Abdi & Ranaldo's own *RFS* Table 1 restates Corwin-Schultz's β with a ½ factor absent from Corwin's own SAS code, and a widely-used practitioner survey garbles Yang-Zhang's k denominator (T/(T−2) for (n+1)/(n−1)). Implement from the formulas below (verified against author code/primary PDFs where stated), and reconcile any secondary against them. Every "MEASURED (ours)" figure below reproduces via `scripts/verify_2437_quant_methods_panel.py` — the script is the recipe (panel definition, bar-eligibility and aggregation rules live in its docstring, not here).
+
+## Spread and liquidity from daily bars
+
+All computable from OHLCV we already store. Log prices throughout (h, l, c = ln H, ln L, ln C).
+
+- **PUBLISHED — Roll (1984), *JF* 39(4), verified against the original PDF:** spread = 2·√(−cov(Δp_t, Δp_{t+1})) — bid-ask bounce leaves first-order serial covariance = −s²/4 in price changes. ⚠ Roll himself *preserved the sign* when covariance came out positive (half his daily estimates were negative); setting positives to zero is the later convention (Harris 1990, codified in Abdi-Ranaldo Table 1: 2·√(max(−cov, 0))). On returns the estimate is the percentage spread (his footnote 5: bias negligible).
+- **PUBLISHED — Corwin & Schultz (2012), *JF* 67(2), verified against the AUTHORS' OWN SAS code:** for day pair (t, t+1), log prices:
+  - β = (h_t − l_t)² + (h_{t+1} − l_{t+1})²  ← plain sum, **no ½ factor**
+  - γ = [ln(H_{t,t+1} / L_{t,t+1})]², where H_{t,t+1} = max(H_t, H_{t+1}) and L_{t,t+1} = min(L_t, L_{t+1})
+  - α = [(√(2β) − √β) / (3 − 2√2)] − √[γ / (3 − 2√2)]
+  - S = 2(e^α − 1)/(1 + e^α). Aggregation, theirs: per-PAIR estimates over overlapping day pairs, negative pair estimates set to 0 (their primary daily estimator), monthly = mean of dailies with ≥12 observations.
+  - Their overnight adjustment, applied to EACH day before its pairs are formed: prior close below today's low → shift today's H and L down by (L_t − C_{t−1}); prior close above today's high → shift both up by (C_{t−1} − H_t).
+- **PUBLISHED — Abdi & Ranaldo (2017), *RFS* 30(12), verified against the paper:** with η_t = (h_t + l_t)/2 (log mid-range), the base moment form is s² = 4·E[(c_t − η_t)(c_t − η_{t+1})] (their Theorem 1); the practical **two-day-corrected estimator** (their eq. 11, the one measured below) moves the max inside: ŝ = mean_t √(max(4(c_t − η_t)(c_t − η_{t+1}), 0)) — the two are NOT algebraically interchangeable. **Their horse race: CHL wins on daily data** — average cross-sectional correlation 0.74 with TAQ effective spreads vs 0.37–0.65 for Corwin-Schultz, Roll, Gibbs, EffTick, FHT (Oct 2003–Dec 2015 monthly panel), with the advantage largest in their less-liquid buckets. Hasbrouck (2009, *JF* 64(3)) is the Bayesian-Gibbs Roll variant (correlation 0.965 with transaction-level estimates). **CONVENTION (our default, not a published verdict):** start with CHL, escalate to Gibbs only if CHL proves insufficient here.
+- ⚠⚠ **MEASURED (ours, 2026-08-15; reproduce: `uv run python scripts/verify_2437_quant_methods_panel.py`) — the LEVEL is unusable here, the RANKING is usable, CHL ranks best:** on 1,629 quoted instruments (trailing 60 `price_daily` bars, no overnight adjustment, vs `quotes.spread_pct`): median estimate ≈ **1.22%** for BOTH estimators vs median quoted **0.126%** — ~10× level mismatch. Candidate explanations, plausible and UNTESTED: the estimators absorb volatility; our quotes are point-in-time snapshots rather than time-matched effective spreads; eToro bars are bid-derived. The measured fact is the mismatch, not its cause. Ranking IS monotone: mean estimate 1.79% in the top quoted-spread quartile vs ~1.06–1.10% in the bottom; **Spearman 0.429 (CHL) vs 0.353 (CS)**. Verdict: admission-filter *ranking* tool for the backtest corpus, NEVER a cost-model input. **CONVENTION (policy):** where a live quote exists, use the quote.
+- **Blocked (repo data fact, per `etoro-api` skill):** Kyle's λ and anything needing signed order flow — no tape, no depth (the WS gap). Amihud |r|/dollar-volume is the flow-free workhorse and already lives in `strategy-evidence` §2.11.
+
+## Range-based volatility (same bars, more information)
+
+- **PUBLISHED — Parkinson (1980), *J. Business* 53(1):** σ̂² = (1/(4·ln 2))·E[(ln(H/L))²]. Up to ~5× more efficient than close-to-close — under its own assumptions (driftless continuous Brownian motion, no overnight jump); the gain shrinks as those fail.
+- **PUBLISHED — Garman & Klass (1980), *J. Business* 53(1):** the form most libraries implement (e.g. TTR): σ̂² = 0.5·(ln(H/L))² − (2·ln2 − 1)·(ln(C/O))². Same zero-drift/no-opening-jump assumptions. ⚠ Their actual "best analytic scale-invariant estimator" is a different formula (0.511(u−d)² − 0.019{c(u+d) − 2ud} − 0.383c², u=ln(H/O), d=ln(L/O), c=ln(C/O)) — do not attach the "best analytic" label to the simple form.
+- **PUBLISHED — Rogers & Satchell (1991), *Ann. Appl. Prob.* 1(4):** σ̂²_RS = ln(H/C)·ln(H/O) + ln(L/C)·ln(L/O) — drift-independent within the day.
+- **PUBLISHED — Yang & Zhang (2000), *J. Business* 73(3):** the one that incorporates overnight gaps — relevant here because gaps are our measured tail killer: σ²_YZ = σ²_overnight + k·σ²_open-close + (1−k)·σ²_RS over an n-day window (n>1), where the overnight and open-close legs are DEMEANED sample variances of ln(O_t/C_{t−1}) and ln(C_t/O_t) respectively, σ²_RS is the window mean of the Rogers-Satchell term, and k = 0.34/(1.34 + (n+1)/(n−1)). ⚠ The k denominator is the confirmed mis-transcription site — pin the (n+1)/(n−1) form. The overnight component alone is a candidate gap-risk feature (**CONVENTION** until measured as one).
+- **MEASURED (ours, 2026-08-15; same panel script):** Parkinson/close-close σ ratio across the 1,629-instrument panel: median **1.104**, IQR [0.95, 1.32] — the two agree to first order on our bars. That is level agreement only; no forecasting-accuracy comparison has been run here.
+
+## Volatility forecasting (bands describe; these predict)
+
+- **PUBLISHED — EWMA (RiskMetrics Technical Document, 4th ed. 1996):** σ²_t = λ·σ²_{t−1} + (1−λ)·r²_{t−1}, **λ = 0.94 for daily returns** (0.97 for a monthly-return series — a different data frequency, not an aggregation of daily forecasts). One causal recursive line.
+- **PUBLISHED — GARCH(1,1) (Bollerslev 1986, *J. Econometrics* 31; ancestor Engle 1982):** σ²_t = ω + α·ε²_{t−1} + β·σ²_{t−1}; covariance stationarity needs ω>0, α,β≥0 and α+β<1, giving unconditional variance ω/(1−α−β). One published worked example — an example, not portable defaults (Engle's *GARCH 101*, *JEP* 2001, Table 3; daily US portfolio returns 1990–2000): ω=1.4e−6, α=0.0772, β=0.9046. EWMA is the integrated case ω=0, α=1−λ, β=λ. **CONVENTION (our default):** start with EWMA, escalate to fitted GARCH only on evidence.
+- Forecast vol exists to feed SIZING and regime context — as a trade signal it is refuted territory here (S-4's compression cut; and Cederburg's replication limits vol-scaling's benefit to momentum/profitability/BAB — `strategy-evidence` §2.4).
+
+## Position sizing — the equations the family was missing
+
+**MEASURED (ours, 2026-08-09, recorded in `docs/proposals/ta/2026-08-09-plan-of-attack.md`):** gaps void stops — 141 of 1,402 filled stops executed at an open beyond the stop level (1,364 event DAYS; a name can stop more than once, hence the larger denominator), worst single trade −87% *with* a 20% stop. Size is the only surviving control, so the sizing math is load-bearing:
+
+- **PUBLISHED — Kelly (1956, *Bell System Tech. J.* 35, verified against the paper):** his form is the even-money ℓ* = q − p via log-growth maximization. ⚠ The textbook f* = p − q/b is Thorp's practitioner restatement, and the continuous f* = μ/σ² is **Thorp (1971; 2006 handbook chapter, Eq. 7.4)** — the log-utility case of Merton (1969). Attribute the continuous form to Thorp/Merton, never to Kelly's paper.
+- **PUBLISHED — fractional Kelly (Thorp 2006 §7.3; MacLean/Thorp/Ziemba 2010/2011):** under the continuous log-growth approximation, a c-fraction bet earns c(2−c) of full-Kelly growth (half-Kelly keeps 75% — exact only in that model), and estimation error in μ makes full Kelly overbet — the asymmetry is the argument. Practitioner default ¼–½ Kelly is **CONVENTION** built on that published asymmetry.
+- **PUBLISHED — volatility scaling, two distinct constructions (do not conflate):** Moreira & Muir (*JF* 2017) weight by inverse *variance* c/σ̂²_{t−1} (previous month's realized). Harvey et al. (*JPM* 2018, 60 assets to 1926, 10% target): Sharpe improvement concentrated in the risk assets they test (equities, credit), negligible in their bond/currency/commodity samples; left-tail severity reduced across their asset classes. Cederburg et al. (*JFE* 2020, 103 strategies): real-time versions generally underperform unmanaged — **exceptions: momentum, profitability and BAB** (matching `strategy-evidence` §2.4, the authority here).
+- ⚠ Kelly-sizing from backtest μ is barred here until a strategy has forward paper history — a declared-trials-deflated μ is exactly the estimation-error case fractional Kelly exists for. `strategy-evidence` owns that bar.
+
+## Trend strength beyond ADX
+
+- **PUBLISHED (practitioner) — Clenow, *Stocks on the Move* (2015), DETAILS-UNCERTAIN on the constant:** OLS regression of ln(price) on time over 90 days; annualized slope × R² as the momentum rank. ⚠ A log-price slope annualizes exponentially (exp(slope)^252 − 1); the (1+slope)^252 form circulating in implementations treats the slope as a simple return — the two disagree, and neither was verified against the book's own page. Reconcile against the book before freezing one; whichever is chosen is a by-construction constant.
+- **CONVENTION (by construction if used) — slope t-statistic:** t = slope/SE of the same regression is a self-contained significance measure; no canonical published treatment as a trend filter was LOCATED (2026-08-15 sweep — an absence of findings, not proof of absence) — Clenow's R² plays that role in the published relative. If gating on it, freeze the window and cut in a version hash.
+- **PUBLISHED — Kaufman Efficiency Ratio (*Smarter Trading*, 1995):** ER = |P_t − P_{t−n}| / Σ|P_i − P_{i−1}| — net move over path length, bounded [0,1]; inside KAMA (fast=2, slow=30 periods) the smoothing constant is SC = [ER·(2/3 − 2/31) + 2/31]². **MEASURED (ours, 2026-08-15; same panel script):** ER(10) across 1,629 instruments — quartiles 0.14 / 0.30 / 0.49, 24.2% above 0.5. ⚠ That is a LAST-BAR cross-section: it shows a mid-range cut is selective in general, and it also means any cut chosen after seeing it is data-informed — a gating threshold must be declared ex ante against the pre-signal population (the candidates doc carries this rule).
+- **PUBLISHED (negative) — Hurst/Lo:** rescaled-range from Hurst (1951); Lo (*Econometrica* 1991) modified R/S found no evidence of long memory in the index-return samples he examined (daily through annual) once short-range dependence is accounted for. **CONVENTION (our stance):** a Hurst-exponent trend claim carries no weight here unless it clears Lo's correction.
+
+## The one-line map
+
+Routing summary only — each row's tags, caveats and evidence live in the sections above; the table asserts nothing beyond them.
+
+| question on a chart | equation to reach for |
+| --- | --- |
+| how expensive is this name to trade (no quote) | Abdi-Ranaldo CHL — *ranking only* here, level is ~10× off |
+| how volatile is it right now | Yang-Zhang (gaps matter) or Parkinson (quick) |
+| how volatile will it be | EWMA λ=0.94; GARCH(1,1) if evidence demands |
+| how much of the move was overnight risk | Yang-Zhang σ²_overnight component |
+| is it trending or chopping | ER(10) (bounded, distribution measured) or Clenow slope×R² |
+| how big should the position be | vol target (declare MM-variance or Harvey-vol form); fractional Kelly only with forward history |
+
+## Cross-links
+
+Hub: [SKILL.md](SKILL.md). Candidate signals built from these: `docs/proposals/ta/2026-08-15-market-technician-derived-candidates.md`. Tradability bars: `quant/strategy-evidence.md` (turnover first; vol-scaling §2.4; Amihud §2.11). Implementation map + version-hash discipline for any constant frozen here: `data-sources/market-structure.md`.

--- a/docs/proposals/ta/2026-08-15-market-technician-derived-candidates.md
+++ b/docs/proposals/ta/2026-08-15-market-technician-derived-candidates.md
@@ -1,0 +1,145 @@
+# Market-technician-derived candidates — combinations with ex-ante evidence, ordered
+
+Companion to `.claude/skills/market-technician/quant-methods.md` (the equations) and the
+S-5…S-10 set. These are **pre-spec candidates**, not strategies: each states its mechanism,
+its ex-ante evidence, its first-order disqualifier check, and its falsification plan
+BEFORE any backtest — the order the prevention history demands (#2260, fake-fib placebo,
+S-1…S-4). Every one goes through `quant/strategy-evidence`'s checklist + the declaration
+gate (#2599/#2600) + the trial register before a single scan runs; nothing here lowers a
+promotion gate.
+
+⚠ Ordering is by STRENGTH OF EX-ANTE EVIDENCE, strongest first. The bottom entries exist
+to be falsified cheaply, and say so.
+
+⚠ **Division of labour with the prereg:** this document fixes each candidate's MECHANISM,
+evidence, disqualifier check and falsification SHAPE. Numeric acceptance thresholds,
+tie/minimum-history/overlap rules, inference machinery (clustered errors, block bootstrap,
+purged walk-forward) and the declared trial count are set in each candidate's
+preregistration under the #2599/#2600 gate — they are not implied defaults here, and a
+candidate picked up without writing that prereg first has skipped the fence this document
+exists behind.
+
+## C-1 Volatility-managed overlay on S-10 (evidence-backed sizing, not a new signal)
+
+- **Mechanism/evidence:** Moreira & Muir (*JF* 2017) scale exposure by `c / σ̂²_{t−1}`
+  (previous month's realized variance); Cederburg et al. (*JFE* 2020, 103 strategies) —
+  the replication that killed vol-scaling on most factors — finds it survives on
+  **momentum, profitability and BAB** (`strategy-evidence` §2.4, the authority). S-10 is
+  cross-sectional momentum — inside the surviving set.
+- **Form:** two published constructions exist and are NOT interchangeable — Moreira-Muir
+  scale by inverse *variance* (`c/σ̂²_{t−1}`, prior month's realized daily variance);
+  Harvey et al. (*JPM* 2018) target *vol* (`target_σ/σ̂`, and find it pays only on
+  equities/credit). Declare ONE ex ante, capped; EWMA λ = 0.94 (RiskMetrics) if a
+  smoother forecast is used.
+- **Turnover check:** overlay adjusts sizes at S-10's existing monthly rebalance only —
+  no new turnover events; passes by construction.
+- **Falsification:** controlled pair vs unscaled S-10 (S-4/S-9 template: identical signal
+  leg, one change); per-regime blocks. Negative control DECLARED NOW, not chosen later:
+  **S-8** (mean reversion — the family Cederburg's replication says vol-scaling does NOT
+  help) runs the same overlay; the prediction is scaled-S-10 improves and scaled-S-8 does
+  not. Both arms enter the trial register together.
+
+## C-2 Spread-ranked admission gate (universe filter attacking the measured cost failure)
+
+- **Mechanism/evidence:** our long-side results die on cost (44 bps drift vs ~50 bps round
+  trip). Spread is estimable from daily bars: Corwin-Schultz (*JF* 2012) and Abdi-Ranaldo
+  (*RFS* 2017, the daily-data horse-race winner). **MEASURED 2026-08-15 on our own panel
+  (n=1,629 quoted instruments, 60-bar window, vs `quotes.spread_pct`):** both estimators'
+  *level* is ~10× the true quoted spread (median ≈1.22% vs 0.126%) — unusable as a cost
+  input — but the *ranking* is monotone (top quoted-spread quartile mean 1.79% vs bottom
+  ~1.06–1.10%), and **CHL ranks better: Spearman 0.429 vs CS 0.353**, matching the
+  published horse race. Formulas + recipe: `quant-methods.md` §"Spread and liquidity".
+- **Form:** exclude names in the top decile of trailing-60-bar **Abdi-Ranaldo CHL**
+  estimate from strategy universes. ⚠ Causality: a CHL contribution for day t consumes
+  day t+1's mid-range — the trailing window at an admission date contains only PAIRS
+  fully complete by that date (effectively data to t−1). Decile-vs-other-cut, tie and
+  minimum-history rules go in the prereg; the decile is a starting convention, declared
+  as such, with its own trial identity.
+- **Falsification:** controlled pair on S-7 first (most signals), and the gate is
+  UNIVERSE-scoped only if it also survives on a second, different-family strategy —
+  one strategy cannot license a general gate. Placebo arm: a random matched-count
+  exclusion (same number of names removed, chosen uniformly) — the gate must beat its
+  own placebo on net expectancy, not just beat "no gate". Acceptance numbers in the
+  prereg.
+- ⚠ Where a live quote exists, the REAL spread wins outright; CHL covers the backtest
+  corpus, where no quote history exists. The 2026-08-15 calibration is a RANKING check
+  against point-in-time quote snapshots (not time-matched effective spreads) — it
+  validates ordering, nothing more.
+
+## C-3 Volume-shock drift (published family, monthly horizon)
+
+- **Mechanism/evidence:** Gervais, Kaniel & Mingelgrin (*JF* 2001) — stocks with
+  unusually high volume relative to their own recent history appreciate over the
+  following month (visibility hypothesis); international extension: Kaniel, Li & Starks.
+  ⚠ Their construction is a relative-volume PORTFOLIO-FORMATION design; the per-name
+  trigger below is a VARIANT of the idea, not their tested rule — it gets its own trial
+  identity and cannot borrow their result as validation, only as mechanism.
+- **Form (shape; details in prereg):** volume(t) in the top decile of the name's own
+  trailing 50-bar distribution (bar t excluded from its own reference window); hold 20
+  bars; fill open(t+1). ⚠ The regime gate is OUR addition, not the paper's — run gated
+  AND ungated arms so the gate's contribution is attributable. ⚠ Research corpus only
+  (volume complete there; `price_daily` is 28.07% NULL — `volume.md` carries both
+  queries); tie/split-adjustment/overlapping-shock rules in the prereg.
+- **Turnover check:** ~monthly holding SUGGESTS it sits inside the Novy-Marx/Velikov
+  bar, but overlapping shocks can multiply entries — measure turnover FIRST on the
+  triggered population, before any outcome is computed.
+- **Falsification:** era-split mandatory (the gap-fade lesson: pooled t 5.73 hid a dead
+  2020+ effect). Primary placebo = matched RANDOM dates per name (same count, uniform);
+  the published natural contrast (their LOW-volume leg should show the opposite sign)
+  runs as a second arm. ⚠ A short lag is NOT a valid null — the claimed effect lasts
+  ~a month, so a 5-bar-lagged twin sits inside the effect window.
+
+## C-4 ER-gated squeeze expansion (S-9 refinement, controlled)
+
+- **Mechanism/evidence:** S-9 fires on Squeeze + 20-bar breakout. Kaufman's Efficiency
+  Ratio `ER = |P_t − P_{t−n}| / Σ|ΔP|` (*Smarter Trading*, 1995) is a bounded [0,1]
+  path-efficiency measure. Ex-ante logic: an approach that reached the breakout
+  EFFICIENTLY is a different auction than one that got there by chop.
+- **Form (shape):** S-9's exact legs + an ER condition computed over bars `t−1−n … t−1` —
+  ⚠ the signal bar itself is EXCLUDED, because a breakout bar is a large directional move
+  and including it makes the gate mechanically self-confirming. ⚠ Threshold honesty: the
+  panel distribution (ER(10) quartiles 0.14/0.30/0.49 across 1,629 instruments,
+  2026-08-15, `quant-methods.md`) was measured on LAST-BAR cross-section, which makes any
+  cut chosen from it data-informed, not "by construction" — the prereg declares the cut
+  ex ante against the PRE-SIGNAL population and registers it as one trial (no threshold
+  sweep).
+- **Falsification:** the S-4/S-9 template a third time — identical bracket, one added
+  condition, attribution clean — PLUS a placebo gate (the same admission rate applied by
+  random draw) so "gate helps" is measured against selectivity itself, not against
+  nothing. One failed threshold kills THIS rule, not ER as a family; the skill records
+  exactly what died.
+
+## C-5 Indicator divergence, by construction (folklore on trial — expected to die)
+
+- **Status:** divergence (price higher-high + oscillator lower-high) is practitioner
+  folklore; no published formulation was located (2026-08-15 sweep) — the same provenance
+  class as fib levels, which our placebo arm killed. This candidate exists to test the
+  folklore properly ONCE and record the verdict either way.
+- **Form (shape):** **RSI-14 only** (OBV is not shipped — `market-structure.md` records
+  no volume-flow indicators; an OBV variant is a separate candidate gated on building
+  one). PRICE pivots via the confirmed-fractal rule (`price_levels.swing_pivots`,
+  half-window 5 — note its first-of-equal-highs tie rule differs from
+  `price_structure.detect_swings`' no-pivot-on-plateau; declare which); bearish
+  divergence = two consecutive confirmed price swing-highs rising while RSI-14's values
+  AT those two pivot bars fall (indicator pivots are NOT separately required — the
+  comparison is at price-pivot bars, stated to remove the ambiguity). Signal exists only
+  at the second pivot's confirmation bar (+5), fill open of the next bar. Max pivot
+  separation, minimum deltas, direction/exit/overlap rules: prereg.
+- **Falsification:** placebo arm NON-NEGOTIABLE, and the primary placebo is
+  RANDOMIZED — fake divergences minted at randomly-chosen confirmed-pivot pairs at the
+  same rate (a lagged-indicator twin retains autocorrelation and is kept only as a
+  secondary arm). If fake ≥ real — the fib outcome — THIS divergence rule joins the
+  refuted list; the verdict does not extend to untested folklore beyond it.
+
+## Not candidates (and why, so they are not re-derived)
+
+- **CS spread as a cost-model input** — falsified on arrival by the level mismatch above.
+- **Kelly-fraction sizing from backtest μ, σ** — the estimation-error overbetting problem
+  (fractional-Kelly literature) plus our μ estimates carrying declared-trial deflation;
+  sizing stays at vol-targeting (C-1) until a strategy has forward paper history.
+- **Anything fib/level-proximity-entry shaped** — closed, do-not-reopen
+  (`2026-08-09-plan-of-attack.md` §5).
+- **Session-VWAP signals** — no stored intraday; build gap (#2477 lineage), not a
+  research gap.
+
+Refs #2437.

--- a/scripts/verify_2437_quant_methods_panel.py
+++ b/scripts/verify_2437_quant_methods_panel.py
@@ -83,7 +83,7 @@ def _spearman(a: np.ndarray, b: np.ndarray) -> float:
 
 def main() -> None:
     with psycopg.connect(settings.database_url) as conn:
-        rows = conn.execute(_SQL, {"n": WINDOW + 1}).fetchall()
+        rows = conn.execute(_SQL, {"n": WINDOW}).fetchall()
         quoted_spread = dict(
             conn.execute(
                 "select instrument_id, spread_pct from quotes where bid > 0 and ask > bid and spread_pct is not null"

--- a/scripts/verify_2437_quant_methods_panel.py
+++ b/scripts/verify_2437_quant_methods_panel.py
@@ -1,0 +1,143 @@
+"""The quant-methods skill's measured panel (#2437, 2026-08-15). Read-only.
+
+Reproduces every MEASURED figure in `.claude/skills/market-technician/quant-methods.md`:
+
+  A. Corwin-Schultz (JF 2012, authors' SAS constants, no overnight adjustment) and
+     Abdi-Ranaldo two-day-corrected CHL (RFS 2017, eq. 11) spread ESTIMATES from
+     daily bars, each compared against the ACTUAL quoted spread (`quotes.spread_pct`).
+  B. Kaufman Efficiency Ratio ER(10) last-bar cross-section.
+  C. Parkinson vs close-to-close volatility ratio.
+
+Panel: every instrument present in `quotes` with bid > 0 and ask > bid and at least
+WINDOW usable trailing bars in `price_daily` (a usable bar has high/low/close > 0 and
+high >= low; bars failing that are dropped, which shortens the window rather than
+interpolating). Estimates use the trailing WINDOW bars ending at each instrument's
+latest stored bar at run time — the panel therefore drifts as bars accrue, which is
+why the skill quotes the run date next to every figure.
+
+Run:  uv run python scripts/verify_2437_quant_methods_panel.py
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import psycopg
+
+from app.config import settings
+
+WINDOW = 60
+ER_PERIOD = 10
+
+#: Corwin-Schultz denominator constant, 3 - 2*sqrt(2), per their own SAS code.
+_CS_CONST = 3 - 2 * math.sqrt(2)
+
+_SQL = """
+with ranked as (
+  select p.instrument_id, p.price_date, p.high, p.low, p.close,
+         row_number() over (partition by p.instrument_id order by p.price_date desc) rn
+  from price_daily p
+  join quotes q on q.instrument_id = p.instrument_id
+  where q.bid > 0 and q.ask > q.bid
+    and p.high > 0 and p.low > 0 and p.close > 0 and p.high >= p.low
+)
+select instrument_id, high, low, close from ranked where rn <= %(n)s
+order by instrument_id, price_date
+"""
+
+
+def corwin_schultz(highs: np.ndarray, lows: np.ndarray) -> float:
+    """Mean over the window's overlapping 2-day pairs; negative pair estimates
+    set to zero (the authors' primary daily estimator). ⚠ No overnight
+    adjustment — stated in the skill; adding it is a declared change."""
+    log_range_sq = np.log(highs / lows) ** 2
+    estimates = []
+    for t in range(len(highs) - 1):
+        beta = log_range_sq[t] + log_range_sq[t + 1]  # plain sum — no 1/2 factor
+        gamma = math.log(max(highs[t], highs[t + 1]) / min(lows[t], lows[t + 1])) ** 2
+        alpha = (math.sqrt(2 * beta) - math.sqrt(beta)) / _CS_CONST - math.sqrt(gamma / _CS_CONST)
+        spread = 2 * (math.exp(alpha) - 1) / (1 + math.exp(alpha))
+        estimates.append(max(spread, 0.0))
+    return float(np.mean(estimates)) if estimates else float("nan")
+
+
+def abdi_ranaldo(highs: np.ndarray, lows: np.ndarray, closes: np.ndarray) -> float:
+    """Two-day-corrected CHL (their eq. 11): mean_t sqrt(max(4(c_t-eta_t)(c_t-eta_{t+1}), 0)),
+    eta = (h + l)/2 in log prices."""
+    h, lo, c = np.log(highs), np.log(lows), np.log(closes)
+    eta = (h + lo) / 2
+    vals = 4 * (c[:-1] - eta[:-1]) * (c[:-1] - eta[1:])
+    return float(np.sqrt(np.maximum(vals, 0)).mean())
+
+
+def efficiency_ratio(closes: np.ndarray, n: int) -> float:
+    c = closes[-(n + 1) :]
+    path = np.abs(np.diff(c)).sum()
+    return float(abs(c[-1] - c[0]) / path) if path > 0 else float("nan")
+
+
+def _spearman(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.corrcoef(np.argsort(np.argsort(a)), np.argsort(np.argsort(b)))[0, 1])
+
+
+def main() -> None:
+    with psycopg.connect(settings.database_url) as conn:
+        rows = conn.execute(_SQL, {"n": WINDOW + 1}).fetchall()
+        quoted_spread = dict(
+            conn.execute(
+                "select instrument_id, spread_pct from quotes where bid > 0 and ask > bid and spread_pct is not null"
+            ).fetchall()
+        )
+
+    by_inst: dict[int, list[tuple[float, float, float]]] = {}
+    for iid, h, lo, c in rows:
+        by_inst.setdefault(iid, []).append((float(h), float(lo), float(c)))
+
+    cs_est, chl_est, quoted, ers, park_ratio = [], [], [], [], []
+    for iid, bars in by_inst.items():
+        if len(bars) < WINDOW:
+            continue
+        arr = np.array(bars[-WINDOW:])
+        highs, lows, closes = arr[:, 0], arr[:, 1], arr[:, 2]
+        er = efficiency_ratio(closes, ER_PERIOD)
+        if np.isfinite(er):
+            ers.append(er)
+        parkinson = np.sqrt(np.mean(np.log(highs / lows) ** 2) / (4 * math.log(2)))
+        close_close = np.std(np.diff(np.log(closes)))
+        if close_close > 0:
+            park_ratio.append(parkinson / close_close)
+        if quoted_spread.get(iid) is not None:
+            cs = corwin_schultz(highs, lows)
+            chl = abdi_ranaldo(highs, lows, closes)
+            if np.isfinite(cs) and np.isfinite(chl):
+                cs_est.append(cs * 100)
+                chl_est.append(chl * 100)
+                quoted.append(float(quoted_spread[iid]))
+
+    cs, chl, qt = np.array(cs_est), np.array(chl_est), np.array(quoted)
+    top = qt >= np.percentile(qt, 75)
+    bottom = qt <= np.percentile(qt, 25)
+    print(f"A. spread estimators vs quoted spread_pct: n={len(qt)}")
+    for name, est in (("CS ", cs), ("CHL", chl)):
+        print(
+            f"   {name} spearman={_spearman(est, qt):.3f} pearson={np.corrcoef(est, qt)[0, 1]:.3f}"
+            f" median_est={np.median(est):.3f}% (quoted median {np.median(qt):.3f}%)"
+            f" top-quartile-mean={est[top].mean():.3f}% bottom={est[bottom].mean():.3f}%"
+        )
+
+    e = np.array(ers)
+    print(
+        f"B. ER({ER_PERIOD}) last-bar cross-section: n={len(e)}"
+        f" quartiles={np.round(np.percentile(e, [25, 50, 75]), 4)} share>0.5={(e > 0.5).mean() * 100:.1f}%"
+    )
+
+    p = np.array(park_ratio)
+    print(
+        f"C. Parkinson/close-close sigma ratio: n={len(p)}"
+        f" median={np.median(p):.3f} IQR={np.round(np.percentile(p, [25, 75]), 4)}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Extends the merged market-technician family (#2725) with the systematic mathematics the operator asked for, plus a candidates proposal turning combinations of the family's concepts into testable signals.

- **`.claude/skills/market-technician/quant-methods.md`** (tenth sub-skill, hub routed): spread estimation from daily bars (Roll 1984; Corwin-Schultz 2012 — formulas verified against the **authors' own SAS code**; Abdi-Ranaldo 2017 CHL), range volatility (Parkinson / Garman-Klass with the "best analytic" label corrected / Rogers-Satchell / Yang-Zhang with the k-constant pinned), forecast vol (RiskMetrics EWMA λ=0.94; GARCH(1,1) with correct stationarity conditions), sizing (Kelly-vs-Thorp attribution fixed — the continuous f* = μ/σ² is Thorp/Merton, not Kelly 1956; fractional Kelly; Moreira-Muir inverse-variance vs Harvey vol-target, kept distinct), trend strength (Clenow slope×R² with its annualization ambiguity flagged; Kaufman ER; Hurst/Lo negative result). Every claim tagged PUBLISHED/MEASURED/CONVENTION/REFUTED. Two live secondary-source mis-transcriptions found during verification are recorded as the skill's own warning (Abdi-Ranaldo's Table 1 restates CS's β with a spurious ½; a practitioner survey garbles YZ's k).
- **`scripts/verify_2437_quant_methods_panel.py`** — the committed reproduce recipe for every MEASURED figure (read-only; panel/eligibility/aggregation rules in its docstring).
- **`docs/proposals/ta/2026-08-15-market-technician-derived-candidates.md`** — five pre-spec candidates ordered by ex-ante evidence, each with mechanism, disqualifier check and falsification SHAPE (placebo arms mandatory; thresholds and inference deferred to each prereg behind the #2599/#2600 gate): vol-managed S-10 overlay (negative control S-8 declared now), CHL admission gate, volume-shock drift variant, ER-gated S-9 controlled pair, RSI divergence by construction.

## Measured (dev DB, 2026-08-15 — reproduce: `uv run python scripts/verify_2437_quant_methods_panel.py`)

On 1,629 quoted instruments (trailing 60 `price_daily` bars vs `quotes.spread_pct`):
- Both spread estimators' **level** is ~10× the actual quoted spread (median est ≈1.22% vs quoted 0.126%) — unusable as a cost input; candidate explanations stated as untested.
- The **ranking** is monotone (top quoted-spread quartile mean 1.79% vs bottom ~1.06–1.10%) and **CHL ranks best: Spearman 0.429 vs CS 0.353** — matching the published horse race. Verdict encoded in the skill: ranking tool only.
- ER(10) cross-section quartiles 0.14/0.30/0.49; Parkinson/close-close σ ratio median 1.104.

## Review

Two Codex passes over the drafts (~40 findings) triaged and fixed pre-push, including: Cederburg scope corrected to **momentum, profitability and BAB** (was "momentum only" — contradicted `strategy-evidence` §2.4), CHL pair-causality rule for trailing windows, ER computed excluding the signal bar (mechanical self-confirmation), placebo-arm validity (lagged twins rejected where inside the effect window; randomized/matched placebos primary), quantifiers scoped to "located, 2026-08-15 sweep".

## Security model

Not applicable — documentation + one read-only measurement script; no endpoints, no writes, no data-path changes.

Refs #2437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
