### PR TITLE
fix(#2437): name S5-S10 in the Strategies workspace

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -119,6 +119,12 @@ _TITLES = {
     "s2-cross-sectional-momentum": "Cross-sectional momentum",
     "s3-mean-reversion-in-trend": "Mean reversion in trend",
     "s4-volatility-compression-breakout": "Volatility compression breakout",
+    "s5-support-bounce": "Support bounce",
+    "s6-resistance-breakout": "Resistance breakout",
+    "s7-trend-pullback": "Trend pullback",
+    "s8-range-mean-reversion": "Range mean reversion",
+    "s9-squeeze-expansion": "Squeeze expansion",
+    "s10-relative-strength-leader": "Relative-strength leader",
 }
 
 _PRESENTATION = {
@@ -137,6 +143,30 @@ _PRESENTATION = {
     "s4-volatility-compression-breakout": (
         "Looks for price breakouts after volatility has contracted.",
         "Up to 40 market days",
+    ),
+    "s5-support-bounce": (
+        "Buys a rejection back above established support in bullish regimes.",
+        "Up to 30 market days",
+    ),
+    "s6-resistance-breakout": (
+        "Buys a volume-confirmed close through established resistance in quiet bull markets.",
+        "Up to 40 market days",
+    ),
+    "s7-trend-pullback": (
+        "Buys RSI recoveries inside established uptrends and exits when the trend weakens.",
+        "Up to 60 market days",
+    ),
+    "s8-range-mean-reversion": (
+        "Buys rebounds from below the lower Bollinger band when ADX indicates a range.",
+        "Up to 15 market days",
+    ),
+    "s9-squeeze-expansion": (
+        "Buys 20-day price breakouts after Bollinger BandWidth reaches a six-month squeeze.",
+        "Up to 40 market days",
+    ),
+    "s10-relative-strength-leader": (
+        "Holds top-decile 63-day leaders above their 50-day average in quiet bull markets.",
+        "Reviewed at each monthly rebalance",
     ),
 }
 

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 
 import psycopg
 
-from app.api.strategies import ResultArm, _current_versions, _promotion_refusals, get_strategy_overview
+from app.api.strategies import (
+    _PRESENTATION,
+    _TITLES,
+    ResultArm,
+    _current_versions,
+    _promotion_refusals,
+    get_strategy_overview,
+)
 from app.services.cost_model import COST_MODEL_ID
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
@@ -26,6 +33,15 @@ def test_current_versions_cover_the_manifest_including_s4() -> None:
     assert set(versions) == set(STRATEGY_MANIFEST)
     assert "s4-volatility-compression-breakout" in versions
     assert all(version.startswith("strategy-registry-v1+") for version in versions.values())
+
+
+def test_every_manifest_strategy_has_operator_readable_presentation() -> None:
+    """A new strategy must not fall through to its internal id and generic copy."""
+
+    assert set(_TITLES) == set(STRATEGY_MANIFEST)
+    assert set(_PRESENTATION) == set(STRATEGY_MANIFEST)
+    assert all(title != strategy_id for strategy_id, title in _TITLES.items())
+    assert all(description != "Evidence-backed automated strategy." for description, _exit in _PRESENTATION.values())
 
 
 def test_result_refusals_fail_closed_without_expanding_the_database() -> None:


### PR DESCRIPTION
## What

- give S5-S10 operator-readable titles, descriptions, and exit timing in `/strategies`
- pin presentation coverage to the complete strategy manifest so a future strategy cannot silently fall back to its internal id and generic copy

## Why

The six strategies are already in the manifest and scan pipeline, but the operator page renders their raw ids (`s5-support-bounce`, etc.) and generic text. This is presentation only: every strategy remains `harness_validation`, no promotion or allocation authority changes, and all existing fail-closed gates remain intact.

## Validation

- `uv run pytest -q tests/test_api_strategies.py`
- `uv run ruff check app/api/strategies.py tests/test_api_strategies.py`
- `uv run ruff format --check app/api/strategies.py tests/test_api_strategies.py`
- `uv run pyright app/api/strategies.py tests/test_api_strategies.py`
- complete local pre-push gate (fast tests, smoke, frontend static gates)

Refs #2437.
