### PR TITLE
fix(#2437): bind MT-1 to causal monthly clock

### DIFF
--- a/app/services/strategy_mt1_trial.py
+++ b/app/services/strategy_mt1_trial.py
@@ -68,7 +68,8 @@ class ScaledBookStructuralAudit:
     """Outcome-free proof required for each scaled book before statistics.
 
     ``decision_dates`` are the dates on which exposure changed or was
-    reaffirmed. They must equal the evaluator-supplied frozen month-end clock;
+    reaffirmed. They must equal the evaluator-supplied frozen first-session
+    monthly clock;
     a subset is not accepted because silently omitting a decision can suppress
     turnover. ``annualised_turnover`` is a decimal multiple (``6`` = 600%).
     """
@@ -132,13 +133,13 @@ class MT1TrialResult:
 
 def _validate_structural_audit(label: str, audit: ScaledBookStructuralAudit) -> None:
     if not audit.expected_decision_dates:
-        raise MT1TrialRefused(f"{label} frozen month-end decision clock is empty")
+        raise MT1TrialRefused(f"{label} frozen first-session monthly decision clock is empty")
     if tuple(sorted(set(audit.expected_decision_dates))) != audit.expected_decision_dates:
         raise MT1TrialRefused(f"{label} expected decision dates must be sorted and unique")
     if tuple(sorted(set(audit.decision_dates))) != audit.decision_dates:
         raise MT1TrialRefused(f"{label} decision dates must be sorted and unique")
     if audit.decision_dates != audit.expected_decision_dates:
-        raise MT1TrialRefused(f"{label} decisions do not equal the frozen month-end clock")
+        raise MT1TrialRefused(f"{label} decisions do not equal the frozen first-session monthly clock")
     if not math.isfinite(audit.annualised_turnover) or audit.annualised_turnover < 0:
         raise MT1TrialRefused(f"{label} annualised turnover is not finite and non-negative")
     if audit.annualised_turnover > MAX_ANNUALISED_TURNOVER:
@@ -157,7 +158,7 @@ def structural_gate(
     _validate_structural_audit("MT-1 scaled", mt1_scaled)
     _validate_structural_audit("S-8 scaled", s8_scaled)
     if mt1_scaled.expected_decision_dates != s8_scaled.expected_decision_dates:
-        raise MT1TrialRefused("MT-1 and S-8 do not share the same frozen month-end exposure clock")
+        raise MT1TrialRefused("MT-1 and S-8 do not share the same frozen first-session monthly exposure clock")
     return StructuralGateReport(
         mt1_decision_dates=len(mt1_scaled.decision_dates),
         s8_decision_dates=len(s8_scaled.decision_dates),

--- a/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
+++ b/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
@@ -39,9 +39,20 @@ termination, quarantine and cost policies. The implementation must expose a sepa
 strategy module and identity hash. Calling S-10's helpers is allowed; reading or relabelling
 an S-10 result is not.
 
-All target-weight decisions occur on the source rule's existing month-end decision dates.
-The overlay may not create an intramonth rebalance. The unscaled reference is recomputed
-fresh in the same invocation and under the same new trial contract.
+All target-weight decisions occur on the source rule's existing **first-session monthly
+decision dates**: exactly `s10_rebalance_dates`, the first weekday panel bar whose calendar
+month differs from the preceding weekday panel bar. Calling this a month-end clock would be
+wrong and non-causal: S-10 deliberately waits until the first bar of the new month rather
+than assuming on the prior bar that no later session will appear. The overlay may not create
+another intramonth rebalance. The unscaled reference is recomputed fresh in the same
+invocation and under the same new trial contract.
+
+Pre-outcome correction, 2026-08-15: the first frozen draft called these
+"month-end" decisions while also requiring an exact copy of S-10. Source inspection before
+the book implementation or any outcome access showed that phrase contradicted
+`s10_rebalance_dates`. This paragraph records the correction rather than silently editing
+the clock: the binding was and remains the source rule's exact dates; no price outcome was
+read and no choice was made between measured variants.
 
 ## Frozen volatility construction
 
@@ -102,10 +113,10 @@ The evaluator must compute all four pairs unconditionally before reporting any o
 4. the fresh S-8 unscaled reference.
 
 "Same overlay" on S-8 means the same aggregate portfolio-level formula, 120-month
-expanding training rule and month-end exposure-update clock. S-8 signals and exits may
-change the underlying reference book intramonth, but its exposure multiplier remains fixed
-until the next month-end. A per-entry, per-name or signal-date scaling rule is not this
-control and must refuse.
+expanding training rule and exact S-10 first-session monthly exposure-update clock. S-8
+signals and exits may change the underlying reference book between those monthly decisions,
+but its exposure multiplier remains fixed until the next one. A per-entry, per-name or
+signal-date scaling rule is not this control and must refuse.
 
 Before the first price/outcome read, add two exact trial-register entries: one for the MT-1
 scaled/unscaled controlled pair and one for the S-8 scaled/unscaled negative-control pair.
@@ -117,8 +128,8 @@ cap, clock, signal family or history policy is a new trial and a new strategy ve
 
 - Full `survivorship_free` research population and its point-in-time termination treatment.
 - Raw prices for signals/fills/cost bands; aligned total-return wealth prices for returns.
-- Signal at the declared month-end decision bar; fills and exits exactly as the source rule
-  permits. No shared signal/outcome print.
+- Signal at the declared first-session monthly decision bar; fills and exits exactly as the
+  source rule permits. No shared signal/outcome print.
 - Current complete cost-model identity, including spread, carry and FX stamps. A missing
   cost term is a structural refusal, never zero.
 - The fixed in-sample/hold-out boundary and all code-pinned recent windows used by the
@@ -131,7 +142,7 @@ cap, clock, signal family or history policy is a new trial and a new strategy ve
 Before any return, Sharpe, drawdown or expectancy value is exposed, report only structural
 counts and traded notional. Refuse outcome access if either scaled book:
 
-- introduces a decision date outside the frozen month-end clock;
+- introduces a decision date outside the frozen S-10 first-session monthly clock;
 - has annualised turnover above 600% (the repository's 50%-per-month viability bar); or
 - cannot reconcile every exposure change to the frozen formula and preceding information.
 
@@ -186,7 +197,7 @@ n = ceil(((z_0.975 + z_0.8) / 0.5)²)
   = 32 independent decision months
 ```
 
-The floor is raised to **36 independent month-end decision dates** to cover three complete
+The floor is raised to **36 independent monthly decision dates** to cover three complete
 calendar years. The calendar-duration floor is
 `ceil(36 × 365.25 / (12 × 7)) = 157 weeks`. These are floors, not a claim that monthly
 returns are independent; prospective inference must still block-bootstrap. A smaller true

--- a/tests/test_strategy_mt1_trial.py
+++ b/tests/test_strategy_mt1_trial.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import math
-from datetime import date
+from datetime import date, timedelta
 
 import numpy as np
 import pytest
 
+from app.services.strategies.s10_relative_strength_leader import s10_rebalance_dates
 from app.services.strategy_mt1_trial import (
     BLOCK_LENGTH_MONTHS,
     BOOTSTRAP_RESAMPLES,
@@ -34,7 +35,13 @@ def _arm(values: list[float], *, offset: int = 0) -> PortfolioArm:
 
 
 def _audit(*, turnover: float = 1.0, reconciled: bool = True) -> ScaledBookStructuralAudit:
-    decisions = tuple(date(2010 + index // 12, index % 12 + 1, 28) for index in range(24))
+    def first_weekday(month: date) -> date:
+        while month.weekday() >= 5:
+            month += timedelta(days=1)
+        return month
+
+    panel_calendar = tuple(first_weekday(_month(index + 119)) for index in range(25))
+    decisions = tuple(sorted(s10_rebalance_dates(panel_calendar)))
     return ScaledBookStructuralAudit(decisions, decisions, turnover, 1_000_000.0, reconciled)
 
 
@@ -145,7 +152,7 @@ def test_fewer_than_120_common_months_refuses() -> None:
             ScaledBookStructuralAudit(
                 _audit().decision_dates[:-1], _audit().expected_decision_dates, 1.0, 1_000_000.0, True
             ),
-            "do not equal the frozen month-end clock",
+            "do not equal the frozen first-session monthly clock",
         ),
     ],
 )
@@ -168,7 +175,7 @@ def test_the_negative_control_must_share_mt1s_frozen_exposure_clock() -> None:
     shifted_dates = tuple(date(day.year, day.month, 27) for day in shifted.decision_dates)
     shifted = ScaledBookStructuralAudit(shifted_dates, shifted_dates, 1.0, 1_000_000.0, True)
 
-    with pytest.raises(MT1TrialRefused, match="same frozen month-end exposure clock"):
+    with pytest.raises(MT1TrialRefused, match="same frozen first-session monthly exposure clock"):
         structural_gate(_audit(), shifted)
 
 


### PR DESCRIPTION
Closes part of #2437

## Correction

The frozen MT-1 draft repeatedly called S-10's schedule a month-end clock. The source rule is explicitly different: `s10_rebalance_dates` acts on the first weekday panel bar whose calendar month differs from the preceding weekday panel bar. That first-session rule is causal; assuming the prior bar is month-end is not.

This PR corrects the prose and evaluator refusal labels, records the correction in the preregistration itself, and makes the evaluator test fixture derive its decision dates through the real S-10 clock. It does not read outcomes, change the trial register, add a candidate declaration, or claim performance.

## Why this is not outcome-driven

The inconsistency was found by source inspection while designing the book engine, before any MT-1 book implementation, trial-register entry, sealed access, or price-outcome run. The preregistration already required an exact copy of S-10; this change resolves contradictory terminology in favour of that pre-existing source binding and records the correction rather than hiding it.

## Verification

- exact commit: f5e9b0c8eddd8d4996fd7b86fe9425bbafd8454c
- 45 focused MT-1/S-10 tests green
- Ruff, formatting and full Pyright green
- full repository pre-push gate green on the exact commit: 25 static invariants, 288 mutation-probe anchors, full fast tests, app/DB smoke and frontend integrity checks

No profitability, evidence-qualification, promotion, allocation or trading-authority claim is made.