### PR TITLE
fix(strategies): normalize halt symbol identity (#2709)

### DIFF
--- a/app/services/strategy_core_preflight.py
+++ b/app/services/strategy_core_preflight.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta
 from decimal import Decimal, InvalidOperation
-from typing import Any, Final, Literal
+from typing import Any, Final, Literal, LiteralString
 from zoneinfo import ZoneInfo
 
 import psycopg
@@ -45,12 +45,13 @@ from app.services.strategy_core_submission_gate import (
     CORE_SUBMISSION_ADVISORY_LOCK,
     core_lock_held,
 )
+from app.services.strategy_halt_identity import INSTRUMENT_HALT_SYMBOL_SQL
 
 #: Frozen with the rule set it stamps.  v1 fixes, BY CONSTRUCTION: the two
 #: freshness bounds below (their INTERVAL is derived from each producer's cadence,
 #: their POSITION in that interval is a choice -- see the constants), the
 #: ``us_equity`` session allow-list, and the refusal precedence order.
-CORE_PREFLIGHT_POLICY_VERSION: Final = "core-preflight-v1"
+CORE_PREFLIGHT_POLICY_VERSION: Final = "core-preflight-v2"
 
 #: The one session calendar this repo has is US
 #: (``app/services/market_calendar.py::us_market_status``), so the only asset class
@@ -240,7 +241,7 @@ class CorePreflightObservation:
 #
 # ⚠ The instrument join is `i.exchange`, NOT `i.exchange_id` -- `exchanges` is keyed
 # by a TEXT id that `instruments` stores in a column of a different name.
-_PREFLIGHT_SQL: Final = """
+_PREFLIGHT_SQL: Final[LiteralString] = f"""
 SELECT (i.instrument_id IS NOT NULL) AS instrument_present,
        i.symbol,
        i.is_tradable,
@@ -250,7 +251,7 @@ SELECT (i.instrument_id IS NOT NULL) AS instrument_present,
        EXISTS (
            SELECT 1 FROM strategy_market_halts mh
            WHERE mh.source = 'nasdaq_trader_rss'
-             AND mh.symbol = upper(i.symbol) AND mh.resumed_at IS NULL
+             AND mh.symbol = {INSTRUMENT_HALT_SYMBOL_SQL} AND mh.resumed_at IS NULL
        ) AS is_halted,
        (SELECT fetched_at FROM strategy_halt_feed_state WHERE source = 'nasdaq_trader_rss')
            AS halt_feed_at,

--- a/app/services/strategy_core_preflight.py
+++ b/app/services/strategy_core_preflight.py
@@ -47,10 +47,11 @@ from app.services.strategy_core_submission_gate import (
 )
 from app.services.strategy_halt_identity import INSTRUMENT_HALT_SYMBOL_SQL
 
-#: Frozen with the rule set it stamps.  v1 fixes, BY CONSTRUCTION: the two
+#: Frozen with the rule set it stamps.  v2 fixes, BY CONSTRUCTION: the two
 #: freshness bounds below (their INTERVAL is derived from each producer's cadence,
 #: their POSITION in that interval is a choice -- see the constants), the
-#: ``us_equity`` session allow-list, and the refusal precedence order.
+#: ``us_equity`` session allow-list, the refusal precedence order, and the shared
+#: versioned Nasdaq/eToro halt-symbol identity rule.
 CORE_PREFLIGHT_POLICY_VERSION: Final = "core-preflight-v2"
 
 #: The one session calendar this repo has is US

--- a/app/services/strategy_halt_identity.py
+++ b/app/services/strategy_halt_identity.py
@@ -1,0 +1,48 @@
+"""One Nasdaq halt-feed identity for every strategy submission path (#2709).
+
+Nasdaq's halt feed publishes the issue symbol from its Symbol Directory; it does
+not know eToro's session/listing suffixes. eBull's measured eToro US-equity
+catalog contains four suffixes that are venue metadata rather than part of that
+issue symbol: ``.RTH``, ``.24-7``, ``.US`` and ``.CH``. They are stripped here,
+narrowly.
+
+Dots are otherwise load-bearing. ``BRK.B`` and ``BF.A`` are distinct share
+classes and Nasdaq itself publishes those dotted identities, while catalog rows
+such as ``.CVR`` and ``.WS`` can denote distinct securities. A generic
+``split('.')`` or regexp would therefore turn a safety check into a different
+fail-open.
+
+Primary-source contract (verified 2026-08-15):
+
+* https://classic.nasdaqtrader.com/Trader.aspx?id=tradehaltcodes defines the
+  feed's field as "Issue Symbol — Symbol of the Issue".
+* https://classic.nasdaqtrader.com/Trader.aspx?id=TradingHaltSearch requires a
+  symbol exactly as it appears in Nasdaq's Symbol Directory.
+* https://www.etoro.com/markets/tcom.ch identifies eToro's ``TCOM.CH`` as the
+  Nasdaq-delayed Trip.com ADR, while https://www.nasdaq.com/market-activity/stocks/tcom
+  identifies that Nasdaq-listed issue as ``TCOM``.
+
+The eToro suffix census is repository evidence: ``research_corpus_ingest.py``
+records ``.RTH``/``.24-7`` as venue variants and ``.US`` as a primary-listing
+suffix. Dev census on 2026-08-15 found 595/9/239/7 tradable US-equity rows for
+``.RTH``/``.24-7``/``.US``/``.CH``, plus 14 class-like dotted symbols which
+must remain unchanged.
+
+The SQL fragment deliberately names the canonical query alias ``i``. Both the
+paper executor and core preflight interpolate this exact LiteralString, so the
+normalisation cannot drift between the two order paths.
+"""
+
+from typing import Final, LiteralString
+
+HALT_IDENTITY_RULE_VERSION: Final = "nasdaq-etoro-halt-identity-v1"
+
+INSTRUMENT_HALT_SYMBOL_SQL: Final[LiteralString] = """
+CASE
+    WHEN right(upper(i.symbol), 5) = '.24-7' THEN left(upper(i.symbol), -5)
+    WHEN right(upper(i.symbol), 4) = '.RTH' THEN left(upper(i.symbol), -4)
+    WHEN right(upper(i.symbol), 3) = '.US' THEN left(upper(i.symbol), -3)
+    WHEN right(upper(i.symbol), 3) = '.CH' THEN left(upper(i.symbol), -3)
+    ELSE upper(i.symbol)
+END
+"""

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -226,7 +226,12 @@ def _load_intent(
     ranking_member_id: int | None,
     now: datetime,
 ) -> tuple[_Intent | None, str | None, bool]:
-    """Load DB gates as one observation; return reason and halt-rule provenance."""
+    """Load one DB observation; the bool says its halt SQL expression ran.
+
+    A fetched row carries ``True`` even when an earlier Python gate rejects it:
+    ``is_halted`` was still selected by the same SQL statement. No row means the
+    halt identity rule was not observed and its audit version must remain NULL.
+    """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             f"""

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -49,6 +49,10 @@ from app.services.strategy_control_plane import (
     registered_strategy_purpose,
 )
 from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
+from app.services.strategy_halt_identity import (
+    HALT_IDENTITY_RULE_VERSION,
+    INSTRUMENT_HALT_SYMBOL_SQL,
+)
 from app.services.strategy_monitoring import load_paper_realised_pnl
 from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
 from app.services.strategy_opportunity_ranker import RANKING_POLICY_VERSION
@@ -221,11 +225,11 @@ def _load_intent(
     signal_id: int,
     ranking_member_id: int | None,
     now: datetime,
-) -> tuple[_Intent | None, str | None]:
-    """Load DB gates as one observation; return a closed reason on absence."""
+) -> tuple[_Intent | None, str | None, bool]:
+    """Load DB gates as one observation; return reason and halt-rule provenance."""
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            """
+            f"""
             SELECT s.signal_id, s.strategy_id, s.strategy_version, s.instrument_id,
                    i.symbol, i.is_tradable, e.asset_class,
                    d.deployment_id, d.capital_limit, d.enabled, d.currency,
@@ -245,7 +249,7 @@ def _load_intent(
                    EXISTS (
                        SELECT 1 FROM strategy_market_halts mh
                        WHERE mh.source = 'nasdaq_trader_rss'
-                         AND mh.symbol = upper(i.symbol) AND mh.resumed_at IS NULL
+                         AND mh.symbol = {INSTRUMENT_HALT_SYMBOL_SQL} AND mh.resumed_at IS NULL
                    ) AS is_halted,
                    EXISTS (
                        SELECT 1 FROM strategy_execution_blocks b WHERE b.active
@@ -387,7 +391,7 @@ def _load_intent(
         )
         row = cur.fetchone()
     if row is None:
-        return None, "signal_not_fired_entry"
+        return None, "signal_not_fired_entry", False
     checks = (
         (bool(row["is_tradable"]), "instrument_not_tradable"),
         (row["asset_class"] == "us_equity", "unsupported_market_session"),
@@ -465,79 +469,83 @@ def _load_intent(
     )
     for passed, reason in checks:
         if not passed:
-            return None, reason
+            return None, reason, True
     quote_at = cast(datetime, row["quoted_at"])
     scan_at = cast(datetime, row["scan_at"])
     halt_feed_at = cast(datetime, row["halt_feed_at"])
     if not _age_ok(quote_at, now=now, max_seconds=int(row["max_quote_age_seconds"])):
-        return None, "quote_stale"
+        return None, "quote_stale", True
     if not _age_ok(scan_at, now=now, max_seconds=int(row["max_scan_age_seconds"])):
-        return None, "scan_stale"
+        return None, "scan_stale", True
     if not _age_ok(halt_feed_at, now=now, max_seconds=int(row["max_halt_feed_age_seconds"])):
-        return None, "halt_feed_stale"
+        return None, "halt_feed_stale", True
     forecast_decided_at = cast(datetime, row["forecast_decided_at"])
     forecast_valid_through = cast(datetime, row["forecast_valid_through"])
     if forecast_decided_at > now or forecast_valid_through < now:
-        return None, "opportunity_forecast_not_current"
+        return None, "opportunity_forecast_not_current", True
     if (
         row["calibration_holdout_end"] is None
         or cast(date, row["calibration_holdout_end"]) >= forecast_decided_at.date()
     ):
-        return None, "opportunity_calibration_knowledge_time_invalid"
+        return None, "opportunity_calibration_knowledge_time_invalid", True
     if row["prospective_assessment_checked_at"] is None or not _age_ok(
         cast(datetime, row["prospective_assessment_checked_at"]),
         now=now,
         max_seconds=int(row["max_assessment_age_days"]) * 86_400,
     ):
-        return None, "opportunity_assessment_stale"
+        return None, "opportunity_assessment_stale", True
     if not _session_is_open(now):
-        return None, "market_session_closed"
-    return _Intent(
-        signal_id=signal_id,
-        strategy_id=str(row["strategy_id"]),
-        strategy_version=str(row["strategy_version"]),
-        instrument_id=int(row["instrument_id"]),
-        symbol=str(row["symbol"]),
-        deployment_id=int(row["deployment_id"]),
-        currency=str(row["currency"]),
-        deployment_limit=Decimal(str(row["capital_limit"])),
-        pool_limit=Decimal(str(row["pool_limit"])),
-        capital_mode=cast(Literal["fixed", "compound"], row["capital_mode"]),
-        pool_reserved=Decimal(str(row["pool_reserved"])),
-        mandate_max_drawdown_pct=Decimal(str(row["mandate_max_drawdown_pct"])),
-        mandate_max_loss_per_position_pct=Decimal(str(row["mandate_max_loss_per_position_pct"])),
-        mandate_max_daily_loss_pct=Decimal(str(row["mandate_max_daily_loss_pct"])),
-        mandate_active_risk_budget_pct=Decimal(str(row["mandate_active_risk_budget_pct"])),
-        mandate_cash_reserve_pct=Decimal(str(row["mandate_cash_reserve_pct"])),
-        mandate_max_concurrent_positions=int(row["mandate_max_concurrent_positions"]),
-        forecast_id=int(row["forecast_id"]),
-        ranking_member_id=int(row["ranking_member_id"]),
-        policy_revision=int(row["policy_revision"]),
-        ticket_sizing_mode=cast(Literal["percent", "fixed"], row["ticket_sizing_mode"]),
-        ticket_fraction=Decimal(str(row["ticket_fraction"])) if row["ticket_fraction"] is not None else None,
-        fixed_ticket_amount=(
-            Decimal(str(row["fixed_ticket_amount"])) if row["fixed_ticket_amount"] is not None else None
+        return None, "market_session_closed", True
+    return (
+        _Intent(
+            signal_id=signal_id,
+            strategy_id=str(row["strategy_id"]),
+            strategy_version=str(row["strategy_version"]),
+            instrument_id=int(row["instrument_id"]),
+            symbol=str(row["symbol"]),
+            deployment_id=int(row["deployment_id"]),
+            currency=str(row["currency"]),
+            deployment_limit=Decimal(str(row["capital_limit"])),
+            pool_limit=Decimal(str(row["pool_limit"])),
+            capital_mode=cast(Literal["fixed", "compound"], row["capital_mode"]),
+            pool_reserved=Decimal(str(row["pool_reserved"])),
+            mandate_max_drawdown_pct=Decimal(str(row["mandate_max_drawdown_pct"])),
+            mandate_max_loss_per_position_pct=Decimal(str(row["mandate_max_loss_per_position_pct"])),
+            mandate_max_daily_loss_pct=Decimal(str(row["mandate_max_daily_loss_pct"])),
+            mandate_active_risk_budget_pct=Decimal(str(row["mandate_active_risk_budget_pct"])),
+            mandate_cash_reserve_pct=Decimal(str(row["mandate_cash_reserve_pct"])),
+            mandate_max_concurrent_positions=int(row["mandate_max_concurrent_positions"]),
+            forecast_id=int(row["forecast_id"]),
+            ranking_member_id=int(row["ranking_member_id"]),
+            policy_revision=int(row["policy_revision"]),
+            ticket_sizing_mode=cast(Literal["percent", "fixed"], row["ticket_sizing_mode"]),
+            ticket_fraction=Decimal(str(row["ticket_fraction"])) if row["ticket_fraction"] is not None else None,
+            fixed_ticket_amount=(
+                Decimal(str(row["fixed_ticket_amount"])) if row["fixed_ticket_amount"] is not None else None
+            ),
+            max_ticket_amount=Decimal(str(row["max_ticket_amount"])),
+            stop_loss_pct=Decimal(str(row["forecast_stop_barrier_pct"])),
+            take_profit_pct=Decimal(str(row["forecast_target_barrier_pct"])),
+            max_quote_age_seconds=int(row["max_quote_age_seconds"]),
+            max_scan_age_seconds=int(row["max_scan_age_seconds"]),
+            max_halt_feed_age_seconds=int(row["max_halt_feed_age_seconds"]),
+            max_cost_age_seconds=int(row["max_cost_age_seconds"]),
+            max_reconciliation_age_seconds=int(row["max_reconciliation_age_seconds"]),
+            max_instrument_exposure_pct=Decimal(str(row["max_instrument_exposure_pct"])),
+            max_portfolio_exposure_pct=Decimal(str(row["max_portfolio_exposure_pct"])),
+            max_drawdown_pct=Decimal(str(row["max_drawdown_pct"])),
+            min_net_expectancy_pct=Decimal(str(row["min_net_expectancy_pct"])),
+            cost_stress_multiplier=Decimal(str(row["cost_stress_multiplier"])),
+            quote_at=quote_at,
+            ask=Decimal(str(row["ask"])),
+            scan_at=scan_at,
+            halt_feed_at=halt_feed_at,
+            gross_expectancy_ci_low_pct=Decimal(str(row["expectancy_ci_low_pct"])),
+            reserved=Decimal(str(row["reserved"])),
         ),
-        max_ticket_amount=Decimal(str(row["max_ticket_amount"])),
-        stop_loss_pct=Decimal(str(row["forecast_stop_barrier_pct"])),
-        take_profit_pct=Decimal(str(row["forecast_target_barrier_pct"])),
-        max_quote_age_seconds=int(row["max_quote_age_seconds"]),
-        max_scan_age_seconds=int(row["max_scan_age_seconds"]),
-        max_halt_feed_age_seconds=int(row["max_halt_feed_age_seconds"]),
-        max_cost_age_seconds=int(row["max_cost_age_seconds"]),
-        max_reconciliation_age_seconds=int(row["max_reconciliation_age_seconds"]),
-        max_instrument_exposure_pct=Decimal(str(row["max_instrument_exposure_pct"])),
-        max_portfolio_exposure_pct=Decimal(str(row["max_portfolio_exposure_pct"])),
-        max_drawdown_pct=Decimal(str(row["max_drawdown_pct"])),
-        min_net_expectancy_pct=Decimal(str(row["min_net_expectancy_pct"])),
-        cost_stress_multiplier=Decimal(str(row["cost_stress_multiplier"])),
-        quote_at=quote_at,
-        ask=Decimal(str(row["ask"])),
-        scan_at=scan_at,
-        halt_feed_at=halt_feed_at,
-        gross_expectancy_ci_low_pct=Decimal(str(row["expectancy_ci_low_pct"])),
-        reserved=Decimal(str(row["reserved"])),
-    ), None
+        None,
+        True,
+    )
 
 
 def _persist_rejection(
@@ -548,6 +556,7 @@ def _persist_rejection(
     now: datetime,
     intent: _Intent | None = None,
     risk: BrokerAccountRiskSnapshot | None = None,
+    halt_identity_evaluated: bool = False,
 ) -> PaperExecutionResult:
     existing = _existing_result(conn, signal_id)
     conn.commit()
@@ -560,10 +569,10 @@ def _persist_rejection(
             INSERT INTO strategy_entry_preflights (
                 signal_id, deployment_id, policy_revision, forecast_id, ranking_member_id,
                 verdict, reason_code,
-                evaluated_at, quote_at, scan_at, halt_feed_at,
+                evaluated_at, quote_at, scan_at, halt_feed_at, halt_identity_rule_version,
                 broker_available_cash, account_equity, account_invested,
                 instrument_invested, gross_expectancy_ci_low_pct
-            ) VALUES (%s, %s, %s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 signal_id,
@@ -576,6 +585,7 @@ def _persist_rejection(
                 intent.quote_at if intent else None,
                 intent.scan_at if intent else None,
                 intent.halt_feed_at if intent else None,
+                HALT_IDENTITY_RULE_VERSION if intent is not None or halt_identity_evaluated else None,
                 risk.available_cash if risk else None,
                 risk.equity if risk else None,
                 risk.total_invested if risk else None,
@@ -1106,7 +1116,7 @@ def _execute_fired_paper_signal_locked(
         if health.active_block:
             return _persist_rejection(conn, signal_id=signal_id, reason_code="reconciliation_overdue", now=evaluated_at)
 
-    intent, reason = _load_intent(
+    intent, reason, halt_identity_evaluated = _load_intent(
         conn,
         signal_id=signal_id,
         ranking_member_id=ranking_member_id,
@@ -1119,6 +1129,7 @@ def _execute_fired_paper_signal_locked(
             signal_id=signal_id,
             reason_code=reason or "preflight_unavailable",
             now=evaluated_at,
+            halt_identity_evaluated=halt_identity_evaluated,
         )
 
     try:
@@ -1211,7 +1222,7 @@ def _execute_fired_paper_signal_locked(
             INSERT INTO strategy_entry_preflights (
                 signal_id, deployment_id, policy_revision, forecast_id, ranking_member_id,
                 verdict, reason_code,
-                evaluated_at, quote_at, scan_at, halt_feed_at,
+                evaluated_at, quote_at, scan_at, halt_feed_at, halt_identity_rule_version,
                 eligibility_checked_at, costs_at, broker_available_cash,
                 account_equity, account_invested, instrument_invested,
                 account_drawdown_pct, allocated_amount,
@@ -1219,7 +1230,7 @@ def _execute_fired_paper_signal_locked(
                 net_expectancy_pct, stop_loss_rate, take_profit_rate
             ) VALUES (
                 %s, %s, %s, %s, %s, 'allocated', 'all_paper_entry_gates_passed',
-                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
             )
             """,
             (
@@ -1232,6 +1243,7 @@ def _execute_fired_paper_signal_locked(
                 intent.quote_at,
                 intent.scan_at,
                 intent.halt_feed_at,
+                HALT_IDENTITY_RULE_VERSION,
                 evaluated_at,
                 costs.last_updated,
                 risk.available_cash,

--- a/sql/358_strategy_halt_identity_provenance.sql
+++ b/sql/358_strategy_halt_identity_provenance.sql
@@ -1,0 +1,15 @@
+-- #2709 — stamp the exact symbol-identity rule used by each strategy entry
+-- preflight. Existing rows remain NULL: they were evaluated with the old exact
+-- `upper(instruments.symbol)` comparison and must not be rewritten to claim the
+-- suffix-aware rule ran historically.
+
+BEGIN;
+
+ALTER TABLE strategy_entry_preflights
+    ADD COLUMN IF NOT EXISTS halt_identity_rule_version TEXT;
+
+COMMENT ON COLUMN strategy_entry_preflights.halt_identity_rule_version IS
+    'Version of the Nasdaq/eToro symbol identity rule actually evaluated. NULL on '
+    'pre-#2709 rows and early refusals that did not reach the halt observation.';
+
+COMMIT;

--- a/tests/test_2603_core_preflight_db.py
+++ b/tests/test_2603_core_preflight_db.py
@@ -128,6 +128,31 @@ def test_the_observation_binds_the_quote_and_exchange_to_the_instrument(
     ebull_test_conn.rollback()
 
 
+def test_core_preflight_matches_a_plain_halt_to_a_session_variant(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """Nasdaq's CORETEST halt applies to eToro's CORETEST.24-7 row."""
+    _seed_instrument(ebull_test_conn)
+    ebull_test_conn.execute(
+        "UPDATE instruments SET symbol='CORETEST.24-7' WHERE instrument_id=%s",
+        (INSTRUMENT_ID,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_market_halts (
+            source, symbol, halt_at, market, reason_code, resumed_at, observed_at
+        ) VALUES ('nasdaq_trader_rss', 'CORETEST', now(), 'NASDAQ', 'T1', NULL, now())
+        """
+    )
+
+    row = ebull_test_conn.execute(_PREFLIGHT_SQL, {"core_instrument_id": INSTRUMENT_ID}).fetchone()
+
+    assert row is not None
+    assert row[1] == "CORETEST.24-7"
+    assert row[6] is True
+    ebull_test_conn.rollback()
+
+
 # --------------------------------------------------------------------------
 # The lock contract
 # --------------------------------------------------------------------------

--- a/tests/test_strategy_halts.py
+++ b/tests/test_strategy_halts.py
@@ -9,6 +9,7 @@ from typing import Any
 import psycopg
 import pytest
 
+from app.services.strategy_halt_identity import INSTRUMENT_HALT_SYMBOL_SQL
 from app.services.strategy_halts import HaltFeedError, parse_halt_rss, store_halt_snapshot
 
 _XML = b"""<?xml version="1.0" encoding="utf-8"?>
@@ -134,3 +135,30 @@ def test_store_upserts_current_state_and_removes_old_rows(
     assert conn.execute(
         "SELECT symbol FROM strategy_market_halts WHERE resumed_at IS NULL ORDER BY symbol"
     ).fetchall() == [("HALT",), ("STILL",)]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("instrument_symbol", "expected_feed_symbol"),
+    [
+        ("AAPL.RTH", "AAPL"),
+        ("AAPL.24-7", "AAPL"),
+        ("ABT.US", "ABT"),
+        ("TCOM.CH", "TCOM"),
+        ("brk.b", "BRK.B"),
+        ("BF.A", "BF.A"),
+        ("ACLX.CVR", "ACLX.CVR"),
+        ("BBBY.WS", "BBBY.WS"),
+        ("ATH.old", "ATH.OLD"),
+    ],
+)
+def test_halt_identity_strips_only_measured_etoro_venue_suffixes(
+    ebull_test_conn: psycopg.Connection[Any],
+    instrument_symbol: str,
+    expected_feed_symbol: str,
+) -> None:
+    row = ebull_test_conn.execute(
+        f"SELECT {INSTRUMENT_HALT_SYMBOL_SQL} FROM (VALUES (%s::text)) AS i(symbol)",
+        (instrument_symbol,),
+    ).fetchone()
+    assert row == (expected_feed_symbol,)

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -40,6 +40,7 @@ from app.services.strategy_control_plane import (
     link_strategy_order,
 )
 from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
+from app.services.strategy_halt_identity import HALT_IDENTITY_RULE_VERSION
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_opportunity_forecast import (
     FORECAST_POLICY_VERSION,
@@ -497,6 +498,10 @@ def test_harness_signal_is_rejected_before_runtime_or_broker_checks(
 
     assert result.verdict == "rejected"
     assert result.reason_code == "harness_validation_only"
+    assert ebull_test_conn.execute(
+        "SELECT halt_identity_rule_version FROM strategy_entry_preflights WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == (None,)
     broker.place_demo_strategy_order.assert_not_called()
 
 
@@ -515,6 +520,33 @@ def test_unregistered_signal_is_rejected_before_runtime_or_broker_checks(
 
     assert result.verdict == "rejected"
     assert result.reason_code == "strategy_not_capital_candidate"
+    broker.place_demo_strategy_order.assert_not_called()
+
+
+def test_plain_nasdaq_halt_refuses_an_etoro_session_variant(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    ebull_test_conn.execute("UPDATE instruments SET symbol='TALLOC.RTH' WHERE instrument_id=2449001")
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_market_halts (
+            source, symbol, halt_at, market, reason_code, resumed_at, observed_at
+        ) VALUES ('nasdaq_trader_rss', 'TALLOC', %s, 'NASDAQ', 'T1', NULL, %s)
+        """,
+        (_NOW, _NOW),
+    )
+    ebull_test_conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "instrument_halted"
+    assert ebull_test_conn.execute(
+        "SELECT halt_identity_rule_version FROM strategy_entry_preflights WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == (HALT_IDENTITY_RULE_VERSION,)
     broker.place_demo_strategy_order.assert_not_called()
 
 
@@ -635,7 +667,8 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
     # insert outright — and a basis that named a path other than the one `_costs`
     # took would pass the CHECK while lying about provenance (#2598 step 4).
     assert conn.execute(
-        "SELECT verdict, allocated_amount, net_expectancy_pct, forecast_id, ranking_member_id, cost_basis "
+        "SELECT verdict, allocated_amount, net_expectancy_pct, forecast_id, ranking_member_id, cost_basis, "
+        "halt_identity_rule_version "
         "FROM strategy_entry_preflights WHERE signal_id=%s",
         (signal_id,),
     ).fetchone() == (
@@ -645,6 +678,7 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
         forecast_id[0],
         forecast_id[1],
         COST_BASIS_BROKER_PREFLIGHT_VALUE,
+        HALT_IDENTITY_RULE_VERSION,
     )
     conn.commit()
 
@@ -670,9 +704,9 @@ def test_missing_opportunity_forecast_refuses_before_broker_access(
     broker.get_account_risk_snapshot.assert_not_called()
     broker.place_demo_strategy_order.assert_not_called()
     assert conn.execute(
-        "SELECT forecast_id FROM strategy_entry_preflights WHERE signal_id=%s",
+        "SELECT forecast_id, halt_identity_rule_version FROM strategy_entry_preflights WHERE signal_id=%s",
         (signal_id,),
-    ).fetchone() == (None,)
+    ).fetchone() == (None, HALT_IDENTITY_RULE_VERSION)
 
 
 def test_unbatched_opportunity_refuses_before_broker_access(


### PR DESCRIPTION
## Outcome

Closes #2709.

Both strategy submission paths now compare Nasdaq halt rows through one versioned identity rule. The rule strips only the measured eToro venue/session suffixes .RTH, .24-7, .US, and .CH. It preserves class shares and distinct dotted securities such as BRK.B, BF.A, .CVR, and .WS.

Nasdaq defines the feed field as the issue symbol and requires halt lookup symbols to match its Symbol Directory:
- https://classic.nasdaqtrader.com/Trader.aspx?id=tradehaltcodes
- https://classic.nasdaqtrader.com/Trader.aspx?id=TradingHaltSearch

The .CH mapping is independently bound by eToro TCOM.CH and Nasdaq TCOM:
- https://www.etoro.com/markets/tcom.ch
- https://www.nasdaq.com/market-activity/stocks/tcom

## Auditability

- Bumps the core preflight policy identity to v2.
- Adds nullable halt_identity_rule_version provenance to paper entry preflights.
- Leaves historical rows and refusals before the halt observation NULL.
- Stamps observed rejections and allocations with nasdaq-etoro-halt-identity-v1.

## Verification

- Focused halt/core/paper integration suite: 109 passed.
- Full fast tier: green.
- Repository pre-push hook: green, including 155 serial smoke checks against dev DB.
- Full DB tier under xdist surfaced six unrelated shared-state failures; all six passed together with -n 0. The repository documents this tier as xdist-flaky.
- Adversarial cases cover .RTH, .24-7, .US, .CH, BRK.B, BF.A, .CVR, .WS, and .OLD.

## Operational note

During broad DB verification, the dev-DB smoke test was unintentionally included and applied migration 358 earlier than planned while frozen in-sample run 98349 was active. The migration is an additive nullable column only. The old worker remained alive and its frozen audit remained running afterward. The official serial smoke gate was then rerun by the pre-push hook and passed.