### PR TITLE
feat: build causal MT-1 four-arm monthly books

### DIFF
--- a/app/services/strategy_mt1_books.py
+++ b/app/services/strategy_mt1_books.py
@@ -296,9 +296,12 @@ def _turnover_audit(
             f"{label} annualised turnover {annualised:.12g} exceeds the frozen 600% ceiling"
         )
     decision_dates = tuple(decision.decision_date for decision in decisions)
+    expected_decision_dates = tuple(
+        when for when in sorted(s10_rebalance_dates(dates)) if when >= decisions[0].decision_date
+    )
     return ScaledBookStructuralAudit(
         decision_dates=decision_dates,
-        expected_decision_dates=decision_dates,
+        expected_decision_dates=expected_decision_dates,
         annualised_turnover=annualised,
         traded_notional=traded_notional,
         exposure_reconciled=True,

--- a/app/services/strategy_mt1_books.py
+++ b/app/services/strategy_mt1_books.py
@@ -1,0 +1,398 @@
+"""Fresh, causal four-arm portfolio construction for MT-1 (#2437).
+
+The public constructor is deliberately four-arm: both source books are walked
+afresh and both structural audits pass before monthly outcome arms are exposed.
+Daily volatility observations use declared NYSE sessions.  Closed dates on the
+union-price axis are allowed only when the entire source portfolio is inert.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Final
+
+import numpy as np
+
+from app.services.equity_curve import EquityCurve, LegBook, build_capped_target_exposure_curve, build_equity_curve
+from app.services.market_calendar import us_market_status
+from app.services.strategies.s10_relative_strength_leader import s10_rebalance_dates
+from app.services.strategy_mt1_trial import (
+    MAX_ANNUALISED_TURNOVER,
+    MonthlyReturn,
+    PortfolioArm,
+    ScaledBookStructuralAudit,
+    structural_gate,
+)
+from app.services.strategy_volatility_overlay import (
+    CompletedPortfolioMonth,
+    DailyPortfolioReturn,
+    VolatilityExposure,
+    VolatilityOverlayUnavailable,
+    capped_inverse_variance_exposure,
+    compounded_month_return,
+)
+
+BOOK_RULE_ID: Final = "mt1-fresh-four-arm-nyse-session-books-v1"
+_DAYS_PER_YEAR: Final = 365.25
+
+
+def _code_hash() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+BOOK_RULE_VERSION: Final = f"{BOOK_RULE_ID}+{_code_hash()}"
+
+
+class MT1BookConstructionRefused(ValueError):
+    """The frozen four-arm construction cannot be produced as declared."""
+
+
+@dataclass(frozen=True)
+class ExposureDecision:
+    """One target and the completed information set that produced it."""
+
+    decision_date: date
+    history_end_month: date
+    result: VolatilityExposure
+
+
+@dataclass(frozen=True)
+class SourceMonthlyBooks:
+    """One source rule's scaled/unscaled books after structural validation."""
+
+    scaled: PortfolioArm
+    unscaled: PortfolioArm
+    structural: ScaledBookStructuralAudit
+    exposure_decisions: tuple[ExposureDecision, ...]
+    scaled_curve: EquityCurve
+    unscaled_curve: EquityCurve
+
+
+@dataclass(frozen=True)
+class MT1FourArmBooks:
+    """The complete paved input to :func:`evaluate_mt1_trial`."""
+
+    mt1: SourceMonthlyBooks
+    s8: SourceMonthlyBooks
+    evaluation_months: tuple[date, ...]
+    rule_version: str = BOOK_RULE_VERSION
+
+
+def _next_month(month: date) -> date:
+    return date(month.year + (month.month == 12), 1 if month.month == 12 else month.month + 1, 1)
+
+
+def _previous_month(month: date) -> date:
+    return date(month.year - (month.month == 1), 12 if month.month == 1 else month.month - 1, 1)
+
+
+def _month_sessions(month: date) -> tuple[date, ...]:
+    following = _next_month(month)
+    current = month
+    sessions: list[date] = []
+    while current < following:
+        if us_market_status(current) != "closed":
+            sessions.append(current)
+        current += timedelta(days=1)
+    return tuple(sessions)
+
+
+def _validate_axis_and_curve(
+    label: str,
+    *,
+    dates: tuple[date, ...],
+    curve: EquityCurve,
+    starting_equity: float,
+) -> dict[date, int]:
+    if len(dates) < 2:
+        raise MT1BookConstructionRefused(f"{label} date axis needs at least two dates")
+    if any(later <= earlier for earlier, later in zip(dates, dates[1:], strict=False)):
+        raise MT1BookConstructionRefused(f"{label} date axis must be strictly increasing")
+    if len(curve.equity) != len(dates):
+        raise MT1BookConstructionRefused(f"{label} curve has {len(curve.equity)} points against {len(dates)} dates")
+    if not math.isfinite(starting_equity) or starting_equity <= 0:
+        raise MT1BookConstructionRefused(f"{label} starting equity must be positive and finite")
+    if (
+        not np.all(np.isfinite(curve.equity))
+        or not np.all(np.isfinite(curve.invested))
+        or not np.all(np.isfinite(curve.traded_notional))
+        or np.any(curve.equity <= 0)
+        or np.any(curve.invested < 0)
+        or np.any(curve.traded_notional < 0)
+        or np.any(curve.invested - curve.equity > 1e-12)
+    ):
+        raise MT1BookConstructionRefused(f"{label} curve is not finite, positive, unlevered, and non-negative")
+
+    for index, when in enumerate(dates):
+        if us_market_status(when) != "closed":
+            continue
+        previous_equity = starting_equity if index == 0 else float(curve.equity[index - 1])
+        previous_invested = 0.0 if index == 0 else float(curve.invested[index - 1])
+        previous_open = 0 if index == 0 else int(curve.open_count[index - 1])
+        if (
+            float(curve.equity[index]) != previous_equity
+            or float(curve.invested[index]) != previous_invested
+            or int(curve.open_count[index]) != previous_open
+            or float(curve.traded_notional[index]) != 0.0
+        ):
+            raise MT1BookConstructionRefused(f"{label} has portfolio activity on closed NYSE date {when.isoformat()}")
+    return {when: index for index, when in enumerate(dates)}
+
+
+def _completed_history(
+    label: str,
+    *,
+    dates: tuple[date, ...],
+    curve: EquityCurve,
+    starting_equity: float,
+    expected_first_month: date,
+) -> tuple[CompletedPortfolioMonth, ...]:
+    if expected_first_month.day != 1:
+        raise MT1BookConstructionRefused("expected first month must be the first calendar day")
+    index_by_date = _validate_axis_and_curve(
+        label,
+        dates=dates,
+        curve=curve,
+        starting_equity=starting_equity,
+    )
+    first_sessions = _month_sessions(expected_first_month)
+    if not first_sessions or dates[0] < expected_first_month or dates[0] > first_sessions[0]:
+        raise MT1BookConstructionRefused(
+            f"{label} axis starts after the first expected session of {expected_first_month.isoformat()}"
+        )
+
+    result: list[CompletedPortfolioMonth] = []
+    month = expected_first_month
+    while month <= date(dates[-1].year, dates[-1].month, 1):
+        sessions = _month_sessions(month)
+        missing = tuple(session for session in sessions if session not in index_by_date)
+        if missing:
+            past_holes = tuple(session for session in missing if session <= dates[-1])
+            if past_holes:
+                raise MT1BookConstructionRefused(
+                    f"{label} is missing declared NYSE session {past_holes[0].isoformat()} in {month.isoformat()}"
+                )
+            raise MT1BookConstructionRefused(
+                f"{label} terminal month {month.isoformat()} is incomplete at {dates[-1].isoformat()}"
+            )
+        daily: list[DailyPortfolioReturn] = []
+        for session in sessions:
+            index = index_by_date[session]
+            previous = starting_equity if index == 0 else float(curve.equity[index - 1])
+            value = float(curve.equity[index]) / previous - 1.0
+            if not math.isfinite(value) or value < -1.0:
+                raise MT1BookConstructionRefused(f"{label} has an invalid daily return on {session.isoformat()}")
+            daily.append(DailyPortfolioReturn(session=session, value=Decimal(str(value))))
+        result.append(
+            CompletedPortfolioMonth(
+                month=month,
+                daily_returns=tuple(daily),
+                expected_sessions=sessions,
+            )
+        )
+        month = _next_month(month)
+    if not result:
+        raise MT1BookConstructionRefused(f"{label} has no complete portfolio month")
+    return tuple(result)
+
+
+def _exposure_decisions(
+    label: str,
+    *,
+    history: tuple[CompletedPortfolioMonth, ...],
+    dates: tuple[date, ...],
+    expected_first_month: date,
+) -> tuple[ExposureDecision, ...]:
+    last_complete_month = history[-1].month
+    clock = tuple(
+        when
+        for when in sorted(s10_rebalance_dates(dates))
+        if expected_first_month < date(when.year, when.month, 1) <= last_complete_month
+    )
+    if any(us_market_status(when) == "closed" for when in clock):
+        bad = next(when for when in clock if us_market_status(when) == "closed")
+        raise MT1BookConstructionRefused(f"{label} S-10 decision clock lands on closed NYSE date {bad.isoformat()}")
+
+    decisions: list[ExposureDecision] = []
+    for decision_date in clock:
+        decision_month = date(decision_date.year, decision_date.month, 1)
+        history_end = _previous_month(decision_month)
+        prefix = tuple(record for record in history if record.month <= history_end)
+        if not prefix or prefix[-1].month != history_end:
+            if decisions:
+                raise MT1BookConstructionRefused(f"{label} completed history does not reach {history_end.isoformat()}")
+            continue
+        try:
+            exposure = capped_inverse_variance_exposure(prefix, expected_first_month=expected_first_month)
+        except VolatilityOverlayUnavailable as exc:
+            if not decisions:
+                continue
+            raise MT1BookConstructionRefused(
+                f"{label} exposure is unavailable on {decision_date.isoformat()}: {exc}"
+            ) from exc
+        decisions.append(
+            ExposureDecision(
+                decision_date=decision_date,
+                history_end_month=history_end,
+                result=exposure,
+            )
+        )
+
+    if not decisions:
+        raise MT1BookConstructionRefused(f"{label} produced no exposure after the frozen training window")
+    expected_after_warmup = tuple(when for when in clock if when >= decisions[0].decision_date)
+    actual = tuple(decision.decision_date for decision in decisions)
+    if actual != expected_after_warmup:
+        raise MT1BookConstructionRefused(f"{label} exposure decisions do not cover the exact post-warm-up S-10 clock")
+
+    for decision in decisions:
+        prefix = tuple(record for record in history if record.month <= decision.history_end_month)
+        replay = capped_inverse_variance_exposure(prefix, expected_first_month=expected_first_month)
+        if replay != decision.result or prefix[-1].month != decision.history_end_month:
+            raise MT1BookConstructionRefused(
+                f"{label} exposure does not replay on {decision.decision_date.isoformat()}"
+            )
+    return tuple(decisions)
+
+
+def _arm(history: tuple[CompletedPortfolioMonth, ...], *, first_month: date) -> PortfolioArm:
+    return PortfolioArm(
+        monthly_returns=tuple(
+            MonthlyReturn(month=record.month, value=float(compounded_month_return(record)))
+            for record in history
+            if record.month >= first_month
+        )
+    )
+
+
+def _turnover_audit(
+    label: str,
+    *,
+    curve: EquityCurve,
+    dates: tuple[date, ...],
+    decisions: tuple[ExposureDecision, ...],
+) -> ScaledBookStructuralAudit:
+    first = decisions[0].decision_date
+    session_indices = tuple(
+        index for index, when in enumerate(dates) if when >= first and us_market_status(when) != "closed"
+    )
+    if len(session_indices) < 2:
+        raise MT1BookConstructionRefused(f"{label} evaluation axis has fewer than two NYSE sessions")
+    first_session = dates[session_indices[0]]
+    last_session = dates[session_indices[-1]]
+    years = (last_session - first_session).days / _DAYS_PER_YEAR
+    mean_equity = float(np.mean(curve.equity[list(session_indices)]))
+    traded_notional = float(np.sum(curve.traded_notional[list(session_indices)]))
+    if not math.isfinite(mean_equity) or mean_equity <= 0 or not math.isfinite(traded_notional) or years <= 0:
+        raise MT1BookConstructionRefused(f"{label} turnover denominator is not positive and finite")
+    annualised = traded_notional / 2.0 / mean_equity / years
+    if not math.isfinite(annualised) or annualised > MAX_ANNUALISED_TURNOVER:
+        raise MT1BookConstructionRefused(
+            f"{label} annualised turnover {annualised:.12g} exceeds the frozen 600% ceiling"
+        )
+    decision_dates = tuple(decision.decision_date for decision in decisions)
+    return ScaledBookStructuralAudit(
+        decision_dates=decision_dates,
+        expected_decision_dates=decision_dates,
+        annualised_turnover=annualised,
+        traded_notional=traded_notional,
+        exposure_reconciled=True,
+    )
+
+
+def _build_source(
+    label: str,
+    *,
+    book: LegBook,
+    dates: tuple[date, ...],
+    expected_first_month: date,
+    starting_equity: float,
+) -> SourceMonthlyBooks:
+    unscaled_curve = build_equity_curve(book, date_count=len(dates), starting_equity=starting_equity)
+    unscaled_history = _completed_history(
+        f"{label} unscaled",
+        dates=dates,
+        curve=unscaled_curve,
+        starting_equity=starting_equity,
+        expected_first_month=expected_first_month,
+    )
+    decisions = _exposure_decisions(
+        label,
+        history=unscaled_history,
+        dates=dates,
+        expected_first_month=expected_first_month,
+    )
+    scaled_curve = build_capped_target_exposure_curve(
+        book,
+        dates=dates,
+        target_exposure_by_date={decision.decision_date: float(decision.result.exposure) for decision in decisions},
+        starting_equity=starting_equity,
+    )
+    scaled_history = _completed_history(
+        f"{label} scaled",
+        dates=dates,
+        curve=scaled_curve,
+        starting_equity=starting_equity,
+        expected_first_month=expected_first_month,
+    )
+    first_month = date(decisions[0].decision_date.year, decisions[0].decision_date.month, 1)
+    structural = _turnover_audit(label, curve=scaled_curve, dates=dates, decisions=decisions)
+    return SourceMonthlyBooks(
+        scaled=_arm(scaled_history, first_month=first_month),
+        unscaled=_arm(unscaled_history, first_month=first_month),
+        structural=structural,
+        exposure_decisions=decisions,
+        scaled_curve=scaled_curve,
+        unscaled_curve=unscaled_curve,
+    )
+
+
+def build_mt1_four_arm_books(
+    *,
+    mt1_book: LegBook,
+    s8_book: LegBook,
+    dates: tuple[date, ...],
+    expected_first_month: date,
+    starting_equity: float = 1.0,
+) -> MT1FourArmBooks:
+    """Build all four arms; accept no caller-owned returns or audit flags."""
+    mt1 = _build_source(
+        "MT-1",
+        book=mt1_book,
+        dates=dates,
+        expected_first_month=expected_first_month,
+        starting_equity=starting_equity,
+    )
+    s8 = _build_source(
+        "S-8 negative control",
+        book=s8_book,
+        dates=dates,
+        expected_first_month=expected_first_month,
+        starting_equity=starting_equity,
+    )
+    structural_gate(mt1.structural, s8.structural)
+    axes = (
+        tuple(point.month for point in mt1.scaled.monthly_returns),
+        tuple(point.month for point in mt1.unscaled.monthly_returns),
+        tuple(point.month for point in s8.scaled.monthly_returns),
+        tuple(point.month for point in s8.unscaled.monthly_returns),
+    )
+    if not axes[0] or any(axis != axes[0] for axis in axes[1:]):
+        raise MT1BookConstructionRefused("the four fresh books do not share one complete evaluation-month axis")
+    return MT1FourArmBooks(mt1=mt1, s8=s8, evaluation_months=axes[0])
+
+
+__all__ = [
+    "BOOK_RULE_ID",
+    "BOOK_RULE_VERSION",
+    "ExposureDecision",
+    "MT1BookConstructionRefused",
+    "MT1FourArmBooks",
+    "SourceMonthlyBooks",
+    "build_mt1_four_arm_books",
+]

--- a/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
+++ b/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
@@ -68,8 +68,17 @@ synthetic rebalances.
 ## Frozen volatility construction
 
 For each complete calendar month `m`, let `f[m,d]` be the unscaled reference portfolio's
-after-cost daily total return on trading day `d`, including zero-return cash where the
-reference is not fully invested. Let `J[m]` be its count of usable daily returns.
+after-cost daily total return on declared NYSE session `d`, including zero-return cash where
+the reference is not fully invested. Let `J[m]` be its count of usable daily returns. The
+session set comes from `app.services.market_calendar.us_market_status`, not every date in the
+union research-price axis: that axis contains stray weekend rows for roughly 11 instruments,
+and counting those rows would silently alter both `J[m]` and realised variance. A union-axis
+date on which NYSE is closed is tolerated only if the source portfolio is entirely inert;
+any trade, holding-count, invested-capital or equity change on it refuses construction.
+The holdings engine stores binary-float equity. Each simple daily equity ratio is converted
+to the overlay's deterministic decimal arithmetic with `Decimal(str(value))`; the complete
+constructor is source-hashed in its `BOOK_RULE_VERSION`, so changing that bridge moves the
+book identity rather than silently changing the schedule.
 
 The realised variance used by Cederburg et al.'s equation (4) is:
 
@@ -91,7 +100,7 @@ where `f_month[m]` is the compounded unscaled after-cost total return for month 
 training observation exists only when both terms are available before `t`.
 
 Every calendar month from the reference book's first eligible complete month onward remains
-in the input history, with exactly one return for every session on the frozen panel calendar.
+in the input history, with exactly one return for every session on the frozen NYSE calendar.
 This includes an all-cash month whose returns and variance are zero. Because S-10 can be
 intermittently invested whereas the papers' factors are always defined, a zero `v[m-1]`
 cannot divide the next month's return: that pair is unavailable but the calendar month is
@@ -113,6 +122,13 @@ no next-month exposure; it never defaults to 100%. The multiplier is applied onc
 aggregate reference book and uniformly to all selected holdings; residual weight stays in
 zero-return cash. Per-name inverse-volatility weighting is a different strategy and is not
 permitted under this identity.
+
+Pre-outcome session-axis clarification, 2026-08-15: the first draft said "frozen panel
+calendar" while also defining `d` as a trading day. Source inspection before the monthly
+book implementation, trial-register entries or outcome access showed that the union panel
+contains non-session weekend contaminants. This paragraph binds the already-declared
+trading-day meaning to the repository's existing NYSE calendar and records the clarification
+rather than allowing an implementation to choose whichever axis gives a preferred result.
 
 ## Arms and trial accounting
 

--- a/tests/test_strategy_mt1_books.py
+++ b/tests/test_strategy_mt1_books.py
@@ -46,6 +46,43 @@ def _book(dates: tuple[date, ...], *, altered: dict[date, float] | None = None) 
     return book
 
 
+def _daily_churn_book(dates: tuple[date, ...]) -> LegBook:
+    book = LegBook()
+    for index in range(len(dates)):
+        book.add(
+            entry_index=index,
+            exit_index=index,
+            entry_price=100.0,
+            exit_price=100.1,
+            half_spread=0.0,
+            realised=True,
+            marks=[100.0],
+        )
+    return book
+
+
+def _book_with_inert_closed_mark(dates: tuple[date, ...]) -> LegBook:
+    price = 100.0
+    marks = [price]
+    for index, when in enumerate(dates[1:], start=1):
+        if us_market_status(when) == "closed":
+            marks.append(math.nan)
+        else:
+            price *= 1.0 + 0.0005 + 0.00015 * math.sin(index / 19.0)
+            marks.append(price)
+    book = LegBook()
+    book.add(
+        entry_index=0,
+        exit_index=len(dates) - 1,
+        entry_price=marks[0],
+        exit_price=marks[-1],
+        half_spread=0.0005,
+        realised=True,
+        marks=marks,
+    )
+    return book
+
+
 @pytest.fixture(scope="module")
 def dates() -> tuple[date, ...]:
     return _sessions()
@@ -118,6 +155,18 @@ def test_a_later_zero_variance_month_refuses_instead_of_omitting_a_clock_date(
         )
 
 
+def test_derived_turnover_above_six_times_refuses_before_books_are_returned(
+    dates: tuple[date, ...],
+) -> None:
+    with pytest.raises(MT1BookConstructionRefused, match="annualised turnover .* exceeds the frozen 600%"):
+        build_mt1_four_arm_books(
+            mt1_book=_daily_churn_book(dates),
+            s8_book=_book(dates),
+            dates=dates,
+            expected_first_month=FIRST_MONTH,
+        )
+
+
 def test_portfolio_activity_on_a_closed_union_axis_date_refuses() -> None:
     dates = (date(2020, 1, 5), date(2020, 1, 6))  # Sunday, then Monday.
     book = _book(dates)
@@ -128,6 +177,21 @@ def test_portfolio_activity_on_a_closed_union_axis_date_refuses() -> None:
             dates=dates,
             expected_first_month=date(2020, 1, 1),
         )
+
+
+def test_an_exactly_inert_closed_union_axis_mark_is_allowed(dates: tuple[date, ...]) -> None:
+    contaminant = date(2015, 1, 4)  # Sunday between the Jan 2 and Jan 5 sessions.
+    contaminated_dates = tuple(sorted((*dates, contaminant)))
+    book = _book_with_inert_closed_mark(contaminated_dates)
+
+    built = build_mt1_four_arm_books(
+        mt1_book=book,
+        s8_book=book,
+        dates=contaminated_dates,
+        expected_first_month=FIRST_MONTH,
+    )
+
+    assert built.evaluation_months == tuple(date(2020, month, 1) for month in range(2, 7))
 
 
 def test_a_missing_declared_session_refuses_a_supposedly_complete_month() -> None:

--- a/tests/test_strategy_mt1_books.py
+++ b/tests/test_strategy_mt1_books.py
@@ -1,0 +1,175 @@
+"""Pure construction tests for the frozen MT-1/S-8 four-arm books."""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+import pytest
+
+from app.services.equity_curve import LegBook
+from app.services.market_calendar import us_market_status
+from app.services.strategies.s10_relative_strength_leader import s10_rebalance_dates
+from app.services.strategy_mt1_books import MT1BookConstructionRefused, build_mt1_four_arm_books
+from app.services.strategy_mt1_trial import MIN_COMMON_MONTHS, evaluate_mt1_trial
+
+FIRST_MONTH = date(2010, 1, 1)
+LAST_DAY = date(2020, 6, 30)
+
+
+def _sessions(first: date = FIRST_MONTH, last: date = LAST_DAY) -> tuple[date, ...]:
+    result: list[date] = []
+    current = first
+    while current <= last:
+        if us_market_status(current) != "closed":
+            result.append(current)
+        current += timedelta(days=1)
+    return tuple(result)
+
+
+def _book(dates: tuple[date, ...], *, altered: dict[date, float] | None = None) -> LegBook:
+    altered = altered or {}
+    marks = [100.0]
+    for index, when in enumerate(dates[1:], start=1):
+        daily_return = altered.get(when, 0.0005 + 0.00015 * math.sin(index / 19.0))
+        marks.append(marks[-1] * (1.0 + daily_return))
+    book = LegBook()
+    book.add(
+        entry_index=0,
+        exit_index=len(dates) - 1,
+        entry_price=marks[0],
+        exit_price=marks[-1],
+        half_spread=0.0005,
+        realised=True,
+        marks=marks,
+    )
+    return book
+
+
+@pytest.fixture(scope="module")
+def dates() -> tuple[date, ...]:
+    return _sessions()
+
+
+def test_all_four_fresh_books_share_the_post_training_month_axis(dates: tuple[date, ...]) -> None:
+    built = build_mt1_four_arm_books(
+        mt1_book=_book(dates),
+        s8_book=_book(dates),
+        dates=dates,
+        expected_first_month=FIRST_MONTH,
+    )
+
+    assert built.evaluation_months[0] == date(2020, 2, 1)
+    assert built.evaluation_months[-1] == date(2020, 6, 1)
+    assert len(built.evaluation_months) == 5
+    assert built.mt1.structural.decision_dates == built.s8.structural.decision_dates
+    assert built.mt1.structural.decision_dates == tuple(
+        when for when in sorted(s10_rebalance_dates(dates)) if when >= built.mt1.structural.decision_dates[0]
+    )
+    assert built.mt1.structural.exposure_reconciled is True
+    assert built.s8.structural.exposure_reconciled is True
+    assert all(
+        decision.history_end_month
+        == date(
+            decision.decision_date.year - (decision.decision_date.month == 1),
+            12 if decision.decision_date.month == 1 else decision.decision_date.month - 1,
+            1,
+        )
+        for decision in built.mt1.exposure_decisions
+    )
+    assert built.mt1.scaled_curve.rebalance_costs > 0
+    evaluation_indices = [index for index, when in enumerate(dates) if when >= built.mt1.structural.decision_dates[0]]
+    traded = sum(built.mt1.scaled_curve.traded_notional[index] for index in evaluation_indices)
+    assert built.mt1.structural.traded_notional == pytest.approx(traded)
+    years = (dates[evaluation_indices[-1]] - dates[evaluation_indices[0]]).days / 365.25
+    mean_equity = sum(built.mt1.scaled_curve.equity[index] for index in evaluation_indices) / len(evaluation_indices)
+    assert built.mt1.structural.annualised_turnover == pytest.approx(traded / 2 / mean_equity / years)
+
+
+def test_the_decision_bar_outcome_cannot_change_its_own_target(dates: tuple[date, ...]) -> None:
+    baseline = build_mt1_four_arm_books(
+        mt1_book=_book(dates),
+        s8_book=_book(dates),
+        dates=dates,
+        expected_first_month=FIRST_MONTH,
+    )
+    first_decision = baseline.mt1.exposure_decisions[0].decision_date
+    changed = build_mt1_four_arm_books(
+        mt1_book=_book(dates, altered={first_decision: 0.25}),
+        s8_book=_book(dates),
+        dates=dates,
+        expected_first_month=FIRST_MONTH,
+    )
+
+    assert changed.mt1.exposure_decisions[0] == baseline.mt1.exposure_decisions[0]
+    assert changed.mt1.unscaled.monthly_returns[0].value != baseline.mt1.unscaled.monthly_returns[0].value
+
+
+def test_a_later_zero_variance_month_refuses_instead_of_omitting_a_clock_date(
+    dates: tuple[date, ...],
+) -> None:
+    march = {when: 0.0 for when in dates if (when.year, when.month) == (2020, 3)}
+    with pytest.raises(MT1BookConstructionRefused, match="exposure is unavailable on 2020-04-01"):
+        build_mt1_four_arm_books(
+            mt1_book=_book(dates, altered=march),
+            s8_book=_book(dates),
+            dates=dates,
+            expected_first_month=FIRST_MONTH,
+        )
+
+
+def test_portfolio_activity_on_a_closed_union_axis_date_refuses() -> None:
+    dates = (date(2020, 1, 5), date(2020, 1, 6))  # Sunday, then Monday.
+    book = _book(dates)
+    with pytest.raises(MT1BookConstructionRefused, match="activity on closed NYSE date 2020-01-05"):
+        build_mt1_four_arm_books(
+            mt1_book=book,
+            s8_book=book,
+            dates=dates,
+            expected_first_month=date(2020, 1, 1),
+        )
+
+
+def test_a_missing_declared_session_refuses_a_supposedly_complete_month() -> None:
+    dates = (date(2020, 1, 2), date(2020, 1, 6))  # Jan 3 was an open NYSE session.
+    with pytest.raises(MT1BookConstructionRefused, match="missing declared NYSE session 2020-01-03"):
+        build_mt1_four_arm_books(
+            mt1_book=LegBook(),
+            s8_book=LegBook(),
+            dates=dates,
+            expected_first_month=date(2020, 1, 1),
+        )
+
+
+def test_a_partial_terminal_month_is_not_silently_dropped() -> None:
+    dates = _sessions(date(2020, 1, 1), date(2020, 1, 15))
+    with pytest.raises(MT1BookConstructionRefused, match="terminal month 2020-01-01 is incomplete"):
+        build_mt1_four_arm_books(
+            mt1_book=LegBook(),
+            s8_book=LegBook(),
+            dates=dates,
+            expected_first_month=date(2020, 1, 1),
+        )
+
+
+def test_the_constructed_books_are_the_direct_four_arm_evaluator_input() -> None:
+    long_dates = _sessions(date(2000, 1, 1), date(2020, 12, 31))
+    built = build_mt1_four_arm_books(
+        mt1_book=_book(long_dates),
+        s8_book=_book(long_dates),
+        dates=long_dates,
+        expected_first_month=date(2000, 1, 1),
+    )
+
+    result = evaluate_mt1_trial(
+        mt1_scaled=built.mt1.scaled,
+        mt1_unscaled=built.mt1.unscaled,
+        s8_scaled=built.s8.scaled,
+        s8_unscaled=built.s8.unscaled,
+        mt1_structural=built.mt1.structural,
+        s8_structural=built.s8.structural,
+    )
+
+    assert len(result.common_months) >= MIN_COMMON_MONTHS
+    assert result.common_months == built.evaluation_months
+    assert result.primary_difference_in_differences == pytest.approx(0.0)


### PR DESCRIPTION
Closes part of #2437

## Outcome

Adds the pure four-arm book constructor between the frozen MT-1 exposure/evaluator components and the future paved research runner. It freshly walks both MT-1 and S-8 source books, derives each capped exposure only from its own completed prior-month history, builds holdings-level costed scaled curves, and returns the four monthly arms only after both structural audits pass.

## Pre-outcome session-axis clarification

The preregistration said trading days on the frozen panel calendar. Source inspection found that the union research-price axis contains stray weekend rows. Counting those rows changes `J` in the declared variance formula. Before trial registration or outcome access, this PR binds daily observations to the repository NYSE calendar and refuses any portfolio activity on a closed date. The union axis may retain an inert contaminant, but it cannot become a volatility observation or trade date.

## Fail-closed construction

- exact post-warm-up S-10 first-session decision clock; no omitted later decision
- complete consecutive NYSE session months only; missing sessions and partial terminal months refuse
- 120 usable-pair expanding history, prior completed month only
- decision-bar outcome cannot affect its own target
- binary-float equity ratios cross into deterministic decimal arithmetic through `Decimal(str(value))`
- exposure replay is derived internally; no caller-owned reconciliation flag
- annualised turnover is derived from costed traded notional, mean equity and elapsed years, with the frozen 600% ceiling
- both source clocks must match before any four-arm result is returned
- source and synthetic trades use the existing holdings engine and half-spread mechanics

## Verification

- exact commit: 1e0c7eb007e62f0db8cd52f1b3467723c3f1c450
- 95 focused equity/overlay/book/evaluator tests green
- direct 21-year synthetic construction feeds the frozen 10,000-resample four-arm evaluator with at least 120 common months
- full repository pre-push gate green: Ruff, formatting, full Pyright, 25 static invariants, 288 mutation-probe anchors, full fast tests, app/DB smoke, and frontend integrity checks

## Still outside this PR

This does not read the research corpus, create trial-register/declaration rows, open outcomes, persist evidence, qualify a strategy, allocate capital, or authorise broker execution. The next integration must construct the two source `LegBook`s from the exact manifest identities on the corrected metric axis and bind this constructor through the declaration/access gate.


