### PR TITLE
chore: register MT-1 controlled trials before outcomes

### DIFF
--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -118,7 +118,7 @@ from typing import Final
 #: Bumped whenever a trial is added or an entry's meaning changes. ⚠ Stored on
 #: the result row beside the DSR: a deflated Sharpe means nothing without the
 #: trial population it was deflated against, and that population grows.
-TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-15-r6"
+TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-15-r7"
 
 #: #2600 Gate D-0.1. Every search this register counts happened at or before this
 #: instant; the two durable clocks (``strategy_results_store.created_at`` and
@@ -592,6 +592,36 @@ TRIAL_REGISTER: Final = TrialRegister(
                 ("s9-squeeze-expansion", "S-9 squeeze expansion"),
                 ("s10-relative-strength-leader", "S-10 relative-strength leader"),
             )
+        ),
+        # ⚠ DECLARED BEFORE EITHER CONTROLLED OUTCOME IS OPENED. These are two
+        # searches, not one: the S-8 negative control has its own scaled versus
+        # unscaled estimand and can falsify an overlay effect that appears on
+        # MT-1. The four monthly arms within the pair are jointly required by
+        # one difference-in-differences evaluator; no favourable arm can be
+        # selected, so the fan-collapse rule makes each pair one search.
+        DeclaredTrial(
+            trial_id="mt1-capped-volatility-managed-relative-strength-v1",
+            description=(
+                "MT-1 capped volatility-managed long-only relative strength: one preregistered scaled/unscaled "
+                "controlled pair, evaluated only inside the frozen four-arm difference-in-differences design."
+            ),
+            evidence=(
+                "docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md "
+                "§'Arms and trial accounting' and §'Frozen primary estimand and inference'; issue #2437"
+            ),
+            exactness=TrialExactness.EXACT,
+        ),
+        DeclaredTrial(
+            trial_id="mt1-s8-capped-volatility-negative-control-v1",
+            description=(
+                "S-8 capped-volatility negative control: one preregistered scaled/unscaled controlled pair, "
+                "jointly required with MT-1 and never independently selectable."
+            ),
+            evidence=(
+                "docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md "
+                "§'Arms and trial accounting' and §'Frozen primary estimand and inference'; issue #2437"
+            ),
+            exactness=TrialExactness.EXACT,
         ),
     ),
 )

--- a/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
+++ b/docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md
@@ -1,8 +1,8 @@
 # MT-1 capped volatility-managed long-only relative strength — preregistration
 
 Date: 2026-08-15  
-Status: design frozen in source before implementation or outcome access; not yet entered in
-`trial_register.py`, not yet frozen in `strategy_preregistration_declarations`, and therefore
+Status: design and both controlled searches frozen in source before outcome access; entered in
+`trial_register.py` r7, not yet frozen in `strategy_preregistration_declarations`, and therefore
 not authorised to open outcomes  
 Parent: #2437  
 Candidate ledger: `2026-08-15-market-technician-derived-candidates.md`

--- a/tests/test_trial_register.py
+++ b/tests/test_trial_register.py
@@ -6,6 +6,7 @@ from datetime import UTC
 
 import pytest
 
+from app.services.strategy_mt1_trial import NEGATIVE_CONTROL_TRIAL_ID, TRIAL_ID
 from app.services.trial_register import (
     TRIAL_REGISTER,
     TRIAL_REGISTER_CUTOFF,
@@ -22,7 +23,7 @@ def _trial(trial_id: str, exactness: TrialExactness = TrialExactness.EXACT) -> D
 
 class TestTheShippedDeclaration:
     def test_the_register_is_stamped_with_its_version(self) -> None:
-        assert TRIAL_REGISTER.version == TRIAL_REGISTER_VERSION
+        assert TRIAL_REGISTER.version == TRIAL_REGISTER_VERSION == "trial-register-2026-08-15-r7"
 
     def test_every_declared_trial_carries_its_evidence(self) -> None:
         """⚠ An entry nobody can trace is indistinguishable from one invented."""
@@ -67,12 +68,26 @@ class TestTheShippedDeclaration:
         the total is caught by neither and is why every family below is pinned
         individually as well.
         """
-        # ⚠ 259 (#2600's Gate D-0.1 reconstruction) + 7 (#2614's C-4 entry, the
-        # first declared BEFORE its run). Moved deliberately, not loosened: the
-        # pin exists to catch a DROPPED entry, and an addition that raises M is
-        # the conservative direction — a larger M lowers the DSR.
-        assert TRIAL_REGISTER.declared_count == 272
+        # ⚠ 259 (#2600's Gate D-0.1 reconstruction) + 7 (#2614's C-4 entry) +
+        # 6 S-5..S-10 declarations + 2 MT-1 controlled pairs. Moved
+        # deliberately, not loosened: the pin exists to catch a DROPPED entry,
+        # and an addition that raises M is the conservative direction — a
+        # larger M lowers the DSR.
+        assert TRIAL_REGISTER.declared_count == 274
         assert TRIAL_REGISTER.declared_count == sum(trial.searches for trial in TRIAL_REGISTER.trials)
+
+    def test_the_two_mt1_controlled_pairs_are_charged_before_outcomes(self) -> None:
+        expected = {
+            "mt1-capped-volatility-managed-relative-strength-v1",
+            "mt1-s8-capped-volatility-negative-control-v1",
+        }
+        assert expected == {TRIAL_ID, NEGATIVE_CONTROL_TRIAL_ID}
+        assert expected <= TRIAL_REGISTER.trial_ids
+        for trial in TRIAL_REGISTER.trials:
+            if trial.trial_id in expected:
+                assert trial.searches == 1
+                assert trial.exactness is TrialExactness.EXACT
+                assert "2026-08-15-mt1-volatility-managed-relative-strength-preregistration.md" in trial.evidence
 
     def test_the_c4_schedule13d_arms_are_counted_before_the_run(self) -> None:
         """#2614 — three arms that load their own bars, plus four 13G rule cells.


### PR DESCRIPTION
Closes part of #2437

## Outcome

Charges the two frozen MT-1 controlled searches to the shared trial register before any corpus outcome is opened:

1. `mt1-capped-volatility-managed-relative-strength-v1` — the jointly evaluated MT-1 scaled/unscaled pair.
2. `mt1-s8-capped-volatility-negative-control-v1` — the jointly evaluated S-8 scaled/unscaled negative-control pair.

Each pair is one exact search under the existing conjunctive-fan rule. They remain two searches because the S-8 pair owns a distinct estimand and can falsify an apparent MT-1 overlay effect. No favourable arm is independently selectable.

## Register movement

- `TRIAL_REGISTER_VERSION`: r6 -> r7
- declared search count: 272 -> 274
- floored historical search count: unchanged
- evaluator constants are bridged to the two literal register identities by a non-drifting test
- preregistration status records that the register step is complete while database declarations and outcome access remain forbidden

## Verification

- exact commit: cc24fdf85dcf95f0cbbb7b505118c654d9958b39
- 60 focused trial-register and MT-1 evaluator tests green
- full repository pre-push gate green: Ruff, formatting, full Pyright, 25 static invariants, 288 mutation-probe anchors, full fast tests, app/DB smoke, and frontend integrity checks

## Authority boundary

This PR does not construct a strategy identity, freeze database declarations, access outcomes, run a backtest, persist evidence, qualify a strategy, allocate capital, or authorise execution. Its purpose is to make the next search honestly count itself before it can happen.
