### PR TITLE
feat(strategies): preregister capped volatility overlay

### DIFF
--- a/app/services/strategy_volatility_overlay.py
+++ b/app/services/strategy_volatility_overlay.py
@@ -1,0 +1,235 @@
+"""Causal portfolio-level inverse-variance exposure for MT-1 (#2437).
+
+Contract: ``docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-
+preregistration.md``.  This module is deliberately pure and sees only completed
+monthly returns.  It does not know a strategy, instrument, signal, price row or
+outcome namespace, so it cannot silently turn the portfolio overlay into
+per-name inverse-volatility weighting.
+
+Published core: Cederburg et al. (2020), equations (3), (4), and their real-time
+normalisation: prior-month realised variance, a 120-month initial training
+period, then expanding history.  eBull's leverage ban adds the by-construction
+``[0, 1]`` cap.  Missing or degenerate history refuses; there is no 100% fallback.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, localcontext
+from pathlib import Path
+from typing import Final
+
+RULE_SET_ID: Final = "capped-portfolio-inverse-variance-v1"
+MIN_TRAINING_MONTHS: Final = 120
+TRADING_DAYS_PER_MONTH: Final = Decimal("22")
+MIN_EXPOSURE: Final = Decimal("0")
+MAX_EXPOSURE: Final = Decimal("1")
+DECIMAL_PRECISION: Final = 50
+
+
+def _code_hash() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+RULE_SET_VERSION: Final = f"{RULE_SET_ID}+{_code_hash()}"
+
+
+class VolatilityOverlayUnavailable(ValueError):
+    """The frozen overlay cannot produce an exposure from the supplied history."""
+
+
+@dataclass(frozen=True)
+class DailyPortfolioReturn:
+    """One dated after-cost decimal return on the frozen panel calendar."""
+
+    session: date
+    value: Decimal
+
+
+@dataclass(frozen=True)
+class CompletedPortfolioMonth:
+    """One complete calendar month and the exact sessions it must cover."""
+
+    month: date
+    daily_returns: tuple[DailyPortfolioReturn, ...]
+    expected_sessions: tuple[date, ...]
+
+
+@dataclass(frozen=True)
+class VolatilityExposure:
+    """One month-ahead exposure and the causal inputs that produced it."""
+
+    exposure: Decimal
+    raw_exposure: Decimal
+    normalization: Decimal
+    prior_month_variance: Decimal
+    training_months: int
+    rule_set_version: str = RULE_SET_VERSION
+
+
+def _next_month(month: date) -> date:
+    return date(month.year + (month.month == 12), 1 if month.month == 12 else month.month + 1, 1)
+
+
+def _validated_returns(record: CompletedPortfolioMonth) -> tuple[Decimal, ...]:
+    if record.month.day != 1:
+        raise VolatilityOverlayUnavailable("completed month keys must be the first calendar day")
+    if not record.expected_sessions:
+        raise VolatilityOverlayUnavailable(f"{record.month.isoformat()} expected session calendar is empty")
+    if tuple(sorted(set(record.expected_sessions))) != record.expected_sessions:
+        raise VolatilityOverlayUnavailable(f"{record.month.isoformat()} expected sessions must be sorted and unique")
+    if any(
+        (session.year, session.month) != (record.month.year, record.month.month) for session in record.expected_sessions
+    ):
+        raise VolatilityOverlayUnavailable(f"{record.month.isoformat()} expected sessions cross a month boundary")
+    actual_sessions = tuple(point.session for point in record.daily_returns)
+    if actual_sessions != record.expected_sessions:
+        raise VolatilityOverlayUnavailable(
+            f"{record.month.isoformat()} daily return dates do not match the expected session calendar"
+        )
+    values = tuple(point.value for point in record.daily_returns)
+    for value in values:
+        if not value.is_finite() or value < Decimal("-1"):
+            raise VolatilityOverlayUnavailable(
+                f"{record.month.isoformat()} contains a non-finite or below-minus-one daily return"
+            )
+    return values
+
+
+def compounded_month_return(record: CompletedPortfolioMonth) -> Decimal:
+    """Compound one complete month; inputs and output are decimal returns."""
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        wealth = Decimal("1")
+        for value in _validated_returns(record):
+            wealth *= Decimal("1") + value
+        result = wealth - Decimal("1")
+    if not result.is_finite():
+        raise VolatilityOverlayUnavailable(f"{record.month.isoformat()} compounded return is non-finite")
+    return result
+
+
+def realised_month_variance(record: CompletedPortfolioMonth) -> Decimal:
+    """Cederburg et al. equation (4): ``(22 / J) * sum(daily_return**2)``."""
+    returns = _validated_returns(record)
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        variance = (
+            TRADING_DAYS_PER_MONTH / Decimal(len(returns)) * sum((value * value for value in returns), Decimal("0"))
+        )
+    if not variance.is_finite():
+        raise VolatilityOverlayUnavailable(f"{record.month.isoformat()} realised variance is non-finite")
+    return variance
+
+
+def _sample_stddev(values: list[Decimal], *, label: str) -> Decimal:
+    if len(values) < 2:
+        raise VolatilityOverlayUnavailable(f"{label} needs at least two observations")
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        mean = sum(values, Decimal("0")) / Decimal(len(values))
+        variance = sum(((value - mean) ** 2 for value in values), Decimal("0")) / Decimal(len(values) - 1)
+        result = variance.sqrt()
+    if not variance.is_finite() or variance <= 0:
+        raise VolatilityOverlayUnavailable(f"{label} sample variance is not positive")
+    if not result.is_finite() or result <= 0:  # pragma: no cover - guarded by variance
+        raise VolatilityOverlayUnavailable(f"{label} sample standard deviation is not positive")
+    return result
+
+
+def capped_inverse_variance_exposure(
+    completed_history: tuple[CompletedPortfolioMonth, ...],
+    *,
+    expected_first_month: date,
+) -> VolatilityExposure:
+    """Return the next month's causal portfolio exposure.
+
+    ``completed_history[-1]`` is the month immediately before the decision.
+    Each training observation ``m`` pairs that month's return with positive
+    variance from ``m-1``. Calendar months remain consecutive, including
+    zero-variance cash months, while an unusable pair is omitted from the
+    expanding normalisation. Consequently at least 120 usable observations and
+    121 completed months are required. ``expected_first_month`` is the
+    evaluator's frozen first eligible complete reference month; binding the
+    first row to it makes a rolling/truncated history fail instead of merely
+    documenting that it should.
+    """
+    if expected_first_month.day != 1:
+        raise VolatilityOverlayUnavailable("expected first month must be the first calendar day")
+    required_history = MIN_TRAINING_MONTHS + 1
+    if len(completed_history) < required_history:
+        raise VolatilityOverlayUnavailable(
+            f"inverse-variance exposure needs {required_history} completed months "
+            f"for {MIN_TRAINING_MONTHS} training observations"
+        )
+    if completed_history[0].month != expected_first_month:
+        raise VolatilityOverlayUnavailable("completed history does not start at the frozen first eligible month")
+
+    previous: date | None = None
+    monthly_returns: list[Decimal] = []
+    monthly_variances: list[Decimal] = []
+    for record in completed_history:
+        if previous is not None and record.month != _next_month(previous):
+            raise VolatilityOverlayUnavailable("completed portfolio months must be unique and consecutive")
+        previous = record.month
+        monthly_returns.append(compounded_month_return(record))
+        monthly_variances.append(realised_month_variance(record))
+
+    prior_variance = monthly_variances[-1]
+    if prior_variance <= 0:
+        raise VolatilityOverlayUnavailable("the prior complete month's realised variance is not positive")
+
+    # f[m] and f[m] / v[m-1] over identical usable months. A zero-variance cash
+    # month stays in the calendar but cannot serve as the next pair's divisor.
+    # The last completed month's return can participate in c[t], while its own
+    # positive variance controls month t exposure.
+    with localcontext() as context:
+        context.prec = DECIMAL_PRECISION
+        training_pairs = [
+            (monthly_returns[index], monthly_variances[index - 1])
+            for index in range(1, len(monthly_returns))
+            if monthly_variances[index - 1] > 0
+        ]
+        if len(training_pairs) < MIN_TRAINING_MONTHS:
+            raise VolatilityOverlayUnavailable(
+                f"inverse-variance normalization needs {MIN_TRAINING_MONTHS} usable training months; "
+                f"received {len(training_pairs)}"
+            )
+        training_returns = [monthly_return for monthly_return, _ in training_pairs]
+        raw_scaled_returns = [
+            monthly_return / previous_variance for monthly_return, previous_variance in training_pairs
+        ]
+        normalization = _sample_stddev(training_returns, label="unscaled training returns") / _sample_stddev(
+            raw_scaled_returns, label="raw inverse-variance training returns"
+        )
+        raw_exposure = normalization / prior_variance
+    if not normalization.is_finite() or normalization <= 0 or not raw_exposure.is_finite():
+        raise VolatilityOverlayUnavailable("inverse-variance normalization or exposure is not positive and finite")
+    exposure = min(MAX_EXPOSURE, max(MIN_EXPOSURE, raw_exposure))
+    return VolatilityExposure(
+        exposure=exposure,
+        raw_exposure=raw_exposure,
+        normalization=normalization,
+        prior_month_variance=prior_variance,
+        training_months=len(training_returns),
+    )
+
+
+__all__ = [
+    "MAX_EXPOSURE",
+    "DECIMAL_PRECISION",
+    "MIN_EXPOSURE",
+    "MIN_TRAINING_MONTHS",
+    "RULE_SET_ID",
+    "RULE_SET_VERSION",
+    "TRADING_DAYS_PER_MONTH",
+    "CompletedPortfolioMonth",
+    "DailyPortfolioReturn",
+    "VolatilityExposure",
+    "VolatilityOverlayUnavailable",
+    "capped_inverse_variance_exposure",
+    "compounded_month_return",
+    "realised_month_variance",
+]

--- a/docs/proposals/ta/2026-08-15-market-technician-derived-candidates.md
+++ b/docs/proposals/ta/2026-08-15-market-technician-derived-candidates.md
@@ -19,25 +19,60 @@ preregistration under the #2599/#2600 gate — they are not implied defaults her
 candidate picked up without writing that prereg first has skipped the fence this document
 exists behind.
 
-## C-1 Volatility-managed overlay on S-10 (evidence-backed sizing, not a new signal)
+## MT-1 Capped volatility-managed long-only relative strength (testable variant, not established alpha)
 
-- **Mechanism/evidence:** Moreira & Muir (*JF* 2017) scale exposure by `c / σ̂²_{t−1}`
-  (previous month's realized variance); Cederburg et al. (*JFE* 2020, 103 strategies) —
-  the replication that killed vol-scaling on most factors — finds it survives on
-  **momentum, profitability and BAB** (`strategy-evidence` §2.4, the authority). S-10 is
-  cross-sectional momentum — inside the surviving set.
+- **Identity correction:** `MT-1` is unique to this market-technician queue. The earlier
+  `C-1` label collided with the separate portfolio-alpha ledger's `C-1` insider-purchase
+  candidate. A trial, declaration, result or UI row must use
+  `mt1-capped-volatility-managed-relative-strength`; it must never reuse S-10's identity,
+  purpose or evidence. S-10 remains a permanent `harness_validation` control.
+- **Mechanism/evidence, with the transfer limit stated:** Moreira & Muir (*JF* 2017)
+  scale exposure by `c / σ̂²_{t−1}` (previous month's realised variance).
+  Cederburg et al. (*JFE* 2020, 103 strategies) find that direct volatility scaling
+  improves all nine momentum portfolios they test, significantly for five. Those tests
+  use zero-cost **long-short factor/anomaly portfolios**. S-10 is a **long-only** ranked
+  leader strategy, so the papers supply a mechanism and prior, not evidence that this
+  implementation is in their surviving set.
 - **Form:** two published constructions exist and are NOT interchangeable — Moreira-Muir
   scale by inverse *variance* (`c/σ̂²_{t−1}`, prior month's realized daily variance);
   Harvey et al. (*JPM* 2018) target *vol* (`target_σ/σ̂`, and find it pays only on
-  equities/credit). Declare ONE ex ante, capped; EWMA λ = 0.94 (RiskMetrics) if a
-  smoother forecast is used.
-- **Turnover check:** overlay adjusts sizes at S-10's existing monthly rebalance only —
-  no new turnover events; passes by construction.
-- **Falsification:** controlled pair vs unscaled S-10 (S-4/S-9 template: identical signal
-  leg, one change); per-regime blocks. Negative control DECLARED NOW, not chosen later:
-  **S-8** (mean reversion — the family Cederburg's replication says vol-scaling does NOT
-  help) runs the same overlay; the prediction is scaled-S-10 improves and scaled-S-8 does
-  not. Both arms enter the trial register together.
+  equities/credit). MT-1 may declare only the Moreira-Muir inverse-variance form. Its
+  preregistration must use Cederburg et al.'s causal real-time normalisation: a 120-month
+  initial training window, expanding thereafter, with `c_t` chosen from completed training
+  months so the unscaled reference and raw inverse-variance reference have equal realised
+  variance. No full-sample normalisation is permitted. The published construction can
+  require substantial leverage: Cederburg et al. report a
+  99th-percentile required position above 400% for each factor and as high as 864% for
+  momentum. eBull forbids leverage, so MT-1 must cap exposure in `[0, 1]` and leave the
+  remainder in zero-return cash. That cap and its fixed normalisation make MT-1 a new
+  by-construction variant; they may not be described as the published rule.
+- **Clock and causality:** compute the previous complete calendar month's realised daily
+  variance of the **unscaled reference portfolio** as `(22/J) × Σ daily_return²`, using
+  only returns known before the current month-end decision. Apply one portfolio-level
+  multiplier to every selected holding. Do not substitute per-name inverse volatility:
+  that changes the cross-sectional signal as well as its aggregate exposure. Fewer than
+  120 usable historical month/lagged-variance pairs, a missing session in the complete
+  calendar history, or non-positive prior-month variance refuses the decision rather than
+  defaulting to 100% exposure. All-cash months remain in the expanding history but cannot
+  serve as a positive lagged-variance divisor.
+- **Turnover check:** the overlay may change target exposure only on S-10's existing
+  month-end decision dates. This creates no extra decision dates, but it can create extra
+  traded notional; therefore turnover does **not** pass by construction and must be
+  measured before any outcome statistic is opened.
+- **Falsification:** run a fresh controlled pair under the new identity: capped-scaled MT-1
+  versus an unscaled reference with the exact same signal, universe, fills, exits, costs,
+  ambiguity/quarantine arms and month-end portfolio clock. No stored S-10 result is a
+  comparator. The negative-control family remains **S-8**, but "the same overlay" means an
+  aggregate S-8 reference book whose exposure is updated on the identical month-end clock;
+  applying a per-trade or signal-date multiplier is a different experiment and refuses the
+  control. The preregistration must freeze the normalisation, minimum prior-month history,
+  zero-variance handling, paired inference and difference-in-differences gate before either
+  outcome is opened. Both evaluated pairs enter the trial register; an unexecuted design
+  does not.
+- **Capital boundary:** MT-1 may be declared `capital_candidate` only after its separate
+  strategy version, survivorship-free universe, carry/FX stamps, forward-shadow floor and
+  complete cost-aware preregistration exist. Until then this entry is a pre-spec and gives
+  no manifest, promotion, forecast, allocator or broker authority.
 
 ## C-2 Spread-ranked admission gate (universe filter attacking the measured cost failure)
 

--- a/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
+++ b/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
@@ -1,0 +1,209 @@
+# MT-1 capped volatility-managed long-only relative strength — preregistration
+
+Date: 2026-08-15  
+Status: design frozen in source before implementation or outcome access; not yet entered in
+`trial_register.py`, not yet frozen in `strategy_preregistration_declarations`, and therefore
+not authorised to open outcomes  
+Parent: #2437  
+Candidate ledger: `2026-08-15-market-technician-derived-candidates.md`
+
+## Purpose and honest name
+
+`mt1-capped-volatility-managed-relative-strength` is a new, separately versioned
+`capital_candidate` hypothesis. It is not S-10, does not inherit S-10's evidence, and may
+not change S-10's permanent `harness_validation` purpose.
+
+The prior is Moreira and Muir, *Volatility-Managed Portfolios* (*Journal of Finance*,
+2017), and Cederburg, O'Doherty, Wang and Yan, *On the Performance of
+Volatility-Managed Portfolios* (*Journal of Financial Economics*, 2020). Cederburg et al.
+find that direct volatility scaling improves all nine momentum portfolios they test,
+significantly for five. Their portfolios are zero-cost long-short factors/anomalies; MT-1
+is a long-only ranked leader book. The evidence therefore motivates this experiment but
+does not validate it.
+
+MT-1 also differs from the published portfolio in two material ways:
+
+- eBull forbids leverage, so the exposure multiplier is clipped to `[0, 1]`; and
+- eBull has no frozen historical risk-free series for this experiment, so the reference
+  uses after-cost total returns and residual capital earns zero, not factor excess returns.
+
+Those deviations are part of the candidate identity. The result must be described as a
+capped long-only variant, never as a replication of either paper.
+
+## Frozen signal and portfolio clock
+
+The signal and exit legs are an exact copy of the source-level S-10 rule at the commit that
+implements MT-1: monthly cross-sectional relative-strength entry, wider retention-band
+exit, causal regime input, identical minimum cross-section, universe, fill, ambiguity,
+termination, quarantine and cost policies. The implementation must expose a separate
+strategy module and identity hash. Calling S-10's helpers is allowed; reading or relabelling
+an S-10 result is not.
+
+All target-weight decisions occur on the source rule's existing month-end decision dates.
+The overlay may not create an intramonth rebalance. The unscaled reference is recomputed
+fresh in the same invocation and under the same new trial contract.
+
+## Frozen volatility construction
+
+For each complete calendar month `m`, let `f[m,d]` be the unscaled reference portfolio's
+after-cost daily total return on trading day `d`, including zero-return cash where the
+reference is not fully invested. Let `J[m]` be its count of usable daily returns.
+
+The realised variance used by Cederburg et al.'s equation (4) is:
+
+```text
+v[m] = (22 / J[m]) × Σ_d f[m,d]²
+```
+
+It is deliberately not demeaned. A month with no usable daily return or non-finite or
+non-positive `v[m]` is unavailable.
+
+For a decision in month `t`, raw inverse-variance reference returns over completed training
+months are:
+
+```text
+g[m] = f_month[m] / v[m-1]
+```
+
+where `f_month[m]` is the compounded unscaled after-cost total return for month `m`. A
+training observation exists only when both terms are available before `t`.
+
+Every calendar month from the reference book's first eligible complete month onward remains
+in the input history, with exactly one return for every session on the frozen panel calendar.
+This includes an all-cash month whose returns and variance are zero. Because S-10 can be
+intermittently invested whereas the papers' factors are always defined, a zero `v[m-1]`
+cannot divide the next month's return: that pair is unavailable but the calendar month is
+not deleted. MT-1 requires at least **120 usable completed training pairs**, matching
+Cederburg et al.'s real-time initial-window count. Thereafter every usable pair from the
+frozen first eligible month remains in the expanding window; it never rolls. At decision
+`t`, compute only from usable training pairs strictly before `t`:
+
+```text
+c[t] = sample_stddev(f_month) / sample_stddev(g)
+raw_exposure[t] = c[t] / v[t-1]
+exposure[t] = min(1, max(0, raw_exposure[t]))
+```
+
+Both sample standard deviations use `n-1`. A missing session in any supposedly complete
+month, a non-finite or non-positive standard deviation, a non-positive `v[t-1]`, or fewer
+than 120 usable pairs refuses that decision. In particular, an all-cash prior month produces
+no next-month exposure; it never defaults to 100%. The multiplier is applied once to the
+aggregate reference book and uniformly to all selected holdings; residual weight stays in
+zero-return cash. Per-name inverse-volatility weighting is a different strategy and is not
+permitted under this identity.
+
+## Arms and trial accounting
+
+The evaluator must compute all four pairs unconditionally before reporting any outcome:
+
+1. MT-1 long-only relative strength, capped-scaled;
+2. the fresh MT-1 unscaled reference;
+3. S-8 range-mean-reversion negative control, capped-scaled; and
+4. the fresh S-8 unscaled reference.
+
+"Same overlay" on S-8 means the same aggregate portfolio-level formula, 120-month
+expanding training rule and month-end exposure-update clock. S-8 signals and exits may
+change the underlying reference book intramonth, but its exposure multiplier remains fixed
+until the next month-end. A per-entry, per-name or signal-date scaling rule is not this
+control and must refuse.
+
+Before the first price/outcome read, add two exact trial-register entries: one for the MT-1
+scaled/unscaled controlled pair and one for the S-8 scaled/unscaled negative-control pair.
+The ambiguity, termination, quarantine, recent-window and regime rows are conjunctive
+robustness reports, not selectable trials. Any different training length, variance formula,
+cap, clock, signal family or history policy is a new trial and a new strategy version.
+
+## Population, timing and costs
+
+- Full `survivorship_free` research population and its point-in-time termination treatment.
+- Raw prices for signals/fills/cost bands; aligned total-return wealth prices for returns.
+- Signal at the declared month-end decision bar; fills and exits exactly as the source rule
+  permits. No shared signal/outcome print.
+- Current complete cost-model identity, including spread, carry and FX stamps. A missing
+  cost term is a structural refusal, never zero.
+- The fixed in-sample/hold-out boundary and all code-pinned recent windows used by the
+  strategy evidence platform. Raw operator-supplied dates are forbidden.
+- The hold-out remains sealed until the complete in-sample controlled experiment and all
+  structural gates pass. A failed in-sample arm ends this version; it is not repaired.
+
+## First-order turnover disqualifier
+
+Before any return, Sharpe, drawdown or expectancy value is exposed, report only structural
+counts and traded notional. Refuse outcome access if either scaled book:
+
+- introduces a decision date outside the frozen month-end clock;
+- has annualised turnover above 600% (the repository's 50%-per-month viability bar); or
+- cannot reconcile every exposure change to the frozen formula and preceding information.
+
+Passing this gate does not imply equal turnover: scaling can add traded notional on an
+existing decision date. Both gross and costed turnover remain outcome-report fields.
+
+## Frozen primary estimand and inference
+
+Collapse daily after-cost returns to one compounded observation per complete calendar
+month, expressed in decimal return units (`0.01` means 1%). With risk-aversion coefficient
+`γ = 5`, matching Cederburg et al.'s base real-time test, define certainty equivalent:
+
+```text
+CER(r) = mean(r) - (γ / 2) × sample_variance(r)
+ΔMT1 = CER(MT1_scaled) - CER(MT1_unscaled)
+ΔS8  = CER(S8_scaled)  - CER(S8_unscaled)
+primary = ΔMT1 - ΔS8
+```
+
+The primary gate is the **lower bound of a two-sided 95% paired moving-block-bootstrap
+interval for `primary` greater than zero**. Resample the same contiguous month blocks and
+indices across all four arms. Block length is 12 months, fixed before outcomes; use 10,000
+replicates and integer seed `243715082026`. A percentile interval is used. Missing months are
+intersected across all four arms before resampling; fewer than 120 common evaluation months
+refuses the experiment.
+
+The following are conjunctive, not alternatives from which a favourable winner may be
+selected:
+
+- the 95% paired bootstrap lower bound for `ΔMT1` is greater than zero;
+- MT-1 scaled maximum drawdown is strictly smaller than its unscaled reference;
+- MT-1 scaled 5% monthly expected shortfall is strictly less negative than its unscaled
+  reference;
+- the scaled result remains positive after the existing cost, synthetic-control,
+  deflated-Sharpe, benchmark, recent-window, ambiguity/quarantine and structural promotion
+  gates; and
+- the latest code-pinned recent window has positive net expectancy. Pre-2000 history cannot
+  rescue it.
+
+No raw-return, Sharpe, drawdown, expected-shortfall, regime or recent-window value may be
+used to alter this version after the first look. One failed conjunct kills this version.
+
+## Forward-shadow floor
+
+The minimum economically meaningful prospective improvement is fixed as a standardised
+paired monthly effect of `0.5`. At two-sided `α = 0.05` and power `0.8`, using the same
+normal approximation as the declaration gate:
+
+```text
+n = ceil(((z_0.975 + z_0.8) / 0.5)²)
+  = ceil((2.8016 / 0.5)²)
+  = 32 independent decision months
+```
+
+The floor is raised to **36 independent month-end decision dates** to cover three complete
+calendar years. The calendar-duration floor is
+`ceil(36 × 365.25 / (12 × 7)) = 157 weeks`. These are floors, not a claim that monthly
+returns are independent; prospective inference must still block-bootstrap. A smaller true
+effect requires more evidence and cannot lower the frozen floor.
+
+## Authority boundary
+
+This document alone authorises nothing. Before outcome access, the implementation must:
+
+1. land under its separate strategy identity and result-version hash;
+2. add the two exact trial-register entries;
+3. merge the current structural-refusal policy version;
+4. freeze a `capital_candidate` declaration for MT-1 with `survivorship_free`, carry and FX
+   stamps that recompute to no structural refusal, plus the 36-date/157-week shadow floor;
+5. freeze the S-8 control as `falsification_only`; and
+6. pass the declaration/access gate through the paved evaluator path.
+
+Even an evidence pass gives no direct broker authority. Promotion, a calibrated opportunity
+forecast, the mandate-driven batch allocator, broker preflight and bounded paper deployment
+must each pass separately. Live/real-money activation remains hard-false.

--- a/tests/test_strategy_volatility_overlay.py
+++ b/tests/test_strategy_volatility_overlay.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.services.strategy_volatility_overlay import (
+    MAX_EXPOSURE,
+    MIN_TRAINING_MONTHS,
+    RULE_SET_ID,
+    RULE_SET_VERSION,
+    CompletedPortfolioMonth,
+    DailyPortfolioReturn,
+    VolatilityOverlayUnavailable,
+    capped_inverse_variance_exposure,
+    compounded_month_return,
+    realised_month_variance,
+)
+
+
+def _month(index: int) -> date:
+    year, zero_based_month = divmod(index, 12)
+    return date(2000 + year, zero_based_month + 1, 1)
+
+
+def _record(month: date, *values: Decimal) -> CompletedPortfolioMonth:
+    sessions = tuple(date(month.year, month.month, day + 1) for day in range(len(values)))
+    return CompletedPortfolioMonth(
+        month=month,
+        daily_returns=tuple(
+            DailyPortfolioReturn(session, value) for session, value in zip(sessions, values, strict=True)
+        ),
+        expected_sessions=sessions,
+    )
+
+
+def _history(*, count: int = MIN_TRAINING_MONTHS + 1, final_multiple: int = 1) -> tuple[CompletedPortfolioMonth, ...]:
+    base = Decimal("0.01")
+    return tuple(
+        _record(
+            _month(index),
+            (base if index % 2 == 0 else -base) * (final_multiple if index == count - 1 else 1),
+        )
+        for index in range(count)
+    )
+
+
+def _exposure(history: tuple[CompletedPortfolioMonth, ...]):
+    return capped_inverse_variance_exposure(history, expected_first_month=history[0].month)
+
+
+def test_month_return_and_variance_use_decimal_compounding_and_equation_four() -> None:
+    record = _record(date(2026, 1, 1), Decimal("0.10"), Decimal("-0.05"))
+
+    assert compounded_month_return(record) == Decimal("0.0450")
+    assert realised_month_variance(record) == Decimal("0.13750")
+
+
+def test_constant_variance_normalises_to_full_but_never_levered_exposure() -> None:
+    decision = _exposure(_history())
+
+    assert decision.training_months == MIN_TRAINING_MONTHS
+    assert decision.raw_exposure == pytest.approx(Decimal("1"), abs=Decimal("1e-45"))
+    assert decision.exposure == MAX_EXPOSURE
+    assert decision.rule_set_version == RULE_SET_VERSION
+    assert RULE_SET_VERSION.startswith(f"{RULE_SET_ID}+")
+
+
+def test_last_month_variance_shock_reduces_next_month_exposure() -> None:
+    decision = _exposure(_history(final_multiple=2))
+
+    # The training pairs all divide by the preceding constant variance, so c_t
+    # remains that variance; the final month's four-times variance makes the
+    # next exposure exactly one quarter.
+    assert decision.raw_exposure == pytest.approx(Decimal("0.25"), abs=Decimal("1e-45"))
+    assert decision.exposure == pytest.approx(Decimal("0.25"), abs=Decimal("1e-45"))
+
+
+def test_expanding_history_is_used_rather_than_truncated_to_120_pairs() -> None:
+    decision = _exposure(_history(count=MIN_TRAINING_MONTHS + 13))
+
+    assert decision.training_months == MIN_TRAINING_MONTHS + 12
+
+
+@pytest.mark.parametrize(
+    ("history", "message"),
+    [
+        (_history(count=MIN_TRAINING_MONTHS), "needs 121 completed months"),
+        (
+            tuple(
+                _record(
+                    _month(index + (1 if index == 10 else 0)),
+                    Decimal("0.01" if index % 2 == 0 else "-0.01"),
+                )
+                for index in range(MIN_TRAINING_MONTHS + 1)
+            ),
+            "unique and consecutive",
+        ),
+    ],
+)
+def test_missing_history_refuses_instead_of_defaulting_to_full_exposure(
+    history: tuple[CompletedPortfolioMonth, ...], message: str
+) -> None:
+    with pytest.raises(VolatilityOverlayUnavailable, match=message):
+        _exposure(history)
+
+
+def test_zero_variance_refuses_instead_of_defaulting_to_full_exposure() -> None:
+    history = tuple(_record(_month(index), Decimal("0")) for index in range(MIN_TRAINING_MONTHS + 1))
+
+    with pytest.raises(VolatilityOverlayUnavailable, match="prior complete month's realised variance is not positive"):
+        _exposure(history)
+
+
+def test_old_cash_month_stays_in_expanding_calendar_but_only_usable_pairs_count() -> None:
+    history = list(_history(count=MIN_TRAINING_MONTHS + 2))
+    history[0] = _record(history[0].month, Decimal("0"))
+
+    decision = _exposure(tuple(history))
+
+    assert decision.training_months == MIN_TRAINING_MONTHS
+
+
+def test_incomplete_session_coverage_refuses() -> None:
+    history = list(_history())
+    extra_session = date(history[10].month.year, history[10].month.month, 2)
+    history[10] = CompletedPortfolioMonth(
+        history[10].month,
+        history[10].daily_returns,
+        (*history[10].expected_sessions, extra_session),
+    )
+
+    with pytest.raises(VolatilityOverlayUnavailable, match="return dates do not match"):
+        _exposure(tuple(history))
+
+
+def test_truncated_expanding_history_refuses_against_frozen_origin() -> None:
+    history = _history(count=MIN_TRAINING_MONTHS + 13)
+
+    with pytest.raises(VolatilityOverlayUnavailable, match="frozen first eligible month"):
+        capped_inverse_variance_exposure(history[12:], expected_first_month=history[0].month)
+
+
+def test_non_month_start_and_invalid_return_are_refused() -> None:
+    with pytest.raises(VolatilityOverlayUnavailable, match="first calendar day"):
+        wrong_month = _record(date(2026, 1, 1), Decimal("0.01"))
+        compounded_month_return(
+            CompletedPortfolioMonth(date(2026, 1, 2), wrong_month.daily_returns, wrong_month.expected_sessions)
+        )
+    with pytest.raises(VolatilityOverlayUnavailable, match="below-minus-one"):
+        realised_month_variance(_record(date(2026, 1, 1), Decimal("-1.01")))


### PR DESCRIPTION
## Outcome

Creates a reviewable, outcome-sealed first capital-candidate design without granting it capital authority.

- renames the ambiguous C-1 pre-spec to the unique MT-1 identity;
- corrects the evidence transfer: published results are long-short factor/anomaly portfolios, while MT-1 is a capped long-only variant;
- makes the leverage mismatch and the S-8 clock mismatch explicit;
- freezes the signal lineage, causal 120-usable-month expanding normalisation, 1x cap, complete-session contract, paired difference-in-differences inference, turnover disqualifier and 36-date/157-week forward-shadow floor;
- adds a pure source-hashed portfolio-level sizing contract with no database or outcome access.

## Fail-closed boundary

This PR deliberately does not add a manifest capital candidate, trial-register entry, database declaration, evaluator, promotion, forecast or broker path. The trial count is not spent until the implementation is complete and the experiment is ready to run. S-10 remains a permanent harness control.

## Verification

- 11 focused volatility-overlay tests;
- Ruff and formatting clean;
- Pyright clean;
- full repository pre-push gate green twice, including all fast tests, app/DB smoke boot and frontend integrity gates.

## Remaining ordered work

1. review and merge this scientific contract;
2. implement the fresh MT-1/S-8 reference books and paired evaluator without reading outcomes;
3. add the two exact trial entries and freeze declarations immediately before the first gated run;
4. run the in-sample experiment, then the sealed hold-out only if every prior gate passes;
5. require the mandate-driven batch allocator before any bounded demo capital.

Refs #2437.