### PR TITLE
Expose exact strategy trade lifecycle

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -721,6 +721,43 @@ class StrategyPositionCloseResponse(BaseModel):
     operation_id: int | None
 
 
+StrategyTradeStatus = Literal["planned", "submitted", "open", "closing", "closed", "failed", "reconcile_required"]
+StrategyOperationStatus = Literal["intent_persisted", "submitted", "applied", "rejected", "reconcile_required"]
+StrategyReconciliationState = Literal[
+    "unresolved", "pending", "resolved", "rejected", "not_found", "ambiguous", "error"
+]
+StrategyCloseHistoryStatus = Literal["not_applicable", "not_closed", "complete", "incomplete", "unavailable"]
+
+
+class StrategyTradeLifecycle(BaseModel):
+    trade_status: StrategyTradeStatus | None
+    ownership_count: int
+    broker_position_id: int | None
+    ownership_status: Literal["active", "released"] | None
+    position_claimed_at: datetime | None
+    position_released_at: datetime | None
+    position_release_reason: str | None
+    latest_operation_type: Literal["fixed_exit_repair", "stop_ratchet", "close"] | None
+    latest_operation_id: int | None
+    latest_operation_order_id: int | None
+    latest_operation_trigger: str | None
+    latest_operation_status: StrategyOperationStatus | None
+    latest_operation_created_at: datetime | None
+    latest_operation_submitted_at: datetime | None
+    latest_operation_resolved_at: datetime | None
+    latest_operation_error: str | None
+    latest_reconciliation_state: StrategyReconciliationState | None
+    latest_reconciliation_broker_status: str | None
+    latest_reconciliation_attempt_count: int | None
+    latest_reconciliation_updated_at: datetime | None
+    latest_reconciliation_error: str | None
+    close_event_count: int | None
+    realised_pnl_usd: Decimal | None
+    observed_fees_usd: Decimal | None
+    close_history_status: StrategyCloseHistoryStatus
+    incomplete_reasons: list[str]
+
+
 class FiredSignal(BaseModel):
     signal_id: int
     strategy_id: str
@@ -745,6 +782,7 @@ class FiredSignal(BaseModel):
     execution_status: str | None
     actual_fill_price: Decimal | None
     slippage_pct: Decimal | None
+    trade_lifecycle: StrategyTradeLifecycle | None
 
 
 class FiredSignalsResponse(BaseModel):
@@ -1983,6 +2021,40 @@ _FIRED_SIGNALS_SQL = """
         JOIN orders ord ON ord.order_id = sto.order_id
         WHERE sto.purpose = 'entry'
         ORDER BY sto.strategy_trade_id, sto.linked_at DESC, sto.order_id DESC
+    ), ownership_rollup AS (
+        SELECT t.strategy_trade_id,
+               COUNT(own.ownership_id)::integer AS ownership_count,
+               CASE WHEN COUNT(own.ownership_id) = 1 THEN MAX(own.broker_position_id) END
+                   AS broker_position_id,
+               CASE WHEN COUNT(own.ownership_id) = 1 THEN MAX(own.status) END AS ownership_status,
+               CASE WHEN COUNT(own.ownership_id) = 1 THEN MAX(own.claimed_at) END AS claimed_at,
+               CASE WHEN COUNT(own.ownership_id) = 1 THEN MAX(own.released_at) END AS released_at,
+               CASE WHEN COUNT(own.ownership_id) = 1 THEN MAX(own.release_reason) END AS release_reason
+        FROM strategy_trades t
+        LEFT JOIN strategy_position_ownership own ON own.strategy_trade_id = t.strategy_trade_id
+        GROUP BY t.strategy_trade_id
+    ), latest_operation AS (
+        SELECT DISTINCT ON (own.strategy_trade_id)
+               own.strategy_trade_id, op.position_operation_id, op.order_id,
+               op.operation_type, op.trigger_code, op.status,
+               op.created_at, op.submitted_at, op.resolved_at, op.last_error_code
+        FROM strategy_position_ownership own
+        JOIN strategy_position_operations op ON op.ownership_id = own.ownership_id
+        ORDER BY own.strategy_trade_id, op.position_operation_id DESC
+    ), close_history AS (
+        SELECT own.strategy_trade_id,
+               COUNT(event.event_id)::integer AS close_event_count,
+               SUM(event.realized_pnl_usd) AS realised_pnl_usd,
+               SUM(event.fees_usd) AS observed_fees_usd,
+               BOOL_AND(event.realized_pnl_usd IS NOT NULL)
+                   FILTER (WHERE event.event_id IS NOT NULL) AS pnl_complete,
+               BOOL_AND(event.fees_usd IS NOT NULL)
+                   FILTER (WHERE event.event_id IS NOT NULL) AS fees_complete
+        FROM strategy_position_ownership own
+        LEFT JOIN trade_events event
+          ON event.position_id = own.broker_position_id
+         AND event.event_kind = 'close'
+        GROUP BY own.strategy_trade_id
     )
     SELECT
         s.signal_id, s.strategy_id, s.strategy_version, s.instrument_id,
@@ -2006,7 +2078,33 @@ _FIRED_SIGNALS_SQL = """
             ELSE COALESCE(eo.status, t.status)
         END AS execution_status,
         ee.average_price AS actual_fill_price,
-        ((ee.average_price - s.fill_price) / NULLIF(s.fill_price, 0)) * 100 AS slippage_pct
+        ((ee.average_price - s.fill_price) / NULLIF(s.fill_price, 0)) * 100 AS slippage_pct,
+        t.status AS lifecycle_trade_status,
+        COALESCE(ownership.ownership_count, 0) AS lifecycle_ownership_count,
+        ownership.broker_position_id AS lifecycle_broker_position_id,
+        ownership.ownership_status AS lifecycle_ownership_status,
+        ownership.claimed_at AS lifecycle_claimed_at,
+        ownership.released_at AS lifecycle_released_at,
+        ownership.release_reason AS lifecycle_release_reason,
+        operation.operation_type AS lifecycle_operation_type,
+        operation.position_operation_id AS lifecycle_operation_id,
+        operation.order_id AS lifecycle_operation_order_id,
+        operation.trigger_code AS lifecycle_operation_trigger,
+        operation.status AS lifecycle_operation_status,
+        operation.created_at AS lifecycle_operation_created_at,
+        operation.submitted_at AS lifecycle_operation_submitted_at,
+        operation.resolved_at AS lifecycle_operation_resolved_at,
+        operation.last_error_code AS lifecycle_operation_error,
+        reconciliation.state AS lifecycle_reconciliation_state,
+        reconciliation.broker_status AS lifecycle_reconciliation_broker_status,
+        reconciliation.attempt_count AS lifecycle_reconciliation_attempt_count,
+        reconciliation.updated_at AS lifecycle_reconciliation_updated_at,
+        reconciliation.last_error_code AS lifecycle_reconciliation_error,
+        COALESCE(history.close_event_count, 0) AS lifecycle_close_event_count,
+        history.realised_pnl_usd AS lifecycle_realised_pnl_usd,
+        history.observed_fees_usd AS lifecycle_observed_fees_usd,
+        history.pnl_complete AS lifecycle_pnl_complete,
+        history.fees_complete AS lifecycle_fees_complete
     FROM strategy_signals s
     JOIN instruments i ON i.instrument_id = s.instrument_id
     LEFT JOIN strategy_outcomes o
@@ -2017,6 +2115,13 @@ _FIRED_SIGNALS_SQL = """
     LEFT JOIN strategy_trades t ON t.funding_decision_id = fd.funding_decision_id
     LEFT JOIN entry_execution ee ON ee.strategy_trade_id = t.strategy_trade_id
     LEFT JOIN entry_order eo ON eo.strategy_trade_id = t.strategy_trade_id
+    LEFT JOIN ownership_rollup ownership ON ownership.strategy_trade_id = t.strategy_trade_id
+    LEFT JOIN latest_operation operation
+      ON operation.strategy_trade_id = t.strategy_trade_id
+     AND ownership.ownership_count = 1
+    LEFT JOIN strategy_order_reconciliation_state reconciliation
+      ON reconciliation.order_id = operation.order_id
+    LEFT JOIN close_history history ON history.strategy_trade_id = t.strategy_trade_id
     WHERE s.verdict = 'fired'
       AND s.strategy_version = ANY(%(versions)s)
       AND (%(strategy_id)s::text IS NULL OR s.strategy_id = %(strategy_id)s)
@@ -2024,6 +2129,132 @@ _FIRED_SIGNALS_SQL = """
     ORDER BY s.signal_id DESC
     LIMIT %(limit)s
 """
+
+
+def _trade_lifecycle(row: Mapping[str, object]) -> StrategyTradeLifecycle | None:
+    if row["funding_status"] != "funded":
+        return None
+
+    trade_status = cast(str | None, row["lifecycle_trade_status"])
+    ownership_count = int(cast(int, row["lifecycle_ownership_count"]))
+    raw_close_event_count = int(cast(int, row["lifecycle_close_event_count"]))
+    ownership_status = cast(str | None, row["lifecycle_ownership_status"])
+    reasons: list[str] = []
+    history_reasons: list[str] = []
+
+    if row["strategy_trade_id"] is None:
+        reasons.append("funding_not_reconciled_to_trade")
+    elif ownership_count == 0:
+        if trade_status not in {"planned", "submitted", "failed"}:
+            reasons.append("trade_not_reconciled_to_position")
+    elif ownership_count > 1:
+        reasons.append("position_ownership_ambiguous")
+    else:
+        if row["lifecycle_broker_position_id"] is None or ownership_status is None:
+            reasons.append("position_ownership_incomplete")
+        if raw_close_event_count == 0 and ownership_status == "released":
+            history_reasons.append("released_position_missing_close_history")
+        if raw_close_event_count > 0:
+            if row["lifecycle_pnl_complete"] is not True:
+                history_reasons.append("realised_pnl_missing_from_history")
+            if row["lifecycle_fees_complete"] is not True:
+                history_reasons.append("fees_missing_from_history")
+        if trade_status == "closed" and ownership_status == "active":
+            reasons.append("closed_trade_has_active_ownership")
+        if ownership_status == "released" and trade_status not in {"closed", "failed"}:
+            reasons.append("released_ownership_trade_not_closed")
+
+    operation_status = row["lifecycle_operation_status"]
+    reconciliation_state = row["lifecycle_reconciliation_state"]
+    if operation_status == "rejected":
+        reasons.append("position_operation_rejected")
+    elif operation_status == "reconcile_required":
+        reasons.append("position_operation_reconciliation_required")
+    if row["lifecycle_operation_error"] is not None:
+        reasons.append("position_operation_error")
+    if reconciliation_state in {"not_found", "ambiguous", "error", "rejected"}:
+        reasons.append(f"position_operation_reconciliation_{reconciliation_state}")
+    if row["lifecycle_reconciliation_error"] is not None and reconciliation_state not in {
+        "not_found",
+        "ambiguous",
+        "error",
+    }:
+        reasons.append("position_operation_reconciliation_error")
+    reasons.extend(history_reasons)
+
+    if trade_status == "failed" and ownership_count == 0:
+        close_history_status: StrategyCloseHistoryStatus = "not_applicable"
+    elif ownership_count == 0 and trade_status in {"planned", "submitted"}:
+        close_history_status = "not_closed"
+    elif row["strategy_trade_id"] is None or ownership_count != 1:
+        close_history_status = "unavailable"
+    elif history_reasons:
+        close_history_status = "incomplete"
+    elif raw_close_event_count == 0:
+        close_history_status = "not_closed"
+    else:
+        close_history_status = "complete"
+
+    history_complete = (
+        ownership_count == 1
+        and raw_close_event_count > 0
+        and row["lifecycle_pnl_complete"] is True
+        and row["lifecycle_fees_complete"] is True
+    )
+    return StrategyTradeLifecycle(
+        trade_status=cast(StrategyTradeStatus | None, trade_status),
+        ownership_count=ownership_count,
+        broker_position_id=(
+            int(cast(int, row["lifecycle_broker_position_id"]))
+            if ownership_count == 1 and row["lifecycle_broker_position_id"] is not None
+            else None
+        ),
+        ownership_status=cast(Literal["active", "released"] | None, ownership_status),
+        position_claimed_at=cast(datetime | None, row["lifecycle_claimed_at"]),
+        position_released_at=cast(datetime | None, row["lifecycle_released_at"]),
+        position_release_reason=cast(str | None, row["lifecycle_release_reason"]),
+        latest_operation_type=cast(
+            Literal["fixed_exit_repair", "stop_ratchet", "close"] | None,
+            row["lifecycle_operation_type"],
+        ),
+        latest_operation_id=(
+            int(cast(int, row["lifecycle_operation_id"])) if row["lifecycle_operation_id"] is not None else None
+        ),
+        latest_operation_order_id=(
+            int(cast(int, row["lifecycle_operation_order_id"]))
+            if row["lifecycle_operation_order_id"] is not None
+            else None
+        ),
+        latest_operation_trigger=cast(str | None, row["lifecycle_operation_trigger"]),
+        latest_operation_status=cast(StrategyOperationStatus | None, row["lifecycle_operation_status"]),
+        latest_operation_created_at=cast(datetime | None, row["lifecycle_operation_created_at"]),
+        latest_operation_submitted_at=cast(datetime | None, row["lifecycle_operation_submitted_at"]),
+        latest_operation_resolved_at=cast(datetime | None, row["lifecycle_operation_resolved_at"]),
+        latest_operation_error=cast(str | None, row["lifecycle_operation_error"]),
+        latest_reconciliation_state=cast(StrategyReconciliationState | None, row["lifecycle_reconciliation_state"]),
+        latest_reconciliation_broker_status=cast(str | None, row["lifecycle_reconciliation_broker_status"]),
+        latest_reconciliation_attempt_count=(
+            int(cast(int, row["lifecycle_reconciliation_attempt_count"]))
+            if row["lifecycle_reconciliation_attempt_count"] is not None
+            else None
+        ),
+        latest_reconciliation_updated_at=cast(datetime | None, row["lifecycle_reconciliation_updated_at"]),
+        latest_reconciliation_error=cast(str | None, row["lifecycle_reconciliation_error"]),
+        close_event_count=(
+            raw_close_event_count
+            if ownership_count == 1 or (ownership_count == 0 and trade_status in {"planned", "submitted", "failed"})
+            else None
+        ),
+        realised_pnl_usd=(Decimal(str(row["lifecycle_realised_pnl_usd"])) if history_complete else None),
+        observed_fees_usd=(Decimal(str(row["lifecycle_observed_fees_usd"])) if history_complete else None),
+        close_history_status=close_history_status,
+        incomplete_reasons=reasons,
+    )
+
+
+def _fired_signal(row: Mapping[str, object]) -> FiredSignal:
+    base = {key: value for key, value in row.items() if not key.startswith("lifecycle_")}
+    return FiredSignal.model_validate({**base, "trade_lifecycle": _trade_lifecycle(row)})
 
 
 @router.get("/signals", response_model=FiredSignalsResponse)
@@ -2046,7 +2277,7 @@ def get_fired_signals(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(_FIRED_SIGNALS_SQL, params)
         rows = list(cur.fetchall())
-    items = [FiredSignal(**row) for row in rows]
+    items = [_fired_signal(row) for row in rows]
     return FiredSignalsResponse(items=items, next_cursor=items[-1].signal_id if len(items) == limit else None)
 
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2784,6 +2784,35 @@ export interface StrategyPositionCloseResponse {
   operation_id: number | null;
 }
 
+export interface StrategyTradeLifecycle {
+  trade_status: "planned" | "submitted" | "open" | "closing" | "closed" | "failed" | "reconcile_required" | null;
+  ownership_count: number;
+  broker_position_id: number | null;
+  ownership_status: "active" | "released" | null;
+  position_claimed_at: string | null;
+  position_released_at: string | null;
+  position_release_reason: string | null;
+  latest_operation_type: "fixed_exit_repair" | "stop_ratchet" | "close" | null;
+  latest_operation_id: number | null;
+  latest_operation_order_id: number | null;
+  latest_operation_trigger: string | null;
+  latest_operation_status: "intent_persisted" | "submitted" | "applied" | "rejected" | "reconcile_required" | null;
+  latest_operation_created_at: string | null;
+  latest_operation_submitted_at: string | null;
+  latest_operation_resolved_at: string | null;
+  latest_operation_error: string | null;
+  latest_reconciliation_state: "unresolved" | "pending" | "resolved" | "rejected" | "not_found" | "ambiguous" | "error" | null;
+  latest_reconciliation_broker_status: string | null;
+  latest_reconciliation_attempt_count: number | null;
+  latest_reconciliation_updated_at: string | null;
+  latest_reconciliation_error: string | null;
+  close_event_count: number | null;
+  realised_pnl_usd: string | null;
+  observed_fees_usd: string | null;
+  close_history_status: "not_applicable" | "not_closed" | "complete" | "incomplete" | "unavailable";
+  incomplete_reasons: string[];
+}
+
 export interface FiredSignal {
   signal_id: number;
   strategy_id: string;
@@ -2808,6 +2837,7 @@ export interface FiredSignal {
   execution_status: string | null;
   actual_fill_price: string | null;
   slippage_pct: string | null;
+  trade_lifecycle: StrategyTradeLifecycle | null;
 }
 
 export interface FiredSignalsResponse {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -302,6 +302,34 @@ const FUNDED_SIGNAL: FiredSignal = {
   execution_status: "filled",
   actual_fill_price: "20.10",
   slippage_pct: "0.5",
+  trade_lifecycle: {
+    trade_status: "closed",
+    ownership_count: 1,
+    broker_position_id: 7001,
+    ownership_status: "released",
+    position_claimed_at: "2026-08-09T10:00:00Z",
+    position_released_at: "2026-08-12T10:00:00Z",
+    position_release_reason: "broker_close_observed",
+    latest_operation_type: "close",
+    latest_operation_id: 88,
+    latest_operation_order_id: 99,
+    latest_operation_trigger: "operator_close",
+    latest_operation_status: "applied",
+    latest_operation_created_at: "2026-08-12T09:58:00Z",
+    latest_operation_submitted_at: "2026-08-12T09:59:00Z",
+    latest_operation_resolved_at: "2026-08-12T10:00:00Z",
+    latest_operation_error: null,
+    latest_reconciliation_state: "resolved",
+    latest_reconciliation_broker_status: "closed",
+    latest_reconciliation_attempt_count: 1,
+    latest_reconciliation_updated_at: "2026-08-12T10:00:00Z",
+    latest_reconciliation_error: null,
+    close_event_count: 1,
+    realised_pnl_usd: "8.75",
+    observed_fees_usd: "1.25",
+    close_history_status: "complete",
+    incomplete_reasons: [],
+  },
 };
 
 function approvedOverview(): StrategyOverviewResponse {
@@ -735,6 +763,7 @@ describe("StrategiesPage", () => {
       execution_status: null,
       actual_fill_price: null,
       slippage_pct: null,
+      trade_lifecycle: null,
     };
     vi.mocked(strategiesApi.fetchFiredSignals).mockResolvedValue({
       items: [FUNDED_SIGNAL, rejected],
@@ -746,6 +775,14 @@ describe("StrategiesPage", () => {
     expect(within(section).getByText("Funded")).toBeInTheDocument();
     expect(within(section).getByText("Not funded")).toBeInTheDocument();
     expect(within(section).getByText("Trade #41")).toBeInTheDocument();
+    expect(within(section).getByText("Position #7001 · released")).toBeInTheDocument();
+    expect(within(section).getByText("close · applied")).toBeInTheDocument();
+    expect(within(section).getByText("Operation #88 · order #99")).toBeInTheDocument();
+    expect(within(section).getByText("Reconciliation resolved · broker closed")).toBeInTheDocument();
+    expect(within(section).getByText("operator close")).toBeInTheDocument();
+    expect(within(section).getByText("1 close event")).toBeInTheDocument();
+    expect(within(section).getByText("US$8.75 realised")).toBeInTheDocument();
+    expect(within(section).getByText("US$1.25 fees")).toBeInTheDocument();
     expect(within(section).getByText("No order submitted")).toBeInTheDocument();
     expect(within(section).getByText("No strategy trade")).toBeInTheDocument();
     expect(within(section).getByText("US$100.00 assigned")).toBeInTheDocument();
@@ -755,6 +792,135 @@ describe("StrategiesPage", () => {
     expect(within(section).getByText("+10.00%")).toBeInTheDocument();
     expect(within(section).getByText("Outcome unresolved")).toBeInTheDocument();
     expect(within(section).getByText("paper pool disabled")).toBeInTheDocument();
+  });
+
+  it("surfaces missing and ambiguous broker lifecycle evidence instead of selecting a position", async () => {
+    const missing: FiredSignal = {
+      ...FUNDED_SIGNAL,
+      signal_id: 89,
+      symbol: "MISS",
+      trade_lifecycle: {
+        ...FUNDED_SIGNAL.trade_lifecycle!,
+        trade_status: "closed",
+        close_event_count: 0,
+        realised_pnl_usd: null,
+        observed_fees_usd: null,
+        close_history_status: "incomplete",
+        incomplete_reasons: ["released_position_missing_close_history"],
+      },
+    };
+    const ambiguous: FiredSignal = {
+      ...FUNDED_SIGNAL,
+      signal_id: 88,
+      symbol: "AMB",
+      trade_lifecycle: {
+        ...FUNDED_SIGNAL.trade_lifecycle!,
+        ownership_count: 2,
+        broker_position_id: null,
+        ownership_status: null,
+        position_claimed_at: null,
+        position_released_at: null,
+        position_release_reason: null,
+        latest_operation_type: null,
+        latest_operation_id: null,
+        latest_operation_order_id: null,
+        latest_operation_trigger: null,
+        latest_operation_status: null,
+        latest_operation_created_at: null,
+        latest_operation_submitted_at: null,
+        latest_operation_resolved_at: null,
+        latest_reconciliation_state: null,
+        latest_reconciliation_broker_status: null,
+        latest_reconciliation_attempt_count: null,
+        latest_reconciliation_updated_at: null,
+        latest_reconciliation_error: null,
+        close_event_count: null,
+        realised_pnl_usd: null,
+        observed_fees_usd: null,
+        close_history_status: "unavailable",
+        incomplete_reasons: ["position_ownership_ambiguous"],
+      },
+    };
+    vi.mocked(strategiesApi.fetchFiredSignals).mockResolvedValue({
+      items: [missing, ambiguous],
+      next_cursor: null,
+    });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const section = (await screen.findByText("Generated trade activity")).closest("section")!;
+    expect(within(section).getByText("Close history incomplete")).toBeInTheDocument();
+    expect(within(section).getByText("Released position is missing broker close history")).toBeInTheDocument();
+    expect(within(section).getByText("2 ownership records · ambiguous")).toBeInTheDocument();
+    expect(within(section).getByText("Close history unavailable")).toBeInTheDocument();
+    expect(within(section).getByText("More than one broker-position ownership record exists")).toBeInTheDocument();
+  });
+
+  it("shows a submitted close as closing without presenting realised P&L", async () => {
+    const closing: FiredSignal = {
+      ...FUNDED_SIGNAL,
+      trade_lifecycle: {
+        ...FUNDED_SIGNAL.trade_lifecycle!,
+        trade_status: "closing",
+        ownership_status: "active",
+        position_released_at: null,
+        position_release_reason: null,
+        latest_operation_trigger: "strategy_exit",
+        latest_operation_status: "submitted",
+        latest_operation_resolved_at: null,
+        latest_reconciliation_state: "pending",
+        latest_reconciliation_broker_status: "pending",
+        latest_reconciliation_updated_at: "2026-08-12T09:59:00Z",
+        close_event_count: 0,
+        realised_pnl_usd: null,
+        observed_fees_usd: null,
+        close_history_status: "not_closed",
+      },
+    };
+    vi.mocked(strategiesApi.fetchFiredSignals).mockResolvedValue({ items: [closing], next_cursor: null });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const section = (await screen.findByText("Generated trade activity")).closest("section")!;
+    expect(within(section).getByText("closing")).toBeInTheDocument();
+    expect(within(section).getByText("close · submitted")).toBeInTheDocument();
+    expect(within(section).getByText("strategy exit")).toBeInTheDocument();
+    expect(within(section).getByText("Reconciliation pending · broker pending")).toBeInTheDocument();
+    expect(within(section).getByText("No broker close yet")).toBeInTheDocument();
+    const row = within(section).getByText("ACME").closest("tr")!;
+    expect(within(row).queryByText(/realised/)).not.toBeInTheDocument();
+  });
+
+  it("renders failed and reconciliation-required trades as risk states", async () => {
+    const failed: FiredSignal = {
+      ...FUNDED_SIGNAL,
+      signal_id: 101,
+      symbol: "FAIL",
+      trade_lifecycle: {
+        ...FUNDED_SIGNAL.trade_lifecycle!,
+        trade_status: "failed",
+        incomplete_reasons: [],
+      },
+    };
+    const reconcileRequired: FiredSignal = {
+      ...FUNDED_SIGNAL,
+      signal_id: 100,
+      symbol: "RECON",
+      trade_lifecycle: {
+        ...FUNDED_SIGNAL.trade_lifecycle!,
+        trade_status: "reconcile_required",
+        incomplete_reasons: [],
+      },
+    };
+    vi.mocked(strategiesApi.fetchFiredSignals).mockResolvedValue({
+      items: [failed, reconcileRequired],
+      next_cursor: null,
+    });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const section = (await screen.findByText("Generated trade activity")).closest("section")!;
+    const failedBadge = within(within(section).getByText("FAIL").closest("tr")!).getByText("failed");
+    const reconcileBadge = within(within(section).getByText("RECON").closest("tr")!).getByText("reconcile required");
+    expect(failedBadge.parentElement).toHaveClass("border-red-300");
+    expect(reconcileBadge.parentElement).toHaveClass("border-red-300");
   });
 
   it("loads older generated decisions through the bounded cursor", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -348,6 +348,21 @@ const REFUSAL_LABELS: Record<string, string> = {
   prospective_assessment_missing: "No current prospective forecast assessment exists",
   prospective_assessment_not_passed: "Recent forecast probabilities failed validation",
   prospective_assessment_stale: "Prospective forecast validation is stale",
+  funding_not_reconciled_to_trade: "Funded decision has not reconciled to a strategy trade",
+  trade_not_reconciled_to_position: "Strategy trade has not reconciled to a broker position",
+  position_ownership_ambiguous: "More than one broker-position ownership record exists",
+  position_ownership_incomplete: "Broker-position ownership is incomplete",
+  released_position_missing_close_history: "Released position is missing broker close history",
+  realised_pnl_missing_from_history: "Broker close history is missing realised P&L",
+  fees_missing_from_history: "Broker close history is missing fees",
+  closed_trade_has_active_ownership: "Closed trade still has active broker-position ownership",
+  released_ownership_trade_not_closed: "Released broker-position ownership belongs to a trade not marked closed",
+  position_operation_rejected: "Latest broker-position operation was rejected",
+  position_operation_reconciliation_required: "Latest broker-position operation requires reconciliation",
+  position_operation_error: "Latest broker-position operation recorded an error",
+  position_operation_reconciliation_not_found: "Latest operation was not found at the broker",
+  position_operation_reconciliation_ambiguous: "Latest operation has ambiguous broker reconciliation",
+  position_operation_reconciliation_error: "Latest operation reconciliation failed",
 };
 
 function refusalLabel(refusal: string): string {
@@ -554,6 +569,23 @@ function outcomeLabel(signal: FiredSignal): string {
   return signal.outcome.replaceAll("_", " ");
 }
 
+function lifecycleTone(signal: FiredSignal): "ok" | "neutral" | "warn" | "risk" | "info" {
+  const lifecycle = signal.trade_lifecycle;
+  if (lifecycle === null) return "neutral";
+  if (lifecycle.trade_status === "failed" || lifecycle.trade_status === "reconcile_required") return "risk";
+  if (lifecycle.incomplete_reasons.length > 0) return "risk";
+  if (lifecycle.trade_status === "closed") return "ok";
+  if (lifecycle.trade_status === "closing") return "warn";
+  if (lifecycle.trade_status === "open") return "info";
+  return "neutral";
+}
+
+function lifecycleLabel(signal: FiredSignal): string {
+  const lifecycle = signal.trade_lifecycle;
+  if (lifecycle === null) return signal.funding_status === "funded" ? "Trade unavailable" : "No funded trade";
+  return lifecycle.trade_status?.replaceAll("_", " ") ?? "Trade unavailable";
+}
+
 function StrategyActivity({
   response,
   strategyTitles,
@@ -613,14 +645,16 @@ function StrategyActivity({
       ) : (
         <>
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[72rem]">
+            <table className="w-full min-w-[88rem]">
               <thead className="border-t border-slate-200 text-left text-[10px] font-semibold uppercase tracking-wider text-slate-500 dark:border-slate-800">
                 <tr>
                   <th className="px-4 py-2">Signal</th>
                   <th className="px-4 py-2">Strategy</th>
                   <th className="px-4 py-2">Allocation</th>
                   <th className="px-4 py-2">Execution</th>
+                  <th className="px-4 py-2">Trade lifecycle</th>
                   <th className="px-4 py-2 text-right">Model / actual fill</th>
+                  <th className="px-4 py-2 text-right">Broker close / P&amp;L</th>
                   <th className="px-4 py-2 text-right">Signal outcome</th>
                 </tr>
               </thead>
@@ -649,10 +683,64 @@ function StrategyActivity({
                         <span className="capitalize">{executionLabel(signal)}</span>
                         <span className="mt-1 block text-slate-500">{signal.strategy_trade_id === null ? "No strategy trade" : `Trade #${signal.strategy_trade_id}`}</span>
                       </td>
+                      <td className="px-4 py-3 text-xs">
+                        <Badge tone={lifecycleTone(signal)}><span className="capitalize">{lifecycleLabel(signal)}</span></Badge>
+                        {signal.trade_lifecycle ? (
+                          <>
+                            <span className="mt-1 block text-slate-500">
+                              {signal.trade_lifecycle.broker_position_id !== null
+                                ? `Position #${signal.trade_lifecycle.broker_position_id} · ${signal.trade_lifecycle.ownership_status}`
+                                : signal.trade_lifecycle.ownership_count > 1
+                                  ? `${signal.trade_lifecycle.ownership_count} ownership records · ambiguous`
+                                  : "Broker position unavailable"}
+                            </span>
+                            {signal.trade_lifecycle.latest_operation_type ? (
+                              <>
+                                <span className="mt-1 block capitalize">
+                                  {signal.trade_lifecycle.latest_operation_type.replaceAll("_", " ")} · {signal.trade_lifecycle.latest_operation_status?.replaceAll("_", " ") ?? "state unavailable"}
+                                </span>
+                                <span className="block text-slate-500">
+                                  {signal.trade_lifecycle.latest_operation_id === null ? "Operation identity unavailable" : `Operation #${signal.trade_lifecycle.latest_operation_id}`}
+                                  {signal.trade_lifecycle.latest_operation_order_id === null ? "" : ` · order #${signal.trade_lifecycle.latest_operation_order_id}`}
+                                </span>
+                              </>
+                            ) : null}
+                            {signal.trade_lifecycle.latest_operation_trigger ? <span className="block text-slate-500">{refusalLabel(signal.trade_lifecycle.latest_operation_trigger)}</span> : null}
+                            {signal.trade_lifecycle.latest_operation_error ? <span className="block text-red-700 dark:text-red-300">{refusalLabel(signal.trade_lifecycle.latest_operation_error)}</span> : null}
+                            {signal.trade_lifecycle.latest_reconciliation_state ? (
+                              <span className="block text-slate-500 capitalize">
+                                Reconciliation {signal.trade_lifecycle.latest_reconciliation_state.replaceAll("_", " ")}
+                                {signal.trade_lifecycle.latest_reconciliation_broker_status ? ` · broker ${signal.trade_lifecycle.latest_reconciliation_broker_status.replaceAll("_", " ")}` : ""}
+                              </span>
+                            ) : null}
+                            {signal.trade_lifecycle.latest_reconciliation_error ? <span className="block text-red-700 dark:text-red-300">{refusalLabel(signal.trade_lifecycle.latest_reconciliation_error)}</span> : null}
+                          </>
+                        ) : null}
+                      </td>
                       <td className="px-4 py-3 text-right text-xs tabular-nums">
                         <span className="block">{money(signal.fill_price)}</span>
                         <span className="text-slate-500">{signal.actual_fill_price === null ? "Actual —" : `${money(signal.actual_fill_price)} actual`}</span>
                         {signal.slippage_pct !== null ? <span className="block text-slate-500">{pctPoints(signal.slippage_pct)} slippage</span> : null}
+                      </td>
+                      <td className="px-4 py-3 text-right text-xs">
+                        {signal.trade_lifecycle === null ? (
+                          <span className="text-slate-500">Not applicable</span>
+                        ) : signal.trade_lifecycle.close_history_status === "not_applicable" ? (
+                          <span className="text-slate-500">No broker position opened</span>
+                        ) : signal.trade_lifecycle.close_history_status === "not_closed" ? (
+                          <span className="text-slate-500">No broker close yet</span>
+                        ) : signal.trade_lifecycle.close_history_status === "complete" ? (
+                          <>
+                            <span className="block">{signal.trade_lifecycle.close_event_count ?? 0} close event{signal.trade_lifecycle.close_event_count === 1 ? "" : "s"}</span>
+                            <span className="mt-1 block font-semibold tabular-nums">{money(signal.trade_lifecycle.realised_pnl_usd)} realised</span>
+                            <span className="block text-slate-500 tabular-nums">{money(signal.trade_lifecycle.observed_fees_usd)} fees</span>
+                          </>
+                        ) : (
+                          <>
+                            <span className="block text-red-700 dark:text-red-300">Close history {signal.trade_lifecycle.close_history_status}</span>
+                            <span className="mt-1 block max-w-64 text-slate-500">{signal.trade_lifecycle.incomplete_reasons.map(refusalLabel).join(" · ")}</span>
+                          </>
+                        )}
                       </td>
                       <td className="px-4 py-3 text-right text-xs">
                         <span className="block capitalize">{outcomeLabel(signal)}</span>

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -685,6 +685,483 @@ def test_unprocessed_current_entry_is_visible_as_not_funded_with_reason(
     assert signal.funding_status == "rejected"
     assert signal.funding_reason == "not_evaluated_by_allocator"
     assert signal.funded_amount is None
+    assert signal.trade_lifecycle is None
+
+
+def test_fired_signal_exposes_exact_completed_trade_lifecycle(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    instrument_id = 2453005
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-03",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, strategy_id, strategy_version)
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    ownership_row = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_position_ownership (
+            strategy_trade_id, broker_position_id, status, released_at, release_reason
+        ) VALUES (%s, 7453005, 'released', now(), 'broker_close_observed')
+        RETURNING ownership_id
+        """,
+        (trade_id,),
+    ).fetchone()
+    assert ownership_row is not None
+    ownership_id = ownership_row[0]
+    order_row = ebull_test_conn.execute(
+        """
+        INSERT INTO orders (
+            broker_order_ref, instrument_id, action, order_type, requested_amount,
+            status, execution_origin, strategy_request_id
+        ) VALUES ('99005', %s, 'SELL', 'MARKET', 100, 'filled', 'strategy', %s)
+        RETURNING order_id
+        """,
+        (instrument_id, uuid4()),
+    ).fetchone()
+    assert order_row is not None
+    order_id = order_row[0]
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_trade_orders (strategy_trade_id, order_id, purpose)
+        VALUES (%s, %s, 'exit')
+        """,
+        (trade_id, order_id),
+    )
+    operation_row = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_position_operations (
+            ownership_id, order_id, operation_type, trigger_code, request_id,
+            status, broker_order_ref, created_at, submitted_at, resolved_at
+        ) VALUES (%s, %s, 'close', 'operator_close', %s,
+                  'applied', 99005, now() - interval '2 minutes',
+                  now() - interval '1 minute', now())
+        RETURNING position_operation_id
+        """,
+        (ownership_id, order_id, uuid4()),
+    ).fetchone()
+    assert operation_row is not None
+    operation_id = operation_row[0]
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_order_reconciliation_state (
+            order_id, state, last_attempt_at, reconciled_at, attempt_count,
+            broker_status, position_count, updated_at
+        ) VALUES (%s, 'resolved', now(), now(), 1, 'closed', 1, now())
+        """,
+        (order_id,),
+    )
+    ebull_test_conn.execute(
+        "UPDATE strategy_trades SET status='closed', updated_at=now() WHERE strategy_trade_id=%s",
+        (trade_id,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO trade_events (
+            position_id, etoro_instrument_id, instrument_id, event_kind, side,
+            units, price, executed_at, fees_usd, realized_pnl_usd, source, raw_payload
+        ) VALUES (7453005, %s, %s, 'close', 'sell', 10, 11, now(), 1.25, 8.75,
+                  'etoro_history', '{}'::jsonb)
+        """,
+        (instrument_id, instrument_id),
+    )
+
+    response = get_fired_signals(cursor=None, limit=50, strategy_id=strategy_id, conn=ebull_test_conn)
+    signal = next(item for item in response.items if item.signal_id == signal_id)
+    lifecycle = signal.trade_lifecycle
+
+    assert lifecycle is not None
+    assert lifecycle.trade_status == "closed"
+    assert lifecycle.ownership_count == 1
+    assert lifecycle.broker_position_id == 7453005
+    assert lifecycle.ownership_status == "released"
+    assert lifecycle.latest_operation_type == "close"
+    assert lifecycle.latest_operation_trigger == "operator_close"
+    assert lifecycle.latest_operation_status == "applied"
+    assert lifecycle.latest_operation_id == operation_id
+    assert lifecycle.latest_operation_order_id == order_id
+    assert lifecycle.latest_reconciliation_state == "resolved"
+    assert lifecycle.latest_reconciliation_broker_status == "closed"
+    assert lifecycle.latest_reconciliation_attempt_count == 1
+    assert lifecycle.latest_reconciliation_error is None
+    assert lifecycle.close_event_count == 1
+    assert lifecycle.realised_pnl_usd == Decimal("8.75")
+    assert lifecycle.observed_fees_usd == Decimal("1.25")
+    assert lifecycle.close_history_status == "complete"
+    assert lifecycle.incomplete_reasons == []
+    assert operation_id > 0
+
+
+def test_fired_signal_keeps_open_owned_trade_distinct_from_closed_history(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    instrument_id = 2453006
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-04",
+        fill_price=Decimal("12"),
+    )
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=_deployment(ebull_test_conn, strategy_id, strategy_version),
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id) VALUES (%s, 7453006)",
+        (trade_id,),
+    )
+
+    response = get_fired_signals(cursor=None, limit=50, strategy_id=strategy_id, conn=ebull_test_conn)
+    matching = [item for item in response.items if item.signal_id == signal_id]
+    assert len(matching) == 1
+    lifecycle = matching[0].trade_lifecycle
+
+    assert lifecycle is not None
+    assert lifecycle.trade_status == "open"
+    assert lifecycle.ownership_status == "active"
+    assert lifecycle.close_event_count == 0
+    assert lifecycle.realised_pnl_usd is None
+    assert lifecycle.observed_fees_usd is None
+    assert lifecycle.close_history_status == "not_closed"
+    assert lifecycle.incomplete_reasons == []
+
+
+def test_fired_signal_treats_failed_entry_without_position_as_terminal_not_missing(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    instrument_id = 2453011
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-04",
+        fill_price=Decimal("12.50"),
+    )
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=_deployment(ebull_test_conn, strategy_id, strategy_version),
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        "UPDATE strategy_trades SET status='failed' WHERE strategy_trade_id=%s",
+        (trade_id,),
+    )
+
+    response = get_fired_signals(cursor=None, limit=50, strategy_id=strategy_id, conn=ebull_test_conn)
+    matching = [item for item in response.items if item.signal_id == signal_id]
+    assert len(matching) == 1
+    lifecycle = matching[0].trade_lifecycle
+
+    assert lifecycle is not None
+    assert lifecycle.trade_status == "failed"
+    assert lifecycle.ownership_count == 0
+    assert lifecycle.broker_position_id is None
+    assert lifecycle.close_history_status == "not_applicable"
+    assert lifecycle.incomplete_reasons == []
+
+
+def test_fired_signal_exposes_a_submitted_close_without_claiming_it_completed(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    instrument_id = 2453009
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-04",
+        fill_price=Decimal("13"),
+    )
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=_deployment(ebull_test_conn, strategy_id, strategy_version),
+        instrument_id=instrument_id,
+    )
+    ownership_row = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id)
+        VALUES (%s, 7453010) RETURNING ownership_id
+        """,
+        (trade_id,),
+    ).fetchone()
+    assert ownership_row is not None
+    ownership_id = ownership_row[0]
+    order_row = ebull_test_conn.execute(
+        """
+        INSERT INTO orders (
+            broker_order_ref, instrument_id, action, order_type, requested_amount,
+            status, execution_origin, strategy_request_id
+        ) VALUES ('99010', %s, 'SELL', 'MARKET', 100, 'pending', 'strategy', %s)
+        RETURNING order_id
+        """,
+        (instrument_id, uuid4()),
+    ).fetchone()
+    assert order_row is not None
+    order_id = order_row[0]
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_position_operations (
+            ownership_id, order_id, operation_type, trigger_code, request_id,
+            status, broker_order_ref, created_at, submitted_at
+        ) VALUES (%s, %s, 'close', 'strategy_exit', %s,
+                  'submitted', 99010, now() - interval '1 minute', now())
+        """,
+        (ownership_id, order_id, uuid4()),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_order_reconciliation_state (
+            order_id, state, last_attempt_at, attempt_count, broker_status,
+            position_count, updated_at
+        ) VALUES (%s, 'pending', now(), 1, 'pending', 1, now())
+        """,
+        (order_id,),
+    )
+    ebull_test_conn.execute(
+        "UPDATE strategy_trades SET status='closing' WHERE strategy_trade_id=%s",
+        (trade_id,),
+    )
+
+    response = get_fired_signals(cursor=None, limit=50, strategy_id=strategy_id, conn=ebull_test_conn)
+    lifecycle = next(item for item in response.items if item.signal_id == signal_id).trade_lifecycle
+
+    assert lifecycle is not None
+    assert lifecycle.trade_status == "closing"
+    assert lifecycle.latest_operation_type == "close"
+    assert lifecycle.latest_operation_trigger == "strategy_exit"
+    assert lifecycle.latest_operation_status == "submitted"
+    assert lifecycle.latest_operation_resolved_at is None
+    assert lifecycle.latest_reconciliation_state == "pending"
+    assert lifecycle.latest_reconciliation_broker_status == "pending"
+    assert lifecycle.close_history_status == "not_closed"
+    assert lifecycle.realised_pnl_usd is None
+
+    ebull_test_conn.execute(
+        """
+        UPDATE strategy_order_reconciliation_state
+        SET state='ambiguous', broker_status='multiple_matches',
+            last_error_code='multiple_position_executions', updated_at=now()
+        WHERE order_id=%s
+        """,
+        (order_id,),
+    )
+    retried = get_fired_signals(cursor=None, limit=50, strategy_id=strategy_id, conn=ebull_test_conn)
+    ambiguous = next(item for item in retried.items if item.signal_id == signal_id).trade_lifecycle
+    assert ambiguous is not None
+    assert ambiguous.latest_reconciliation_state == "ambiguous"
+    assert ambiguous.latest_reconciliation_error == "multiple_position_executions"
+    assert ambiguous.close_history_status == "not_closed"
+    assert ambiguous.incomplete_reasons == ["position_operation_reconciliation_ambiguous"]
+
+    ebull_test_conn.execute(
+        """
+        UPDATE strategy_order_reconciliation_state
+        SET state='rejected', broker_status='rejected',
+            reconciled_at=now(), last_error_code=NULL, updated_at=now()
+        WHERE order_id=%s
+        """,
+        (order_id,),
+    )
+    rejected_response = get_fired_signals(
+        cursor=None,
+        limit=50,
+        strategy_id=strategy_id,
+        conn=ebull_test_conn,
+    )
+    rejected = next(item for item in rejected_response.items if item.signal_id == signal_id).trade_lifecycle
+    assert rejected is not None
+    assert rejected.latest_reconciliation_state == "rejected"
+    assert rejected.latest_reconciliation_error is None
+    assert rejected.incomplete_reasons == ["position_operation_reconciliation_rejected"]
+
+
+def test_fired_signal_fails_closed_on_released_position_without_close_history(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    instrument_id = 2453007
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-05",
+        fill_price=Decimal("14"),
+    )
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=_deployment(ebull_test_conn, strategy_id, strategy_version),
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_position_ownership (
+            strategy_trade_id, broker_position_id, status, released_at, release_reason
+        ) VALUES (%s, 7453007, 'released', now(), 'position_disappeared')
+        """,
+        (trade_id,),
+    )
+    ebull_test_conn.execute(
+        "UPDATE strategy_trades SET status='closed' WHERE strategy_trade_id=%s",
+        (trade_id,),
+    )
+
+    response = get_fired_signals(cursor=None, limit=50, strategy_id=strategy_id, conn=ebull_test_conn)
+    lifecycle = next(item for item in response.items if item.signal_id == signal_id).trade_lifecycle
+
+    assert lifecycle is not None
+    assert lifecycle.close_history_status == "incomplete"
+    assert lifecycle.realised_pnl_usd is None
+    assert lifecycle.observed_fees_usd is None
+    assert lifecycle.incomplete_reasons == ["released_position_missing_close_history"]
+
+
+def test_fired_signal_never_returns_a_partial_close_money_pair(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    instrument_id = 2453012
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-05",
+        fill_price=Decimal("15"),
+    )
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=_deployment(ebull_test_conn, strategy_id, strategy_version),
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_position_ownership (
+            strategy_trade_id, broker_position_id, status, released_at, release_reason
+        ) VALUES (%s, 7453012, 'released', now(), 'broker_close_observed')
+        """,
+        (trade_id,),
+    )
+    ebull_test_conn.execute(
+        "UPDATE strategy_trades SET status='closed' WHERE strategy_trade_id=%s",
+        (trade_id,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO trade_events (
+            position_id, etoro_instrument_id, instrument_id, event_kind, side,
+            units, price, executed_at, fees_usd, realized_pnl_usd, source, raw_payload
+        ) VALUES (7453012, %s, %s, 'close', 'sell', 1, 16, now(), 2, NULL,
+                  'etoro_history', '{}'::jsonb)
+        """,
+        (instrument_id, instrument_id),
+    )
+
+    response = get_fired_signals(cursor=None, limit=50, strategy_id=strategy_id, conn=ebull_test_conn)
+    lifecycle = next(item for item in response.items if item.signal_id == signal_id).trade_lifecycle
+
+    assert lifecycle is not None
+    assert lifecycle.close_event_count == 1
+    assert lifecycle.close_history_status == "incomplete"
+    assert lifecycle.realised_pnl_usd is None
+    assert lifecycle.observed_fees_usd is None
+    assert lifecycle.incomplete_reasons == ["realised_pnl_missing_from_history"]
+
+
+def test_fired_signal_does_not_choose_between_ambiguous_position_owners(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    instrument_id = 2453008
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-06",
+        fill_price=Decimal("16"),
+    )
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=_deployment(ebull_test_conn, strategy_id, strategy_version),
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_position_ownership (
+            strategy_trade_id, broker_position_id, status, released_at, release_reason
+        ) VALUES
+            (%s, 7453008, 'released', now(), 'first_claim_released'),
+            (%s, 7453009, 'released', now(), 'second_claim_released')
+        """,
+        (trade_id, trade_id),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO trade_events (
+            position_id, etoro_instrument_id, instrument_id, event_kind, side,
+            units, price, executed_at, fees_usd, realized_pnl_usd, source, raw_payload
+        ) VALUES
+            (7453008, %s, %s, 'close', 'sell', 1, 17, now() - interval '1 minute',
+             1, 4, 'etoro_history', '{}'::jsonb),
+            (7453009, %s, %s, 'close', 'sell', 1, 18, now(),
+             2, 5, 'etoro_history', '{}'::jsonb)
+        """,
+        (instrument_id, instrument_id, instrument_id, instrument_id),
+    )
+
+    response = get_fired_signals(cursor=None, limit=50, strategy_id=strategy_id, conn=ebull_test_conn)
+    matching = [item for item in response.items if item.signal_id == signal_id]
+    assert len(matching) == 1
+    lifecycle = matching[0].trade_lifecycle
+
+    assert lifecycle is not None
+    assert lifecycle.ownership_count == 2
+    assert lifecycle.broker_position_id is None
+    assert lifecycle.ownership_status is None
+    assert lifecycle.latest_operation_status is None
+    assert lifecycle.close_history_status == "unavailable"
+    assert lifecycle.close_event_count is None
+    assert lifecycle.realised_pnl_usd is None
+    assert lifecycle.observed_fees_usd is None
+    assert lifecycle.incomplete_reasons == ["position_ownership_ambiguous"]
 
 
 def _session(username: str = "allocation-operator") -> SessionRow:


### PR DESCRIPTION
Closes #2753.

## Outcome

Extends the current-version `/strategies/signals` activity contract and strategy workspace from entry-side visibility through the exact broker-position lifecycle:

- durable strategy-trade state and exact ownership identity;
- latest material close/ratchet/repair operation and its immutable operation/order IDs;
- close-order reconciliation state, broker state, attempts and errors;
- broker-observed close count, realised P&L and fees;
- clear lifecycle and close-history completeness states in the UI.

## Fail-closed properties

- Aggregated/lateral CTEs retain one API row per signal; one-to-many ownership and close ledgers cannot duplicate pagination rows.
- More than one ownership record is surfaced as ambiguous; no broker position or operation is selected.
- Ownership always joins through `strategy_trade_id`, and broker history through the exact owned `broker_position_id`; there is no instrument inference.
- Realised P&L and fees are returned only as a complete pair when every observed close event contains both. Partial broker history returns null money fields plus stable reasons.
- A failed entry with no broker position is a legitimate terminal/no-position lifecycle, distinct from a funded open/closing/closed trade that failed to reconcile.
- Rejected funding decisions remain orderless; no execution, promotion, paper or live gate changes.
- Rule-defined signal outcome remains explicitly separated from broker-observed realised P&L.

## Verification

- 26 DB-backed strategy monitoring/lifecycle tests, including open, submitted close, complete close, failed entry, missing history, partial money and ambiguous ownership.
- 37 focused StrategiesPage tests.
- 70 broader API, monitoring, position-manager, order-reconciliation and paper-runtime tests.
- Full frontend suite: 137 files / 1,524 tests.
- Complete local pre-push gate: Ruff, format, Pyright, 288 mutation-probe anchors, 1,522 fast tests, smoke suite and frontend hygiene checks.

The existing non-blocking dev-DB size warning remains 72 GB; no validation gate failed.