### PR TITLE
feat(#2437): add costed target exposure curve

### DIFF
--- a/app/services/equity_curve.py
+++ b/app/services/equity_curve.py
@@ -60,7 +60,7 @@ recomputed fill could be expressed. The caller resolves them from the ledger.
 from __future__ import annotations
 
 from array import array
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date
 from typing import Final
@@ -109,6 +109,15 @@ ENTRY_WEIGHT_DRIFT_RULE_ID: Final = "entry_weight_drift_v1"
 #: panel-calendar month end. It separates ordinary portfolio maintenance from
 #: v1's accidental coupling of turnover to how often any name opens or closes.
 MONTH_END_REBALANCE_RULE_ID: Final = "calendar_month_end_equal_weight_v1"
+
+#: MT-1's holdings-level overlay engine. The exposure decision is known before
+#: the declared monthly bar, but the synthetic portfolio trade is applied only
+#: AFTER that bar's mark; consequently the new target affects the following
+#: close-to-close return and cannot consume the decision bar's outcome. Source
+#: entries/exits retain their stored open fills. Overlay and event rebalances
+#: share step 4 below, so simultaneous trades are netted before the existing
+#: holding-specific half-spread is charged.
+CAPPED_TARGET_EXPOSURE_RULE_ID: Final = "capped_target_exposure_after_decision_close_v1"
 
 #: How criterion 7's buy-and-hold BENCHMARK is composed. ⚠ FROZEN AND HASHED —
 #: it is ``ResultIdentity.benchmark_rule``, and it exists as a separate id for
@@ -320,6 +329,7 @@ def _build_strategy_curve(
     starting_equity: float = 1.0,
     rebalance_events: bool,
     scheduled_rebalance_indices: frozenset[int] = frozenset(),
+    scheduled_exposure_by_index: Mapping[int, float] | None = None,
 ) -> EquityCurve:
     """Shared strategy walk; ``rebalance_events`` is the #2430 A/B switch.
 
@@ -385,6 +395,7 @@ def _build_strategy_curve(
     event_dates = 0
     short_funded = 0
     stale_marks = 0
+    target_exposure = 1.0 if scheduled_exposure_by_index is None else 0.0
 
     for day in range(date_count):
         opened_today = opening[day]
@@ -445,7 +456,7 @@ def _build_strategy_curve(
                 equity_ref += units[leg] * last_price[leg]
         basket = len(open_legs) + len(opened_today)
         for leg in opened_today:
-            target = equity_ref / basket
+            target = target_exposure * equity_ref / basket
             allocation = min(target, cash)
             if allocation < target:
                 short_funded += 1
@@ -475,6 +486,12 @@ def _build_strategy_curve(
         for leg in freezing_today:
             last_price[leg] = exit_price[leg]
             frozen.add(leg)
+
+        if scheduled_exposure_by_index is not None and frozen:
+            raise ValueError(
+                "a capped target-exposure curve cannot carry an untradeable frozen leg — "
+                "uniform portfolio scaling would be unreachable"
+            )
 
         # 3. MARK TO THE CLOSE. A leg whose series has no bar today keeps its
         #    previous mark (§3.3's halt) and the carry-forward is counted.
@@ -508,12 +525,16 @@ def _build_strategy_curve(
         #    a target the frozen leg can never move to and force every tradeable
         #    leg to absorb the shortfall, which is a different sizing rule.
         tradeable = [leg for leg in open_legs if leg not in frozen]
-        rebalance_now = (rebalance_events and event) or day in scheduled_rebalance_indices
+        exposure_changes = False
+        if scheduled_exposure_by_index is not None and day in scheduled_exposure_by_index:
+            exposure_changes = True
+            target_exposure = scheduled_exposure_by_index[day]
+        rebalance_now = (rebalance_events and event) or day in scheduled_rebalance_indices or exposure_changes
         if rebalance_now and tradeable:
             held = 0.0
             for leg in tradeable:
                 held += units[leg] * last_price[leg]
-            target = (cash + held) / len(tradeable)
+            target = target_exposure * (cash + held) / len(tradeable)
             buyers: list[int] = []
             for leg in tradeable:
                 value = units[leg] * last_price[leg]
@@ -618,6 +639,51 @@ def build_month_end_rebalanced_curve(
         starting_equity=starting_equity,
         rebalance_events=False,
         scheduled_rebalance_indices=month_ends,
+    )
+
+
+def build_capped_target_exposure_curve(
+    book: LegBook,
+    *,
+    dates: Sequence[date],
+    target_exposure_by_date: Mapping[date, float],
+    starting_equity: float = 1.0,
+) -> EquityCurve:
+    """Run one source book under a causal, unlevered exposure schedule.
+
+    Before the first supplied decision the sleeve remains in cash. On a
+    decision date the existing source holdings are marked first, then rebalanced
+    uniformly to the new aggregate target; that target therefore applies to the
+    *next* close-to-close return. Source entry/exit events between decisions
+    rebalance the book under the last target without changing it. All synthetic
+    trades use the same per-leg half-spread and sell-before-buy cash cap as the
+    production curve.
+
+    The caller must derive the dates and exposures from the frozen causal
+    history. This function validates shape and mechanics only; it deliberately
+    cannot invent a missing decision or exposure.
+    """
+    if any(later <= earlier for earlier, later in zip(dates, dates[1:], strict=False)):
+        raise ValueError("dates must be strictly increasing for a causal exposure schedule")
+    if not target_exposure_by_date:
+        raise ValueError("target exposure schedule is empty")
+    date_index = {when: index for index, when in enumerate(dates)}
+    scheduled: dict[int, float] = {}
+    for when, raw_target in target_exposure_by_date.items():
+        if when not in date_index:
+            raise ValueError(f"exposure decision {when} is outside the curve date axis")
+        if isinstance(raw_target, bool):
+            raise ValueError(f"exposure target on {when} must be numeric, not boolean")
+        target = float(raw_target)
+        if not np.isfinite(target) or not 0.0 <= target <= 1.0:
+            raise ValueError(f"exposure target on {when} must be finite and in [0, 1], got {raw_target!r}")
+        scheduled[date_index[when]] = target
+    return _build_strategy_curve(
+        book,
+        date_count=len(dates),
+        starting_equity=starting_equity,
+        rebalance_events=True,
+        scheduled_exposure_by_index=scheduled,
     )
 
 
@@ -792,6 +858,7 @@ def build_buy_and_hold_curve(
 
 
 __all__ = [
+    "CAPPED_TARGET_EXPOSURE_RULE_ID",
     "BENCHMARK_RULE_ID",
     "ENTRY_WEIGHT_DRIFT_RULE_ID",
     "MONTH_END_REBALANCE_RULE_ID",
@@ -799,6 +866,7 @@ __all__ = [
     "EquityCurve",
     "LegBook",
     "build_buy_and_hold_curve",
+    "build_capped_target_exposure_curve",
     "build_entry_weight_drift_curve",
     "build_equity_curve",
     "build_month_end_rebalanced_curve",

--- a/app/services/equity_curve.py
+++ b/app/services/equity_curve.py
@@ -115,8 +115,9 @@ MONTH_END_REBALANCE_RULE_ID: Final = "calendar_month_end_equal_weight_v1"
 #: AFTER that bar's mark; consequently the new target affects the following
 #: close-to-close return and cannot consume the decision bar's outcome. Source
 #: entries/exits retain their stored open fills. Overlay and event rebalances
-#: share step 4 below, so simultaneous trades are netted before the existing
-#: holding-specific half-spread is charged.
+#: share one closing step 4 over the post-fill holdings; source fills remain
+#: distinct and every synthetic trade pays the existing holding-specific
+#: half-spread.
 CAPPED_TARGET_EXPOSURE_RULE_ID: Final = "capped_target_exposure_after_decision_close_v1"
 
 #: How criterion 7's buy-and-hold BENCHMARK is composed. ⚠ FROZEN AND HASHED —
@@ -858,8 +859,8 @@ def build_buy_and_hold_curve(
 
 
 __all__ = [
-    "CAPPED_TARGET_EXPOSURE_RULE_ID",
     "BENCHMARK_RULE_ID",
+    "CAPPED_TARGET_EXPOSURE_RULE_ID",
     "ENTRY_WEIGHT_DRIFT_RULE_ID",
     "MONTH_END_REBALANCE_RULE_ID",
     "SIZING_RULE_ID",

--- a/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
+++ b/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
@@ -54,6 +54,17 @@ the book implementation or any outcome access showed that phrase contradicted
 the clock: the binding was and remains the source rule's exact dates; no price outcome was
 read and no choice was made between measured variants.
 
+The exposure statistic for that date uses information only through the prior completed
+calendar month and is therefore fixed before the decision bar opens. The synthetic sizing
+trade executes after that decision bar's close mark, using the holdings-level engine's
+existing per-leg half-spread, sell-before-buy ordering and cash cap. The new target applies
+only to the following close-to-close return; it never scales the decision bar's return.
+This is identified as
+`capped_target_exposure_after_decision_close_v1`. Source-strategy entries and exits retain
+their original stored open fills. When a source event and an exposure decision share a
+date, step 4 performs one closing rebalance over the post-fill holdings rather than two
+synthetic rebalances.
+
 ## Frozen volatility construction
 
 For each complete calendar month `m`, let `f[m,d]` be the unscaled reference portfolio's
@@ -128,8 +139,10 @@ cap, clock, signal family or history policy is a new trial and a new strategy ve
 
 - Full `survivorship_free` research population and its point-in-time termination treatment.
 - Raw prices for signals/fills/cost bands; aligned total-return wealth prices for returns.
-- Signal at the declared first-session monthly decision bar; fills and exits exactly as the
-  source rule permits. No shared signal/outcome print.
+- Exposure input ends at the prior completed month and the target is fixed before the
+  declared first-session monthly decision bar; its synthetic sizing trade uses that bar's
+  close and affects only later returns. Underlying signal fills and exits remain exactly as
+  the source rule permits. No input return is also an outcome return under the new target.
 - Current complete cost-model identity, including spread, carry and FX stamps. A missing
   cost term is a structural refusal, never zero.
 - The fixed in-sample/hold-out boundary and all code-pinned recent windows used by the

--- a/tests/test_equity_curve.py
+++ b/tests/test_equity_curve.py
@@ -18,11 +18,13 @@ import pytest
 
 from app.services.equity_curve import (
     BENCHMARK_RULE_ID,
+    CAPPED_TARGET_EXPOSURE_RULE_ID,
     ENTRY_WEIGHT_DRIFT_RULE_ID,
     MONTH_END_REBALANCE_RULE_ID,
     SIZING_RULE_ID,
     LegBook,
     build_buy_and_hold_curve,
+    build_capped_target_exposure_curve,
     build_entry_weight_drift_curve,
     build_equity_curve,
     build_month_end_rebalanced_curve,
@@ -35,6 +37,7 @@ SPEC_SIZING_RULE = "equal_weight_concurrent_v1"
 #: #2430's frozen research arm. It is deliberately not production evidence.
 SPEC_ENTRY_WEIGHT_DRIFT_RULE = "entry_weight_drift_v1"
 SPEC_MONTH_END_REBALANCE_RULE = "calendar_month_end_equal_weight_v1"
+SPEC_CAPPED_TARGET_EXPOSURE_RULE = "capped_target_exposure_after_decision_close_v1"
 
 #: #2426's benchmark rule, transcribed from
 #: ``docs/proposals/ta/2026-08-08-buy-and-hold-benchmark.md`` §2.4.
@@ -86,6 +89,14 @@ class TestSpecConstants:
     def test_the_month_end_arm_has_a_distinct_declared_identity(self) -> None:
         assert MONTH_END_REBALANCE_RULE_ID == SPEC_MONTH_END_REBALANCE_RULE
         assert MONTH_END_REBALANCE_RULE_ID not in {SIZING_RULE_ID, ENTRY_WEIGHT_DRIFT_RULE_ID}
+
+    def test_the_capped_exposure_engine_has_a_distinct_declared_identity(self) -> None:
+        assert CAPPED_TARGET_EXPOSURE_RULE_ID == SPEC_CAPPED_TARGET_EXPOSURE_RULE
+        assert CAPPED_TARGET_EXPOSURE_RULE_ID not in {
+            SIZING_RULE_ID,
+            ENTRY_WEIGHT_DRIFT_RULE_ID,
+            MONTH_END_REBALANCE_RULE_ID,
+        }
 
 
 class TestLegBookRefuses:
@@ -605,3 +616,115 @@ class TestBuyAndHoldComposition:
         curve = build_buy_and_hold_curve(book, date_count=4)
         # Opens on 0 and 2, both close on 3.
         assert curve.event_dates == 3
+
+
+class TestCappedTargetExposureCurve:
+    DATES = (
+        date(2020, 1, 2),
+        date(2020, 1, 3),
+        date(2020, 1, 6),
+        date(2020, 1, 7),
+        date(2020, 1, 8),
+    )
+
+    @staticmethod
+    def _rising_book(*, half_spread: float = 0.0, realised: bool = True) -> LegBook:
+        book = LegBook()
+        _leg(
+            book,
+            entry=0,
+            exit_=4,
+            entry_price=100.0,
+            exit_price=146.41,
+            marks=[100.0, 110.0, 121.0, 133.1, 146.41],
+            half_spread=half_spread,
+            realised=realised,
+        )
+        return book
+
+    def test_a_new_target_applies_only_after_the_decision_bars_return(self) -> None:
+        curve = build_capped_target_exposure_curve(
+            self._rising_book(),
+            dates=self.DATES,
+            target_exposure_by_date={self.DATES[0]: 0.5, self.DATES[2]: 0.25},
+        )
+
+        # The first target trades after day 0's mark. Two subsequent 10% source
+        # moves therefore add 5% each; day 2's lower target only affects day 3.
+        assert list(curve.equity[:4]) == pytest.approx([1.0, 1.05, 1.105, 1.132625])
+        assert list(curve.invested[:4]) == pytest.approx([0.5, 0.55, 0.27625, 0.303875])
+        assert list(curve.traded_notional[:4]) == pytest.approx([0.5, 0.0, 0.32875, 0.0])
+
+    def test_exposure_changes_charge_each_holding_spread_and_preserve_cash(self) -> None:
+        book = LegBook()
+        _leg(
+            book,
+            entry=0,
+            exit_=2,
+            entry_price=100.0,
+            exit_price=100.0,
+            marks=[100.0, 100.0, 100.0],
+            half_spread=0.01,
+        )
+        curve = build_capped_target_exposure_curve(
+            book,
+            dates=self.DATES[:3],
+            target_exposure_by_date={self.DATES[0]: 0.5, self.DATES[1]: 0.0},
+        )
+
+        assert list(curve.equity) == pytest.approx([0.995, 0.99, 0.99])
+        assert list(curve.traded_notional) == pytest.approx([0.5, 0.5, 0.0])
+        assert curve.rebalance_costs == pytest.approx(0.01)
+        assert min(curve.equity - curve.invested) >= 0.0
+
+    def test_intramonth_source_events_keep_the_last_target_and_net_once(self) -> None:
+        book = LegBook()
+        _leg(book, entry=0, exit_=4, entry_price=100.0, exit_price=100.0, marks=[100.0] * 5)
+        _leg(book, entry=2, exit_=4, entry_price=100.0, exit_price=100.0, marks=[100.0] * 3)
+
+        curve = build_capped_target_exposure_curve(
+            book,
+            dates=self.DATES,
+            target_exposure_by_date={self.DATES[0]: 0.5},
+        )
+
+        assert curve.equity[2] == pytest.approx(1.0)
+        assert curve.invested[2] == pytest.approx(0.5)
+        # 0.25 buys the new leg and 0.25 sells the old one: the event is one
+        # netted uniform rebalance under the unchanged 50% aggregate target.
+        assert curve.traded_notional[2] == pytest.approx(0.5)
+
+    @pytest.mark.parametrize(
+        ("schedule", "message"),
+        [
+            ({}, "schedule is empty"),
+            ({date(2019, 12, 31): 0.5}, "outside the curve date axis"),
+            ({DATES[0]: -0.01}, "in \\[0, 1\\]"),
+            ({DATES[0]: 1.01}, "in \\[0, 1\\]"),
+            ({DATES[0]: math.nan}, "finite"),
+            ({DATES[0]: True}, "not boolean"),
+        ],
+    )
+    def test_invalid_or_levered_schedules_refuse(self, schedule: dict[date, float], message: str) -> None:
+        with pytest.raises(ValueError, match=message):
+            build_capped_target_exposure_curve(
+                self._rising_book(),
+                dates=self.DATES,
+                target_exposure_by_date=schedule,
+            )
+
+    def test_an_untradeable_frozen_leg_refuses_uniform_scaling(self) -> None:
+        with pytest.raises(ValueError, match="untradeable frozen leg"):
+            build_capped_target_exposure_curve(
+                self._rising_book(realised=False),
+                dates=self.DATES,
+                target_exposure_by_date={self.DATES[0]: 0.5},
+            )
+
+    def test_a_non_increasing_axis_refuses(self) -> None:
+        with pytest.raises(ValueError, match="strictly increasing"):
+            build_capped_target_exposure_curve(
+                self._rising_book(),
+                dates=(self.DATES[0], self.DATES[0], *self.DATES[2:]),
+                target_exposure_by_date={self.DATES[0]: 0.5},
+            )


### PR DESCRIPTION
Closes part of #2437

## Outcome

Adds the opt-in holdings-level portfolio engine needed to construct MT-1 and its S-8 negative-control scaled books without using an `exposure × return` shortcut. Existing strategy-curve callers retain their prior full-exposure behavior.

## Mechanics frozen

- distinct identity: `capped_target_exposure_after_decision_close_v1`
- begins in cash until the caller supplies the first causal target
- accepts only finite targets in `[0, 1]`; leverage is impossible
- marks the declared decision bar before applying the new target, so only subsequent returns use it
- preserves source entries/exits at their stored open fills
- applies the last exposure target to source events between monthly decisions
- performs one closing uniform rebalance over post-fill holdings when a source event and target decision share a date
- charges each synthetic buy/sell with the existing leg-specific half-spread, sells before buys, and caps buys by cash
- refuses an untradeable frozen leg because uniform scaling would be unreachable
- reports the actual costed equity, invested capital, traded notional and rebalance costs through the existing `EquityCurve`

The preregistration now explicitly freezes that the volatility input ends at the prior completed month, the target is fixed before the first-session monthly bar, the sizing trade occurs after that bar's close mark, and the new target cannot consume that bar's outcome.

## Verification

- exact commit: 4326bd4a6b4c18f7070ab6960c2a2e88de8fa52e
- 57 equity-curve tests green
- 239 equity/backtest/statistics/overlay/MT-1 integration tests green
- full repository pre-push gate green on the exact commit: Ruff, formatting, full Pyright, 25 static invariants, 288 mutation-probe anchors, full fast tests, app/DB smoke and frontend integrity checks

## Still outside this PR

This does not derive the monthly exposure schedule, expose outcomes, add trial-register entries or declarations, persist strategy evidence, qualify a strategy, allocate capital, or authorise trading. The next book-builder layer must construct the fresh S-10/S-8 references, derive exposures from complete causal monthly histories, and produce the structural audit inputs.

