### PR TITLE
research(ta): measure PEAD forward arrival ceiling

### DIFF
--- a/app/services/pead_feasibility.py
+++ b/app/services/pead_feasibility.py
@@ -1,0 +1,264 @@
+"""Outcome-free arrival and dependence census for PEAD follow-up #2493.
+
+This module may inspect the signal entry open and the twenty sessions strictly
+before entry.  It deliberately has no exit-price or return field: the opened
+#2476 result is motivation, never a planning sample for the prospective trial.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any, Final
+
+import psycopg
+
+from app.services.market_calendar import us_market_status
+from app.services.pead_candidate import TriggeredSueEvent
+from app.services.pead_outcomes import (
+    MIN_ENTRY_PRICE,
+    MIN_MEDIAN_DOLLAR_VOLUME,
+    PRIMARY_START,
+    earliest_entry_date,
+)
+from app.services.price_quarantine import RULE_SET_VERSION as QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_result import CORPUS_FROZEN_LAST_BAR, CORPUS_VENDORS
+
+HOLD_SESSIONS: Final = 62
+
+
+@dataclass(frozen=True)
+class PreOutcomeWindow:
+    event_index: int
+    instrument_id: int
+    accession_number: str
+    series_id: int | None
+    entry_date: date | None
+    entry_open: Decimal | None
+    entry_return_usable: bool | None
+    prior_sessions: int
+    valid_liquidity_sessions: int
+    median_dollar_volume: Decimal | None
+
+
+@dataclass(frozen=True)
+class EligiblePeadEvent:
+    instrument_id: int
+    accession_number: str
+    entry_date: date
+
+
+_CREATE_TEMP_EVENTS = """
+    CREATE TEMP TABLE pead_feasibility_events (
+        event_index      INTEGER PRIMARY KEY,
+        instrument_id    BIGINT NOT NULL,
+        entry_not_before DATE NOT NULL,
+        accession_number TEXT NOT NULL
+    ) ON COMMIT DROP
+"""
+
+
+# Every close selected here is constrained strictly before the selected entry.
+# The only on/after-entry value is the entry open itself.
+_PRE_OUTCOME_WINDOWS_SQL = """
+    WITH event_series AS (
+        SELECT e.*, s.series_id
+        FROM pead_feasibility_events e
+        LEFT JOIN research_price_series s
+          ON s.instrument_id = e.instrument_id
+         AND s.vendor = %(corpus_vendor)s
+    ), entries AS (
+        SELECT e.event_index, picked.entry_date, picked.entry_open,
+               picked.entry_return_usable
+        FROM event_series e
+        LEFT JOIN LATERAL (
+            SELECT d.bar_date AS entry_date, d.open AS entry_open,
+                   coalesce(q.return_usable, TRUE) AS entry_return_usable
+            FROM research_price_quarantine_coverage cov
+            JOIN research_price_daily d
+              ON d.series_id = cov.series_id
+             AND d.bar_date BETWEEN cov.first_bar AND cov.last_bar
+            LEFT JOIN research_bar_quarantine q
+              ON q.series_id = d.series_id
+             AND q.bar_date = d.bar_date
+             AND q.rule_set_version = %(quarantine_version)s
+            WHERE cov.series_id = e.series_id
+              AND cov.rule_set_version = %(quarantine_version)s
+              AND d.bar_date >= e.entry_not_before
+              AND d.bar_date <= %(frontier)s
+            ORDER BY d.bar_date
+            LIMIT 1
+        ) picked ON TRUE
+    ), prior_ranked AS (
+        SELECT e.event_index, d.close, d.volume,
+               coalesce(q.return_usable, TRUE) AS return_usable,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date DESC) AS rn
+        FROM event_series e
+        JOIN entries p USING (event_index)
+        JOIN research_price_quarantine_coverage cov
+          ON cov.series_id = e.series_id
+         AND cov.rule_set_version = %(quarantine_version)s
+        JOIN research_price_daily d
+          ON d.series_id = e.series_id
+         AND d.bar_date < p.entry_date
+         AND d.bar_date BETWEEN cov.first_bar AND cov.last_bar
+        LEFT JOIN research_bar_quarantine q
+          ON q.series_id = d.series_id
+         AND q.bar_date = d.bar_date
+         AND q.rule_set_version = %(quarantine_version)s
+    ), liquidity AS (
+        SELECT event_index,
+               count(*) FILTER (WHERE rn <= 20) AS prior_sessions,
+               count(*) FILTER (
+                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
+               ) AS valid_liquidity_sessions,
+               percentile_cont(0.5) WITHIN GROUP (ORDER BY close * volume) FILTER (
+                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
+               ) AS median_dollar_volume
+        FROM prior_ranked
+        GROUP BY event_index
+    )
+    SELECT e.event_index, e.instrument_id, e.accession_number, e.series_id,
+           p.entry_date, p.entry_open, p.entry_return_usable,
+           coalesce(l.prior_sessions, 0), coalesce(l.valid_liquidity_sessions, 0),
+           l.median_dollar_volume
+    FROM event_series e
+    LEFT JOIN entries p USING (event_index)
+    LEFT JOIN liquidity l USING (event_index)
+    ORDER BY e.event_index
+"""
+
+
+def load_pre_outcome_windows(
+    conn: psycopg.Connection[Any], events: Sequence[TriggeredSueEvent]
+) -> tuple[PreOutcomeWindow, ...]:
+    selected = [item for item in events if item.side == "long" and item.event.observation.filed_date >= PRIMARY_START]
+    conn.execute("DROP TABLE IF EXISTS pead_feasibility_events")
+    conn.execute(_CREATE_TEMP_EVENTS)
+    with conn.cursor() as cursor:
+        with cursor.copy(
+            "COPY pead_feasibility_events (event_index, instrument_id, entry_not_before, accession_number) FROM STDIN"
+        ) as copy:
+            for index, item in enumerate(selected):
+                observation = item.event.observation
+                copy.write_row(
+                    (
+                        index,
+                        observation.instrument_id,
+                        earliest_entry_date(observation.filed_date, observation.accepted_at),
+                        observation.accession_number,
+                    )
+                )
+    rows = conn.execute(
+        _PRE_OUTCOME_WINDOWS_SQL,
+        {
+            "corpus_vendor": CORPUS_VENDORS[0],
+            "quarantine_version": QUARANTINE_RULE_SET_VERSION,
+            "frontier": CORPUS_FROZEN_LAST_BAR,
+        },
+    ).fetchall()
+    return tuple(
+        PreOutcomeWindow(
+            event_index=int(row[0]),
+            instrument_id=int(row[1]),
+            accession_number=str(row[2]),
+            series_id=None if row[3] is None else int(row[3]),
+            entry_date=row[4],
+            entry_open=None if row[5] is None else Decimal(row[5]),
+            entry_return_usable=row[6],
+            prior_sessions=int(row[7]),
+            valid_liquidity_sessions=int(row[8]),
+            median_dollar_volume=None if row[9] is None else Decimal(row[9]),
+        )
+        for row in rows
+    )
+
+
+def eligible_events(
+    windows: Sequence[PreOutcomeWindow],
+) -> tuple[tuple[EligiblePeadEvent, ...], Mapping[str, int]]:
+    """Apply entry-known gates and suppress alternative share classes."""
+    refusals: Counter[str] = Counter()
+    grouped: dict[str, list[PreOutcomeWindow]] = defaultdict(list)
+    for window in windows:
+        if window.series_id is None or window.entry_date is None or window.entry_open is None:
+            refusals["price_series_or_entry_missing"] += 1
+        elif not window.entry_return_usable:
+            refusals["quarantined_entry"] += 1
+        elif window.entry_open < MIN_ENTRY_PRICE:
+            refusals["entry_price_below_floor"] += 1
+        elif window.prior_sessions != 20 or window.valid_liquidity_sessions != 20:
+            refusals["incomplete_prior_liquidity_window"] += 1
+        elif window.median_dollar_volume is None or window.median_dollar_volume < MIN_MEDIAN_DOLLAR_VOLUME:
+            refusals["median_dollar_volume_below_floor"] += 1
+        else:
+            grouped[window.accession_number].append(window)
+
+    output: list[EligiblePeadEvent] = []
+    for accession, candidates in grouped.items():
+        candidates.sort(
+            key=lambda item: (item.median_dollar_volume or Decimal("0"), -item.instrument_id),
+            reverse=True,
+        )
+        chosen = candidates[0]
+        if chosen.entry_date is None:
+            raise RuntimeError("eligible PEAD feasibility row has no entry date")
+        refusals["share_class_duplicates_suppressed"] += len(candidates) - 1
+        output.append(
+            EligiblePeadEvent(
+                instrument_id=chosen.instrument_id,
+                accession_number=accession,
+                entry_date=chosen.entry_date,
+            )
+        )
+    output.sort(key=lambda item: (item.entry_date, item.accession_number))
+    refusals["input_long_signal_rows"] = len(windows)
+    refusals["eligible_issuer_events"] = len(output)
+    return tuple(output), dict(sorted(refusals.items()))
+
+
+def purged_date_count(
+    entry_dates: Sequence[date], session_dates: Sequence[date], *, hold_sessions: int = HOLD_SESSIONS
+) -> int:
+    """Greedy maximum date count with at least ``hold_sessions`` session indices apart."""
+    if hold_sessions < 1:
+        raise ValueError("hold_sessions must be positive")
+    index = {session: offset for offset, session in enumerate(sorted(set(session_dates)))}
+    selected = 0
+    next_allowed = -1
+    for entry_date in sorted(set(entry_dates)):
+        position = index.get(entry_date)
+        if position is None:
+            raise ValueError(f"entry date {entry_date} is absent from the declared session calendar")
+        if position >= next_allowed:
+            selected += 1
+            next_allowed = position + hold_sessions
+    return selected
+
+
+def market_session_dates(first: date, last: date) -> tuple[date, ...]:
+    """Return the repo's declared NYSE sessions over a closed interval."""
+    if first > last:
+        raise ValueError("first session boundary must not follow last")
+    result: list[date] = []
+    current = first
+    while current <= last:
+        if us_market_status(current) != "closed":
+            result.append(current)
+        current += timedelta(days=1)
+    return tuple(result)
+
+
+__all__ = [
+    "EligiblePeadEvent",
+    "HOLD_SESSIONS",
+    "PreOutcomeWindow",
+    "_PRE_OUTCOME_WINDOWS_SQL",
+    "eligible_events",
+    "load_pre_outcome_windows",
+    "market_session_dates",
+    "purged_date_count",
+]

--- a/app/services/pead_feasibility.py
+++ b/app/services/pead_feasibility.py
@@ -171,7 +171,7 @@ def load_pre_outcome_windows(
             entry_return_usable=row[6],
             prior_sessions=int(row[7]),
             valid_liquidity_sessions=int(row[8]),
-            median_dollar_volume=None if row[9] is None else Decimal(row[9]),
+            median_dollar_volume=None if row[9] is None else Decimal(str(row[9])),
         )
         for row in rows
     )

--- a/docs/proposals/ta/2026-08-15-pead-forward-feasibility-census.md
+++ b/docs/proposals/ta/2026-08-15-pead-forward-feasibility-census.md
@@ -1,0 +1,72 @@
+# Long-only PEAD forward-feasibility census
+
+Status: **arrival measured / power verdict refused** for #2493. This is an
+outcome-free planning census, not a return result, holdout, promotion record or
+authority to create strategy/runtime state.
+
+## Boundary and reproduction
+
+The verifier rebuilds the frozen `pead-historical-sue-net-income-v1` long-signal
+rule, expands issuer share-class alternatives only after signal construction,
+and applies the declared USD 5 entry-open and prior-20-session USD 10m median
+dollar-volume floors. SEC `accepted_at` controls the earliest possible open
+where present; a missing timestamp advances to the next filed-date boundary.
+
+It may select the entry open and closes strictly before entry for liquidity. It
+has no exit-price, holding-period return, comparator-return or outcome field.
+`tests/test_pead_feasibility.py` guards that boundary.
+
+Reproduce with:
+
+```text
+PYTHONPATH=. uv run python scripts/verify_2493_pead_feasibility.py
+```
+
+The 2026-08-15 capture used Company Facts SHA-256
+`0c5b0d0b61257f6856f6c30311806d782d45d6d32118280d75bc859d57ad9c20`.
+That is **not** the #2476 result's declared archive
+`126056a91f8d0446bd0f9c04f7db84da7e405d171c541fe72c7aae70d5b6c02b`.
+The scheduled SEC refresh atomically replaces the mutable cache and no copy of
+the older archive was found locally. These counts are therefore a newly hashed
+source-rule census, not an exact reproduction of #2476. The verifier prints
+this distinction rather than silently claiming source identity.
+
+## Measured arrival ceiling
+
+Through the frozen 2026-07-08 price frontier, the refreshed source produced:
+
+| measure | full 2022+ census | trailing 24 months from 2024-07-08 |
+| --- | ---: | ---: |
+| eligible long issuer-events | 1,269 | 764 |
+| distinct entry dates | 393 | 215 |
+| greedily purged 62-NYSE-session dates | 18 | 8 |
+
+Eligible event arrivals by entry year were 164 (2022), 174 (2023), 342
+(2024), 351 (2025), and 238 through the frontier in 2026. The entry-known
+refusals were 327 below the price floor, 55 with an incomplete prior-liquidity
+window, 759 below the liquidity floor, 192 without a usable series/entry, and 6
+suppressed alternative share classes, from 2,608 expanded long-signal rows.
+
+The purged count uses the repository's declared NYSE calendar. A retained date
+must be at least 62 market-session indices after the prior retained date. It is
+a conservative fully non-overlapping dependence ceiling, not a claim that
+same-date issuers are economically identical or that a block-bootstrap ESS is
+exactly eight.
+
+## Decision
+
+Do not start forward shadow collection from this census alone. The ticket has
+not independently frozen either:
+
+- the minimum net effect required to improve the operator's F-0 portfolio
+  after its risk penalty; or
+- a compatible prospective planning dispersion/block model.
+
+The already observed +2.676% #2476 long-arm mean is forbidden as either input.
+Without both inputs there is no honest sample requirement or time-to-power, so
+the requested `data_infeasible` versus preregister decision remains refused.
+The measured fact available to that decision is stark: a full purge supplies
+only eight non-overlapping decision dates inside the 24-month relevance
+horizon. Any less-conservative dependence model must be frozen and justified
+before it is used to turn the larger nominal event count into effective
+evidence.

--- a/scripts/verify_2493_pead_feasibility.py
+++ b/scripts/verify_2493_pead_feasibility.py
@@ -1,0 +1,85 @@
+"""Measure #2493 PEAD arrival/dependence without reading an outcome price."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from datetime import date
+from pathlib import Path
+
+import psycopg
+
+from app.config import settings
+from app.security.master_key import resolve_data_dir
+from app.services.pead_candidate import build_archive_source, expand_instrument_alternatives
+from app.services.pead_feasibility import (
+    eligible_events,
+    load_pre_outcome_windows,
+    market_session_dates,
+    purged_date_count,
+)
+from app.services.strategy_result import CORPUS_FROZEN_LAST_BAR
+
+PRIOR_TRIAL_ARCHIVE_SHA256 = "126056a91f8d0446bd0f9c04f7db84da7e405d171c541fe72c7aae70d5b6c02b"
+
+
+def _two_years_before(value: date) -> date:
+    try:
+        return value.replace(year=value.year - 2)
+    except ValueError:  # February 29
+        return value.replace(year=value.year - 2, day=28)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--archive",
+        type=Path,
+        default=resolve_data_dir() / "sec" / "bulk" / "companyfacts.zip",
+    )
+    args = parser.parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        build, loaded = build_archive_source(conn, args.archive)
+        expanded = expand_instrument_alternatives(build.triggers, build.instrument_alternatives)
+        windows = load_pre_outcome_windows(conn, expanded)
+        events, refusals = eligible_events(windows)
+
+    entry_dates = tuple(item.entry_date for item in events)
+    distinct_dates = tuple(sorted(set(entry_dates)))
+    if not distinct_dates:
+        raise RuntimeError("the frozen PEAD rule produced no eligible long entries")
+    session_dates = market_session_dates(distinct_dates[0], CORPUS_FROZEN_LAST_BAR)
+    trailing_start = _two_years_before(CORPUS_FROZEN_LAST_BAR)
+    recent_dates = tuple(item for item in entry_dates if trailing_start <= item <= CORPUS_FROZEN_LAST_BAR)
+    yearly = Counter(item.year for item in entry_dates)
+
+    print("#2493 PEAD feasibility census — entry and pre-entry data only")
+    print(f"companyfacts archive SHA-256: {loaded.archive_sha256}")
+    source_relation = (
+        "exact #2476 archive"
+        if loaded.archive_sha256 == PRIOR_TRIAL_ARCHIVE_SHA256
+        else "refreshed capture; not an exact #2476 archive reproduction"
+    )
+    print(f"source relation:             {source_relation}")
+    print(f"frozen price frontier:        {CORPUS_FROZEN_LAST_BAR}")
+    print(f"eligible long issuer-events:  {len(events):,}")
+    print(f"distinct entry dates:         {len(distinct_dates):,}")
+    print(f"purged 62-session dates:      {purged_date_count(entry_dates, session_dates):,}")
+    print(f"trailing-24-month start:      {trailing_start}")
+    print(f"trailing-24-month events:     {len(recent_dates):,}")
+    print(f"trailing-24-month dates:      {len(set(recent_dates)):,}")
+    print(f"trailing-24-month purged:     {purged_date_count(recent_dates, session_dates):,}")
+    print("yearly eligible events:")
+    for year, count in sorted(yearly.items()):
+        print(f"  {year}: {count:,}")
+    print("entry-known refusal census:")
+    for reason, count in refusals.items():
+        print(f"  {reason:<42} {count:>10,}")
+    print("power verdict: refused — minimum worthwhile net effect and compatible planning dispersion are not frozen")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pead_feasibility.py
+++ b/tests/test_pead_feasibility.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from app.services.pead_feasibility import (
+    _PRE_OUTCOME_WINDOWS_SQL,
+    PreOutcomeWindow,
+    eligible_events,
+    market_session_dates,
+    purged_date_count,
+)
+
+
+def _window(*, instrument_id: int = 1, accession: str = "a", median: str = "20000000") -> PreOutcomeWindow:
+    return PreOutcomeWindow(
+        event_index=instrument_id,
+        instrument_id=instrument_id,
+        accession_number=accession,
+        series_id=instrument_id,
+        entry_date=date(2025, 1, 2),
+        entry_open=Decimal("10"),
+        entry_return_usable=True,
+        prior_sessions=20,
+        valid_liquidity_sessions=20,
+        median_dollar_volume=Decimal(median),
+    )
+
+
+def test_census_sql_cannot_read_a_post_entry_close_or_outcome_horizon() -> None:
+    lowered = _PRE_OUTCOME_WINDOWS_SQL.lower()
+    assert "exit" not in lowered
+    assert "return_pct" not in lowered
+    assert "d.bar_date < p.entry_date" in lowered
+    assert "entry_open" in lowered
+    assert "d.close" in lowered  # prior liquidity only, guarded by the strict boundary above
+
+
+def test_eligibility_uses_pre_entry_liquidity_and_deduplicates_share_classes() -> None:
+    events, census = eligible_events(
+        (
+            _window(instrument_id=1, accession="same", median="15000000"),
+            _window(instrument_id=2, accession="same", median="25000000"),
+            _window(instrument_id=3, accession="thin", median="9000000"),
+        )
+    )
+    assert [(item.instrument_id, item.accession_number) for item in events] == [(2, "same")]
+    assert census["share_class_duplicates_suppressed"] == 1
+    assert census["median_dollar_volume_below_floor"] == 1
+
+
+def test_purged_count_uses_session_distance_not_nominal_events() -> None:
+    start = date(2025, 1, 1)
+    sessions = tuple(start + timedelta(days=offset) for offset in range(200))
+    entries = (sessions[0], sessions[0], sessions[10], sessions[61], sessions[62], sessions[124])
+    assert purged_date_count(entries, sessions, hold_sessions=62) == 3
+
+
+def test_market_session_dates_uses_declared_nyse_calendar() -> None:
+    # 2025-07-04 was an NYSE closure; the surrounding Thursday/Monday were open.
+    assert market_session_dates(date(2025, 7, 3), date(2025, 7, 7)) == (
+        date(2025, 7, 3),
+        date(2025, 7, 7),
+    )


### PR DESCRIPTION
## Outcome

Measures the first #2493 feasibility input without opening any new PEAD outcome: the eligible long-SUE arrival population and a conservative 62-session non-overlap ceiling.

The 2026-08-15 refreshed source has 1,269 eligible issuer-events on 393 entry dates from 2022+, but only 8 fully purged decision dates in the trailing 24-month relevance horizon. This PR deliberately refuses a power/time verdict because the minimum worthwhile net effect and compatible prospective planning dispersion are not independently frozen.

## Evidence boundary

- entry open plus the 20 sessions strictly before entry only;
- no exit price, outcome horizon, comparator return or return calculation;
- exact existing `accepted_at`, price, liquidity, quarantine and share-class-selection rules;
- repo NYSE calendar for 62-session purging;
- guard test pins the absence of exit/return SQL.

## Provenance correction

The current Company Facts cache hashes to `0c5b0d…`, not #2476's declared `126056…`. The older mutable-cache artifact is not present locally. The verifier and result record explicitly label this as a refreshed source-rule census, not an exact #2476 archive reproduction.

## Validation

- targeted PEAD suite: 22 passed;
- full pre-push gate green: whole-repo Ruff, formatting, Pyright, invariant scripts, fast test tier, smoke suite, and frontend integrity checks;
- source-only verifier reproduced the documented census.

Closes only the arrival-census subtask; does not close #2493 or create strategy/runtime state.

Refs #2493. Refs #2476.
