### PR TITLE
feat(#2437): add frozen MT-1 trial evaluator

### DIFF
--- a/app/services/strategy_mt1_trial.py
+++ b/app/services/strategy_mt1_trial.py
@@ -1,0 +1,341 @@
+"""Pure evaluator for the frozen MT-1 four-arm controlled trial (#2437).
+
+This module does not load prices, query the result ledger, or authorise an
+outcome read.  It accepts four already-built, after-cost monthly return books
+and applies the estimand frozen in
+``docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-
+preregistration.md``.  Keeping the statistic here allows the implementation to
+be reviewed before the trial register and sealed-outcome gate are opened.
+
+The primary comparison is a difference in differences: volatility scaling's
+CER improvement on MT-1 less the same improvement on the S-8 negative control.
+All four arms use identical resampled month indices in every replication.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Final, cast
+
+import numpy as np
+import numpy.typing as npt
+
+TRIAL_ID: Final = "mt1-capped-volatility-managed-relative-strength-v1"
+NEGATIVE_CONTROL_TRIAL_ID: Final = "mt1-s8-capped-volatility-negative-control-v1"
+RISK_AVERSION: Final = 5.0
+BLOCK_LENGTH_MONTHS: Final = 12
+BOOTSTRAP_RESAMPLES: Final = 10_000
+BOOTSTRAP_SEED: Final = 243_715_082_026
+CONFIDENCE: Final = 0.95
+MIN_COMMON_MONTHS: Final = 120
+MAX_ANNUALISED_TURNOVER: Final = 6.0
+EXPECTED_SHORTFALL_TAIL: Final = 0.05
+_BOOTSTRAP_BATCH: Final = 200
+
+
+def _code_hash() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+TRIAL_EVALUATOR_VERSION: Final = f"mt1-four-arm-cer-mbb-v1+{_code_hash()}"
+
+
+class MT1TrialRefused(ValueError):
+    """The frozen trial cannot be evaluated from the supplied evidence."""
+
+
+@dataclass(frozen=True)
+class MonthlyReturn:
+    """One complete calendar month's after-cost decimal portfolio return."""
+
+    month: date
+    value: float
+
+
+@dataclass(frozen=True)
+class PortfolioArm:
+    """One of the four frozen arms, on its complete-month outcome axis."""
+
+    monthly_returns: tuple[MonthlyReturn, ...]
+
+
+@dataclass(frozen=True)
+class ScaledBookStructuralAudit:
+    """Outcome-free proof required for each scaled book before statistics.
+
+    ``decision_dates`` are the dates on which exposure changed or was
+    reaffirmed. They must equal the evaluator-supplied frozen month-end clock;
+    a subset is not accepted because silently omitting a decision can suppress
+    turnover. ``annualised_turnover`` is a decimal multiple (``6`` = 600%).
+    """
+
+    decision_dates: tuple[date, ...]
+    expected_decision_dates: tuple[date, ...]
+    annualised_turnover: float
+    traded_notional: float
+    exposure_reconciled: bool
+
+
+@dataclass(frozen=True)
+class StructuralGateReport:
+    mt1_decision_dates: int
+    s8_decision_dates: int
+    mt1_annualised_turnover: float
+    s8_annualised_turnover: float
+    mt1_traded_notional: float
+    s8_traded_notional: float
+
+
+@dataclass(frozen=True)
+class PercentileInterval:
+    low: float
+    high: float
+
+
+@dataclass(frozen=True)
+class ArmRiskReport:
+    certainty_equivalent: float
+    maximum_drawdown: float
+    expected_shortfall_5: float
+
+
+@dataclass(frozen=True)
+class MT1TrialResult:
+    """The frozen historical statistic, not a promotion or capital decision."""
+
+    common_months: tuple[date, ...]
+    excluded_months_by_arm: tuple[int, int, int, int]
+    structural: StructuralGateReport
+    mt1_scaled: ArmRiskReport
+    mt1_unscaled: ArmRiskReport
+    s8_scaled: ArmRiskReport
+    s8_unscaled: ArmRiskReport
+    mt1_delta_cer: float
+    s8_delta_cer: float
+    primary_difference_in_differences: float
+    mt1_delta_interval: PercentileInterval
+    primary_interval: PercentileInterval
+    primary_lower_bound_positive: bool
+    mt1_lower_bound_positive: bool
+    mt1_drawdown_improved: bool
+    mt1_expected_shortfall_improved: bool
+    historical_statistical_conjuncts_pass: bool
+    evaluator_version: str = TRIAL_EVALUATOR_VERSION
+    bootstrap_block_length: int = BLOCK_LENGTH_MONTHS
+    bootstrap_resamples: int = BOOTSTRAP_RESAMPLES
+    bootstrap_seed: int = BOOTSTRAP_SEED
+
+
+def _validate_structural_audit(label: str, audit: ScaledBookStructuralAudit) -> None:
+    if not audit.expected_decision_dates:
+        raise MT1TrialRefused(f"{label} frozen month-end decision clock is empty")
+    if tuple(sorted(set(audit.expected_decision_dates))) != audit.expected_decision_dates:
+        raise MT1TrialRefused(f"{label} expected decision dates must be sorted and unique")
+    if tuple(sorted(set(audit.decision_dates))) != audit.decision_dates:
+        raise MT1TrialRefused(f"{label} decision dates must be sorted and unique")
+    if audit.decision_dates != audit.expected_decision_dates:
+        raise MT1TrialRefused(f"{label} decisions do not equal the frozen month-end clock")
+    if not math.isfinite(audit.annualised_turnover) or audit.annualised_turnover < 0:
+        raise MT1TrialRefused(f"{label} annualised turnover is not finite and non-negative")
+    if audit.annualised_turnover > MAX_ANNUALISED_TURNOVER:
+        raise MT1TrialRefused(f"{label} annualised turnover exceeds 600%")
+    if not math.isfinite(audit.traded_notional) or audit.traded_notional < 0:
+        raise MT1TrialRefused(f"{label} traded notional is not finite and non-negative")
+    if not audit.exposure_reconciled:
+        raise MT1TrialRefused(f"{label} exposure changes do not reconcile to the frozen formula")
+
+
+def structural_gate(
+    mt1_scaled: ScaledBookStructuralAudit,
+    s8_scaled: ScaledBookStructuralAudit,
+) -> StructuralGateReport:
+    """Apply the turnover/clock/reconciliation gate without return inputs."""
+    _validate_structural_audit("MT-1 scaled", mt1_scaled)
+    _validate_structural_audit("S-8 scaled", s8_scaled)
+    if mt1_scaled.expected_decision_dates != s8_scaled.expected_decision_dates:
+        raise MT1TrialRefused("MT-1 and S-8 do not share the same frozen month-end exposure clock")
+    return StructuralGateReport(
+        mt1_decision_dates=len(mt1_scaled.decision_dates),
+        s8_decision_dates=len(s8_scaled.decision_dates),
+        mt1_annualised_turnover=mt1_scaled.annualised_turnover,
+        s8_annualised_turnover=s8_scaled.annualised_turnover,
+        mt1_traded_notional=mt1_scaled.traded_notional,
+        s8_traded_notional=s8_scaled.traded_notional,
+    )
+
+
+def _arm_map(label: str, arm: PortfolioArm) -> dict[date, float]:
+    months = tuple(point.month for point in arm.monthly_returns)
+    if tuple(sorted(set(months))) != months:
+        raise MT1TrialRefused(f"{label} months must be sorted and unique")
+    values: dict[date, float] = {}
+    for point in arm.monthly_returns:
+        if point.month.day != 1:
+            raise MT1TrialRefused(f"{label} month keys must be first calendar days")
+        if not math.isfinite(point.value) or point.value < -1.0:
+            raise MT1TrialRefused(f"{label} contains a non-finite or below-minus-one monthly return")
+        values[point.month] = point.value
+    return values
+
+
+def certainty_equivalent(values: npt.NDArray[np.float64]) -> float:
+    if values.ndim != 1 or len(values) < 2:
+        raise MT1TrialRefused("certainty equivalent needs at least two monthly returns")
+    with np.errstate(over="ignore", invalid="ignore"):
+        result = float(np.mean(values) - (RISK_AVERSION / 2.0) * np.var(values, ddof=1))
+    if not math.isfinite(result):
+        raise MT1TrialRefused("certainty equivalent is not finite")
+    return result
+
+
+def maximum_drawdown(values: npt.NDArray[np.float64]) -> float:
+    """Return conventional non-negative peak-to-trough drawdown magnitude."""
+    with np.errstate(over="ignore", invalid="ignore", divide="ignore"):
+        wealth = np.cumprod(1.0 + values)
+    if not np.all(np.isfinite(wealth)):
+        raise MT1TrialRefused("monthly return path produces non-finite wealth")
+    peaks = np.maximum.accumulate(np.concatenate((np.asarray([1.0]), wealth)))
+    drawdowns = 1.0 - wealth / peaks[1:]
+    return max(0.0, float(np.max(drawdowns, initial=0.0)))
+
+
+def expected_shortfall_5(values: npt.NDArray[np.float64]) -> float:
+    if not len(values):
+        raise MT1TrialRefused("expected shortfall needs at least one monthly return")
+    tail_count = max(1, math.ceil(len(values) * EXPECTED_SHORTFALL_TAIL))
+    return float(np.mean(np.sort(values)[:tail_count]))
+
+
+def _risk_report(values: npt.NDArray[np.float64]) -> ArmRiskReport:
+    return ArmRiskReport(
+        certainty_equivalent=certainty_equivalent(values),
+        maximum_drawdown=maximum_drawdown(values),
+        expected_shortfall_5=expected_shortfall_5(values),
+    )
+
+
+def _paired_bootstrap(
+    arms: npt.NDArray[np.float64],
+) -> tuple[PercentileInterval, PercentileInterval]:
+    month_count = arms.shape[1]
+    blocks_per_sample = math.ceil(month_count / BLOCK_LENGTH_MONTHS)
+    possible_starts = month_count - BLOCK_LENGTH_MONTHS + 1
+    if possible_starts < 1:  # pragma: no cover - guarded by MIN_COMMON_MONTHS
+        raise MT1TrialRefused("common month axis is shorter than the frozen block length")
+
+    generator = np.random.default_rng(BOOTSTRAP_SEED)
+    mt1_statistics = np.empty(BOOTSTRAP_RESAMPLES, dtype=np.float64)
+    primary_statistics = np.empty(BOOTSTRAP_RESAMPLES, dtype=np.float64)
+    offsets = np.arange(BLOCK_LENGTH_MONTHS, dtype=np.int64)
+    written = 0
+    while written < BOOTSTRAP_RESAMPLES:
+        batch_size = min(_BOOTSTRAP_BATCH, BOOTSTRAP_RESAMPLES - written)
+        starts = generator.integers(0, possible_starts, size=(batch_size, blocks_per_sample), dtype=np.int64)
+        indices = (starts[:, :, None] + offsets[None, None, :]).reshape(batch_size, -1)[:, :month_count]
+        sampled = arms[:, indices]
+        cer = np.mean(sampled, axis=2) - (RISK_AVERSION / 2.0) * np.var(sampled, axis=2, ddof=1)
+        mt1_delta = cer[0] - cer[1]
+        s8_delta = cer[2] - cer[3]
+        mt1_statistics[written : written + batch_size] = mt1_delta
+        primary_statistics[written : written + batch_size] = mt1_delta - s8_delta
+        written += batch_size
+
+    if not np.all(np.isfinite(mt1_statistics)) or not np.all(np.isfinite(primary_statistics)):
+        raise MT1TrialRefused("paired bootstrap produced a non-finite statistic")
+
+    tail = (1.0 - CONFIDENCE) * 50.0
+    mt1_low, mt1_high = np.percentile(mt1_statistics, [tail, 100.0 - tail], method="linear")
+    primary_low, primary_high = np.percentile(primary_statistics, [tail, 100.0 - tail], method="linear")
+    return (
+        PercentileInterval(float(mt1_low), float(mt1_high)),
+        PercentileInterval(float(primary_low), float(primary_high)),
+    )
+
+
+def evaluate_mt1_trial(
+    *,
+    mt1_scaled: PortfolioArm,
+    mt1_unscaled: PortfolioArm,
+    s8_scaled: PortfolioArm,
+    s8_unscaled: PortfolioArm,
+    mt1_structural: ScaledBookStructuralAudit,
+    s8_structural: ScaledBookStructuralAudit,
+) -> MT1TrialResult:
+    """Evaluate all four arms under the preregistered paired statistic.
+
+    Structural audits are checked before any outcome statistic is calculated.
+    Passing this function's conjuncts is deliberately named *historical
+    statistical* evidence: the standard promotion, recent-window, cost,
+    synthetic-control and DSR gates remain separate and mandatory.
+    """
+    structural = structural_gate(mt1_structural, s8_structural)
+    labelled_arms = (
+        ("MT-1 scaled", mt1_scaled),
+        ("MT-1 unscaled", mt1_unscaled),
+        ("S-8 scaled", s8_scaled),
+        ("S-8 unscaled", s8_unscaled),
+    )
+    mappings = tuple(_arm_map(label, arm) for label, arm in labelled_arms)
+    common = tuple(sorted(set.intersection(*(set(mapping) for mapping in mappings))))
+    if len(common) < MIN_COMMON_MONTHS:
+        raise MT1TrialRefused(f"paired trial needs {MIN_COMMON_MONTHS} common complete months; received {len(common)}")
+    excluded = tuple(len(mapping) - len(common) for mapping in mappings)
+    matrix = np.asarray([[mapping[month] for month in common] for mapping in mappings], dtype=np.float64)
+    reports = tuple(_risk_report(row) for row in matrix)
+    mt1_delta = reports[0].certainty_equivalent - reports[1].certainty_equivalent
+    s8_delta = reports[2].certainty_equivalent - reports[3].certainty_equivalent
+    primary = mt1_delta - s8_delta
+    mt1_interval, primary_interval = _paired_bootstrap(matrix)
+    primary_positive = primary_interval.low > 0.0
+    mt1_positive = mt1_interval.low > 0.0
+    drawdown_improved = reports[0].maximum_drawdown < reports[1].maximum_drawdown
+    expected_shortfall_improved = reports[0].expected_shortfall_5 > reports[1].expected_shortfall_5
+    conjuncts = primary_positive and mt1_positive and drawdown_improved and expected_shortfall_improved
+    return MT1TrialResult(
+        common_months=common,
+        excluded_months_by_arm=cast(tuple[int, int, int, int], excluded),
+        structural=structural,
+        mt1_scaled=reports[0],
+        mt1_unscaled=reports[1],
+        s8_scaled=reports[2],
+        s8_unscaled=reports[3],
+        mt1_delta_cer=mt1_delta,
+        s8_delta_cer=s8_delta,
+        primary_difference_in_differences=primary,
+        mt1_delta_interval=mt1_interval,
+        primary_interval=primary_interval,
+        primary_lower_bound_positive=primary_positive,
+        mt1_lower_bound_positive=mt1_positive,
+        mt1_drawdown_improved=drawdown_improved,
+        mt1_expected_shortfall_improved=expected_shortfall_improved,
+        historical_statistical_conjuncts_pass=conjuncts,
+    )
+
+
+__all__ = [
+    "BLOCK_LENGTH_MONTHS",
+    "BOOTSTRAP_RESAMPLES",
+    "BOOTSTRAP_SEED",
+    "MAX_ANNUALISED_TURNOVER",
+    "MIN_COMMON_MONTHS",
+    "NEGATIVE_CONTROL_TRIAL_ID",
+    "TRIAL_EVALUATOR_VERSION",
+    "TRIAL_ID",
+    "ArmRiskReport",
+    "MT1TrialRefused",
+    "MT1TrialResult",
+    "MonthlyReturn",
+    "PercentileInterval",
+    "PortfolioArm",
+    "ScaledBookStructuralAudit",
+    "StructuralGateReport",
+    "certainty_equivalent",
+    "evaluate_mt1_trial",
+    "expected_shortfall_5",
+    "maximum_drawdown",
+    "structural_gate",
+]

--- a/tests/test_strategy_mt1_trial.py
+++ b/tests/test_strategy_mt1_trial.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import math
+from datetime import date
+
+import numpy as np
+import pytest
+
+from app.services.strategy_mt1_trial import (
+    BLOCK_LENGTH_MONTHS,
+    BOOTSTRAP_RESAMPLES,
+    BOOTSTRAP_SEED,
+    MIN_COMMON_MONTHS,
+    TRIAL_EVALUATOR_VERSION,
+    MonthlyReturn,
+    MT1TrialRefused,
+    PortfolioArm,
+    ScaledBookStructuralAudit,
+    certainty_equivalent,
+    evaluate_mt1_trial,
+    expected_shortfall_5,
+    maximum_drawdown,
+    structural_gate,
+)
+
+
+def _month(index: int) -> date:
+    year, zero_month = divmod(index, 12)
+    return date(2000 + year, zero_month + 1, 1)
+
+
+def _arm(values: list[float], *, offset: int = 0) -> PortfolioArm:
+    return PortfolioArm(tuple(MonthlyReturn(_month(index + offset), value) for index, value in enumerate(values)))
+
+
+def _audit(*, turnover: float = 1.0, reconciled: bool = True) -> ScaledBookStructuralAudit:
+    decisions = tuple(date(2010 + index // 12, index % 12 + 1, 28) for index in range(24))
+    return ScaledBookStructuralAudit(decisions, decisions, turnover, 1_000_000.0, reconciled)
+
+
+def _trial(**overrides: object):
+    # Same 0.5% mean in both MT-1 arms; scaling removes enough dispersion to
+    # improve CER, drawdown and the lower tail without manufacturing extra mean.
+    mt1_scaled = [0.01 if index % 2 == 0 else 0.0 for index in range(MIN_COMMON_MONTHS)]
+    mt1_unscaled = [0.04 if index % 2 == 0 else -0.03 for index in range(MIN_COMMON_MONTHS)]
+    s8_unscaled = [0.004 if index % 2 == 0 else -0.004 for index in range(MIN_COMMON_MONTHS)]
+    s8_scaled = list(s8_unscaled)
+    arguments: dict[str, object] = {
+        "mt1_scaled": _arm(mt1_scaled),
+        "mt1_unscaled": _arm(mt1_unscaled),
+        "s8_scaled": _arm(s8_scaled),
+        "s8_unscaled": _arm(s8_unscaled),
+        "mt1_structural": _audit(),
+        "s8_structural": _audit(),
+    }
+    arguments.update(overrides)
+    return evaluate_mt1_trial(**arguments)  # type: ignore[arg-type]
+
+
+def test_frozen_four_arm_trial_is_deterministic_and_reports_provenance() -> None:
+    first = _trial()
+    second = _trial()
+
+    assert first == second
+    assert first.bootstrap_block_length == BLOCK_LENGTH_MONTHS == 12
+    assert first.bootstrap_resamples == BOOTSTRAP_RESAMPLES == 10_000
+    assert first.bootstrap_seed == BOOTSTRAP_SEED == 243_715_082_026
+    assert first.evaluator_version == TRIAL_EVALUATOR_VERSION
+    assert first.mt1_delta_interval.low > 0
+    assert first.primary_interval.low > 0
+    assert first.mt1_drawdown_improved
+    assert first.mt1_expected_shortfall_improved
+    assert first.historical_statistical_conjuncts_pass
+
+
+def test_negative_control_is_subtracted_from_mt1_improvement() -> None:
+    values = [0.01 if index % 2 == 0 else -0.01 for index in range(MIN_COMMON_MONTHS)]
+    result = _trial(s8_scaled=_arm([value * 0.5 for value in values]), s8_unscaled=_arm(values))
+
+    assert result.primary_difference_in_differences == pytest.approx(result.mt1_delta_cer - result.s8_delta_cer)
+    assert result.primary_difference_in_differences < result.mt1_delta_cer
+
+
+def test_identical_mt1_and_control_pairs_have_exactly_zero_paired_primary_interval() -> None:
+    scaled = [0.01 if index % 3 else -0.005 for index in range(MIN_COMMON_MONTHS)]
+    unscaled = [0.03 if index % 3 else -0.02 for index in range(MIN_COMMON_MONTHS)]
+    result = _trial(
+        mt1_scaled=_arm(scaled),
+        mt1_unscaled=_arm(unscaled),
+        s8_scaled=_arm(scaled),
+        s8_unscaled=_arm(unscaled),
+    )
+
+    assert result.primary_interval.low == 0.0
+    assert result.primary_interval.high == 0.0
+
+
+def test_interval_regression_pins_seed_blocks_pairing_cer_and_percentile_tails() -> None:
+    indexes = range(MIN_COMMON_MONTHS)
+    mt1_scaled = [0.004 + 0.012 * math.sin(index / 5) + 0.002 * math.cos(index / 17) for index in indexes]
+    mt1_unscaled = [0.004 + 0.025 * math.sin(index / 5) + 0.006 * math.cos(index / 11) for index in indexes]
+    s8_scaled = [0.001 + 0.010 * math.sin(index / 7) for index in indexes]
+    s8_unscaled = [0.001 + 0.012 * math.sin(index / 7) + 0.001 * math.cos(index / 13) for index in indexes]
+
+    result = _trial(
+        mt1_scaled=_arm(mt1_scaled),
+        mt1_unscaled=_arm(mt1_unscaled),
+        s8_scaled=_arm(s8_scaled),
+        s8_unscaled=_arm(s8_unscaled),
+    )
+
+    assert result.mt1_delta_cer == pytest.approx(0.0010335601196231159, abs=1e-15)
+    assert result.primary_difference_in_differences == pytest.approx(0.0011434851063477334, abs=1e-15)
+    assert result.mt1_delta_interval.low == pytest.approx(-0.004435213432705545, abs=1e-15)
+    assert result.mt1_delta_interval.high == pytest.approx(0.005599250327585452, abs=1e-15)
+    assert result.primary_interval.low == pytest.approx(-0.004289905335013397, abs=1e-15)
+    assert result.primary_interval.high == pytest.approx(0.0057473838633777296, abs=1e-15)
+
+
+def test_months_are_intersected_and_exclusions_are_visible() -> None:
+    extended = [0.01 if index % 2 == 0 else -0.01 for index in range(MIN_COMMON_MONTHS + 1)]
+    result = _trial(
+        mt1_scaled=_arm(extended),
+        mt1_unscaled=_arm(extended[1:], offset=1),
+        s8_scaled=_arm(extended),
+        s8_unscaled=_arm(extended),
+    )
+
+    assert result.common_months[0] == _month(1)
+    assert result.excluded_months_by_arm == (1, 0, 1, 1)
+
+
+def test_fewer_than_120_common_months_refuses() -> None:
+    short = _arm([0.01] * (MIN_COMMON_MONTHS - 1))
+    with pytest.raises(MT1TrialRefused, match="120 common complete months"):
+        _trial(mt1_scaled=short)
+
+
+@pytest.mark.parametrize(
+    ("audit", "message"),
+    [
+        (_audit(turnover=6.000001), "exceeds 600%"),
+        (_audit(reconciled=False), "do not reconcile"),
+        (
+            ScaledBookStructuralAudit(
+                _audit().decision_dates[:-1], _audit().expected_decision_dates, 1.0, 1_000_000.0, True
+            ),
+            "do not equal the frozen month-end clock",
+        ),
+    ],
+)
+def test_structural_gate_refuses_before_statistics(audit: ScaledBookStructuralAudit, message: str) -> None:
+    with pytest.raises(MT1TrialRefused, match=message):
+        _trial(mt1_structural=audit)
+
+
+def test_structural_gate_reports_counts_not_returns() -> None:
+    report = structural_gate(_audit(turnover=6.0), _audit(turnover=0.5))
+
+    assert report.mt1_decision_dates == 24
+    assert report.mt1_annualised_turnover == 6.0
+    assert report.s8_annualised_turnover == 0.5
+    assert not hasattr(report, "return")
+
+
+def test_the_negative_control_must_share_mt1s_frozen_exposure_clock() -> None:
+    shifted = _audit()
+    shifted_dates = tuple(date(day.year, day.month, 27) for day in shifted.decision_dates)
+    shifted = ScaledBookStructuralAudit(shifted_dates, shifted_dates, 1.0, 1_000_000.0, True)
+
+    with pytest.raises(MT1TrialRefused, match="same frozen month-end exposure clock"):
+        structural_gate(_audit(), shifted)
+
+
+def test_risk_statistics_use_sample_variance_drawdown_magnitude_and_ceil_tail() -> None:
+    values = np.asarray([0.10, -0.20, 0.05, -0.01, 0.02] + [0.03] * 15, dtype=np.float64)
+
+    assert certainty_equivalent(values) == pytest.approx(np.mean(values) - 2.5 * np.var(values, ddof=1))
+    assert maximum_drawdown(np.asarray([0.10, -0.20, 0.05])) == pytest.approx(0.20)
+    assert expected_shortfall_5(values) == -0.20
+
+
+def test_non_finite_derived_wealth_or_cer_refuses() -> None:
+    enormous = np.asarray([1e308, 1e308], dtype=np.float64)
+
+    with pytest.raises(MT1TrialRefused, match="certainty equivalent is not finite"):
+        certainty_equivalent(enormous)
+    with pytest.raises(MT1TrialRefused, match="non-finite wealth"):
+        maximum_drawdown(enormous)
+
+
+@pytest.mark.parametrize(
+    "arm",
+    [
+        PortfolioArm((MonthlyReturn(date(2020, 1, 2), 0.01),)),
+        PortfolioArm((MonthlyReturn(date(2020, 1, 1), float("nan")),)),
+        PortfolioArm((MonthlyReturn(date(2020, 1, 1), -1.01),)),
+        PortfolioArm((MonthlyReturn(date(2020, 2, 1), 0.01), MonthlyReturn(date(2020, 1, 1), 0.01))),
+    ],
+)
+def test_invalid_arm_axes_and_values_refuse(arm: PortfolioArm) -> None:
+    with pytest.raises(MT1TrialRefused):
+        _trial(mt1_scaled=arm)
+
+
+def test_passing_historical_statistic_does_not_claim_promotion() -> None:
+    result = _trial()
+
+    assert result.historical_statistical_conjuncts_pass
+    assert not hasattr(result, "promotable")
+    assert not hasattr(result, "capital_eligible")


### PR DESCRIPTION
Closes part of #2437

## Outcome

Implements the pure, outcome-source-independent statistic for the preregistered MT-1 four-arm controlled experiment. This PR does not open price outcomes, alter the trial register, freeze a database declaration, promote a strategy, or authorise capital.

## Frozen contract enforced

- evaluates MT-1 scaled/unscaled and S-8 scaled/unscaled unconditionally on one common complete-month axis
- computes CER with gamma=5 and sample variance
- reports the preregistered difference in differences: MT-1 CER improvement minus S-8 CER improvement
- uses the same paired moving-block indices across all four arms, 12-month blocks, 10,000 replications, seed 243715082026, and a two-sided 95% linear-percentile interval
- requires at least 120 common months
- requires both scaled arms to match one frozen month-end decision clock, reconcile every exposure change, and remain at or below 600% annualised turnover before calculating outcome statistics
- reports positive-difference lower bounds, drawdown improvement, and 5% expected-shortfall improvement as conjuncts
- labels the aggregate only as historical statistical conjuncts; no promotable or capital-eligible field exists
- refuses non-finite inputs and derived arithmetic
- pins exact synthetic interval outputs so changes to the seed, blocks, pairing, CER or percentile tails fail regression

## Verification completed

- exact current commit: a69450f256d3b91b4419af5dfe8f3a7cf6645ad2
- 18 focused evaluator tests green on the exact current commit
- 147 overlay/evaluator/bootstrap/trial-register/declaration-gate tests were green before the test-only interval-regression amendment
- full repository pre-push gate green on the exact current commit: Ruff, formatting, full Pyright, 25 static invariants, 288 mutation-probe anchors, full fast tests (including all 18 evaluator tests), app/DB smoke, and frontend integrity checks

## Explicitly still required

- build the four fresh portfolio books from the causal backtest path, including exact daily/session, cost, universe, ambiguity, termination and quarantine provenance
- derive rather than accept the structural turnover/reconciliation audit inputs
- review and merge this pure evaluator before adding the two trial-register entries
- freeze the MT-1 capital-candidate and S-8 falsification-only database declarations
- pass the sealed access gate before any outcome read
- run in-sample first; a failed arm ends this version
- separately pass synthetic-control, DSR, benchmark, recent-window and all promotion gates

This PR deliberately makes no claim that MT-1 is profitable or evidence-qualified.