### PR TITLE
Show generated trade activity on strategy workspace

### DIFF
--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as strategiesApi from "@/api/strategies";
-import type { StrategyOverviewResponse, StrategyOwnedPosition, StrategyResultArm } from "@/api/types";
+import type { FiredSignal, StrategyOverviewResponse, StrategyOwnedPosition, StrategyResultArm } from "@/api/types";
 import { StrategiesPage } from "@/pages/StrategiesPage";
 
 const ARM: StrategyResultArm = {
@@ -278,6 +278,32 @@ const OWNED_POSITION: StrategyOwnedPosition = {
   valuation_available: true,
 };
 
+const FUNDED_SIGNAL: FiredSignal = {
+  signal_id: 91,
+  strategy_id: "s1-time-series-momentum",
+  strategy_version: "strategy-registry-v1+abc",
+  instrument_id: 101,
+  symbol: "ACME",
+  company_name: "Acme Corp",
+  signal_bar_date: "2026-08-08",
+  signal_kind: "entry",
+  fill_bar_date: "2026-08-09",
+  fill_price: "20",
+  universe: "validated_us_equity",
+  outcome: "target_first",
+  exit_bar_date: "2026-08-12",
+  exit_price: "22",
+  gross_return_pct: "10",
+  outcome_reason: "take_profit_reached",
+  funding_status: "funded",
+  funding_reason: "all_paper_entry_gates_passed",
+  funded_amount: "100",
+  strategy_trade_id: 41,
+  execution_status: "filled",
+  actual_fill_price: "20.10",
+  slippage_pct: "0.5",
+};
+
 function approvedOverview(): StrategyOverviewResponse {
   const strategy = OVERVIEW.strategies[0]!;
   return {
@@ -340,6 +366,7 @@ describe("StrategiesPage", () => {
       positions: [],
       live_quote_instrument_ids: [],
     });
+    vi.spyOn(strategiesApi, "fetchFiredSignals").mockResolvedValue({ items: [], next_cursor: null });
   });
 
   it("keeps unapproved backtests out of portfolio performance", async () => {
@@ -688,6 +715,99 @@ describe("StrategiesPage", () => {
     expect(screen.getByText("A separate manual position in ACME is not part of this request and will remain untouched.")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Close position" }));
     await waitFor(() => expect(close).toHaveBeenCalledWith(41, 7001));
+    await waitFor(() => expect(strategiesApi.fetchFiredSignals).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows funded and rejected decisions through execution and outcome without inventing orders", async () => {
+    const rejected: FiredSignal = {
+      ...FUNDED_SIGNAL,
+      signal_id: 90,
+      symbol: "SAFE",
+      outcome: null,
+      exit_bar_date: null,
+      exit_price: null,
+      gross_return_pct: null,
+      outcome_reason: null,
+      funding_status: "rejected",
+      funding_reason: "paper_pool_disabled",
+      funded_amount: null,
+      strategy_trade_id: null,
+      execution_status: null,
+      actual_fill_price: null,
+      slippage_pct: null,
+    };
+    vi.mocked(strategiesApi.fetchFiredSignals).mockResolvedValue({
+      items: [FUNDED_SIGNAL, rejected],
+      next_cursor: null,
+    });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const section = (await screen.findByText("Generated trade activity")).closest("section")!;
+    expect(within(section).getByText("Funded")).toBeInTheDocument();
+    expect(within(section).getByText("Not funded")).toBeInTheDocument();
+    expect(within(section).getByText("Trade #41")).toBeInTheDocument();
+    expect(within(section).getByText("No order submitted")).toBeInTheDocument();
+    expect(within(section).getByText("No strategy trade")).toBeInTheDocument();
+    expect(within(section).getByText("US$100.00 assigned")).toBeInTheDocument();
+    expect(within(section).getByText("US$20.10 actual")).toBeInTheDocument();
+    expect(within(section).getByText("+0.50% slippage")).toBeInTheDocument();
+    expect(within(section).getByText("target first")).toBeInTheDocument();
+    expect(within(section).getByText("+10.00%")).toBeInTheDocument();
+    expect(within(section).getByText("Outcome unresolved")).toBeInTheDocument();
+    expect(within(section).getByText("paper pool disabled")).toBeInTheDocument();
+  });
+
+  it("loads older generated decisions through the bounded cursor", async () => {
+    const older = { ...FUNDED_SIGNAL, signal_id: 75, symbol: "OLD" };
+    vi.mocked(strategiesApi.fetchFiredSignals)
+      .mockResolvedValueOnce({ items: [FUNDED_SIGNAL], next_cursor: 91 })
+      .mockResolvedValueOnce({ items: [older], next_cursor: null });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Load older activity" }));
+
+    expect(await screen.findByText("OLD")).toBeInTheDocument();
+    expect(strategiesApi.fetchFiredSignals).toHaveBeenNthCalledWith(2, 91);
+    expect(screen.getByText("2 decisions shown")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Load older activity" })).not.toBeInTheDocument();
+  });
+
+  it("keeps current activity visible when an older page fails and retries the same cursor", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const older = { ...FUNDED_SIGNAL, signal_id: 75, symbol: "OLD" };
+    vi.mocked(strategiesApi.fetchFiredSignals)
+      .mockResolvedValueOnce({ items: [FUNDED_SIGNAL], next_cursor: 91 })
+      .mockRejectedValueOnce(new Error("older page unavailable"))
+      .mockResolvedValueOnce({ items: [older], next_cursor: null });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Load older activity" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Older activity could not be loaded");
+    expect(screen.getByText("ACME")).toBeInTheDocument();
+    expect(screen.getByText("1 decision shown")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Retry older activity" }));
+    expect(await screen.findByText("OLD")).toBeInTheDocument();
+    expect(strategiesApi.fetchFiredSignals).toHaveBeenNthCalledWith(3, 91);
+  });
+
+  it("renders an honest empty activity state", async () => {
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    expect(await screen.findByText("No generated decisions yet")).toBeInTheDocument();
+    expect(screen.getByText("Fired entry and exit signals will appear here after the daily strategy scan.")).toBeInTheDocument();
+  });
+
+  it("isolates an activity failure and recovers on explicit retry", async () => {
+    vi.mocked(strategiesApi.fetchFiredSignals)
+      .mockRejectedValueOnce(new Error("activity unavailable"))
+      .mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const heading = await screen.findByText("Generated trade activity");
+    const section = heading.closest("section")!;
+    expect(within(section).getByRole("alert")).toHaveTextContent("Failed to load");
+    await userEvent.click(within(section).getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("No generated decisions yet")).toBeInTheDocument();
   });
 
   it("toggles an approved strategy for the next run", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -4,6 +4,7 @@ import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "rec
 
 import {
   closeStrategyOwnedPosition,
+  fetchFiredSignals,
   fetchStrategyOverview,
   fetchStrategyOwnedPositions,
   fetchStrategyPnlHistory,
@@ -13,6 +14,8 @@ import {
   updateStrategySizing,
 } from "@/api/strategies";
 import type {
+  FiredSignal,
+  FiredSignalsResponse,
   StrategyEvidenceWindow,
   StrategyFireRate,
   StrategyOverview,
@@ -530,6 +533,150 @@ function EmptyPnlChart() {
         </p>
       </div>
     </div>
+  );
+}
+
+function fundingPresentation(signal: FiredSignal): { label: string; tone: "ok" | "neutral" | "warn" } {
+  if (signal.funding_status === "funded") return { label: "Funded", tone: "ok" };
+  if (signal.funding_status === "rejected") return { label: "Not funded", tone: "warn" };
+  return { label: "No capital needed", tone: "neutral" };
+}
+
+function executionLabel(signal: FiredSignal): string {
+  if (signal.execution_status) return signal.execution_status.replaceAll("_", " ");
+  if (signal.funding_status === "rejected") return "No order submitted";
+  if (signal.funding_status === "not_applicable") return "Exit observation";
+  return "Awaiting broker state";
+}
+
+function outcomeLabel(signal: FiredSignal): string {
+  if (signal.outcome === null) return "Outcome unresolved";
+  return signal.outcome.replaceAll("_", " ");
+}
+
+function StrategyActivity({
+  response,
+  strategyTitles,
+  onRetry,
+}: {
+  response: FiredSignalsResponse;
+  strategyTitles: Record<string, string>;
+  onRetry: () => void;
+}) {
+  const [olderItems, setOlderItems] = useState<FiredSignal[]>([]);
+  const [nextCursor, setNextCursor] = useState(response.next_cursor);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreFailed, setLoadMoreFailed] = useState(false);
+
+  useEffect(() => {
+    setOlderItems([]);
+    setNextCursor(response.next_cursor);
+    setLoadMoreFailed(false);
+  }, [response]);
+
+  const items = [...response.items, ...olderItems];
+
+  async function loadMore() {
+    if (nextCursor === null || loadingMore) return;
+    setLoadingMore(true);
+    setLoadMoreFailed(false);
+    try {
+      const page = await fetchFiredSignals(nextCursor);
+      const seen = new Set(items.map((item) => item.signal_id));
+      setOlderItems((current) => [...current, ...page.items.filter((item) => !seen.has(item.signal_id))]);
+      setNextCursor(page.next_cursor);
+    } catch (error) {
+      console.error("Strategy activity pagination failed:", error);
+      setLoadMoreFailed(true);
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
+  return (
+    <section className="border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex flex-wrap items-start justify-between gap-3 px-5 py-4">
+        <div>
+          <h2 className="text-sm font-semibold">Generated trade activity</h2>
+          <p className="mt-1 max-w-3xl text-xs text-slate-500">
+            Fired signals through allocation and demo execution. The final column is the rule-defined signal outcome, not realised broker P&amp;L. Rejected decisions are retained as the unfunded shadow record; they never created an order.
+          </p>
+        </div>
+        <button type="button" onClick={onRetry} className="min-h-10 border border-slate-300 px-3 text-xs font-medium hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800">
+          Refresh activity
+        </button>
+      </div>
+      {items.length === 0 ? (
+        <div className="border-t border-slate-200 px-5 py-5 dark:border-slate-800">
+          <EmptyState title="No generated decisions yet" description="Fired entry and exit signals will appear here after the daily strategy scan." />
+        </div>
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[72rem]">
+              <thead className="border-t border-slate-200 text-left text-[10px] font-semibold uppercase tracking-wider text-slate-500 dark:border-slate-800">
+                <tr>
+                  <th className="px-4 py-2">Signal</th>
+                  <th className="px-4 py-2">Strategy</th>
+                  <th className="px-4 py-2">Allocation</th>
+                  <th className="px-4 py-2">Execution</th>
+                  <th className="px-4 py-2 text-right">Model / actual fill</th>
+                  <th className="px-4 py-2 text-right">Signal outcome</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((signal) => {
+                  const funding = fundingPresentation(signal);
+                  return (
+                    <tr key={signal.signal_id} className="border-t border-slate-200 align-top dark:border-slate-800">
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <strong className="text-sm">{signal.symbol}</strong>
+                          <Badge tone="neutral">{signal.signal_kind}</Badge>
+                        </div>
+                        <span className="mt-1 block text-xs text-slate-500">Signal #{signal.signal_id} · {formatDate(signal.signal_bar_date)}</span>
+                      </td>
+                      <td className="px-4 py-3 text-xs">
+                        <span className="block font-medium text-slate-800 dark:text-slate-100">{strategyTitles[signal.strategy_id] ?? signal.strategy_id}</span>
+                        <span className="text-slate-500">{shortVersion(signal.strategy_version)} · {signal.universe}</span>
+                      </td>
+                      <td className="px-4 py-3 text-xs">
+                        <Badge tone={funding.tone}>{funding.label}</Badge>
+                        <span className="mt-1 block max-w-64 text-slate-500">{refusalLabel(signal.funding_reason)}</span>
+                        {signal.funded_amount !== null ? <span className="mt-1 block tabular-nums">{money(signal.funded_amount)} assigned</span> : null}
+                      </td>
+                      <td className="px-4 py-3 text-xs">
+                        <span className="capitalize">{executionLabel(signal)}</span>
+                        <span className="mt-1 block text-slate-500">{signal.strategy_trade_id === null ? "No strategy trade" : `Trade #${signal.strategy_trade_id}`}</span>
+                      </td>
+                      <td className="px-4 py-3 text-right text-xs tabular-nums">
+                        <span className="block">{money(signal.fill_price)}</span>
+                        <span className="text-slate-500">{signal.actual_fill_price === null ? "Actual —" : `${money(signal.actual_fill_price)} actual`}</span>
+                        {signal.slippage_pct !== null ? <span className="block text-slate-500">{pctPoints(signal.slippage_pct)} slippage</span> : null}
+                      </td>
+                      <td className="px-4 py-3 text-right text-xs">
+                        <span className="block capitalize">{outcomeLabel(signal)}</span>
+                        <span className="mt-1 block tabular-nums">{pctPoints(signal.gross_return_pct)}</span>
+                        {signal.outcome_reason ? <span className="block text-slate-500">{refusalLabel(signal.outcome_reason)}</span> : null}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex items-center justify-between gap-3 border-t border-slate-200 px-5 py-3 dark:border-slate-800">
+            <span className="text-xs text-slate-500">{items.length} decision{items.length === 1 ? "" : "s"} shown</span>
+            {nextCursor !== null ? (
+              <button type="button" disabled={loadingMore} onClick={() => void loadMore()} className="min-h-10 border border-slate-300 px-3 text-xs font-medium disabled:opacity-50 dark:border-slate-700">
+                {loadingMore ? "Loading…" : loadMoreFailed ? "Retry older activity" : "Load older activity"}
+              </button>
+            ) : null}
+          </div>
+          {loadMoreFailed ? <p role="alert" className="px-5 pb-3 text-xs text-red-700 dark:text-red-300">Older activity could not be loaded. Current rows remain unchanged.</p> : null}
+        </>
+      )}
+    </section>
   );
 }
 
@@ -1186,10 +1333,15 @@ export function StrategiesPage() {
   const overview = useAsync(fetchStrategyOverview, []);
   const pnlHistory = useAsync(fetchStrategyPnlHistory, []);
   const ownedPositions = useAsync(fetchStrategyOwnedPositions, []);
+  const activity = useAsync(() => fetchFiredSignals(null), []);
   const [closeFor, setCloseFor] = useState<StrategyOwnedPosition | null>(null);
   const [refreshingEvidence, setRefreshingEvidence] = useState(false);
   const [refreshEvidenceError, setRefreshEvidenceError] = useState<string | null>(null);
   const summary = useMemo(() => overview.data ? aggregate(overview.data) : null, [overview.data]);
+  const strategyTitles = useMemo(
+    () => Object.fromEntries((overview.data?.strategies ?? []).map((strategy) => [strategy.strategy_id, strategy.title])),
+    [overview.data],
+  );
   const capitalCandidates = overview.data?.strategies.filter((strategy) => strategy.purpose === "capital_candidate") ?? [];
   const approvedStrategies = capitalCandidates.filter((strategy) => strategy.allocation_ready || strategy.allocation.enabled);
   const researchCandidates = capitalCandidates.filter((strategy) => !strategy.allocation_ready && !strategy.allocation.enabled);
@@ -1275,6 +1427,17 @@ export function StrategiesPage() {
             <LiveQuoteProvider instrumentIds={ownedPositions.data.live_quote_instrument_ids}>
               <OpenStrategyPositions positions={ownedPositions.data.positions} onClose={setCloseFor} />
             </LiveQuoteProvider>
+          ) : null}
+
+          {activity.loading ? (
+            <SectionSkeleton rows={4} />
+          ) : activity.error ? (
+            <section className="border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900">
+              <h2 className="mb-3 text-sm font-semibold">Generated trade activity</h2>
+              <SectionError onRetry={activity.refetch} />
+            </section>
+          ) : activity.data ? (
+            <StrategyActivity response={activity.data} strategyTitles={strategyTitles} onRetry={activity.refetch} />
           ) : null}
 
           {forwardCandidates.length ? <SignalValidation overview={overview.data} strategies={forwardCandidates} /> : null}
@@ -1379,6 +1542,7 @@ export function StrategiesPage() {
               ownedPositions.refetch();
               overview.refetch();
               pnlHistory.refetch();
+              activity.refetch();
             }}
           />
         </>


### PR DESCRIPTION
Closes #2751.

## Outcome

Adds a bounded, cursor-paginated activity ledger to `/strategies` using the existing current-version `/strategies/signals` contract. Operators can now follow fired signals through allocator verdict, funded amount, strategy-trade identity, demo execution state, model/actual fill and slippage, and rule-defined outcome from the same page.

## Honesty and safety

- Rejected allocator decisions remain visible as unfunded shadow records and explicitly say no order/trade was created.
- The UI labels the final value as a **signal outcome**, explicitly distinct from realised broker P&L.
- Exact-owned open positions remain the only closeable rows.
- This adds no direct order path and changes no promotion, paper, or live gate.
- A successful close request refreshes activity alongside positions, P&L and overview.
- Initial errors are isolated; failed older-page loads preserve current rows and retry the same cursor.

## Verification

- Focused StrategiesPage suite: 35/35
- Full frontend suite: 137 files, 1,522 tests
- Production frontend build
- Full local pre-push gate: Ruff, format, Pyright, repository invariant checks, 1,522 fast tests, smoke suite, frontend hygiene gates

The dev-DB bloat check emitted its existing non-blocking 72 GB warning; no test or validation gate failed.