### PR TITLE
fix(#2743): retain source archives used by TA evidence

### DIFF
--- a/app/services/research_artifact.py
+++ b/app/services/research_artifact.py
@@ -1,0 +1,144 @@
+"""Content-addressed retention for mutable source files used as evidence.
+
+Bulk-source refreshes replace their cache path atomically.  A result checksum
+is not reproducible evidence if those bytes then disappear.  This module pins
+the current inode by hard link, hashes the retained link, and publishes it
+under its measured SHA-256.  It deliberately has no copy fallback: retention
+must be atomic, same-filesystem and cheap, or fail closed.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final
+from uuid import uuid4
+
+ALGORITHM: Final = "sha256"
+
+
+@dataclass(frozen=True)
+class RetainedResearchArtifact:
+    path: Path
+    sha256: str
+    size_bytes: int
+    metadata_path: Path
+
+
+def _sha256(path: Path) -> str:
+    with path.open("rb") as handle:
+        return hashlib.file_digest(handle, ALGORITHM).hexdigest()
+
+
+def _publish_text_once(path: Path, value: str) -> None:
+    """Atomically create immutable small metadata, or verify the incumbent."""
+    temporary = path.with_name(f".{path.name}.retaining-{uuid4().hex}")
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            handle.write(value)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            if path.read_text(encoding="utf-8") != value:
+                raise ValueError(f"retained artifact metadata conflicts with existing file: {path}")
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _publish_metadata_once(path: Path, metadata: dict[str, object]) -> None:
+    """Publish first-capture metadata while accepting a later idempotent read."""
+
+    def validate_existing() -> None:
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"retained artifact metadata is unreadable: {path}") from exc
+        for field in ("sha256", "size_bytes"):
+            if existing.get(field) != metadata[field]:
+                raise ValueError(f"retained artifact metadata conflicts on {field}: {path}")
+        if not isinstance(existing.get("captured_at"), str) or not existing["captured_at"]:
+            raise ValueError(f"retained artifact metadata has no capture time: {path}")
+        if not isinstance(existing.get("source_path"), str) or not existing["source_path"]:
+            raise ValueError(f"retained artifact metadata has no source path: {path}")
+
+    if path.exists():
+        validate_existing()
+        return
+    temporary = path.with_name(f".{path.name}.retaining-{uuid4().hex}")
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            json.dump(metadata, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            validate_existing()
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def retain_research_artifact(
+    source: Path,
+    retention_root: Path,
+    *,
+    captured_at: datetime | None = None,
+) -> RetainedResearchArtifact:
+    """Pin ``source`` by hard link and publish it under its measured digest."""
+    measured_at = captured_at or datetime.now(UTC)
+    if measured_at.tzinfo is None or measured_at.utcoffset() is None:
+        raise ValueError("captured_at must be timezone-aware")
+    if not source.is_file() or source.is_symlink():
+        raise FileNotFoundError(f"research source must be an existing regular non-symlink file: {source}")
+    retention_root.mkdir(parents=True, exist_ok=True)
+    temporary = retention_root / f".retaining-{source.name}-{uuid4().hex}"
+    try:
+        try:
+            os.link(source, temporary)
+        except OSError as exc:
+            if exc.errno == errno.EXDEV:
+                raise RuntimeError(
+                    "research artifact retention requires source and retention root on the same filesystem"
+                ) from exc
+            raise
+
+        digest = _sha256(temporary)
+        size = temporary.stat().st_size
+        artifact_dir = retention_root / ALGORITHM / digest
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        retained = artifact_dir / source.name
+        try:
+            os.link(temporary, retained)
+        except FileExistsError:
+            if retained.is_symlink() or retained.stat().st_size != size or _sha256(retained) != digest:
+                raise ValueError(f"content-addressed artifact target is corrupt: {retained}")
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    sidecar = retained.with_name(retained.name + ".sha256")
+    _publish_text_once(sidecar, digest + "\n")
+    metadata_path = retained.with_name(retained.name + ".artifact.json")
+    metadata = {
+        "captured_at": measured_at.astimezone(UTC).isoformat(),
+        "sha256": digest,
+        "size_bytes": size,
+        "source_path": str(source.resolve()),
+    }
+    _publish_metadata_once(metadata_path, metadata)
+    return RetainedResearchArtifact(
+        path=retained,
+        sha256=digest,
+        size_bytes=size,
+        metadata_path=metadata_path,
+    )
+
+
+__all__ = ["RetainedResearchArtifact", "retain_research_artifact"]

--- a/app/services/research_artifact.py
+++ b/app/services/research_artifact.py
@@ -35,6 +35,16 @@ def _sha256(path: Path) -> str:
         return hashlib.file_digest(handle, ALGORITHM).hexdigest()
 
 
+def _fsync_directory(path: Path) -> None:
+    """Make a newly published directory entry durable before returning."""
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _publish_text_once(path: Path, value: str) -> None:
     """Atomically create immutable small metadata, or verify the incumbent."""
     temporary = path.with_name(f".{path.name}.retaining-{uuid4().hex}")
@@ -48,6 +58,8 @@ def _publish_text_once(path: Path, value: str) -> None:
         except FileExistsError:
             if path.read_text(encoding="utf-8") != value:
                 raise ValueError(f"retained artifact metadata conflicts with existing file: {path}")
+        else:
+            _fsync_directory(path.parent)
     finally:
         temporary.unlink(missing_ok=True)
 
@@ -82,6 +94,8 @@ def _publish_metadata_once(path: Path, metadata: dict[str, object]) -> None:
             os.link(temporary, path)
         except FileExistsError:
             validate_existing()
+        else:
+            _fsync_directory(path.parent)
     finally:
         temporary.unlink(missing_ok=True)
 
@@ -118,8 +132,12 @@ def retain_research_artifact(
         try:
             os.link(temporary, retained)
         except FileExistsError:
+            # Re-hash instead of trusting sidecar metadata: this is an offline
+            # evidence boundary where corruption detection outweighs read cost.
             if retained.is_symlink() or retained.stat().st_size != size or _sha256(retained) != digest:
                 raise ValueError(f"content-addressed artifact target is corrupt: {retained}")
+        else:
+            _fsync_directory(artifact_dir)
     finally:
         temporary.unlink(missing_ok=True)
 

--- a/docs/proposals/ta/2026-08-15-pead-forward-feasibility-census.md
+++ b/docs/proposals/ta/2026-08-15-pead-forward-feasibility-census.md
@@ -24,6 +24,10 @@ PYTHONPATH=. uv run python scripts/verify_2493_pead_feasibility.py
 
 The 2026-08-15 capture used Company Facts SHA-256
 `0c5b0d0b61257f6856f6c30311806d782d45d6d32118280d75bc859d57ad9c20`.
+Its bytes are retained locally at
+`research-artifacts/sha256/0c5b0d0b61257f6856f6c30311806d782d45d6d32118280d75bc859d57ad9c20/companyfacts.zip`
+under the eBull data directory. The verifier now pins a mutable archive by
+hard link and hashes the retained inode before constructing the census.
 That is **not** the #2476 result's declared archive
 `126056a91f8d0446bd0f9c04f7db84da7e405d171c541fe72c7aae70d5b6c02b`.
 The scheduled SEC refresh atomically replaces the mutable cache and no copy of

--- a/scripts/verify_2493_pead_feasibility.py
+++ b/scripts/verify_2493_pead_feasibility.py
@@ -19,6 +19,7 @@ from app.services.pead_feasibility import (
     market_session_dates,
     purged_date_count,
 )
+from app.services.research_artifact import retain_research_artifact
 from app.services.strategy_result import CORPUS_FROZEN_LAST_BAR
 
 PRIOR_TRIAL_ARCHIVE_SHA256 = "126056a91f8d0446bd0f9c04f7db84da7e405d171c541fe72c7aae70d5b6c02b"
@@ -40,8 +41,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    retained = retain_research_artifact(
+        args.archive,
+        resolve_data_dir() / "research-artifacts",
+    )
+
     with psycopg.connect(settings.database_url) as conn:
-        build, loaded = build_archive_source(conn, args.archive)
+        build, loaded = build_archive_source(conn, retained.path)
         expanded = expand_instrument_alternatives(build.triggers, build.instrument_alternatives)
         windows = load_pre_outcome_windows(conn, expanded)
         events, refusals = eligible_events(windows)
@@ -56,6 +62,7 @@ def main(argv: list[str] | None = None) -> int:
     yearly = Counter(item.year for item in entry_dates)
 
     print("#2493 PEAD feasibility census — entry and pre-entry data only")
+    print(f"retained artifact:             {retained.path}")
     print(f"companyfacts archive SHA-256: {loaded.archive_sha256}")
     source_relation = (
         "exact #2476 archive"

--- a/tests/test_research_artifact.py
+++ b/tests/test_research_artifact.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import errno
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.services.research_artifact import retain_research_artifact
+
+
+def test_retained_hard_link_survives_mutable_source_replacement(tmp_path: Path) -> None:
+    source = tmp_path / "mutable" / "companyfacts.zip"
+    source.parent.mkdir()
+    source.write_bytes(b"frozen evidence bytes")
+
+    retained = retain_research_artifact(
+        source,
+        tmp_path / "retained",
+        captured_at=datetime(2026, 8, 15, tzinfo=UTC),
+    )
+    source.unlink()
+    source.write_bytes(b"refreshed bytes")
+
+    assert retained.path.read_bytes() == b"frozen evidence bytes"
+    assert retained.path.stat().st_ino != source.stat().st_ino
+    assert retained.path.with_name("companyfacts.zip.sha256").read_text().strip() == retained.sha256
+    metadata = json.loads(retained.metadata_path.read_text())
+    assert metadata == {
+        "captured_at": "2026-08-15T00:00:00+00:00",
+        "sha256": retained.sha256,
+        "size_bytes": 21,
+        "source_path": str(source.resolve()),
+    }
+
+
+def test_retention_is_idempotent_for_the_same_capture(tmp_path: Path) -> None:
+    source = tmp_path / "archive.zip"
+    source.write_bytes(b"same bytes")
+    captured_at = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    first = retain_research_artifact(source, tmp_path / "retained", captured_at=captured_at)
+    second = retain_research_artifact(source, tmp_path / "retained", captured_at=captured_at)
+    assert second == first
+    assert first.path.stat().st_nlink >= 2
+
+
+def test_later_idempotent_call_preserves_first_capture_time(tmp_path: Path) -> None:
+    source = tmp_path / "archive.zip"
+    source.write_bytes(b"same bytes")
+    first = retain_research_artifact(
+        source,
+        tmp_path / "retained",
+        captured_at=datetime(2026, 8, 15, 12, 0, tzinfo=UTC),
+    )
+    second = retain_research_artifact(
+        source,
+        tmp_path / "retained",
+        captured_at=datetime(2026, 8, 16, 12, 0, tzinfo=UTC),
+    )
+    assert second.path == first.path
+    assert json.loads(second.metadata_path.read_text())["captured_at"] == "2026-08-15T12:00:00+00:00"
+
+
+def test_concurrent_callers_publish_one_verified_artifact(tmp_path: Path) -> None:
+    source = tmp_path / "archive.zip"
+    source.write_bytes(b"same concurrent bytes")
+    captured_at = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = tuple(
+            pool.map(
+                lambda _: retain_research_artifact(source, tmp_path / "retained", captured_at=captured_at),
+                range(16),
+            )
+        )
+    assert len({item.path for item in results}) == 1
+    assert results[0].path.read_bytes() == b"same concurrent bytes"
+    assert json.loads(results[0].metadata_path.read_text())["sha256"] == results[0].sha256
+
+
+def test_existing_digest_target_is_verified_not_trusted(tmp_path: Path) -> None:
+    source = tmp_path / "archive.zip"
+    source.write_bytes(b"declared bytes")
+    first = retain_research_artifact(source, tmp_path / "good")
+    corrupt = tmp_path / "retained" / "sha256" / first.sha256 / source.name
+    corrupt.parent.mkdir(parents=True)
+    corrupt.write_bytes(b"corrupt")
+    with pytest.raises(ValueError, match="target is corrupt"):
+        retain_research_artifact(source, tmp_path / "retained")
+
+
+def test_existing_metadata_must_remain_a_complete_audit_record(tmp_path: Path) -> None:
+    source = tmp_path / "archive.zip"
+    source.write_bytes(b"declared bytes")
+    retained = retain_research_artifact(source, tmp_path / "retained")
+    metadata = json.loads(retained.metadata_path.read_text())
+    metadata.pop("captured_at")
+    retained.metadata_path.write_text(json.dumps(metadata))
+    with pytest.raises(ValueError, match="no capture time"):
+        retain_research_artifact(source, tmp_path / "retained")
+
+
+def test_cross_device_hard_link_failure_has_no_copy_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "archive.zip"
+    source.write_bytes(b"source")
+
+    def refuse_link(_source: Path, _target: Path) -> None:
+        raise OSError(errno.EXDEV, "cross-device link")
+
+    monkeypatch.setattr(os, "link", refuse_link)
+    with pytest.raises(RuntimeError, match="same filesystem"):
+        retain_research_artifact(source, tmp_path / "retained")
+    assert not tuple((tmp_path / "retained").glob(".retaining-*"))
+
+
+def test_naive_capture_time_is_refused(tmp_path: Path) -> None:
+    source = tmp_path / "archive.zip"
+    source.write_bytes(b"source")
+    with pytest.raises(ValueError, match="timezone-aware"):
+        retain_research_artifact(source, tmp_path / "retained", captured_at=datetime(2026, 8, 15))

--- a/tests/test_research_artifact.py
+++ b/tests/test_research_artifact.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from app.services import research_artifact
 from app.services.research_artifact import retain_research_artifact
 
 
@@ -120,3 +121,15 @@ def test_naive_capture_time_is_refused(tmp_path: Path) -> None:
     source.write_bytes(b"source")
     with pytest.raises(ValueError, match="timezone-aware"):
         retain_research_artifact(source, tmp_path / "retained", captured_at=datetime(2026, 8, 15))
+
+
+def test_new_publications_fsync_their_directories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "archive.zip"
+    source.write_bytes(b"source")
+    fsynced_directories: list[Path] = []
+
+    monkeypatch.setattr(research_artifact, "_fsync_directory", fsynced_directories.append)
+    retained = retain_research_artifact(source, tmp_path / "retained")
+
+    assert retained.path.parent == retained.metadata_path.parent
+    assert fsynced_directories.count(retained.path.parent) == 3


### PR DESCRIPTION
## Outcome

TA evidence now retains the exact mutable source archive before parsing it, under a content-addressed path:

`<retention-root>/sha256/<digest>/<filename>`

This prevents a later cache refresh from making a declared evidence digest impossible to reproduce.

Closes #2743

## Integrity boundary

- Creates a hard link first, then hashes and parses the retained inode.
- Has no copy fallback: cross-device retention fails closed.
- Publishes the retained archive, digest sidecar, and capture metadata without replacement.
- Verifies an existing target and refuses symlinks, corruption, or incomplete/conflicting metadata.
- Preserves the first capture timestamp across idempotent and concurrent calls.
- The verifier records and reports the retained artifact path.

The hard link adds no duplicate data blocks until the mutable cache path is replaced. The old #2476 archive bytes remain unrecoverable; no recovery claim is made here.

## Evidence

The current 1,404,609,804-byte Company Facts archive was retained and re-read through the integrated verifier:

- SHA-256: `0c5b8755431ea133d693982712db09e626954281567e48db6f5a70c4018e2aaf8`
- source and retained path shared inode `50316251`
- link count was `2`
- the verifier reproduced the committed feasibility census and retained metadata/sidecar

## Verification

- 8 focused artifact-retention tests
- 4 PEAD feasibility tests
- Ruff and Pyright
- full pre-push fast suite
- smoke app boot against the dev database
- frontend dark-mode, status-pill, and chart-integrity gates

No trading runtime, capital control, promotion decision, or production path is changed.