### PR TITLE
Compose exact holdout ambiguity support

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -105,6 +105,8 @@ from app.services.strategy_result_ambiguity import (
     AmbiguityRecord,
     ComparisonBasis,
     ambiguity_promotion_refusals,
+    composed_holdout_ambiguity_refusals,
+    record_sha256,
 )
 from app.services.strategy_wealth import load_strategy_wealth_history
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
@@ -965,6 +967,45 @@ def _current_versions() -> dict[str, str]:
     }
 
 
+def _ambiguity_record_from_result_row(
+    row: dict[str, object],
+    *,
+    prefix: str = "",
+) -> AmbiguityRecord | None:
+    """Rebuild one API query's frozen ambiguity payload.
+
+    The API query aliases the local and exact-support records into the same
+    field shape. Keeping one constructor prevents the operator surface from
+    interpreting the two records under subtly different null or numeric rules.
+    """
+    rule = row.get(f"{prefix}ambiguity_record_rule_version")
+    if rule is None:
+        return None
+    record = AmbiguityRecord(
+        ambiguity_rule_version=str(rule),
+        comparison_basis=cast(ComparisonBasis, row[f"{prefix}ambiguity_comparison_basis"]),
+        best_case_sharpe=(
+            None
+            if row.get(f"{prefix}ambiguity_best_case_sharpe") is None
+            else float(cast(Decimal, row[f"{prefix}ambiguity_best_case_sharpe"]))
+        ),
+        worst_case_sharpe=(
+            None
+            if row.get(f"{prefix}ambiguity_worst_case_sharpe") is None
+            else float(cast(Decimal, row[f"{prefix}ambiguity_worst_case_sharpe"]))
+        ),
+        cohort_gap_threshold=(
+            None
+            if row.get(f"{prefix}ambiguity_cohort_gap_threshold") is None
+            else float(cast(Decimal, row[f"{prefix}ambiguity_cohort_gap_threshold"]))
+        ),
+    )
+    payload_key = f"{prefix}ambiguity_payload_sha256"
+    if payload_key in row and record_sha256(record) != str(row[payload_key]):
+        raise RuntimeError(f"strategy overview {prefix or 'local '}ambiguity payload hash mismatch")
+    return record
+
+
 def _promotion_refusals(
     row: dict[str, object],
     *,
@@ -1006,34 +1047,22 @@ def _promotion_refusals(
         refusals.append("trial_register_superseded")
     if row["effective_sample_size"] is None:
         refusals.append("effective_sample_size_not_computed")
+    is_holdout = row.get("namespace") == "hold_out"
     if not ambiguity_complete:
         refusals.append("ambiguity_arms_not_compared")
-    elif row.get("ambiguity_record_rule_version") is None:
-        refusals.append("ambiguity_verdict_unrecorded")
     else:
-        record = AmbiguityRecord(
-            ambiguity_rule_version=str(row["ambiguity_record_rule_version"]),
-            comparison_basis=cast(ComparisonBasis, row["ambiguity_comparison_basis"]),
-            best_case_sharpe=(
-                None
-                if row.get("ambiguity_best_case_sharpe") is None
-                else float(cast(Decimal, row["ambiguity_best_case_sharpe"]))
-            ),
-            worst_case_sharpe=(
-                None
-                if row.get("ambiguity_worst_case_sharpe") is None
-                else float(cast(Decimal, row["ambiguity_worst_case_sharpe"]))
-            ),
-            cohort_gap_threshold=(
-                None
-                if row.get("ambiguity_cohort_gap_threshold") is None
-                else float(cast(Decimal, row["ambiguity_cohort_gap_threshold"]))
-            ),
-        )
-        refusals.extend(ambiguity_promotion_refusals(record))
+        local_record = _ambiguity_record_from_result_row(row)
+        if is_holdout:
+            support_record = (
+                _ambiguity_record_from_result_row(row, prefix="support_")
+                if row.get("control_support_candidate_count") == 1
+                else None
+            )
+            refusals.extend(composed_holdout_ambiguity_refusals(local_record, support_record))
+        else:
+            refusals.extend(ambiguity_promotion_refusals(local_record))
     if not quarantine_complete:
         refusals.append("quarantine_arms_not_compared")
-    is_holdout = row.get("namespace") == "hold_out"
     control_prefix = "control_" if is_holdout else ""
     support_is_unique = row.get("control_support_candidate_count") == 1 if is_holdout else True
     if not support_is_unique or row.get(f"{control_prefix}synthetic_control_model_id") is None:
@@ -1068,7 +1097,14 @@ _RESULTS_SQL = """
         ambiguity.comparison_basis AS ambiguity_comparison_basis,
         ambiguity.best_case_sharpe AS ambiguity_best_case_sharpe,
         ambiguity.worst_case_sharpe AS ambiguity_worst_case_sharpe,
-        ambiguity.cohort_gap_threshold AS ambiguity_cohort_gap_threshold
+        ambiguity.cohort_gap_threshold AS ambiguity_cohort_gap_threshold,
+        ambiguity.payload_sha256 AS ambiguity_payload_sha256,
+        support_ambiguity.ambiguity_rule_version AS support_ambiguity_record_rule_version,
+        support_ambiguity.comparison_basis AS support_ambiguity_comparison_basis,
+        support_ambiguity.best_case_sharpe AS support_ambiguity_best_case_sharpe,
+        support_ambiguity.worst_case_sharpe AS support_ambiguity_worst_case_sharpe,
+        support_ambiguity.cohort_gap_threshold AS support_ambiguity_cohort_gap_threshold,
+        support_ambiguity.payload_sha256 AS support_ambiguity_payload_sha256
     FROM strategy_results_store r
     LEFT JOIN (
         SELECT strategy_id, strategy_version,
@@ -1083,6 +1119,8 @@ _RESULTS_SQL = """
       ON control_result.result_id = control_support.control_result_id
     LEFT JOIN strategy_result_ambiguity ambiguity
       ON ambiguity.result_id = r.result_id
+    LEFT JOIN strategy_result_ambiguity support_ambiguity
+      ON support_ambiguity.result_id = control_support.control_result_id
     WHERE r.strategy_version = ANY(%(versions)s)
       AND r.namespace = 'hold_out'
       AND r.corpus_version = %(corpus_version)s

--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -2715,7 +2715,13 @@ def _ambiguity_record_for(
     best_sharpe = sharpes.get("best_case")
     worst_sharpe = sharpes.get("worst_case")
     threshold = None
-    if best_sharpe is not None and worst_sharpe is not None:
+    # The random-entry cohort is an in-sample construction. In a combined
+    # invocation ``ArmMeasurement.cohort`` still describes the in-sample
+    # Sharpe, so applying it to the sibling holdout measurement would either
+    # raise the provenance binding below or, if that binding were weakened,
+    # compare two different namespaces. The holdout record stays honestly
+    # unjudged and promotion may compose its exact in-sample verdict (#2749).
+    if result.identity.namespace == CONTROL_NAMESPACE and best_sharpe is not None and worst_sharpe is not None:
         threshold = matched_control_margin(
             None if by_arm["best_case"].cohort is None else by_arm["best_case"].cohort.control,
             None if by_arm["worst_case"].cohort is None else by_arm["worst_case"].cohort.control,

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -28,7 +28,7 @@ from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyPurpose
 from app.services.strategy_promotion_evidence import evidence_refusals
 from app.services.strategy_promotion_evidence_store import load_promotion_evidences
 from app.services.strategy_result import holdout_count_promotion_refusals, structural_promotion_refusals
-from app.services.strategy_result_ambiguity import ambiguity_promotion_refusals, load_result_ambiguities
+from app.services.strategy_result_ambiguity import load_promotion_ambiguity_refusals
 from app.services.strategy_result_universe import load_result_universes, universe_promotion_refusals
 
 Stage = Literal[
@@ -557,7 +557,7 @@ def promote_strategy(
             # record anywhere in the batch now raises before ANY result's
             # refusals are gathered. Within a result nothing moves.
             universes = load_result_universes(conn, result_ids)
-            ambiguities = load_result_ambiguities(conn, result_ids)
+            ambiguity_refusals = load_promotion_ambiguity_refusals(conn, result_ids)
             stored_refusals = stored_result_promotion_refusals_for(conn, result_ids)
             evidences = load_promotion_evidences(conn, result_ids)
             for result_id in result_ids:
@@ -580,7 +580,7 @@ def promote_strategy(
                 # frozen record rather than trusted. Same shape and the same
                 # argument as the universe replay above; the record stores the
                 # comparison's INPUTS so the verdict can be disagreed with.
-                refusals.extend(ambiguity_promotion_refusals(ambiguities.get(result_id)))
+                refusals.extend(ambiguity_refusals[result_id])
                 # #2625 — the row's own STRUCTURAL stamps. ⚠ These were
                 # persisted and never replayed: before this, a result stamped
                 # `survivor_only` / `carry_unmodelled` / `fx_unmodelled` — which

--- a/app/services/strategy_result_ambiguity.py
+++ b/app/services/strategy_result_ambiguity.py
@@ -280,6 +280,91 @@ def ambiguity_promotion_refusals(record: AmbiguityRecord | None) -> tuple[str, .
     return tuple(refusals)
 
 
+def composed_holdout_ambiguity_refusals(
+    local_record: AmbiguityRecord | None,
+    support_record: AmbiguityRecord | None,
+) -> tuple[str, ...]:
+    """Compose one holdout pair with its exact in-sample §3.4 support (#2749).
+
+    The holdout record is always authoritative when it is absent, corrupt
+    (raised while loading), unrecognised, material, or directly proves a zero
+    gap. Only the honest ``ambiguity_arms_not_compared`` state may consult the
+    derived in-sample companion. This never applies an in-sample threshold to
+    holdout Sharpes; it replays the companion's own complete verdict instead.
+
+    ``support_record is None`` covers both no unique identity-compatible
+    companion and a companion with no frozen ambiguity record. In either case
+    the local measured-but-unjudged verdict remains the truthful refusal.
+    """
+    local_refusals = ambiguity_promotion_refusals(local_record)
+    if local_refusals != ("ambiguity_arms_not_compared",) or support_record is None:
+        return local_refusals
+    return ambiguity_promotion_refusals(support_record)
+
+
+def exact_ambiguity_support_id(candidate_count: int, support_id: int | None) -> int | None:
+    """Accept only the view's one-candidate/one-id state.
+
+    The view already emits ``NULL`` unless its count is exactly one. Rechecking
+    both fields here is deliberate defence in depth: a future view must not be
+    able to hand promotion a favourable id while admitting multiple candidates.
+    """
+    if candidate_count != 1 or support_id is None:
+        return None
+    return support_id
+
+
+_SELECT_PROMOTION_SUPPORT = """
+    SELECT r.result_id, r.namespace,
+           COALESCE(s.candidate_count, 0), s.control_result_id
+    FROM strategy_results_store r
+    LEFT JOIN strategy_result_control_support s
+      ON s.holdout_result_id = r.result_id
+    WHERE r.result_id = ANY(%(result_ids)s::bigint[])
+"""
+
+
+def load_promotion_ambiguity_refusals(
+    conn: psycopg.Connection[Any], result_ids: Sequence[int]
+) -> dict[int, tuple[str, ...]]:
+    """Batched ambiguity replay for pinned results, including #2749 support.
+
+    The support view derives its candidate from immutable identity pins; no
+    caller supplies a support id and these reads record no holdout access. The
+    result is refusal codes rather than records, so this cannot become another
+    public door for reading withheld metrics.
+    """
+    if not result_ids:
+        return {}
+    rows = conn.execute(_SELECT_PROMOTION_SUPPORT, {"result_ids": list(result_ids)}).fetchall()
+    census = {int(row[0]): (str(row[1]), int(row[2]), None if row[3] is None else int(row[3])) for row in rows}
+    missing = set(result_ids) - set(census)
+    if missing:
+        raise RuntimeError(f"no stored result row for result_id(s) {sorted(missing)}")
+
+    local_records = load_result_ambiguities(conn, result_ids)
+    support_ids_by_result: dict[int, int] = {}
+    for result_id in result_ids:
+        namespace, candidate_count, support_id = census[result_id]
+        local_refusals = ambiguity_promotion_refusals(local_records.get(result_id))
+        exact_support = exact_ambiguity_support_id(candidate_count, support_id)
+        if namespace == "hold_out" and local_refusals == ("ambiguity_arms_not_compared",) and exact_support is not None:
+            support_ids_by_result[result_id] = exact_support
+    support_records = load_result_ambiguities(conn, sorted(set(support_ids_by_result.values())))
+
+    return {
+        result_id: (
+            composed_holdout_ambiguity_refusals(
+                local_records.get(result_id),
+                support_records.get(support_ids_by_result[result_id]) if result_id in support_ids_by_result else None,
+            )
+            if census[result_id][0] == "hold_out"
+            else ambiguity_promotion_refusals(local_records.get(result_id))
+        )
+        for result_id in result_ids
+    }
+
+
 __all__ = [
     "AMBIGUITY_RULE_VERSION",
     "LEGACY_AMBIGUITY_RULE_VERSION",
@@ -288,7 +373,10 @@ __all__ = [
     "ComparisonBasis",
     "ambiguity_promotion_refusals",
     "ambiguity_verdict",
+    "composed_holdout_ambiguity_refusals",
+    "exact_ambiguity_support_id",
     "load_result_ambiguity",
+    "load_promotion_ambiguity_refusals",
     "matched_control_margin",
     "record_sha256",
     "store_result_ambiguity",

--- a/docs/proposals/ta/2026-08-15-holdout-ambiguity-support.md
+++ b/docs/proposals/ta/2026-08-15-holdout-ambiguity-support.md
@@ -1,0 +1,47 @@
+# Holdout ambiguity support (#2749)
+
+## Decision
+
+A holdout result keeps its own immutable §3.4 ambiguity record. When that
+record contains unequal arm Sharpes it correctly has no cohort threshold,
+because the 1,000-member random-entry control is never run over withheld data.
+Promotion may resolve only that `ambiguity_arms_not_compared` state from the
+one exact full-corpus in-sample companion already derived by
+`strategy_result_control_support`.
+
+The support id is never caller-selected. It matches the holdout result on the
+strategy and result identity, including ambiguity rule, immutable validated
+universe and all measurement/rule stamps. Missing or duplicate candidates do
+not produce a support id.
+
+## Precedence
+
+The holdout record is loaded and hash-verified first:
+
+1. absent remains `ambiguity_verdict_unrecorded`;
+2. corrupt raises as an integrity failure;
+3. unrecognised, material, shared-measurement and equal-arm verdicts remain
+   authoritative;
+4. only the sole `ambiguity_arms_not_compared` outcome may consult support;
+5. absent, unrecognised, not-compared or material support remains fail-closed.
+
+The in-sample threshold is never compared with holdout Sharpes and is never
+copied onto a holdout row. The companion's own complete verdict is replayed.
+This keeps the roles distinct: the holdout row proves both withheld arms were
+measured, while the in-sample falsification adjudicates sensitivity to the
+daily-OHLC tie rule without spending another withheld look.
+
+## Consumers
+
+- The promotion transition returns only composed refusal codes and batches all
+  direct/support reads; it does not expose withheld metrics or record a new
+  holdout access.
+- The Strategies API applies the same pure precedence function and verifies the
+  hashes of both SQL-loaded ambiguity payloads.
+- Monitoring and paper execution continue to require a durable promotion and
+  therefore inherit this gate; their existing exact synthetic-control support
+  checks remain unchanged.
+
+This repair opens no holdout, allocates no capital and changes no live-money
+path. Every declared holdout window and every ambiguity/quarantine arm must
+still satisfy its own conjunctive performance and promotion-evidence gates.

--- a/scripts/probe_2749_holdout_ambiguity_support.py
+++ b/scripts/probe_2749_holdout_ambiguity_support.py
@@ -1,0 +1,97 @@
+"""Adversarial revert probes for #2749's holdout ambiguity composition.
+
+    uv run python scripts/probe_2749_holdout_ambiguity_support.py
+
+The harness mutates tracked source temporarily and restores it in ``finally``.
+A defect counts as caught only when the unmodified selected test passes and the
+one-behaviour mutation exits pytest with an assertion failure (code 1).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.probe_2240_cost_model import PYTEST_PASSED, PYTEST_TEST_FAILED, run, selected
+
+REPLAY = Path("app/services/strategy_result_ambiguity.py")
+RUNNER = Path("app/services/backtest_run.py")
+SOURCES = (REPLAY, RUNNER)
+PURE_TESTS = "tests/test_strategy_result_ambiguity.py"
+RUNNER_TESTS = "tests/test_backtest_run.py"
+
+PROBES: list[tuple[str, Path, str, str, str, str]] = [
+    (
+        "a favourable support id accepted from multiple candidates",
+        REPLAY,
+        "    if candidate_count != 1 or support_id is None:",
+        "    if candidate_count < 1 or support_id is None:",
+        PURE_TESTS,
+        "test_a_favourable_id_cannot_be_selected_without_exactly_one_candidate",
+    ),
+    (
+        "favourable support allowed to override authoritative local evidence",
+        REPLAY,
+        '    if local_refusals != ("ambiguity_arms_not_compared",) or support_record is None:',
+        "    if support_record is None:",
+        PURE_TESTS,
+        "test_support_cannot_override_an_authoritative_local_state",
+    ),
+    (
+        "an in-sample cohort threshold applied to holdout Sharpes",
+        RUNNER,
+        "    if result.identity.namespace == CONTROL_NAMESPACE and best_sharpe is not None "
+        "and worst_sharpe is not None:",
+        "    if best_sharpe is not None and worst_sharpe is not None:",
+        RUNNER_TESTS,
+        "test_a_combined_run_never_applies_the_in_sample_cohort_to_holdout_sharpes",
+    ),
+]
+
+
+def main() -> int:
+    originals = {source: source.read_text() for source in SOURCES}
+    failures: list[str] = []
+    try:
+        for name, source, old, new, test_file, selector in PROBES:
+            if selected(test_file, selector) == 0:
+                failures.append(f"{name}: selector names no test")
+                print(f"  {'*** NO SUCH TEST ***':<24} {name}", flush=True)
+                continue
+            count = originals[source].count(old)
+            if count != 1:
+                failures.append(f"{name}: anchor occurs {count} times, expected 1")
+                print(f"  {'*** BAD ANCHOR ***':<24} {name}", flush=True)
+                continue
+            baseline = run([test_file], selector)
+            if baseline != PYTEST_PASSED:
+                failures.append(f"{name}: baseline exits {baseline}")
+                print(f"  {'*** BAD BASELINE ***':<24} {name}", flush=True)
+                continue
+            source.write_text(originals[source].replace(old, new))
+            caught = run([test_file], selector) == PYTEST_TEST_FAILED
+            source.write_text(originals[source])
+            if caught:
+                print(f"  {'CAUGHT':<24} {name}", flush=True)
+            else:
+                failures.append(f"{name}: mutation was not caught by exit 1")
+                print(f"  {'*** NOT CAUGHT ***':<24} {name}", flush=True)
+    finally:
+        for source, original in originals.items():
+            source.write_text(original)
+
+    restored = all(run([test_file], selector) == PYTEST_PASSED for _, _, _, _, test_file, selector in PROBES)
+    print(f"\nrestored suite: {'PASS' if restored else '*** FAIL ***'}", flush=True)
+    if not restored:
+        failures.append("restored suite fails")
+    if failures:
+        print("\nUNCAUGHT:\n" + "\n".join(f"  {failure}" for failure in failures), flush=True)
+        return 1
+    print(f"\nall {len(PROBES)} probes caught", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -6,11 +6,13 @@ from datetime import date
 from decimal import Decimal
 
 import psycopg
+import pytest
 
 from app.api.strategies import (
     _PRESENTATION,
     _TITLES,
     ResultArm,
+    _ambiguity_record_from_result_row,
     _current_versions,
     _promotion_refusals,
     get_strategy_overview,
@@ -25,7 +27,7 @@ from app.services.result_ledger import store_holdout_result, store_in_sample_res
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
 from app.services.strategy_result import LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS
-from app.services.strategy_result_ambiguity import AMBIGUITY_RULE_VERSION
+from app.services.strategy_result_ambiguity import AMBIGUITY_RULE_VERSION, AmbiguityRecord, record_sha256
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
 from tests.test_result_ledger import build_metrics, build_result
 
@@ -36,6 +38,29 @@ _IMMATERIAL_AMBIGUITY: dict[str, object] = {
     "ambiguity_worst_case_sharpe": None,
     "ambiguity_cohort_gap_threshold": None,
 }
+
+
+def test_operator_ambiguity_payloads_are_hash_verified_when_loaded_from_sql() -> None:
+    record = AmbiguityRecord(
+        ambiguity_rule_version=AMBIGUITY_RULE_VERSION,
+        comparison_basis="arm_sharpes",
+        best_case_sharpe=0.7,
+        worst_case_sharpe=0.4,
+        cohort_gap_threshold=0.5,
+    )
+    row: dict[str, object] = {
+        "support_ambiguity_record_rule_version": record.ambiguity_rule_version,
+        "support_ambiguity_comparison_basis": record.comparison_basis,
+        "support_ambiguity_best_case_sharpe": record.best_case_sharpe,
+        "support_ambiguity_worst_case_sharpe": record.worst_case_sharpe,
+        "support_ambiguity_cohort_gap_threshold": record.cohort_gap_threshold,
+        "support_ambiguity_payload_sha256": record_sha256(record),
+    }
+
+    assert _ambiguity_record_from_result_row(row, prefix="support_") == record
+    row["support_ambiguity_payload_sha256"] = "0" * 64
+    with pytest.raises(RuntimeError, match="ambiguity payload hash mismatch"):
+        _ambiguity_record_from_result_row(row, prefix="support_")
 
 
 def test_current_versions_cover_the_manifest_including_s4() -> None:
@@ -235,6 +260,56 @@ def test_holdout_display_uses_derived_control_and_not_its_empty_own_columns() ->
         )
         == []
     )
+
+
+def test_holdout_display_composes_the_exact_in_sample_ambiguity_verdict() -> None:
+    row: dict[str, object] = {
+        **_IMMATERIAL_AMBIGUITY,
+        "ambiguity_comparison_basis": "arm_sharpes",
+        "ambiguity_best_case_sharpe": 0.7,
+        "ambiguity_worst_case_sharpe": 0.4,
+        "ambiguity_cohort_gap_threshold": None,
+        "support_ambiguity_record_rule_version": AMBIGUITY_RULE_VERSION,
+        "support_ambiguity_comparison_basis": "arm_sharpes",
+        "support_ambiguity_best_case_sharpe": 0.7,
+        "support_ambiguity_worst_case_sharpe": 0.4,
+        "support_ambiguity_cohort_gap_threshold": 0.5,
+        "namespace": "hold_out",
+        "purpose": "capital_candidate",
+        "universe_basis": "survivorship_free",
+        "carry_unmodelled": False,
+        "fx_unmodelled": False,
+        "evaluated_instrument_count": 3,
+        "deflated_sharpe": 0.8,
+        "trial_count": TRIAL_REGISTER.declared_count,
+        "effective_sample_size": 200,
+        "trial_register_version": TRIAL_REGISTER_VERSION,
+        "synthetic_control_model_id": None,
+        "control_support_candidate_count": 1,
+        "control_synthetic_control_model_id": "random-entry-v1",
+        "control_synthetic_control_mean_return_ci_low_pct": -1,
+        "control_synthetic_control_mean_return_ci_high_pct": 1,
+        "control_sharpe": 0.8,
+        "control_synthetic_control_sharpe_threshold": 0.5,
+    }
+
+    assert (
+        _promotion_refusals(
+            row,
+            ambiguity_complete=True,
+            quarantine_complete=True,
+            accesses_complete=True,
+        )
+        == []
+    )
+
+    row["control_support_candidate_count"] = 0
+    assert _promotion_refusals(
+        row,
+        ambiguity_complete=True,
+        quarantine_complete=True,
+        accesses_complete=True,
+    ) == ["ambiguity_arms_not_compared", "synthetic_control_not_run"]
 
 
 def test_partial_arm_refusals_do_not_claim_the_completed_comparison_is_missing() -> None:

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -1159,13 +1159,22 @@ class TestAmbiguityMateriality:
     """A real level-arm delta cannot be waved through without its threshold."""
 
     @staticmethod
-    def _arm(ambiguity: str | None, sharpe: float, *, control: SyntheticControl | None = None) -> ArmMeasurement:
+    def _arm(
+        ambiguity: str | None,
+        sharpe: float,
+        *,
+        control: SyntheticControl | None = None,
+        holdout_sharpe: float | None = None,
+    ) -> ArmMeasurement:
+        namespaces = {"in_sample": _measurement(sharpe=sharpe)}
+        if holdout_sharpe is not None:
+            namespaces["hold_out"] = _measurement(namespace="hold_out", sharpe=holdout_sharpe)
         return ArmMeasurement(
             strategy_id="s4",
             strategy_version="v1",
             ambiguity_arm=ambiguity,  # type: ignore[arg-type]
             quarantine_arm="masked",
-            namespaces={"in_sample": _measurement(sharpe=sharpe)},
+            namespaces=namespaces,  # type: ignore[arg-type]
             holdout_positions_discarded=0,
             close_sources={},
             series_evaluated=1,
@@ -1177,6 +1186,18 @@ class TestAmbiguityMateriality:
     def _result() -> StrategyResult:
         return build_result(
             _measurement(),
+            strategy_id="s4",
+            strategy_version="v1",
+            purpose="capital_candidate",
+            ambiguity_arm="best_case",
+            quarantine_arm="masked",
+            deflated=None,
+        )
+
+    @staticmethod
+    def _holdout_result(*, sharpe: float) -> StrategyResult:
+        return build_result(
+            _measurement(namespace="hold_out", sharpe=sharpe),
             strategy_id="s4",
             strategy_version="v1",
             purpose="capital_candidate",
@@ -1217,6 +1238,27 @@ class TestAmbiguityMateriality:
         record = _ambiguity_record_for(arms, self._result())
         assert record.cohort_gap_threshold == pytest.approx(0.1)
         assert _ambiguity_material_for(arms, self._result()) is True
+
+    def test_a_combined_run_never_applies_the_in_sample_cohort_to_holdout_sharpes(self) -> None:
+        arms = (
+            self._arm(
+                "best_case",
+                0.6,
+                holdout_sharpe=0.8,
+                control=_control(ci_low=-0.1, ci_high=0.1, cohort_sharpe=0.2, strategy_sharpe=0.6),
+            ),
+            self._arm(
+                "worst_case",
+                0.4,
+                holdout_sharpe=0.3,
+                control=_control(ci_low=-0.1, ci_high=0.1, cohort_sharpe=0.3, strategy_sharpe=0.4),
+            ),
+        )
+
+        record = _ambiguity_record_for(arms, self._holdout_result(sharpe=0.8))
+
+        assert (record.best_case_sharpe, record.worst_case_sharpe) == (0.8, 0.3)
+        assert record.cohort_gap_threshold is None
 
     def test_a_non_finite_sharpe_reads_as_unpriced_rather_than_crashing(self) -> None:
         # ⚠ The old code reached `None` here BY ACCIDENT — `nan == nan` is

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -62,6 +62,7 @@ from app.services.strategy_result import EVALUATION_WINDOW_START, HOLDOUT_BOUNDA
 from app.services.strategy_result_ambiguity import (
     AMBIGUITY_RULE_VERSION,
     AmbiguityRecord,
+    load_promotion_ambiguity_refusals,
     load_result_ambiguities,
     store_result_ambiguity,
 )
@@ -183,6 +184,26 @@ def _ambiguity_record(conn: psycopg.Connection[Any], result_id: int) -> None:
         record=AmbiguityRecord(
             ambiguity_rule_version=AMBIGUITY_RULE_VERSION,
             comparison_basis="shared_measurement",
+        ),
+    )
+
+
+def _arm_ambiguity_record(
+    conn: psycopg.Connection[Any],
+    result_id: int,
+    *,
+    threshold: float | None,
+) -> None:
+    """A real two-arm §3.4 record; ``None`` is holdout's honest local state."""
+    store_result_ambiguity(
+        conn,
+        result_id=result_id,
+        record=AmbiguityRecord(
+            ambiguity_rule_version=AMBIGUITY_RULE_VERSION,
+            comparison_basis="arm_sharpes",
+            best_case_sharpe=0.7,
+            worst_case_sharpe=0.4,
+            cohort_gap_threshold=threshold,
         ),
     )
 
@@ -1658,6 +1679,60 @@ def test_holdout_replay_uses_the_exact_in_sample_control_without_copying_it(
     ).fetchone() == (1, support_id)
 
 
+def test_holdout_ambiguity_replay_uses_exact_in_sample_support_without_cross_namespace_maths(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    support_id, holdout_id = _holdout_with_control_support(ebull_test_conn)
+    _arm_ambiguity_record(ebull_test_conn, holdout_id, threshold=None)
+    _arm_ambiguity_record(ebull_test_conn, support_id, threshold=0.5)
+
+    assert load_promotion_ambiguity_refusals(ebull_test_conn, [holdout_id]) == {holdout_id: ()}
+    # The holdout record remains its own measured-but-unjudged payload; support
+    # is replayed, never copied onto withheld evidence.
+    assert load_result_ambiguities(ebull_test_conn, [holdout_id])[holdout_id].cohort_gap_threshold is None
+
+
+def test_missing_local_holdout_ambiguity_cannot_be_rescued_by_support(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    support_id, holdout_id = _holdout_with_control_support(ebull_test_conn)
+    _arm_ambiguity_record(ebull_test_conn, support_id, threshold=0.5)
+
+    assert load_promotion_ambiguity_refusals(ebull_test_conn, [holdout_id]) == {
+        holdout_id: ("ambiguity_verdict_unrecorded",)
+    }
+
+
+def test_material_in_sample_ambiguity_blocks_the_composed_holdout(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    support_id, holdout_id = _holdout_with_control_support(ebull_test_conn)
+    _arm_ambiguity_record(ebull_test_conn, holdout_id, threshold=None)
+    _arm_ambiguity_record(ebull_test_conn, support_id, threshold=0.1)
+
+    assert load_promotion_ambiguity_refusals(ebull_test_conn, [holdout_id]) == {holdout_id: ("ambiguity_material",)}
+
+
+def test_corrupt_local_holdout_ambiguity_raises_before_support_can_rescue_it(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    support_id, holdout_id = _holdout_with_control_support(ebull_test_conn)
+    _arm_ambiguity_record(ebull_test_conn, support_id, threshold=0.5)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_result_ambiguity (
+            result_id, ambiguity_rule_version, comparison_basis,
+            best_case_sharpe, worst_case_sharpe, cohort_gap_threshold,
+            payload_sha256
+        ) VALUES (%s, %s, 'arm_sharpes', 0.7, 0.4, NULL, %s)
+        """,
+        (holdout_id, AMBIGUITY_RULE_VERSION, "0" * 64),
+    )
+
+    with pytest.raises(RuntimeError, match="ambiguity hash mismatch"):
+        load_promotion_ambiguity_refusals(ebull_test_conn, [holdout_id])
+
+
 def test_a_failing_in_sample_control_fails_the_composed_holdout_verdict(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:
@@ -1714,7 +1789,9 @@ def test_control_support_window_literals_track_the_runner_contract(
 def test_ambiguous_control_support_fails_closed(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:
-    _support_id, holdout_id = _holdout_with_control_support(ebull_test_conn)
+    support_id, holdout_id = _holdout_with_control_support(ebull_test_conn)
+    _arm_ambiguity_record(ebull_test_conn, holdout_id, threshold=None)
+    _arm_ambiguity_record(ebull_test_conn, support_id, threshold=0.5)
     # A second full-corpus-looking in-sample identity differs only in its end
     # date. The derived view counts both; it never picks MIN(result_id).
     second_masked = _promotable_row(
@@ -1750,6 +1827,9 @@ def test_ambiguous_control_support_fails_closed(
         (holdout_id,),
     ).fetchone() == (2, None)
     assert "synthetic_control_not_run" in stored_result_promotion_refusals(ebull_test_conn, holdout_id)
+    assert load_promotion_ambiguity_refusals(ebull_test_conn, [holdout_id]) == {
+        holdout_id: ("ambiguity_arms_not_compared",)
+    }
 
 
 def test_historical_promotion_accepts_control_free_holdout_with_exact_support(
@@ -1765,11 +1845,12 @@ def test_historical_promotion_accepts_control_free_holdout_with_exact_support(
         promoted_by="operator",
         reason="register candidate",
     )
-    _support_id, holdout_id = _holdout_with_control_support(
+    support_id, holdout_id = _holdout_with_control_support(
         ebull_test_conn,
         strategy_id="S-GOV",
     )
-    _ambiguity_record(ebull_test_conn, holdout_id)
+    _arm_ambiguity_record(ebull_test_conn, holdout_id, threshold=None)
+    _arm_ambiguity_record(ebull_test_conn, support_id, threshold=0.5)
     store_promotion_evidence(
         ebull_test_conn,
         result_id=holdout_id,

--- a/tests/test_strategy_result_ambiguity.py
+++ b/tests/test_strategy_result_ambiguity.py
@@ -20,6 +20,8 @@ from app.services.strategy_result_ambiguity import (
     AmbiguityRecord,
     ambiguity_promotion_refusals,
     ambiguity_verdict,
+    composed_holdout_ambiguity_refusals,
+    exact_ambiguity_support_id,
     matched_control_margin,
     record_sha256,
 )
@@ -307,3 +309,50 @@ class TestRefusals:
             "ambiguity_rule_unrecognised",
             "ambiguity_arms_not_compared",
         }
+
+
+class TestHoldoutComposition:
+    """#2749 — only a measured-but-unjudged holdout may use exact support."""
+
+    def test_exact_immaterial_support_closes_the_uncompared_holdout_clause(self) -> None:
+        assert composed_holdout_ambiguity_refusals(_arms(0.7, 0.4), _arms(0.7, 0.4, 0.5)) == ()
+
+    def test_exact_material_support_blocks_the_holdout(self) -> None:
+        assert composed_holdout_ambiguity_refusals(_arms(0.7, 0.4), _arms(0.7, 0.4, 0.1)) == ("ambiguity_material",)
+
+    def test_missing_support_leaves_the_local_not_compared_refusal(self) -> None:
+        assert composed_holdout_ambiguity_refusals(_arms(0.7, 0.4), None) == ("ambiguity_arms_not_compared",)
+
+    @pytest.mark.parametrize(
+        ("local", "expected"),
+        [
+            (None, ("ambiguity_verdict_unrecorded",)),
+            (_SHARED, ()),
+            (_arms(0.7, 0.4, 0.1), ("ambiguity_material",)),
+        ],
+    )
+    def test_support_cannot_override_an_authoritative_local_state(
+        self,
+        local: AmbiguityRecord | None,
+        expected: tuple[str, ...],
+    ) -> None:
+        favourable = _arms(0.7, 0.4, 0.5)
+        assert composed_holdout_ambiguity_refusals(local, favourable) == expected
+
+    def test_an_unrecognised_support_rule_remains_fail_closed(self) -> None:
+        stale = replace(_arms(0.7, 0.4, 0.5), ambiguity_rule_version="ambiguity-verdict-2099-v9")
+        assert composed_holdout_ambiguity_refusals(_arms(0.7, 0.4), stale) == ("ambiguity_rule_unrecognised",)
+
+    @pytest.mark.parametrize(
+        ("candidate_count", "support_id"),
+        [(0, None), (0, 41), (1, None), (2, None), (2, 41)],
+    )
+    def test_a_favourable_id_cannot_be_selected_without_exactly_one_candidate(
+        self,
+        candidate_count: int,
+        support_id: int | None,
+    ) -> None:
+        assert exact_ambiguity_support_id(candidate_count, support_id) is None
+
+    def test_exactly_one_candidate_and_one_id_is_accepted(self) -> None:
+        assert exact_ambiguity_support_id(1, 41) == 41


### PR DESCRIPTION
## Outcome

Removes the impossible holdout ambiguity gate without running a random-entry
cohort over withheld data or comparing an in-sample threshold with holdout
Sharpes.

The holdout result keeps its own immutable ambiguity record. A missing,
corrupt, unrecognised, material, shared or exactly-equal local verdict remains
authoritative. Only the honest `ambiguity_arms_not_compared` state may replay
the ambiguity verdict from the exact full-corpus in-sample companion already
derived by `strategy_result_control_support`; callers cannot choose a support
id, and duplicate or missing candidates remain closed.

## End-to-end consistency

- promotion batches and hash-verifies local/support ambiguity records and
  returns refusal codes rather than exposing withheld metrics;
- the Strategies API uses the same pure precedence rule and now verifies both
  ambiguity payload hashes before rendering them;
- combined in-sample/holdout runs explicitly leave the holdout threshold null,
  preventing the in-sample cohort from being applied to a different namespace;
- no holdout access is recorded by support replay, no record is copied onto the
  holdout row, and monitoring/paper execution still require a durable passing
  promotion plus their existing exact control checks.

## Outcome blindness

Issue #2749 and this rule were frozen while run 98349 remained active and its
atomic result relations were unreadable. This change opens no holdout, selects
no strategy, allocates no capital, and changes no live-money path.

## Verification

- full repository pre-push gate green before commit and again on the exact
  pushed commit;
- pyright: 0 errors and 0 warnings;
- affected backtest, ambiguity DB, promotion, API, monitoring, paper-executor
  and holdout-namespace suites green;
- real Postgres coverage includes missing/corrupt local evidence, exact,
  duplicate, material and missing support, plus the historical promotion
  transition;
- 3/3 adversarial probes caught favourable support-id selection, support
  overriding authoritative local evidence, and cross-namespace threshold use;
  restored suite green.

Closes #2749
