### PR TITLE
feature(#2437): store causal regime evidence

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -3648,10 +3648,6 @@ def _regime_cohorts_for(arms: Sequence[ArmMeasurement], result: StrategyResult) 
         ):
             outcome = measurement.namespaces.get(result.identity.namespace)
             if outcome is not None:
-                if sum(cohort.trade_count for cohort in outcome.regime_cohorts) != result.metrics.trade_count:
-                    raise RuntimeError(
-                        f"{result.identity.version} would store regime cohorts that do not reconcile to its trade count"
-                    )
                 return outcome.regime_cohorts
     raise RuntimeError(f"no measurement matches the stored row {result.identity.version}")
 

--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -90,6 +90,7 @@ from app.services.equity_curve import (
     build_month_end_rebalanced_curve,
 )
 from app.services.indicator_series import BarSeries, Universe
+from app.services.market_regime import Regime
 from app.services.market_regime_provider import MarketRegimeProvider
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.outcome_resolver import ExitLevels, UnresolvedReason, resolve_outcome
@@ -135,6 +136,12 @@ from app.services.strategies.validated_universe import (
     load_validated_universe,
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry, StrategyPurpose
+from app.services.strategy_regime_evidence import (
+    RegimeCohort,
+    RegimeTradeObservation,
+    build_regime_cohorts,
+    store_result_regime_cohorts,
+)
 from app.services.strategy_registry import (
     SignalKind,
     StrategyIdentity,
@@ -466,6 +473,9 @@ class NamespaceMeasurement:
     #: on a survivor universe. Stored per result row by the ledger writer,
     #: which refuses a ``survivorship_free`` row without one.
     termination_census: Mapping[str, int] = field(default_factory=dict)
+    #: One causal signal-date cohort for every realised trade. The child rows
+    #: explain this result; they are not separate promotion candidates.
+    regime_cohorts: tuple[RegimeCohort, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -979,6 +989,7 @@ class _NamespaceBook:
     entry_dates: list[date] = field(default_factory=list)
     #: Positionally parallel to `entry_dates`; `TradeReturns` enforces that.
     exit_dates: list[date] = field(default_factory=list)
+    regime_observations: list[RegimeTradeObservation] = field(default_factory=list)
     instruments: set[int] = field(default_factory=set)
     positions: int = 0
     open_at_end: int = 0
@@ -1206,6 +1217,7 @@ def _absorb(
     books: Mapping[ResultNamespace, _NamespaceBook],
     close_sources: Counter[str],
     discarded: Counter[str],
+    market_regime_by_date: Mapping[date, Regime | None],
     termination_class: str | None = None,
 ) -> None:
     """Route one instrument's costed positions into their namespace books.
@@ -1309,6 +1321,14 @@ def _absorb(
             # #2623 gap 1. The exit bar was never lost here — the namespace split
             # above already reads it — only never carried into the metric set.
             book.exit_dates.append(close_bar_date)
+            book.regime_observations.append(
+                RegimeTradeObservation(
+                    instrument_key=instrument_id,
+                    signal_date=position.entry_signal_bar_date,
+                    net_return_pct=(exit_price - entry_price) / entry_price * 100.0,
+                    regime=market_regime_by_date.get(position.entry_signal_bar_date),
+                )
+            )
 
 
 @dataclass(frozen=True)
@@ -1566,6 +1586,13 @@ def _measure_namespace(
             f"{len(dates)} dates and the block bootstrap computed no effective sample size — criterion 3 forbids "
             "reporting a nominal n in its place, so no row can be written for it"
         )
+    regime_cohorts = build_regime_cohorts(book.regime_observations, root_seed=BACKTEST_BOOTSTRAP_SEED)
+    cohort_trade_count = sum(cohort.trade_count for cohort in regime_cohorts)
+    if cohort_trade_count != metrics.trade_count:
+        raise RuntimeError(
+            f"the {namespace} regime cohorts carry {cohort_trade_count} realised trades against the parent "
+            f"metric's {metrics.trade_count} — every realised trade must have exactly one causal signal-date label"
+        )
     return NamespaceMeasurement(
         namespace=namespace,
         metrics=metrics,
@@ -1584,6 +1611,7 @@ def _measure_namespace(
         short_funded_entries=curve.short_funded_entries,
         traded_notional_total=float(curve.traded_notional.sum()),
         termination_census=dict(book.terminations),
+        regime_cohorts=regime_cohorts,
     )
 
 
@@ -1633,6 +1661,7 @@ def evaluate_arm(
     # with no real connection.
     if regime_provider is None:
         regime_provider = MarketRegimeProvider.load_research(conn)
+    market_regime_by_date = dict(zip(corpus.axis, regime_provider.for_dates(corpus.axis).values, strict=True))
     started = time.monotonic()
     if return_basis not in {LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS}:
         raise ValueError(f"unknown return basis {return_basis!r}")
@@ -1771,6 +1800,7 @@ def evaluate_arm(
             books=books,
             close_sources=close_sources,
             discarded=discarded,
+            market_regime_by_date=market_regime_by_date,
         )
         if collector is not None:
             collector.collect(
@@ -1933,6 +1963,7 @@ def evaluate_level_arms(
     # with no real connection.
     if regime_provider is None:
         regime_provider = MarketRegimeProvider.load_research(conn)
+    market_regime_by_date = dict(zip(corpus.axis, regime_provider.for_dates(corpus.axis).values, strict=True))
     started = time.monotonic()
     if return_basis not in {LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS}:
         raise ValueError(f"unknown return basis {return_basis!r}")
@@ -2093,6 +2124,7 @@ def evaluate_level_arms(
                 books=books[ambiguity],
                 close_sources=close_sources[ambiguity],
                 discarded=discarded[ambiguity],
+                market_regime_by_date=market_regime_by_date,
                 termination_class=termination_label,
             )
             arm_collector = collectors[ambiguity]
@@ -3321,6 +3353,12 @@ def _write_rows(
                 for result_id, result in zip(ids, (masked, admitted), strict=True):
                     _store_universe_record(conn, result_id, result, arms=arms, validated=validated)
                     _store_ambiguity_record(conn, result_id, result, arms=arms)
+                    store_result_regime_cohorts(
+                        conn,
+                        result_id=result_id,
+                        cohorts=_regime_cohorts_for(arms, result),
+                        expected_trade_count=result.metrics.trade_count,
+                    )
                     if corpus.universe_basis == "survivorship_free":
                         store_termination_census(
                             conn,
@@ -3348,6 +3386,12 @@ def _write_rows(
                 )
                 _store_universe_record(conn, result_id, result, arms=arms, validated=validated)
                 _store_ambiguity_record(conn, result_id, result, arms=arms)
+                store_result_regime_cohorts(
+                    conn,
+                    result_id=result_id,
+                    cohorts=_regime_cohorts_for(arms, result),
+                    expected_trade_count=result.metrics.trade_count,
+                )
                 if corpus.universe_basis == "survivorship_free":
                     store_termination_census(
                         conn,
@@ -3592,6 +3636,24 @@ def _termination_census_for(
     raise RuntimeError(  # pragma: no cover - every stored row came from a measurement
         f"no measurement matches the stored row {result.identity.version}"
     )
+
+
+def _regime_cohorts_for(arms: Sequence[ArmMeasurement], result: StrategyResult) -> tuple[RegimeCohort, ...]:
+    """The causal regime cohorts produced by the exact measurement behind a row."""
+    for measurement in arms:
+        if (
+            measurement.strategy_id == result.identity.strategy_id
+            and measurement.quarantine_arm == result.identity.quarantine_arm
+            and measurement.ambiguity_arm in {None, result.identity.ambiguity_arm}
+        ):
+            outcome = measurement.namespaces.get(result.identity.namespace)
+            if outcome is not None:
+                if sum(cohort.trade_count for cohort in outcome.regime_cohorts) != result.metrics.trade_count:
+                    raise RuntimeError(
+                        f"{result.identity.version} would store regime cohorts that do not reconcile to its trade count"
+                    )
+                return outcome.regime_cohorts
+    raise RuntimeError(f"no measurement matches the stored row {result.identity.version}")
 
 
 def _store_ambiguity_record(

--- a/app/services/strategy_regime_evidence.py
+++ b/app/services/strategy_regime_evidence.py
@@ -1,0 +1,256 @@
+"""Immutable per-regime trade cohorts attached to a strategy result (#2437).
+
+The regime is classified on the entry SIGNAL date: that is the information the
+strategy consumed when it decided to fire.  Classifying on the next-open fill or
+the eventual exit would condition a decision on state that did not exist yet.
+
+These cohorts explain a parent result; they are not independently promotable
+results.  Portfolio path statistics (especially drawdown) remain on the parent,
+because filtering closed trades cannot reconstruct overlapping marked paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Final, Literal, get_args
+
+import numpy as np
+import psycopg
+
+from app.services.block_bootstrap import (
+    BOOTSTRAP_MODEL_ID,
+    BootstrapResult,
+    block_bootstrap_expectancy,
+    cluster_by_date,
+)
+from app.services.market_regime import Regime
+
+RegimeCohortLabel = Literal["bull_quiet", "bull_volatile", "bear_quiet", "bear_volatile", "unclassified"]
+REGIME_COHORT_LABELS: Final[frozenset[str]] = frozenset(get_args(RegimeCohortLabel))
+
+
+@dataclass(frozen=True)
+class RegimeTradeObservation:
+    instrument_key: int
+    signal_date: date
+    net_return_pct: float
+    regime: Regime | None
+
+    def __post_init__(self) -> None:
+        if self.instrument_key == 0:
+            raise ValueError("instrument_key cannot be zero")
+        if not math.isfinite(self.net_return_pct):
+            raise ValueError("net_return_pct must be finite")
+
+    @property
+    def label(self) -> RegimeCohortLabel:
+        return "unclassified" if self.regime is None else self.regime.value
+
+
+@dataclass(frozen=True)
+class RegimeCohort:
+    regime: RegimeCohortLabel
+    trade_count: int
+    instrument_count: int
+    decision_date_count: int
+    losing_trade_count: int
+    expectancy_pct: float
+    profit_factor: float | None
+    worst_trade_pct: float
+    effective_sample_size: float | None
+    expectancy_ci_low_pct: float | None
+    expectancy_ci_high_pct: float | None
+    bootstrap_block_length: int | None
+    bootstrap_cluster_count: int | None
+    bootstrap_resamples: int | None
+    bootstrap_seed: int | None
+    bootstrap_design_effect: float | None
+    bootstrap_model_id: str | None
+
+    def __post_init__(self) -> None:
+        if self.regime not in REGIME_COHORT_LABELS:
+            raise ValueError(f"unknown regime cohort {self.regime!r}")
+        if self.trade_count < 1:
+            raise ValueError("a regime cohort needs at least one realised trade")
+        if not 1 <= self.instrument_count <= self.trade_count:
+            raise ValueError("instrument_count must be inside [1, trade_count]")
+        if not 1 <= self.decision_date_count <= self.trade_count:
+            raise ValueError("decision_date_count must be inside [1, trade_count]")
+        if not 0 <= self.losing_trade_count <= self.trade_count:
+            raise ValueError("losing_trade_count must be inside [0, trade_count]")
+        if (self.profit_factor is None) != (self.losing_trade_count == 0):
+            raise ValueError("profit_factor is absent exactly when the cohort has no losing trade")
+        for name in ("expectancy_pct", "worst_trade_pct"):
+            if not math.isfinite(getattr(self, name)):
+                raise ValueError(f"{name} must be finite")
+        if self.profit_factor is not None and (not math.isfinite(self.profit_factor) or self.profit_factor < 0):
+            raise ValueError("profit_factor must be finite and non-negative when present")
+        if self.worst_trade_pct > self.expectancy_pct:
+            raise ValueError("worst_trade_pct cannot exceed the cohort expectancy")
+        bootstrap = (
+            self.effective_sample_size,
+            self.expectancy_ci_low_pct,
+            self.expectancy_ci_high_pct,
+            self.bootstrap_block_length,
+            self.bootstrap_cluster_count,
+            self.bootstrap_resamples,
+            self.bootstrap_seed,
+            self.bootstrap_design_effect,
+            self.bootstrap_model_id,
+        )
+        if sum(value is not None for value in bootstrap) not in {0, len(bootstrap)}:
+            raise ValueError("bootstrap fields must be all present or all absent")
+        if self.effective_sample_size is not None:
+            assert self.expectancy_ci_low_pct is not None
+            assert self.expectancy_ci_high_pct is not None
+            assert self.bootstrap_block_length is not None
+            assert self.bootstrap_cluster_count is not None
+            assert self.bootstrap_resamples is not None
+            assert self.bootstrap_seed is not None
+            assert self.bootstrap_design_effect is not None
+            assert self.bootstrap_model_id is not None
+            numeric = (
+                self.effective_sample_size,
+                self.expectancy_ci_low_pct,
+                self.expectancy_ci_high_pct,
+                self.bootstrap_design_effect,
+            )
+            if any(value is None or not math.isfinite(value) for value in numeric):
+                raise ValueError("bootstrap numeric fields must be finite")
+            if self.effective_sample_size <= 0 or self.bootstrap_design_effect <= 0:
+                raise ValueError("bootstrap effective sample and design effect must be positive")
+            if self.expectancy_ci_low_pct > self.expectancy_ci_high_pct:
+                raise ValueError("bootstrap expectancy interval is inverted")
+            if (
+                min(
+                    self.bootstrap_block_length,
+                    self.bootstrap_cluster_count,
+                    self.bootstrap_resamples,
+                )
+                <= 0
+            ):
+                raise ValueError("bootstrap counts must be positive")
+            if self.bootstrap_seed < 0:
+                raise ValueError("bootstrap_seed must be non-negative")
+            if not self.bootstrap_model_id.strip():
+                raise ValueError("bootstrap_model_id must be non-empty")
+
+
+def _seed(root_seed: int, label: RegimeCohortLabel) -> int:
+    return int.from_bytes(hashlib.sha256(f"{root_seed}:{label}".encode()).digest()[:4], "big")
+
+
+def _cohort(label: RegimeCohortLabel, rows: Sequence[RegimeTradeObservation], *, root_seed: int) -> RegimeCohort:
+    returns = np.asarray([row.net_return_pct for row in rows], dtype=np.float64)
+    losing = returns[returns < 0]
+    winning = returns[returns > 0]
+    bootstrap = block_bootstrap_expectancy(
+        cluster_by_date(returns.tolist(), [row.signal_date for row in rows]),
+        seed=_seed(root_seed, label),
+    )
+    return RegimeCohort(
+        regime=label,
+        trade_count=len(rows),
+        instrument_count=len({row.instrument_key for row in rows}),
+        decision_date_count=len({row.signal_date for row in rows}),
+        losing_trade_count=len(losing),
+        expectancy_pct=float(np.mean(returns)),
+        profit_factor=None if not len(losing) else float(winning.sum() / abs(losing.sum())),
+        worst_trade_pct=float(np.min(returns)),
+        **_bootstrap_fields(bootstrap),
+    )
+
+
+def _bootstrap_fields(result: BootstrapResult | None) -> dict[str, Any]:
+    if result is None:
+        return {
+            "effective_sample_size": None,
+            "expectancy_ci_low_pct": None,
+            "expectancy_ci_high_pct": None,
+            "bootstrap_block_length": None,
+            "bootstrap_cluster_count": None,
+            "bootstrap_resamples": None,
+            "bootstrap_seed": None,
+            "bootstrap_design_effect": None,
+            "bootstrap_model_id": None,
+        }
+    return {
+        "effective_sample_size": result.effective_sample_size,
+        "expectancy_ci_low_pct": result.ci_low_pct,
+        "expectancy_ci_high_pct": result.ci_high_pct,
+        "bootstrap_block_length": result.block_length,
+        "bootstrap_cluster_count": result.cluster_count,
+        "bootstrap_resamples": result.resamples,
+        "bootstrap_seed": result.seed,
+        "bootstrap_design_effect": result.design_effect,
+        "bootstrap_model_id": BOOTSTRAP_MODEL_ID,
+    }
+
+
+def build_regime_cohorts(observations: Sequence[RegimeTradeObservation], *, root_seed: int) -> tuple[RegimeCohort, ...]:
+    grouped: dict[RegimeCohortLabel, list[RegimeTradeObservation]] = defaultdict(list)
+    for row in observations:
+        grouped[row.label].append(row)
+    return tuple(_cohort(label, grouped[label], root_seed=root_seed) for label in sorted(grouped))
+
+
+def store_result_regime_cohorts(
+    conn: psycopg.Connection[Any],
+    *,
+    result_id: int,
+    cohorts: Sequence[RegimeCohort],
+    expected_trade_count: int,
+) -> None:
+    if not cohorts:
+        raise ValueError("every result with realised trades must store at least one regime cohort")
+    if len({row.regime for row in cohorts}) != len(cohorts):
+        raise ValueError("a result cannot store the same regime cohort twice")
+    if sum(row.trade_count for row in cohorts) != expected_trade_count:
+        raise ValueError("regime cohort trade counts do not reconcile to the parent result")
+    parent = conn.execute("SELECT trade_count FROM strategy_results_store WHERE result_id=%s", (result_id,)).fetchone()
+    if parent is None:
+        raise ValueError(f"parent strategy result {result_id} does not exist")
+    if int(parent[0]) != expected_trade_count:
+        raise ValueError(
+            f"regime cohort expected trade count {expected_trade_count} does not match parent result {int(parent[0])}"
+        )
+    with conn.cursor() as cursor:
+        cursor.executemany(
+            """
+            INSERT INTO strategy_result_regime_cohorts (
+                result_id, regime, trade_count, instrument_count, decision_date_count,
+                losing_trade_count, expectancy_pct, profit_factor, worst_trade_pct,
+                effective_sample_size, expectancy_ci_low_pct, expectancy_ci_high_pct,
+                bootstrap_block_length, bootstrap_cluster_count, bootstrap_resamples,
+                bootstrap_seed, bootstrap_design_effect, bootstrap_model_id
+            ) VALUES (
+                %(result_id)s, %(regime)s, %(trade_count)s, %(instrument_count)s, %(decision_date_count)s,
+                %(losing_trade_count)s, %(expectancy_pct)s, %(profit_factor)s, %(worst_trade_pct)s,
+                %(effective_sample_size)s, %(expectancy_ci_low_pct)s, %(expectancy_ci_high_pct)s,
+                %(bootstrap_block_length)s, %(bootstrap_cluster_count)s, %(bootstrap_resamples)s,
+                %(bootstrap_seed)s, %(bootstrap_design_effect)s, %(bootstrap_model_id)s
+            )
+            """,
+            ({"result_id": result_id, **row.__dict__} for row in cohorts),
+        )
+    stored = conn.execute(
+        "SELECT count(*), coalesce(sum(trade_count), 0) FROM strategy_result_regime_cohorts WHERE result_id=%s",
+        (result_id,),
+    ).fetchone()
+    if stored is None or int(stored[0]) != len(cohorts) or int(stored[1]) != expected_trade_count:
+        raise RuntimeError("stored regime cohorts did not round-trip or reconcile to the parent result")
+
+
+__all__ = [
+    "REGIME_COHORT_LABELS",
+    "RegimeCohort",
+    "RegimeCohortLabel",
+    "RegimeTradeObservation",
+    "build_regime_cohorts",
+    "store_result_regime_cohorts",
+]

--- a/app/services/strategy_regime_evidence.py
+++ b/app/services/strategy_regime_evidence.py
@@ -206,8 +206,8 @@ def store_result_regime_cohorts(
     cohorts: Sequence[RegimeCohort],
     expected_trade_count: int,
 ) -> None:
-    if not cohorts:
-        raise ValueError("every result with realised trades must store at least one regime cohort")
+    if not cohorts and expected_trade_count != 0:
+        raise ValueError("a result with realised trades must store at least one regime cohort")
     if len({row.regime for row in cohorts}) != len(cohorts):
         raise ValueError("a result cannot store the same regime cohort twice")
     if sum(row.trade_count for row in cohorts) != expected_trade_count:
@@ -219,6 +219,8 @@ def store_result_regime_cohorts(
         raise ValueError(
             f"regime cohort expected trade count {expected_trade_count} does not match parent result {int(parent[0])}"
         )
+    if not cohorts:
+        return
     with conn.cursor() as cursor:
         cursor.executemany(
             """

--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -118,7 +118,7 @@ from typing import Final
 #: Bumped whenever a trial is added or an entry's meaning changes. ⚠ Stored on
 #: the result row beside the DSR: a deflated Sharpe means nothing without the
 #: trial population it was deflated against, and that population grows.
-TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-12-r5"
+TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-15-r6"
 
 #: #2600 Gate D-0.1. Every search this register counts happened at or before this
 #: instant; the two durable clocks (``strategy_results_store.created_at`` and
@@ -566,6 +566,32 @@ TRIAL_REGISTER: Final = TrialRegister(
             "sha256 8f4424bea0581ba501d9779b93ff9268c65c6f0c899f1a66962bcb260cce895f. Issues #2614, #2582",
             exactness=TrialExactness.EXACT,
             searches=7,
+        ),
+        # ⚠ DECLARED BEFORE THE FIRST BACKTEST. The four robustness rows
+        # (ambiguity best/worst x quarantine admitted/masked), the eight pinned
+        # recent windows, and the declared regime cohorts are conjunctive
+        # reports of one frozen rule. No winner may be selected from them, so
+        # each strategy is one search under the register's fan-collapse rule.
+        # A later parameter or domain variant is a new entry, even if it keeps
+        # the same human-readable strategy name.
+        *(
+            DeclaredTrial(
+                trial_id=strategy_id,
+                description=f"{label}: first survivorship-free, cost-aware walk-forward and recent-window run.",
+                evidence=(
+                    "docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md §0 and §3; "
+                    "issue #2437 comment 2026-08-14 (queue item 6 staked before evaluation)"
+                ),
+                exactness=TrialExactness.EXACT,
+            )
+            for strategy_id, label in (
+                ("s5-support-bounce", "S-5 support bounce"),
+                ("s6-resistance-breakout", "S-6 resistance breakout"),
+                ("s7-trend-pullback", "S-7 trend pullback"),
+                ("s8-range-mean-reversion", "S-8 range mean reversion"),
+                ("s9-squeeze-expansion", "S-9 squeeze expansion"),
+                ("s10-relative-strength-leader", "S-10 relative-strength leader"),
+            )
         ),
     ),
 )

--- a/docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md
+++ b/docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md
@@ -133,6 +133,18 @@ inherited from §3.5 of the parent catalogue.
   but every rule above is long-only; a short arm is a separate document with its own
   hard-to-borrow cost model.
 
+## §4.1 Declaration before evaluation
+
+The first price-data evaluation of S-5…S-10 is charged to the shared trial register
+before the hold-out is opened: one exact search per frozen strategy. The ambiguity,
+quarantine, pinned recent-window and declared regime reports are jointly required
+robustness views; none may be selected as a winner, so they collapse to one search by
+the register's standing fan rule. Any parameter, cadence or permitted-regime variant
+is a new trial and must be appended before it reads price outcomes.
+
+These six initial results remain `harness_validation`. Registering the searches does
+not relabel them as capital candidates and does not weaken any promotion refusal.
+
 ## §5 Order of work
 
 1. Regime filter + level construction (§1, §2) — shared, and every strategy depends on them.

--- a/sql/355_strategy_result_regime_cohorts.sql
+++ b/sql/355_strategy_result_regime_cohorts.sql
@@ -1,0 +1,70 @@
+-- #2437 — causal, immutable per-regime trade cohorts for each backtest result.
+-- The parent row remains the promotion unit and owns portfolio path metrics.
+-- These children answer where its realised trades occurred without pretending
+-- that a filtered list of closed returns can reconstruct drawdown.
+
+CREATE TABLE IF NOT EXISTS strategy_result_regime_cohorts (
+    result_id BIGINT NOT NULL REFERENCES strategy_results_store(result_id) ON DELETE RESTRICT,
+    regime TEXT NOT NULL CHECK (regime IN (
+        'bull_quiet', 'bull_volatile', 'bear_quiet', 'bear_volatile', 'unclassified'
+    )),
+    trade_count INTEGER NOT NULL CHECK (trade_count > 0),
+    instrument_count INTEGER NOT NULL CHECK (instrument_count BETWEEN 1 AND trade_count),
+    decision_date_count INTEGER NOT NULL CHECK (decision_date_count BETWEEN 1 AND trade_count),
+    losing_trade_count INTEGER NOT NULL CHECK (losing_trade_count BETWEEN 0 AND trade_count),
+    expectancy_pct NUMERIC NOT NULL,
+    profit_factor NUMERIC,
+    worst_trade_pct NUMERIC NOT NULL,
+    effective_sample_size NUMERIC,
+    expectancy_ci_low_pct NUMERIC,
+    expectancy_ci_high_pct NUMERIC,
+    bootstrap_block_length INTEGER,
+    bootstrap_cluster_count INTEGER,
+    bootstrap_resamples INTEGER,
+    bootstrap_seed BIGINT,
+    bootstrap_design_effect NUMERIC,
+    bootstrap_model_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (result_id, regime),
+    CHECK ((profit_factor IS NULL) = (losing_trade_count = 0)),
+    CHECK (expectancy_pct > '-Infinity'::numeric AND expectancy_pct < 'Infinity'::numeric),
+    CHECK (worst_trade_pct > '-Infinity'::numeric AND worst_trade_pct < 'Infinity'::numeric),
+    CHECK (worst_trade_pct <= expectancy_pct),
+    CHECK (profit_factor IS NULL OR (
+        profit_factor >= 0 AND profit_factor < 'Infinity'::numeric
+    )),
+    CHECK (expectancy_ci_low_pct IS NULL OR expectancy_ci_low_pct <= expectancy_ci_high_pct),
+    CHECK (effective_sample_size IS NULL OR effective_sample_size > 0),
+    CHECK (expectancy_ci_low_pct IS NULL OR (
+        expectancy_ci_low_pct > '-Infinity'::numeric AND expectancy_ci_low_pct < 'Infinity'::numeric AND
+        expectancy_ci_high_pct > '-Infinity'::numeric AND expectancy_ci_high_pct < 'Infinity'::numeric
+    )),
+    CHECK (bootstrap_block_length IS NULL OR bootstrap_block_length > 0),
+    CHECK (bootstrap_cluster_count IS NULL OR bootstrap_cluster_count > 0),
+    CHECK (bootstrap_resamples IS NULL OR bootstrap_resamples > 0),
+    CHECK (bootstrap_seed IS NULL OR bootstrap_seed >= 0),
+    CHECK (bootstrap_design_effect IS NULL OR bootstrap_design_effect > 0),
+    CHECK (bootstrap_model_id IS NULL OR btrim(bootstrap_model_id) <> ''),
+    CHECK (num_nonnulls(
+        effective_sample_size, expectancy_ci_low_pct, expectancy_ci_high_pct,
+        bootstrap_block_length, bootstrap_cluster_count, bootstrap_resamples,
+        bootstrap_seed, bootstrap_design_effect, bootstrap_model_id
+    ) IN (0, 9))
+);
+
+COMMENT ON TABLE strategy_result_regime_cohorts IS
+    'Immutable causal signal-date regime breakdown of a parent strategy result (#2437). '
+    'Cohort trade counts must reconcile to the parent realised trade count. Portfolio path metrics remain on parent.';
+
+CREATE OR REPLACE FUNCTION prevent_strategy_result_regime_cohort_mutation()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'strategy result regime cohorts are immutable; create a new result identity';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_strategy_result_regime_cohort_immutable
+    ON strategy_result_regime_cohorts;
+CREATE TRIGGER trg_strategy_result_regime_cohort_immutable
+BEFORE UPDATE OR DELETE ON strategy_result_regime_cohorts
+FOR EACH ROW EXECUTE FUNCTION prevent_strategy_result_regime_cohort_mutation();

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -415,7 +415,7 @@ def test_overview_maps_only_exact_current_holdout_provenance(
     assert strategy.legacy_result_count == 3
 
 
-def test_overview_declares_only_level_strategies_forward_resolvable(
+def test_overview_declares_exactly_the_manifest_strategies_with_exit_adapters_as_forward_resolvable(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     overview = get_strategy_overview(ebull_test_conn)
@@ -426,4 +426,10 @@ def test_overview_declares_only_level_strategies_forward_resolvable(
         "s2-cross-sectional-momentum": False,
         "s3-mean-reversion-in-trend": False,
         "s4-volatility-compression-breakout": True,
+        "s5-support-bounce": True,
+        "s6-resistance-breakout": True,
+        "s7-trend-pullback": True,
+        "s8-range-mean-reversion": True,
+        "s9-squeeze-expansion": True,
+        "s10-relative-strength-leader": False,
     }

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -57,7 +57,7 @@ from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, FX_UNMODELL
 from app.services.deflated_sharpe import DSR_MODEL_ID, TradeMoments
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID, LegBook
 from app.services.indicator_series import BarSeries
-from app.services.market_regime import RegimeSeries, unconstrained_regime
+from app.services.market_regime import Regime, RegimeSeries, unconstrained_regime
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.position_builder import Position, Window
 from app.services.position_costing import cost_position
@@ -76,6 +76,7 @@ from app.services.research_price_structure_store import (
 )
 from app.services.signal_ledger import LedgerRow
 from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_regime_evidence import RegimeTradeObservation
 from app.services.strategy_result import (
     AMBIGUITY_ARMS,
     CORPUS_VERSION,
@@ -964,11 +965,15 @@ class TestTotalReturnStrategyLeg:
             books=books,  # type: ignore[arg-type]
             close_sources=Counter(),
             discarded=Counter(),
+            market_regime_by_date={date(2024, 1, 1): Regime.BULL_QUIET},
         )
         book = books["hold_out"]
         assert book.returns[0] > 0.0
         assert book.book.entry_price[0] < float(position.entry_fill_price)
         assert book.book.marks.tolist() == [80.0, 90.0]
+        assert len(book.regime_observations) == 1
+        assert book.regime_observations[0].signal_date == position.entry_signal_bar_date
+        assert book.regime_observations[0].regime is Regime.BULL_QUIET
 
 
 class TestNamespaceAxis:
@@ -1068,6 +1073,14 @@ class TestNamespaceAxis:
         for offset, value in enumerate((20.0, -5.0, 7.5, -2.0)):
             book.returns.append(value)
             book.entry_dates.append(axis[3 + offset])
+            book.regime_observations.append(
+                RegimeTradeObservation(
+                    instrument_key=1,
+                    signal_date=axis[3 + offset],
+                    net_return_pct=value,
+                    regime=Regime.BULL_QUIET,
+                )
+            )
             # #2623 gap 1 — the three axes are positionally parallel and
             # `TradeReturns` refuses a short one, so a hand-built book has to
             # fill this too. Exit one bar after entry; the durations are not

--- a/tests/test_strategy_regime_evidence.py
+++ b/tests/test_strategy_regime_evidence.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.services.market_regime import Regime
+from app.services.strategy_regime_evidence import RegimeTradeObservation, build_regime_cohorts
+
+
+def _rows() -> list[RegimeTradeObservation]:
+    start = date(2024, 1, 1)
+    regimes = (Regime.BULL_QUIET, Regime.BEAR_QUIET, None)
+    return [
+        RegimeTradeObservation(
+            instrument_key=(index % 4) + 1,
+            signal_date=start + timedelta(days=index),
+            net_return_pct=(1.0 if index % 3 else -0.5) + index / 100,
+            regime=regimes[index % len(regimes)],
+        )
+        for index in range(36)
+    ]
+
+
+def test_every_trade_lands_in_exactly_one_closed_regime_cohort() -> None:
+    observations = _rows()
+    cohorts = build_regime_cohorts(observations, root_seed=4242)
+    assert [row.regime for row in cohorts] == ["bear_quiet", "bull_quiet", "unclassified"]
+    assert sum(row.trade_count for row in cohorts) == len(observations)
+    assert all(row.instrument_count == 4 for row in cohorts)
+    assert all(row.decision_date_count == row.trade_count for row in cohorts)
+
+
+def test_bootstrap_is_deterministic_per_regime() -> None:
+    first = build_regime_cohorts(_rows(), root_seed=4242)
+    second = build_regime_cohorts(_rows(), root_seed=4242)
+    assert first == second
+    assert all(row.effective_sample_size is not None for row in first)
+    assert len({row.bootstrap_seed for row in first}) == len(first)
+
+
+def test_non_finite_return_is_refused_before_it_can_reach_storage() -> None:
+    with pytest.raises(ValueError, match="net_return_pct must be finite"):
+        RegimeTradeObservation(
+            instrument_key=1,
+            signal_date=date(2024, 1, 1),
+            net_return_pct=float("nan"),
+            regime=Regime.BULL_QUIET,
+        )

--- a/tests/test_strategy_regime_evidence_db.py
+++ b/tests/test_strategy_regime_evidence_db.py
@@ -33,12 +33,23 @@ def _cohorts():
 
 
 def _result(*, trade_count: int = 20):
+    empty_overrides = (
+        {
+            "profit_factor": None,
+            "hold_days_p25": None,
+            "median_hold_days": None,
+            "hold_days_p75": None,
+        }
+        if trade_count == 0
+        else {}
+    )
     return build_result(
         namespace="in_sample",
         metrics=build_metrics(
             trade_count=trade_count,
             losing_trade_count=min(10, trade_count),
             open_trade_count=0,
+            **empty_overrides,
         ),
     )
 
@@ -82,6 +93,20 @@ def test_actual_parent_count_mismatch_refuses_before_insert(ebull_test_conn: psy
             cohorts=_cohorts(),
             expected_trade_count=20,
         )
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_result_regime_cohorts WHERE result_id=%s",
+        (result_id,),
+    ).fetchone() == (0,)
+
+
+def test_zero_trade_parent_stores_no_empty_placeholder_cohort(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    result_id = store_in_sample_result(ebull_test_conn, _result(trade_count=0))
+    store_result_regime_cohorts(
+        ebull_test_conn,
+        result_id=result_id,
+        cohorts=(),
+        expected_trade_count=0,
+    )
     assert ebull_test_conn.execute(
         "SELECT count(*) FROM strategy_result_regime_cohorts WHERE result_id=%s",
         (result_id,),

--- a/tests/test_strategy_regime_evidence_db.py
+++ b/tests/test_strategy_regime_evidence_db.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services.market_regime import Regime
+from app.services.result_ledger import store_in_sample_result
+from app.services.strategy_regime_evidence import (
+    RegimeTradeObservation,
+    build_regime_cohorts,
+    store_result_regime_cohorts,
+)
+from tests.test_result_ledger import build_metrics, build_result
+
+pytestmark = pytest.mark.integration
+
+
+def _cohorts():
+    start = date(2024, 1, 1)
+    observations = [
+        RegimeTradeObservation(
+            instrument_key=index % 3 + 1,
+            signal_date=start + timedelta(days=index),
+            net_return_pct=1.0 if index % 2 else -0.5,
+            regime=Regime.BULL_QUIET if index < 10 else Regime.BEAR_QUIET,
+        )
+        for index in range(20)
+    ]
+    return build_regime_cohorts(observations, root_seed=17)
+
+
+def _result(*, trade_count: int = 20):
+    return build_result(
+        namespace="in_sample",
+        metrics=build_metrics(
+            trade_count=trade_count,
+            losing_trade_count=min(10, trade_count),
+            open_trade_count=0,
+        ),
+    )
+
+
+def test_store_round_trips_and_reconciles(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    result_id = store_in_sample_result(ebull_test_conn, _result())
+    cohorts = _cohorts()
+    store_result_regime_cohorts(
+        ebull_test_conn,
+        result_id=result_id,
+        cohorts=cohorts,
+        expected_trade_count=20,
+    )
+    assert ebull_test_conn.execute(
+        "SELECT regime, trade_count FROM strategy_result_regime_cohorts WHERE result_id=%s ORDER BY regime",
+        (result_id,),
+    ).fetchall() == [("bear_quiet", 10), ("bull_quiet", 10)]
+
+
+def test_parent_count_mismatch_refuses_before_insert(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    result_id = store_in_sample_result(ebull_test_conn, _result())
+    with pytest.raises(ValueError, match="do not reconcile"):
+        store_result_regime_cohorts(
+            ebull_test_conn,
+            result_id=result_id,
+            cohorts=_cohorts(),
+            expected_trade_count=19,
+        )
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_result_regime_cohorts WHERE result_id=%s",
+        (result_id,),
+    ).fetchone() == (0,)
+
+
+def test_actual_parent_count_mismatch_refuses_before_insert(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    result_id = store_in_sample_result(ebull_test_conn, _result(trade_count=21))
+    with pytest.raises(ValueError, match="does not match parent result 21"):
+        store_result_regime_cohorts(
+            ebull_test_conn,
+            result_id=result_id,
+            cohorts=_cohorts(),
+            expected_trade_count=20,
+        )
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_result_regime_cohorts WHERE result_id=%s",
+        (result_id,),
+    ).fetchone() == (0,)
+
+
+def test_cohorts_are_immutable(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    result_id = store_in_sample_result(ebull_test_conn, _result())
+    store_result_regime_cohorts(
+        ebull_test_conn,
+        result_id=result_id,
+        cohorts=_cohorts(),
+        expected_trade_count=20,
+    )
+    with pytest.raises(psycopg.errors.RaiseException, match="immutable"):
+        with ebull_test_conn.transaction():
+            ebull_test_conn.execute(
+                "UPDATE strategy_result_regime_cohorts SET trade_count=9 WHERE result_id=%s",
+                (result_id,),
+            )

--- a/tests/test_trial_register.py
+++ b/tests/test_trial_register.py
@@ -71,7 +71,7 @@ class TestTheShippedDeclaration:
         # first declared BEFORE its run). Moved deliberately, not loosened: the
         # pin exists to catch a DROPPED entry, and an addition that raises M is
         # the conservative direction — a larger M lowers the DSR.
-        assert TRIAL_REGISTER.declared_count == 266
+        assert TRIAL_REGISTER.declared_count == 272
         assert TRIAL_REGISTER.declared_count == sum(trial.searches for trial in TRIAL_REGISTER.trials)
 
     def test_the_c4_schedule13d_arms_are_counted_before_the_run(self) -> None:
@@ -117,7 +117,14 @@ class TestTheShippedDeclaration:
         winner, so counting it would inflate M and understate the DSR. The
         register's header states this test; this pins it.
         """
-        assert not any(trial.startswith(("s5", "s6")) for trial in TRIAL_REGISTER.trial_ids)
+        assert {
+            "s5-support-bounce",
+            "s6-resistance-breakout",
+            "s7-trend-pullback",
+            "s8-range-mean-reversion",
+            "s9-squeeze-expansion",
+            "s10-relative-strength-leader",
+        } <= TRIAL_REGISTER.trial_ids
 
 
 class TestSharpeVariance:


### PR DESCRIPTION
## Outcome

- Declares the first S5-S10 price-data searches in the shared trial register before evaluation (M 266 → 272).
- Attaches an immutable, causal signal-date regime breakdown to every newly stored strategy result.
- Requires child cohort trade counts to reconcile both in memory and against the actual parent ledger row.
- Reports cohort expectancy, profit factor, worst trade, clustered block-bootstrap interval/ESS and full bootstrap provenance.
- Keeps parent results as the only promotion unit; closed-trade subsets do not pretend to reconstruct drawdown.
- Repairs the stale strategies API assertion so it covers all ten manifest strategies and their actual forward-outcome adapters.

## Validation

- Focused service/API/schema/smoke slice: 166 passed serially.
- Full pre-push gate: ruff, format, pyright, 25 structural lints, 288 revert-probe anchors, full fast tier, smoke tier, and frontend integrity gates all green.
- Full DB tier was also attempted. It exposed 10 live-daemon advisory-lock/pool contention failures and 2 unrelated baseline fixture drifts; the changed DB/API/schema slice was then rerun serially and passed. These are stated rather than relabelled green.

## Safety / research posture

- Regime is classified on the entry signal date, never fill or exit date.
- Unclassifiable dates are explicit `unclassified`, so no realised trade disappears.
- These rows are explanatory children, not independently selectable winners.
- Results remain `harness_validation`; this PR neither promotes a strategy nor enables capital.

Refs #2437. Does not close the umbrella.