### PR TITLE
fix(#2733): refuse gap-through exit brackets

### DIFF
--- a/app/services/outcome_resolver.py
+++ b/app/services/outcome_resolver.py
@@ -515,3 +515,16 @@ def resolve_outcome(
         exit_price=exit_open,
         entry_price=entry_price,
     )
+
+
+# Shared by every manifest adapter before constructing ``ExitLevels``.  This
+# lives in the versioned resolver module because orderability is an outcome
+# interpretation rule, not an entry signal rule: changing it moves
+# ``RULE_SET_VERSION`` while preserving the causal signal identity.
+def exit_levels_are_orderable(*, entry_price: Decimal, take_profit: Decimal | None, stop_loss: Decimal) -> bool:
+    """Whether a next-open fill can enter before either exit has triggered."""
+    if not entry_price.is_finite() or entry_price <= 0:
+        return False
+    if not stop_loss.is_finite() or stop_loss <= 0 or stop_loss >= entry_price:
+        return False
+    return take_profit is None or (take_profit.is_finite() and take_profit > entry_price)

--- a/app/services/strategy_exit_levels_batch.py
+++ b/app/services/strategy_exit_levels_batch.py
@@ -14,7 +14,7 @@ from decimal import Decimal
 from math import isfinite
 
 from app.services.indicator_series import BarSeries, Universe, atr_series
-from app.services.outcome_resolver import ExitLevels, UnresolvedReason
+from app.services.outcome_resolver import ExitLevels, UnresolvedReason, exit_levels_are_orderable
 from app.services.strategies.s4_volatility_compression_breakout import (
     ATR_PERIOD,
     ATR_STOP_MULTIPLE,
@@ -53,7 +53,7 @@ def s4_exit_levels_batch(
         distance = Decimal(str(value))
         stop = entry_price - Decimal(str(ATR_STOP_MULTIPLE)) * distance
         target = entry_price + Decimal(str(ATR_TARGET_MULTIPLE)) * distance
-        if not target.is_finite() or not stop.is_finite() or stop <= 0 or stop >= entry_price or target <= entry_price:
+        if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
             levels.append("unorderable_exit_levels")
             continue
         levels.append(ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=MAX_HOLD_BARS))

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -75,7 +75,7 @@ from typing import Literal, Protocol, get_args
 
 from app.services.indicator_series import BarSeries, Universe
 from app.services.market_regime import RegimeSeries
-from app.services.outcome_resolver import ExitLevels, UnresolvedReason
+from app.services.outcome_resolver import ExitLevels, UnresolvedReason, exit_levels_are_orderable
 from app.services.position_builder import ExitRegime
 from app.services.strategies.s1_time_series_momentum import S1_STRATEGY_ID, s1_identity, s1_signals
 from app.services.strategies.s2_cross_sectional_momentum import (
@@ -621,7 +621,7 @@ def _s9_exit_levels(
         )
     except ValueError, IndexError:
         return "unorderable_exit_levels"
-    if target <= stop:
+    if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
         return "unorderable_exit_levels"
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
@@ -661,11 +661,11 @@ def _s7_exit_levels(
     ⚠ ``take_profit=None`` is the STOP-ONLY bracket ``outcome_resolver``
     documents — rules 2/3/5 of its precedence table are unreachable and the
     target-side close comes from the exit leg or the hold cap instead.
-    ⚠ ``stop <= 0`` replaces the siblings' ``target <= stop`` orderability
-    check: with no target the only unorderable state is a stop at or below
-    zero, which a low-priced high-ATR name genuinely produces (``ExitLevels``
-    itself refuses it, so it must be a typed refusal here, not a raise that
-    aborts the whole batch).
+    ⚠ With no target, orderability still requires ``0 < stop < entry``. A
+    low-priced high-ATR name can produce a non-positive stop, while a gap down
+    can fill at or below the signal-time stop. Both mean the setup was already
+    consumed before entry and become typed refusals rather than exceptions that
+    abort the whole batch.
     """
     try:
         target, stop, max_hold = s7_exit_bracket(
@@ -677,7 +677,7 @@ def _s7_exit_levels(
         # `atr_series`. A narrow except that reads as exhaustive is worse than
         # none (S-5's recorded lesson).
         return "unorderable_exit_levels"
-    if stop <= 0:
+    if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
         return "unorderable_exit_levels"
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
@@ -707,11 +707,11 @@ def _s8_exit_levels(
 ) -> ExitLevels | UnresolvedReason:
     """Adapt S-8's bracket to the outcome reason contract.
 
-    ⚠ ``target <= stop`` is MORE reachable here than for the entry-anchored
-    strategies and is still not a bug. S-8's target is the signal bar's middle
-    band while its stop is anchored to the fill, so a gap up through the band on
-    the open of ``t+1`` inverts them — the rule's thesis was consumed before the
-    position existed, and an unresolved outcome is the truthful record of that.
+    ⚠ S-8's target is the signal bar's middle band while its stop is anchored
+    to the fill. A gap up through the band on the open of ``t+1`` can therefore
+    put the target at or below entry even when target remains above stop. The
+    rule's thesis was consumed before the position existed, and an unresolved
+    outcome is the truthful record of that.
     """
     try:
         target, stop, max_hold = s8_exit_bracket(
@@ -719,7 +719,7 @@ def _s8_exit_levels(
         )
     except ValueError, IndexError:
         return "unorderable_exit_levels"
-    if target <= stop:
+    if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
         return "unorderable_exit_levels"
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
@@ -759,7 +759,7 @@ def _s5_exit_levels(
         # per-bar failure abort the WHOLE outcome batch — a narrow except that
         # reads as exhaustive is worse than no except at all.
         return "unorderable_exit_levels"
-    if target <= stop:
+    if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
         return "unorderable_exit_levels"
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
@@ -811,11 +811,12 @@ def _s6_exit_levels(
         # inside `atr_series` / `levels_at`. A narrow except that reads as
         # exhaustive is worse than none.
         return "unorderable_exit_levels"
-    if target <= stop:
+    if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
         # Reachable, and not a bug to prevent: the stop is anchored to the LEVEL
         # while the target is anchored to the ENTRY, so a fill far below the
-        # level can invert them. That asymmetry is the rule (see the S-6 module
-        # docstring), so an inverted bracket is a real state to refuse.
+        # level can put the stop at or above entry. That asymmetry is the rule
+        # (see the S-6 module docstring), so an already-triggered bracket is a
+        # real state to refuse.
         return "unorderable_exit_levels"
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 

--- a/tests/test_2437_exit_level_refusal_surface.py
+++ b/tests/test_2437_exit_level_refusal_surface.py
@@ -31,7 +31,9 @@ from decimal import Decimal
 
 import pytest
 
+from app.services import strategy_manifest
 from app.services.indicator_series import BarSeries
+from app.services.outcome_resolver import exit_levels_are_orderable
 from app.services.strategies.s5_support_bounce import s5_exit_bracket
 from app.services.strategies.s6_resistance_breakout import s6_exit_bracket
 from app.services.strategies.s9_squeeze_expansion import s9_exit_bracket
@@ -98,3 +100,63 @@ def test_index_error_is_reachable(strategy_id: str) -> None:
             entry_price=Decimal("100"),
             universe="survivor_only",
         )
+
+
+@pytest.mark.parametrize(
+    ("strategy_id", "factory_name", "target", "stop", "entry"),
+    [
+        # Measured 2026-08-15: S-5 signal 306648 filled at 48.01 after
+        # gapping through its signal-time 50.2965 stop.
+        ("s5-support-bounce", "s5_exit_bracket", Decimal("55"), Decimal("50.2965"), Decimal("48.01")),
+        ("s6-resistance-breakout", "s6_exit_bracket", Decimal("55"), Decimal("50"), Decimal("48")),
+        # The target can be above the stop yet already below the gap-up entry.
+        ("s8-range-mean-reversion", "s8_exit_bracket", Decimal("99"), Decimal("98"), Decimal("100")),
+        # Stop-only rules owe the same boundary.
+        ("s7-trend-pullback", "s7_exit_bracket", None, Decimal("100"), Decimal("100")),
+        ("s9-squeeze-expansion", "s9_exit_bracket", Decimal("101"), Decimal("100"), Decimal("100")),
+    ],
+)
+def test_a_gap_through_an_exit_is_a_typed_refusal_not_a_batch_abort(
+    monkeypatch: pytest.MonkeyPatch,
+    strategy_id: str,
+    factory_name: str,
+    target: Decimal | None,
+    stop: Decimal,
+    entry: Decimal,
+) -> None:
+    monkeypatch.setattr(strategy_manifest, factory_name, lambda *args, **kwargs: (target, stop, 20))
+    adapter = STRATEGY_MANIFEST[strategy_id].exit_levels
+    assert adapter is not None
+    assert adapter(_series(), signal_index=20, entry_price=entry, universe="survivor_only") == (
+        "unorderable_exit_levels"
+    )
+
+
+@pytest.mark.parametrize(
+    ("entry", "target", "stop", "expected"),
+    [
+        ("100", "110", "90", True),
+        ("100", None, "90", True),
+        ("100", "100", "90", False),
+        ("100", "110", "100", False),
+        ("100", None, "100", False),
+        ("0", "110", "90", False),
+        ("NaN", "110", "90", False),
+        ("100", "Infinity", "90", False),
+        ("100", "110", "NaN", False),
+    ],
+)
+def test_shared_orderability_boundary(
+    entry: str,
+    target: str | None,
+    stop: str,
+    expected: bool,
+) -> None:
+    assert (
+        exit_levels_are_orderable(
+            entry_price=Decimal(entry),
+            take_profit=None if target is None else Decimal(target),
+            stop_loss=Decimal(stop),
+        )
+        is expected
+    )


### PR DESCRIPTION
Closes #2733

## What changed
- enforce the long-only orderability boundary `0 < stop < next-open fill < target` for every level-based strategy (target optional for S-7)
- record gap-through setups as the closed-vocabulary `unorderable_exit_levels` refusal instead of aborting outcome resolution
- cover the measured S-5 incident, analogous S-6/S-7/S-8/S-9 paths, S-4 batch parity, equality boundaries, and non-finite values

## Production verification
Before this change, outcome job 98140 aborted on S-5 signal 306648 because its 48.01 next-open fill was below the 50.2965 stop. Running the resolver with this branch completed as job 98148: selected=445, written=13, immature=432, ambiguous=1. Affected brackets were stored as typed unresolved outcomes; no invalid trade result was booked.

## Verification
- focused suite: 166 tests passed before final boundary additions
- final targeted suite: exit refusal, resolver, manifest, outcome job, batch and S-7/S-8/S-9 suites passed
- ruff format/check and pyright passed
- full pre-push gate passed, including pure suite and DB smoke
