### PR TITLE
feature(#2721): activate survivorship-free evidence identity

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -24,7 +24,7 @@ from app.security.master_key import MasterKeyError, ensure_broker_key_loaded
 from app.security.secrets_crypto import CredentialCryptoConfigError
 from app.security.sessions import SessionRow
 from app.services.account_equity_evidence import load_account_equity_evidence
-from app.services.backtest_run import BACKTEST_UNIVERSE, runnable_strategies
+from app.services.backtest_run import BACKTEST_UNIVERSE, corpus_version_for, runnable_strategies
 from app.services.broker_credentials import (
     CredentialDecryptError,
     CredentialNotFound,
@@ -99,7 +99,7 @@ from app.services.strategy_position_manager import (
     manage_owned_position,
 )
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
-from app.services.strategy_result import CORPUS_VERSION, TOTAL_RETURN_BASIS
+from app.services.strategy_result import TOTAL_RETURN_BASIS
 from app.services.strategy_wealth import load_strategy_wealth_history
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
@@ -1216,7 +1216,7 @@ def _evidence_window_counts(strategies: list[StrategyOverview]) -> tuple[int, in
 
     A missing member is missing evidence, never an exception. With no runnable
     strategies there is no evidence population, so the completed denominator
-    is zero rather than vacuously all eight.
+    is zero rather than vacuously all declared windows.
     """
     statuses = [
         {window.window_id: window.status for window in strategy.evidence_windows}
@@ -1247,7 +1247,7 @@ def _current_identity_pins() -> dict[str, str]:
     """
     return {
         "namespace": "hold_out",
-        "corpus_version": CORPUS_VERSION,
+        "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
         "cost_model_id": COST_MODEL_ID,
         "sizing_rule": SIZING_RULE_ID,
         "benchmark_rule": BENCHMARK_RULE_ID,
@@ -1340,7 +1340,7 @@ def get_strategy_overview(
     version_values = list(versions.values())
     params = {
         "versions": version_values,
-        "corpus_version": CORPUS_VERSION,
+        "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
         "cost_model_id": COST_MODEL_ID,
         "sizing_rule": SIZING_RULE_ID,
         "benchmark_rule": BENCHMARK_RULE_ID,

--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -38,12 +38,12 @@ The runner computes ATR at signal bar ``t``, fixes the bracket around the
 ``level_based`` entry with no factory remains a named exclusion; it is never
 silently skipped.
 
-⚠ IT READS THE FROZEN RESEARCH CORPUS ONLY. ``load_masked_series`` at
-``CORPUS_VERSION``; ``strategy_signal_scan`` reads live ``price_daily`` through
-``price_masked_bars``. The two sources are deliberately different and their rows
-are not comparable. S-2 is where that could slip — assembling a panel is the one
-place a ``price_daily`` read would look like a convenience rather than a corpus
-change.
+⚠ IT READS THE FROZEN RESEARCH CORPUS ONLY. Its result rows carry
+``corpus_version_for(BACKTEST_UNIVERSE)``; ``strategy_signal_scan`` reads live
+``price_daily`` through ``price_masked_bars``. The two sources are deliberately
+different and their rows are not comparable. S-2 is where that could slip —
+assembling a panel is the one place a ``price_daily`` read would look like a
+convenience rather than a corpus change.
 """
 
 from __future__ import annotations
@@ -257,15 +257,15 @@ def _emit_series_progress(
         )
 
 
-#: The research corpus is survivor-only (#2284) and every row this job writes
-#: inherits that label (#2288). ⚠ It is BOTH the ``Universe`` hashed into
-#: ``StrategyIdentity`` and the ``universe_basis`` stamped on the result, and
-#: they must not drift apart: the identity says what the strategy was told, the
-#: basis says what the gate refuses on.
-BACKTEST_UNIVERSE: Universe = "survivor_only"
+#: #2721 acceptance makes the termination-aware Intrader archive the one
+#: evidence basis used by the backtester, API, scheduler and paper runtime.
+#: This is BOTH the ``Universe`` hashed into ``StrategyIdentity`` and the
+#: ``universe_basis`` stamped on a result. The old survivor corpus remains an
+#: explicit diagnostic arm, never the default capital-evidence identity.
+BACKTEST_UNIVERSE: Universe = "survivorship_free"
 
 
-def _corpus_version_for(universe_basis: Universe) -> str:
+def corpus_version_for(universe_basis: Universe) -> str:
     """The frozen corpus version a result under this universe stamps (#2721).
 
     ``CORPUS_VENDORS``'s own docstring declares *"A SECOND VENDOR MOVES THIS
@@ -2574,8 +2574,9 @@ def build_result(
     rather than a placeholder written — a blank would pass ``NOT NULL`` and
     silently merge two results (the #2286 shape).
     """
-    window = evaluation_window or Window(start=EVALUATION_WINDOW_START, end=EVALUATION_WINDOW_END)
-    corpus_version = _corpus_version_for(universe_basis)
+    default_end = INTRADER_CAPTURE_DATE if universe_basis == "survivorship_free" else EVALUATION_WINDOW_END
+    window = evaluation_window or Window(start=EVALUATION_WINDOW_START, end=default_end)
+    corpus_version = corpus_version_for(universe_basis)
     return StrategyResult(
         identity=ResultIdentity(
             strategy_id=strategy_id,
@@ -2992,7 +2993,7 @@ def run_backtest(
             sizing_rule=SIZING_RULE_ID,
             benchmark_rule=BENCHMARK_RULE_ID,
             cost_model_id=COST_MODEL_ID,
-            corpus_version=_corpus_version_for(universe),
+            corpus_version=corpus_version_for(universe),
             window_start=corpus.window.start,
             window_end=corpus.window.end,
             position_rule_set_version=POSITION_RULE_SET_VERSION,
@@ -3937,6 +3938,7 @@ __all__ = [
     "assert_no_existing_results",
     "build_in_sample_split",
     "build_result",
+    "corpus_version_for",
     "deflate_group",
     "evaluate_arm",
     "load_corpus",

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -313,8 +313,6 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
                 "year-2022",
                 "year-2023",
                 "year-2024",
-                "year-2025",
-                "year-2026-ytd",
             ),
         ),
         ParamMetadata(

--- a/app/services/strategy_recent_evidence.py
+++ b/app/services/strategy_recent_evidence.py
@@ -6,13 +6,12 @@ operator search until a favourable interval appeared and then present that row
 as if it were the declared test.  The registry also gives the monitoring API a
 complete denominator: a missing row is visible as missing evidence.
 
-Only compact aggregate result rows are stored.  Daily bars remain in the
-existing research corpus and indicators/positions are recomputed while a run is
-active, so adding all eight windows costs 128 rows at the current four runnable
-controls (8 windows x 4 strategies x 2 ambiguity x 2 quarantine), not another
-time-series store.  Only S-4 independently resolves best/worst ambiguity; the
-shared non-level measurement for S-1..S-3 is deliberately carried under both
-arm identities to keep the immutable denominator complete.
+The survivorship-free archive is frozen at 2024-09-27. A window beyond that
+date cannot earn the label, so post-capture calendar years are prospective
+shadow evidence, not historical backtest windows. The six windows below end at
+or before that hard bound; keeping the old 2025/2026 windows in this denominator
+would make allocation permanently impossible while describing unavailable data
+as an unfinished job.
 """
 
 from __future__ import annotations
@@ -24,6 +23,7 @@ from typing import Final, Literal
 
 from app.services.position_builder import Window
 from app.services.strategy_result import EVALUATION_WINDOW_END, HOLDOUT_BOUNDARY
+from app.services.universe_selection import INTRADER_CAPTURE_DATE
 
 RecentEvidenceWindowId = Literal[
     "primary-2022-plus",
@@ -32,8 +32,6 @@ RecentEvidenceWindowId = Literal[
     "year-2022",
     "year-2023",
     "year-2024",
-    "year-2025",
-    "year-2026-ytd",
 ]
 
 
@@ -53,17 +51,36 @@ class RecentEvidenceWindow:
             raise ValueError(
                 f"recent evidence {self.window_id} ends {self.window.end}, after corpus {EVALUATION_WINDOW_END}"
             )
+        if self.window.end > INTRADER_CAPTURE_DATE:
+            raise ValueError(
+                f"recent evidence {self.window_id} ends {self.window.end}, after the survivorship-free "
+                f"archive capture {INTRADER_CAPTURE_DATE}"
+            )
 
 
 _WINDOWS = (
-    RecentEvidenceWindow("primary-2022-plus", "Primary: 2022 onward", Window(date(2022, 1, 1), EVALUATION_WINDOW_END)),
-    RecentEvidenceWindow("rolling-36m", "Rolling 36 months", Window(date(2023, 7, 9), EVALUATION_WINDOW_END)),
-    RecentEvidenceWindow("rolling-24m", "Rolling 24 months", Window(date(2024, 7, 9), EVALUATION_WINDOW_END)),
+    RecentEvidenceWindow(
+        "primary-2022-plus",
+        "Primary: 2022 through archive capture",
+        Window(date(2022, 1, 1), INTRADER_CAPTURE_DATE),
+    ),
+    RecentEvidenceWindow(
+        "rolling-36m",
+        "36 months through archive capture",
+        Window(date(2021, 9, 28), INTRADER_CAPTURE_DATE),
+    ),
+    RecentEvidenceWindow(
+        "rolling-24m",
+        "24 months through archive capture",
+        Window(date(2022, 9, 28), INTRADER_CAPTURE_DATE),
+    ),
     RecentEvidenceWindow("year-2022", "Calendar 2022", Window(date(2022, 1, 1), date(2022, 12, 31))),
     RecentEvidenceWindow("year-2023", "Calendar 2023", Window(date(2023, 1, 1), date(2023, 12, 31))),
-    RecentEvidenceWindow("year-2024", "Calendar 2024", Window(date(2024, 1, 1), date(2024, 12, 31))),
-    RecentEvidenceWindow("year-2025", "Calendar 2025", Window(date(2025, 1, 1), date(2025, 12, 31))),
-    RecentEvidenceWindow("year-2026-ytd", "2026 year to corpus date", Window(date(2026, 1, 1), EVALUATION_WINDOW_END)),
+    RecentEvidenceWindow(
+        "year-2024",
+        "2024 through archive capture",
+        Window(date(2024, 1, 1), INTRADER_CAPTURE_DATE),
+    ),
 )
 
 RECENT_EVIDENCE_WINDOWS: Final = MappingProxyType({item.window_id: item for item in _WINDOWS})

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5528,9 +5528,9 @@ def _open_backtest_progress_writer(
 def strategy_backtest_run(params: Mapping[str, Any]) -> None:
     """Persist criterion 9's arm pairs for every runnable strategy (#2394 §3.2).
 
-    DB-only (no external I/O): reads the FROZEN research corpus through
-    ``research_price_structure_store.load_masked_series`` at ``CORPUS_VERSION``
-    and writes ``strategy_results`` / ``strategy_results_store`` +
+    DB-only (no external I/O): reads the frozen corpus selected by
+    ``backtest_run.BACKTEST_UNIVERSE`` and stamps its matching corpus version;
+    writes ``strategy_results`` / ``strategy_results_store`` +
     ``strategy_holdout_accesses`` through ``result_ledger``. It touches no
     broker path and no live-data path.
 
@@ -5705,7 +5705,12 @@ def _recent_evidence_completion(
     Counting dates alone could mistake stale cost, corpus or rule-set rows for
     current evidence.
     """
-    from app.services.backtest_run import BACKTEST_UNIVERSE, RESULT_SCOPE, runnable_strategies
+    from app.services.backtest_run import (
+        BACKTEST_UNIVERSE,
+        RESULT_SCOPE,
+        corpus_version_for,
+        runnable_strategies,
+    )
     from app.services.cost_model import COST_MODEL_ID
     from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
     from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
@@ -5719,7 +5724,6 @@ def _recent_evidence_completion(
     from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
     from app.services.strategy_result import (
         AMBIGUITY_ARMS,
-        CORPUS_VERSION,
         TOTAL_RETURN_BASIS,
         AmbiguityArm,
         ResultIdentity,
@@ -5745,7 +5749,7 @@ def _recent_evidence_completion(
                             sizing_rule=SIZING_RULE_ID,
                             benchmark_rule=BENCHMARK_RULE_ID,
                             cost_model_id=COST_MODEL_ID,
-                            corpus_version=CORPUS_VERSION,
+                            corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
                             window_start=item.window.start,
                             window_end=item.window.end,
                             position_rule_set_version=POSITION_RULE_SET_VERSION,

--- a/docs/proposals/ta/2026-08-13-prior-version-track-records.md
+++ b/docs/proposals/ta/2026-08-13-prior-version-track-records.md
@@ -160,7 +160,10 @@ existing one.
 
 `StrategiesPage.tsx:50` — `primaryEvidence()` matches `window.window_id === "primary"`. No such id
 exists: the declared ids are `primary-2022-plus`, `rolling-36m`, `rolling-24m`, `year-2022`,
-`year-2023`, `year-2024`, `year-2025`, `year-2026-ytd`
+`year-2023`, `year-2024`, `year-2025`, `year-2026-ytd`. This was the denominator
+at the time of this document; #2721's activation later removes the post-archive
+2025/2026 members because Intrader is frozen at 2024-09-27 (see
+`2026-08-15-2721-survivorship-free-activation.md`).
 (`app/services/strategy_recent_evidence.py:29`). The first branch is dead, so the function always
 falls through to "first window with `status === "complete"`". That is order-dependent and silently
 picks a **different window** whenever the primary window is `partial` while a calendar-year window

--- a/docs/proposals/ta/2026-08-15-2721-survivorship-free-activation.md
+++ b/docs/proposals/ta/2026-08-15-2721-survivorship-free-activation.md
@@ -1,0 +1,89 @@
+# #2721 — activate the survivorship-free evidence identity
+
+Status: historical activation gate accepted on 2026-08-15; full evidence is
+recorded in issue #2721 comment `5300786612`.
+
+## Decision
+
+`BACKTEST_UNIVERSE` becomes `survivorship_free`. This is the identity used by
+the backtester, Strategies API, recent-evidence scheduler and paper runtime.
+`survivor_only` remains available only as an explicit diagnostic arm; it is not
+capital evidence.
+
+The change is deliberately separate from the termination implementation. PRs
+#2731/#2732 wired the universe and termination rule while the historical Form 25
+expansion was still running. Activating the default before that census would
+have made an implementation claim into an accepted data claim.
+
+## Corpus identity must move with the universe
+
+The survivor archive and Intrader archive have different vendors and frozen
+frontiers. A survivorship-free row is stamped
+`icyDenev/Intrader@2024-09-27`; it must never be queried as the legacy
+`CORPUS_VERSION`. `corpus_version_for(universe)` is therefore the shared source
+used by the writer, API current-result filter and scheduler completion check.
+Otherwise a correct run would be stored and then rendered as missing.
+
+## The archive boundary changes the historical denominator
+
+Intrader's measured and load-time-asserted capture date is 2024-09-27. #2721's
+hard bound says a window ending later can never earn `survivorship_free` on
+this archive. The pinned historical windows are consequently:
+
+| id | start | end |
+| --- | --- | --- |
+| `primary-2022-plus` | 2022-01-01 | 2024-09-27 |
+| `rolling-36m` | 2021-09-28 | 2024-09-27 |
+| `rolling-24m` | 2022-09-28 | 2024-09-27 |
+| `year-2022` | 2022-01-01 | 2022-12-31 |
+| `year-2023` | 2023-01-01 | 2023-12-31 |
+| `year-2024` | 2024-01-01 | 2024-09-27 |
+
+The former 2025 and 2026 windows are removed, not marked incomplete. Those
+dates require prospective shadow evidence from the live signal/outcome ledgers;
+calling them an unfinished historical backtest would create a denominator the
+archive can never complete and would permanently block allocation for the wrong
+reason.
+
+This does not weaken the forward gate. Historical evidence ends at archive
+capture; promotion and demo execution separately require a frozen
+preregistration, prospective decision dates/calendar span, forecast assessment,
+allocation controls and the broker preflight.
+
+## Activation gate
+
+Merge only after all of the following succeed on the same database state:
+
+1. 2013–2021 Form 25 harvest completes with zero unfetched filings and a
+   per-year filing/resolution census.
+2. Intrader and PapersWithBacktest delisting links are rebuilt from the expanded
+   register.
+3. `scripts.verify_2721_survivorship_universe --smoke-run 100` reports exact
+   universe reconciliation and rolls its limited smoke rows back.
+4. The final provision/termination-class census is posted to #2721.
+
+No preregistration is frozen before this activation: it would bind immutable
+terms to the old `survivor_only` strategy versions.
+
+## Accepted census
+
+The 2013–2021 expansion harvested 7,999 filings. The equity/common cohort has
+2,669 filings; symbol resolution is effectively absent before inline XBRL and
+must not be described as unbiased. In 2021, the acquisition/failure mix differs
+by 9.0 percentage points between unresolved and resolved issuers (z=2.45).
+Absent linkage therefore remains unchecked, never checked-clean.
+
+After both-vendor relink, full-population verification measured:
+
+- exact `survivor_only` restoration: 5,265 series and zero Intrader;
+- `survivorship_free`: 22,879 vendor series, 17,290 admitted, 5,589
+  unlinked-alive excluded, zero unharvested;
+- 12,641 terminating series: 11,388 unknown, 699 operation-of-law, 342
+  q-suffix OTC unverified, 211 exchange failure and 1 exchange failure (a)(4);
+- exact reconciliation of every selection stratum;
+- a 100-series rollback-only smoke wrote four in-sample rows and their
+  termination censuses, then persisted nothing.
+
+This accepts the data identity and its stated limitations. It is not evidence
+that any strategy is profitable, and it does not authorise preregistration,
+promotion or allocation by itself.

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -172,10 +172,10 @@ const OVERVIEW: StrategyOverviewResponse = {
     ],
   },
   evidence_refresh: {
-    frozen_through: "2026-07-08",
+    frozen_through: "2024-09-27",
     completed_windows: 1,
     partial_windows: 0,
-    total_windows: 8,
+    total_windows: 6,
     status: "idle",
     request_id: null,
     requested_at: null,
@@ -581,7 +581,7 @@ describe("StrategiesPage", () => {
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
 
     await userEvent.click(await screen.findByText("Research & validation"));
-    expect(await screen.findByText(/Evidence 1\/8/)).toHaveTextContent("frozen through 08 Jul 2026");
+    expect(await screen.findByText(/Evidence 1\/6/)).toHaveTextContent("frozen through 27 Sept 2024");
     await userEvent.click(screen.getByRole("button", { name: "Refresh evidence" }));
 
     await waitFor(() => expect(refresh).toHaveBeenCalledOnce());

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -49,8 +49,8 @@ function pctPoints(value: string | null): string {
 
 /** The declared id is `primary-2022-plus`, not `primary` (#2624).
  *
- * `app/services/strategy_recent_evidence.py` declares exactly eight ids and
- * `primary` is not among them, so this lookup used to be dead and the function
+ * `app/services/strategy_recent_evidence.py` declares the bounded historical
+ * ids, and `primary` is not among them, so this lookup used to be dead and the function
  * always fell through to "first window with status complete". That is
  * order-dependent: whenever the primary window is `partial` while a calendar-year
  * window is `complete`, the headline "Expected / trade" silently described 2022
@@ -1152,9 +1152,9 @@ function ResearchCandidate({ strategy }: { strategy: StrategyOverview }) {
 
 function ValidationControl({ strategy }: { strategy: StrategyOverview }) {
   const arm = representativeArm(strategy);
-  // ⚠ This — NOT `EvidenceDetail` — is where the four strategies that exist are
-  // rendered, because all of them are `harness_validation` (#2624). Putting the
-  // rotation notice only on the capital-candidate path would have shipped a
+  // ⚠ This — NOT `EvidenceDetail` — is where manifest strategies still marked
+  // `harness_validation` are rendered (#2624). Putting the rotation notice
+  // only on the capital-candidate path would have shipped a
   // payload nothing displays; caught by walking the real page, not by the
   // component tests, whose fixture is a candidate.
   return (

--- a/tests/test_2721_universe_selection.py
+++ b/tests/test_2721_universe_selection.py
@@ -22,8 +22,8 @@ from app.services import backtest_run
 from app.services.backtest_run import (
     BACKTEST_UNIVERSE,
     STANDING_REFUSALS,
-    _corpus_version_for,
     _terminate_open_positions,
+    corpus_version_for,
     load_corpus,
 )
 from app.services.indicator_series import BarSeries
@@ -177,10 +177,10 @@ class TestWindowBounds:
                 evaluation_window=Window(start=date(2020, 1, 1), end=INTRADER_CAPTURE_DATE.replace(year=2025)),
             )
 
-    def test_the_survivor_default_is_unchanged(self) -> None:
-        assert BACKTEST_UNIVERSE == "survivor_only"
-        assert _corpus_version_for("survivor_only") == CORPUS_VERSION
-        assert _corpus_version_for("survivorship_free") == f"{SURVIVORSHIP_FREE_VENDOR}@2024-09-27"
+    def test_the_accepted_survivorship_free_universe_is_the_default(self) -> None:
+        assert BACKTEST_UNIVERSE == "survivorship_free"
+        assert corpus_version_for("survivor_only") == CORPUS_VERSION
+        assert corpus_version_for("survivorship_free") == f"{SURVIVORSHIP_FREE_VENDOR}@2024-09-27"
 
 
 class TestWriteBoundary:

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -15,6 +15,7 @@ from app.api.strategies import (
     _promotion_refusals,
     get_strategy_overview,
 )
+from app.services.backtest_run import BACKTEST_UNIVERSE, corpus_version_for
 from app.services.cost_model import COST_MODEL_ID
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
@@ -23,7 +24,7 @@ from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERS
 from app.services.result_ledger import store_holdout_result, store_in_sample_result
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
-from app.services.strategy_result import CORPUS_VERSION, LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS
+from app.services.strategy_result import LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
 from tests.test_result_ledger import build_metrics, build_result
 
@@ -294,7 +295,7 @@ def test_empty_ledgers_still_return_all_manifest_strategies(
     assert [item.strategy_id for item in overview.strategies] == sorted(STRATEGY_MANIFEST)
     assert all(item.scan.status == "never_run" for item in overview.strategies)
     assert all(not item.all_recent_evidence_complete for item in overview.strategies)
-    assert all(len(item.evidence_windows) == 8 for item in overview.strategies)
+    assert all(len(item.evidence_windows) == len(RECENT_EVIDENCE_WINDOWS) for item in overview.strategies)
     assert not overview.automation_readiness.ready
     assert overview.automation_readiness.state == "no_capital_candidates"
     assert overview.automation_readiness.capital_candidate_count == 0
@@ -400,7 +401,7 @@ def test_overview_maps_only_exact_current_holdout_provenance(
         "strategy_version": strategy_version,
         "window_start": window.start,
         "window_end": window.end,
-        "corpus_version": CORPUS_VERSION,
+        "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
         "cost_model_id": COST_MODEL_ID,
         "sizing_rule": SIZING_RULE_ID,
         "benchmark_rule": BENCHMARK_RULE_ID,

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -90,6 +90,7 @@ from app.services.strategy_result import (
 from app.services.strategy_segmented_evaluation import segmented_member
 from app.services.strategy_statistics import StrategyMetrics
 from app.services.trial_register import TRIAL_REGISTER
+from app.services.universe_selection import INTRADER_CAPTURE_DATE, SURVIVORSHIP_FREE_VENDOR
 from app.services.walk_forward import FOLD_COUNT, WALK_FORWARD_MODEL_ID
 from app.workers.scheduler import _optional_str  # noqa: PLC2701 - the blank-is-absent rule under test
 
@@ -390,7 +391,6 @@ class TestExpectedRefusals:
 
     def test_full_holdout_run_with_a_dsr_leaves_only_the_standing_refusals(self) -> None:
         assert _expected_refusals(holdout_requested=True, deflated=True) == STANDING_REFUSALS | {
-            "universe_basis_not_survivorship_free",
             "synthetic_control_not_run",
         }
 
@@ -409,14 +409,12 @@ class TestExpectedRefusals:
             deflated=True,
             purpose="harness_validation",
         ) == STANDING_REFUSALS | {
-            "universe_basis_not_survivorship_free",
             "harness_validation_only",
             "synthetic_control_not_run",
         }
 
     def test_in_sample_run_adds_holdout_never_evaluated(self) -> None:
         assert _expected_refusals(holdout_requested=False, deflated=True) == STANDING_REFUSALS | {
-            "universe_basis_not_survivorship_free",
             "holdout_never_evaluated",
             "synthetic_control_not_run",
         }
@@ -450,7 +448,6 @@ class TestExpectedRefusals:
         assert _expected_refusals(
             holdout_requested=False, deflated=False, prior_holdout_evaluations=12
         ) == STANDING_REFUSALS | {
-            "universe_basis_not_survivorship_free",
             "deflated_sharpe_not_computed",
             "trial_count_undeclared",
             "synthetic_control_not_run",
@@ -461,7 +458,6 @@ class TestExpectedRefusals:
         DSR at all, and collapsing them would make "which of the two is missing"
         unanswerable."""
         assert _expected_refusals(holdout_requested=True, deflated=False) == STANDING_REFUSALS | {
-            "universe_basis_not_survivorship_free",
             "deflated_sharpe_not_computed",
             "trial_count_undeclared",
             "synthetic_control_not_run",
@@ -651,15 +647,15 @@ class TestBuildResult:
         assert identity.result_scope == "sleeve"
         assert identity.sizing_rule == SIZING_RULE_ID
         assert identity.cost_model_id == COST_MODEL_ID
-        assert identity.corpus_version == CORPUS_VERSION
+        assert identity.corpus_version == f"{SURVIVORSHIP_FREE_VENDOR}@{INTRADER_CAPTURE_DATE.isoformat()}"
         assert identity.window_start == EVALUATION_WINDOW_START
-        assert identity.window_end == EVALUATION_WINDOW_END
+        assert identity.window_end == INTRADER_CAPTURE_DATE
         assert identity.position_rule_set_version == POSITION_RULE_SET_VERSION
         # ⚠⚠ THE QUARANTINE RULE SET, not StrategyIdentity.input_rule_set_versions
         # (indicator-only, and already inside strategy_version — folding it in
         # here would hash it twice).
         assert identity.input_rule_set_version == QUARANTINE_RULE_SET_VERSION
-        assert result.universe_basis == "survivor_only"
+        assert result.universe_basis == "survivorship_free"
         assert result.evaluated_instrument_count == 2
 
     def test_no_dsr_leaves_both_criterion_6_scalars_null(self) -> None:

--- a/tests/test_strategy_recent_evidence.py
+++ b/tests/test_strategy_recent_evidence.py
@@ -12,9 +12,15 @@ import pytest
 
 from app.api.strategies import _evidence_window_counts
 from app.services.backtest_run import BacktestProgressEvent
+from app.services.position_builder import Window
 from app.services.processes.param_metadata import MANUAL_TRIGGER_JOB_METADATA
-from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS, recent_evidence_window
+from app.services.strategy_recent_evidence import (
+    RECENT_EVIDENCE_WINDOWS,
+    RecentEvidenceWindow,
+    recent_evidence_window,
+)
 from app.services.strategy_result import EVALUATION_WINDOW_END, HOLDOUT_BOUNDARY
+from app.services.universe_selection import INTRADER_CAPTURE_DATE
 from app.workers import scheduler
 
 
@@ -26,18 +32,27 @@ def test_all_required_windows_are_named_and_inside_the_holdout_corpus() -> None:
         "year-2022",
         "year-2023",
         "year-2024",
-        "year-2025",
-        "year-2026-ytd",
     )
     assert all(item.required_for_allocation for item in RECENT_EVIDENCE_WINDOWS.values())
     assert all(item.window.start >= HOLDOUT_BOUNDARY for item in RECENT_EVIDENCE_WINDOWS.values())
     assert all(item.window.end <= EVALUATION_WINDOW_END for item in RECENT_EVIDENCE_WINDOWS.values())
+    assert all(item.window.end <= INTRADER_CAPTURE_DATE for item in RECENT_EVIDENCE_WINDOWS.values())
     assert RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window.start == date(2022, 1, 1)
+    assert RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window.end == INTRADER_CAPTURE_DATE
 
 
 def test_raw_or_unknown_window_ids_are_refused() -> None:
     with pytest.raises(ValueError, match="unknown recent evidence window"):
         recent_evidence_window("2025-03-01:2025-04-01")
+
+
+def test_a_post_capture_window_cannot_be_declared_as_survivorship_free_evidence() -> None:
+    with pytest.raises(ValueError, match="after the survivorship-free archive capture"):
+        RecentEvidenceWindow(
+            "year-2024",
+            "invalid post-capture window",
+            Window(date(2024, 1, 1), date(2024, 12, 31)),
+        )
 
 
 def test_manual_job_exposes_ids_but_never_raw_dates() -> None:


### PR DESCRIPTION
Closes #2721

## What changes
- switches the shared backtester/API/scheduler/paper identity from `survivor_only` to `survivorship_free`
- stamps and queries the Intrader corpus version consistently instead of the legacy survivor corpus
- bounds the default evaluation and six historical evidence windows to the archive capture date, 2024-09-27
- removes impossible 2025/2026 historical windows; those dates belong to prospective signal/outcome evidence
- retains `survivor_only` only as an explicit diagnostic arm

## Historical activation gate
- 7,999 Form 25 filings harvested for 2013–2021; both vendor archives relinked
- exact survivor restoration: 5,265 series, zero Intrader
- survivorship-free reconciliation: 22,879 total = 17,290 admitted + 5,589 unlinked-alive + 0 unharvested
- 12,641 terminating series classified; 100-series end-to-end smoke wrote four rows and their censuses, then rolled back
- full census and the measured resolution-bias limitation are posted at #2721 comment 5300786612

## Important limitation
Symbol resolution is not unbiased and is effectively absent before inline XBRL. In 2021 the resolved/unresolved acquisition-vs-failure mix differs by 9 points (z=2.45); unlinked names remain unchecked, never checked-clean. This PR activates the best available termination-aware identity with that limitation explicit. It does not claim profitability or authorise capital.

## Verification
- 249 focused backend/integration tests spanning universe selection, backtest, recent evidence, API, promotion, paper executor, and monitoring
- all 1,515 frontend unit tests and frontend typecheck
- repo-wide Ruff, format, Pyright
- complete pre-push gate including app lifespan smoke against the migrated dev DB and frontend static gates