### PR TITLE
Show account reconciliation gaps on strategy workspace

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -531,6 +531,8 @@ class AccountEquityEvidenceView(BaseModel):
     official_unrealised_pnl: Decimal | None
     local_eod_currency: str | None
     local_eod_value: Decimal | None
+    local_eod_positions_priced: int | None
+    local_eod_stale_mark_positions: int | None
     difference: Decimal | None
     comparable: Literal[False]
     incomplete_reasons: list[str]
@@ -1918,6 +1920,8 @@ def get_strategy_overview(
             official_unrealised_pnl=account_equity.official_unrealised_pnl,
             local_eod_currency=account_equity.local_eod_currency,
             local_eod_value=account_equity.local_eod_value,
+            local_eod_positions_priced=account_equity.local_eod_positions_priced,
+            local_eod_stale_mark_positions=account_equity.local_eod_stale_mark_positions,
             difference=account_equity.difference,
             comparable=account_equity.comparable,
             incomplete_reasons=list(account_equity.incomplete_reasons),

--- a/app/services/account_equity_evidence.py
+++ b/app/services/account_equity_evidence.py
@@ -48,6 +48,8 @@ class AccountEquityEvidence:
     official_unrealised_pnl: Decimal | None
     local_eod_currency: str | None
     local_eod_value: Decimal | None
+    local_eod_positions_priced: int | None
+    local_eod_stale_mark_positions: int | None
     difference: Decimal | None
     comparable: Literal[False]
     incomplete_reasons: tuple[str, ...]
@@ -198,12 +200,7 @@ def load_account_equity_evidence(
                  OR coalesce(local.positions_no_fx,0) > 0
                  OR coalesce(local.cash_no_fx_currencies,0) > 0 AS local_valuation_incomplete,
                latest.account_currency_id,
-               -- ⚠ `stale_mark_positions` is deliberately NOT projected. The
-               -- verdict comes from `oldest_mark_date` alone (see
-               -- `mark_effectiveness_reasons`), and the count has no API
-               -- consumer yet — it is stored evidence for the reconciliation
-               -- write-up, queryable directly. #2602 item 4.
-               local.oldest_mark_date,local.positions_priced
+               local.oldest_mark_date,local.positions_priced,local.stale_mark_positions
         FROM latest
         LEFT JOIN portfolio_eod_snapshots local ON local.snapshot_date=latest.snapshot_date
         """,
@@ -223,6 +220,8 @@ def load_account_equity_evidence(
             official_unrealised_pnl=None,
             local_eod_currency=None,
             local_eod_value=None,
+            local_eod_positions_priced=None,
+            local_eod_stale_mark_positions=None,
             difference=None,
             comparable=False,
             incomplete_reasons=("official_account_equity_missing",),
@@ -272,6 +271,8 @@ def load_account_equity_evidence(
         official_unrealised_pnl=Decimal(str(row[6])),
         local_eod_currency=local_currency,
         local_eod_value=local_value,
+        local_eod_positions_priced=None if row[13] is None else int(row[13]),
+        local_eod_stale_mark_positions=None if row[14] is None else int(row[14]),
         difference=(
             official_equity - local_value
             if local_value is not None and official_currency is not None and local_currency == official_currency

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2658,6 +2658,8 @@ export interface StrategyOverviewResponse {
     official_unrealised_pnl: string | null;
     local_eod_currency: string | null;
     local_eod_value: string | null;
+    local_eod_positions_priced: number | null;
+    local_eod_stale_mark_positions: number | null;
     difference: string | null;
     comparable: false;
     incomplete_reasons: string[];

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -99,6 +99,8 @@ const OVERVIEW: StrategyOverviewResponse = {
     official_unrealised_pnl: null,
     local_eod_currency: null,
     local_eod_value: null,
+    local_eod_positions_priced: null,
+    local_eod_stale_mark_positions: null,
     difference: null,
     comparable: false,
     incomplete_reasons: ["official_account_equity_missing"],
@@ -426,6 +428,8 @@ describe("StrategiesPage", () => {
         official_unrealised_pnl: "100.00",
         local_eod_currency: "USD",
         local_eod_value: "1020.00",
+        local_eod_positions_priced: 2,
+        local_eod_stale_mark_positions: 0,
         difference: "5.00",
         comparable: false,
         incomplete_reasons: ["local_eod_effective_time_unknown"],
@@ -435,7 +439,8 @@ describe("StrategiesPage", () => {
     const performance = (await screen.findByText("Portfolio performance")).closest("section")!;
     expect(within(performance).getByText("3 daily official snapshots")).toBeInTheDocument();
     expect(within(performance).getByText("US$1,025.00")).toBeInTheDocument();
-    expect(within(performance).getByText("Reconciliation collecting")).toBeInTheDocument();
+    expect(within(performance).getByText("Reconciliation incomplete")).toBeInTheDocument();
+    expect(within(performance).getByText("The effective dates of the local valuation marks were not recorded.")).toBeInTheDocument();
     expect(within(performance).getByText("No automated P&L yet")).toBeInTheDocument();
   });
 
@@ -455,6 +460,8 @@ describe("StrategiesPage", () => {
         official_unrealised_pnl: "100.00",
         local_eod_currency: null,
         local_eod_value: null,
+        local_eod_positions_priced: null,
+        local_eod_stale_mark_positions: null,
         difference: null,
         comparable: false,
         incomplete_reasons: ["account_currency_not_documented"],
@@ -465,6 +472,70 @@ describe("StrategiesPage", () => {
     expect(within(performance).getByText("Currency unverified")).toBeInTheDocument();
     expect(within(performance).queryByText("US$1,025.00")).not.toBeInTheDocument();
     expect(within(performance).queryByText(/1,025\.00/)).not.toBeInTheDocument();
+    expect(within(performance).getByText("The broker reported an account currency that is not documented for this USD-only trading lane.")).toBeInTheDocument();
+  });
+
+  it("shows carried-forward mark magnitude and never hides an unknown account-evidence reason", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      account_equity_evidence: {
+        status: "collecting",
+        days_collected: 4,
+        snapshot_date: "2026-08-12",
+        observed_at: "2026-08-12T19:00:00Z",
+        account_currency_id: 1,
+        currency: "USD",
+        official_equity: "1025.00",
+        official_available_cash: "525.00",
+        official_total_invested: "400.00",
+        official_unrealised_pnl: "100.00",
+        local_eod_currency: "USD",
+        local_eod_value: "1020.00",
+        local_eod_positions_priced: 7,
+        local_eod_stale_mark_positions: 3,
+        difference: "5.00",
+        comparable: false,
+        incomplete_reasons: [
+          "account_currency_assumed_not_observed",
+          "same_day_local_eod_snapshot_missing",
+          "local_eod_currency_mismatch",
+          "local_eod_valuation_incomplete",
+          "local_eod_marks_carried_forward",
+          "future_account_reason",
+        ],
+      },
+    });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const performance = (await screen.findByText("Portfolio performance")).closest("section")!;
+    expect(within(performance).getByText("This snapshot predates observed broker account currency; its currency cannot be trusted.")).toBeInTheDocument();
+    expect(within(performance).getByText("The same-day local end-of-day valuation is missing.")).toBeInTheDocument();
+    expect(within(performance).getByText("The broker account and local valuation currencies do not match.")).toBeInTheDocument();
+    expect(within(performance).getByText("The local valuation is missing at least one price or currency conversion.")).toBeInTheDocument();
+    expect(within(performance).getByText("3 of 7 priced positions use a carried-forward closing mark.")).toBeInTheDocument();
+    expect(within(performance).getByText("future_account_reason")).toBeInTheDocument();
+  });
+
+  it("states that reconciliation policy is missing when measurements have no named caveat", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      account_equity_evidence: {
+        ...OVERVIEW.account_equity_evidence,
+        status: "collecting",
+        days_collected: 4,
+        currency: "USD",
+        official_equity: "1025.00",
+        local_eod_currency: "USD",
+        local_eod_value: "1020.00",
+        local_eod_positions_priced: 2,
+        local_eod_stale_mark_positions: 0,
+        incomplete_reasons: [],
+      },
+    });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const performance = (await screen.findByText("Portfolio performance")).closest("section")!;
+    expect(within(performance).getByText("Comparison tolerance not defined")).toBeInTheDocument();
   });
 
   it("separates unapproved research from selectable strategies", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -369,6 +369,47 @@ function refusalLabel(refusal: string): string {
   return REFUSAL_LABELS[refusal] ?? refusal.replaceAll("_", " ");
 }
 
+const ACCOUNT_EVIDENCE_REASON_LABELS: Record<string, string> = {
+  official_account_equity_missing: "Official account equity starts collecting with the next portfolio sync.",
+  account_currency_assumed_not_observed: "This snapshot predates observed broker account currency; its currency cannot be trusted.",
+  account_currency_not_documented: "The broker reported an account currency that is not documented for this USD-only trading lane.",
+  same_day_local_eod_snapshot_missing: "The same-day local end-of-day valuation is missing.",
+  local_eod_currency_mismatch: "The broker account and local valuation currencies do not match.",
+  local_eod_valuation_incomplete: "The local valuation is missing at least one price or currency conversion.",
+  local_eod_effective_time_unknown: "The effective dates of the local valuation marks were not recorded.",
+};
+
+function accountEvidenceReasonLabel(
+  reason: string,
+  evidence: StrategyOverviewResponse["account_equity_evidence"],
+): string {
+  if (reason === "local_eod_marks_carried_forward") {
+    const stale = evidence.local_eod_stale_mark_positions;
+    const priced = evidence.local_eod_positions_priced;
+    if (typeof stale === "number" && typeof priced === "number") {
+      return `${stale} of ${priced} priced ${priced === 1 ? "position uses" : "positions use"} a carried-forward closing mark.`;
+    }
+    return "The local valuation includes carried-forward closing marks.";
+  }
+  // An upstream reason added before this UI is deployed must remain visible.
+  return ACCOUNT_EVIDENCE_REASON_LABELS[reason] ?? reason;
+}
+
+function AccountEvidenceReasons({
+  evidence,
+}: {
+  evidence: StrategyOverviewResponse["account_equity_evidence"];
+}) {
+  if (evidence.incomplete_reasons.length === 0) return null;
+  return (
+    <ul className="mt-2 space-y-1 text-amber-700 dark:text-amber-300">
+      {evidence.incomplete_reasons.map((reason) => (
+        <li key={reason}>{accountEvidenceReasonLabel(reason, evidence)}</li>
+      ))}
+    </ul>
+  );
+}
+
 function aggregate(overview: StrategyOverviewResponse) {
   const pnlValues = overview.strategies.map((strategy) => number(strategy.pnl.total_pnl));
   const forwardStrategies = overview.strategies.filter((strategy) => strategy.forward_outcome_supported);
@@ -470,35 +511,40 @@ function AccountEvidence({ overview }: { overview: StrategyOverviewResponse }) {
     return (
       <div className="mt-5 border-t border-slate-200 pt-3 text-xs text-slate-500 dark:border-slate-800">
         <span className="font-medium text-slate-700 dark:text-slate-300">Account evidence</span>
-        <span className="ml-2">Official account equity starts collecting with the next portfolio sync.</span>
+        <AccountEvidenceReasons evidence={evidence} />
       </div>
     );
   }
   return (
-    <div className="mt-5 flex flex-wrap items-end justify-between gap-3 border-t border-slate-200 pt-3 text-xs dark:border-slate-800">
-      <div>
-        <span className="font-medium text-slate-700 dark:text-slate-300">Account evidence</span>
-        <span className="ml-2 text-slate-500">
-          {evidence.days_collected} daily official {evidence.days_collected === 1 ? "snapshot" : "snapshots"}
-        </span>
-      </div>
-      <div className="flex gap-5 text-right">
+    <div className="mt-5 border-t border-slate-200 pt-3 text-xs dark:border-slate-800">
+      <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <span className="block text-slate-500">Broker equity</span>
-          {currency === null ? (
-            <strong className="text-amber-700 dark:text-amber-300">Currency unverified</strong>
-          ) : (
-            <strong>{formatMoney(evidence.official_equity === null ? null : Number(evidence.official_equity), currency)}</strong>
-          )}
+          <span className="font-medium text-slate-700 dark:text-slate-300">Account evidence</span>
+          <span className="ml-2 text-slate-500">
+            {evidence.days_collected} daily official {evidence.days_collected === 1 ? "snapshot" : "snapshots"}
+          </span>
         </div>
-        {evidence.local_eod_value !== null && evidence.local_eod_currency !== null ? (
+        <div className="flex gap-5 text-right">
           <div>
-            <span className="block text-slate-500">Local valuation</span>
-            <strong>{formatMoney(Number(evidence.local_eod_value), evidence.local_eod_currency)}</strong>
+            <span className="block text-slate-500">Broker equity</span>
+            {currency === null ? (
+              <strong className="text-amber-700 dark:text-amber-300">Currency unverified</strong>
+            ) : (
+              <strong>{formatMoney(evidence.official_equity === null ? null : Number(evidence.official_equity), currency)}</strong>
+            )}
           </div>
-        ) : null}
-        <div className="self-end text-amber-700 dark:text-amber-300">Reconciliation collecting</div>
+          {evidence.local_eod_value !== null && evidence.local_eod_currency !== null ? (
+            <div>
+              <span className="block text-slate-500">Local valuation</span>
+              <strong>{formatMoney(Number(evidence.local_eod_value), evidence.local_eod_currency)}</strong>
+            </div>
+          ) : null}
+          <div className="self-end text-amber-700 dark:text-amber-300">
+            {evidence.incomplete_reasons.length > 0 ? "Reconciliation incomplete" : "Comparison tolerance not defined"}
+          </div>
+        </div>
       </div>
+      <AccountEvidenceReasons evidence={evidence} />
     </div>
   );
 }

--- a/tests/test_account_equity_evidence.py
+++ b/tests/test_account_equity_evidence.py
@@ -46,6 +46,8 @@ def test_empty_account_equity_evidence_is_explicit(ebull_test_conn: psycopg.Conn
     evidence = load_account_equity_evidence(ebull_test_conn, environment="demo")
     assert evidence.status == "unavailable"
     assert evidence.days_collected == 0
+    assert evidence.local_eod_positions_priced is None
+    assert evidence.local_eod_stale_mark_positions is None
     assert evidence.incomplete_reasons == ("official_account_equity_missing",)
 
 
@@ -347,6 +349,8 @@ def test_marks_on_the_session_retire_the_effective_time_caveat(
     )
     evidence = load_account_equity_evidence(ebull_test_conn, environment="demo")
     assert evidence.incomplete_reasons == ()
+    assert evidence.local_eod_positions_priced == 2
+    assert evidence.local_eod_stale_mark_positions == 0
     # ⚠ Still not comparable. Clearing every named caveat does NOT make the two
     # totals reconciled — that needs item 4's declared tolerance, which this
     # slice does not ship. `comparable` staying False with an empty reason list
@@ -371,3 +375,5 @@ def test_a_carried_forward_mark_is_named_rather_than_absorbed(
     )
     evidence = load_account_equity_evidence(ebull_test_conn, environment="demo")
     assert evidence.incomplete_reasons == ("local_eod_marks_carried_forward",)
+    assert evidence.local_eod_positions_priced == 2
+    assert evidence.local_eod_stale_mark_positions == 1


### PR DESCRIPTION
Refs #2693

## What
- render every account-equity evidence caveat on `/strategies` with operator-readable copy
- preserve unknown future reason slugs verbatim instead of silently dropping them
- project priced-position and stale-mark counts through the service/API and show carried-forward magnitude (for example, 3 of 7)
- replace the misleading unconditional `Reconciliation collecting` label with `Reconciliation incomplete` or `Comparison tolerance not defined`

## Safety
- presentation/evidence only; no allocation, execution, promotion, or capital authority changes
- official and local totals remain explicitly non-comparable
- missing/unknown currency remains fail-visible and never receives an inferred symbol

## Verification
- complete local `.githooks/pre-push` gate green
- focused account evidence + strategy monitoring: 51 passed
- focused Strategies page: 40 passed
- Pyright, Ruff, TypeScript typecheck and UI integrity gates green

Issue closure remains pending rendered-page QA on the served dev stack. Runtime is deliberately frozen while in-sample run 98349 is active.