### PR TITLE
Bind MT-1 identities and preregistration declarations

### DIFF
--- a/app/services/equity_curve.py
+++ b/app/services/equity_curve.py
@@ -59,10 +59,12 @@ recomputed fill could be expressed. The caller resolves them from the ledger.
 
 from __future__ import annotations
 
+import hashlib
 from array import array
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date
+from pathlib import Path
 from typing import Final
 
 import numpy as np
@@ -97,6 +99,16 @@ import numpy.typing as npt
 #:      ``cash >= 0`` hold by construction rather than by tolerance, and the
 #:      under-investment that leaves is exactly the cost charged.
 SIZING_RULE_ID: Final = "equal_weight_concurrent_v1"
+
+
+def _code_hash() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+# MT-1 depends on both curve constructors in this module. This source-derived
+# version prevents either engine changing while its four-arm book identity is
+# silently reused; it is intentionally broader than the public sizing-rule ID.
+EQUITY_CURVE_ENGINE_VERSION: Final = f"equity-curve-engine-v1+{_code_hash()}"
 
 #: Research arm for #2430. A new position receives the same causal entry-time
 #: target as v1 (equity divided by the post-entry concurrent count), but every
@@ -861,6 +873,7 @@ def build_buy_and_hold_curve(
 __all__ = [
     "BENCHMARK_RULE_ID",
     "CAPPED_TARGET_EXPOSURE_RULE_ID",
+    "EQUITY_CURVE_ENGINE_VERSION",
     "ENTRY_WEIGHT_DRIFT_RULE_ID",
     "MONTH_END_REBALANCE_RULE_ID",
     "SIZING_RULE_ID",

--- a/app/services/market_calendar.py
+++ b/app/services/market_calendar.py
@@ -46,11 +46,13 @@ closed day shown as open).
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
+from pathlib import Path
 from types import MappingProxyType
-from typing import Literal, cast
+from typing import Final, Literal, cast
 
 from pandas import Series, Timestamp
 from pandas.tseries.holiday import (
@@ -64,6 +66,15 @@ from pandas.tseries.holiday import (
     USThanksgivingDay,
     nearest_workday,
 )
+
+RULE_SET_ID: Final = "nyse-market-calendar-v1"
+
+
+def _code_hash() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+RULE_SET_VERSION: Final = f"{RULE_SET_ID}+{_code_hash()}"
 
 
 class _NyseHolidayCalendar(AbstractHolidayCalendar):

--- a/app/services/strategy_mt1_books.py
+++ b/app/services/strategy_mt1_books.py
@@ -18,7 +18,14 @@ from typing import Final
 
 import numpy as np
 
-from app.services.equity_curve import EquityCurve, LegBook, build_capped_target_exposure_curve, build_equity_curve
+from app.services.equity_curve import (
+    EQUITY_CURVE_ENGINE_VERSION,
+    EquityCurve,
+    LegBook,
+    build_capped_target_exposure_curve,
+    build_equity_curve,
+)
+from app.services.market_calendar import RULE_SET_VERSION as MARKET_CALENDAR_RULE_VERSION
 from app.services.market_calendar import us_market_status
 from app.services.strategies.s10_relative_strength_leader import s10_rebalance_dates
 from app.services.strategy_mt1_trial import (
@@ -45,7 +52,7 @@ def _code_hash() -> str:
     return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
 
 
-BOOK_RULE_VERSION: Final = f"{BOOK_RULE_ID}+{_code_hash()}"
+BOOK_RULE_VERSION: Final = f"{BOOK_RULE_ID}+{_code_hash()}+{EQUITY_CURVE_ENGINE_VERSION}+{MARKET_CALENDAR_RULE_VERSION}"
 
 
 class MT1BookConstructionRefused(ValueError):

--- a/app/services/strategy_mt1_identity.py
+++ b/app/services/strategy_mt1_identity.py
@@ -1,0 +1,95 @@
+"""Distinct identities for MT-1 and its S-8 negative control (#2437).
+
+Neither identity is placed in ``STRATEGY_MANIFEST`` yet.  The ordinary runner
+would apply ``equal_weight_concurrent_v1`` and persist an unscaled result, which
+is not MT-1.  They become runnable only through the dedicated four-arm path
+that builds the source S-10/S-8 books, applies the causal overlay, and enforces
+the preregistered paired evaluator.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Final
+
+from app.services.equity_curve import CAPPED_TARGET_EXPOSURE_RULE_ID
+from app.services.indicator_series import Universe
+from app.services.strategies.s8_range_mean_reversion import s8_identity
+from app.services.strategies.s10_relative_strength_leader import s10_identity
+from app.services.strategy_mt1_books import BOOK_RULE_VERSION
+from app.services.strategy_mt1_trial import (
+    NEGATIVE_CONTROL_TRIAL_ID,
+    TRIAL_CONTRACT_VERSION,
+    TRIAL_EVALUATOR_VERSION,
+    TRIAL_ID,
+)
+from app.services.strategy_registry import StrategyIdentity
+from app.services.strategy_volatility_overlay import RULE_SET_VERSION as OVERLAY_RULE_SET_VERSION
+
+MT1_STRATEGY_ID: Final = TRIAL_ID
+S8_CONTROL_STRATEGY_ID: Final = NEGATIVE_CONTROL_TRIAL_ID
+
+
+def _source_hash() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def _identity(
+    *,
+    strategy_id: str,
+    source_strategy_version: str,
+    decision_clock_strategy_version: str,
+    universe: Universe,
+    cost_model_id: str,
+) -> StrategyIdentity:
+    if not cost_model_id.strip():
+        raise ValueError("cost_model_id must be a non-empty declaration; pass app.services.cost_model.COST_MODEL_ID")
+    return StrategyIdentity(
+        strategy_id=strategy_id,
+        params={
+            "source_strategy_version": source_strategy_version,
+            "decision_clock_strategy_version": decision_clock_strategy_version,
+            "overlay_rule_set_version": OVERLAY_RULE_SET_VERSION,
+            "target_exposure_rule": CAPPED_TARGET_EXPOSURE_RULE_ID,
+            "four_arm_book_rule_version": BOOK_RULE_VERSION,
+            "trial_contract_version": TRIAL_CONTRACT_VERSION,
+            "trial_evaluator_version": TRIAL_EVALUATOR_VERSION,
+        },
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def mt1_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The capped S-10 candidate, distinct from every S-10 result."""
+    source = s10_identity(universe=universe, cost_model_id=cost_model_id)
+    return _identity(
+        strategy_id=MT1_STRATEGY_ID,
+        source_strategy_version=source.version,
+        decision_clock_strategy_version=source.version,
+        universe=universe,
+        cost_model_id=cost_model_id,
+    )
+
+
+def s8_control_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The capped S-8 falsification control, distinct from every S-8 result."""
+    source = s8_identity(universe=universe, cost_model_id=cost_model_id)
+    clock = s10_identity(universe=universe, cost_model_id=cost_model_id)
+    return _identity(
+        strategy_id=S8_CONTROL_STRATEGY_ID,
+        source_strategy_version=source.version,
+        decision_clock_strategy_version=clock.version,
+        universe=universe,
+        cost_model_id=cost_model_id,
+    )
+
+
+__all__ = [
+    "MT1_STRATEGY_ID",
+    "S8_CONTROL_STRATEGY_ID",
+    "mt1_identity",
+    "s8_control_identity",
+]

--- a/app/services/strategy_mt1_trial.py
+++ b/app/services/strategy_mt1_trial.py
@@ -26,6 +26,7 @@ import numpy.typing as npt
 
 TRIAL_ID: Final = "mt1-capped-volatility-managed-relative-strength-v1"
 NEGATIVE_CONTROL_TRIAL_ID: Final = "mt1-s8-capped-volatility-negative-control-v1"
+TRIAL_CONTRACT_VERSION: Final = "mt1-four-arm-controlled-trial-2026-08-15-v1"
 RISK_AVERSION: Final = 5.0
 BLOCK_LENGTH_MONTHS: Final = 12
 BOOTSTRAP_RESAMPLES: Final = 10_000
@@ -324,6 +325,7 @@ __all__ = [
     "MAX_ANNUALISED_TURNOVER",
     "MIN_COMMON_MONTHS",
     "NEGATIVE_CONTROL_TRIAL_ID",
+    "TRIAL_CONTRACT_VERSION",
     "TRIAL_EVALUATOR_VERSION",
     "TRIAL_ID",
     "ArmRiskReport",

--- a/scripts/freeze_2437_mt1_declarations.py
+++ b/scripts/freeze_2437_mt1_declarations.py
@@ -1,0 +1,219 @@
+"""Freeze MT-1 and its S-8 control declarations before any outcome access.
+
+The two rows jointly bind the four-arm controlled experiment frozen in
+``docs/proposals/ta/2026-08-15-mt1-volatility-managed-relative-strength-
+preregistration.md``. Run ``--dry-run`` first and inspect both complete digest
+payloads. The write path is one transaction: either both declarations exist
+with the expected digests or neither new row is committed.
+
+This script must be merged before it is run. The structural-policy guard
+refreshes ``origin/main`` and refuses a write when the policy in this tree is
+not the merged policy. Outcomes remain sealed until a separate evaluator path
+successfully requires these exact declarations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from typing import Final
+
+import psycopg
+
+from app.config import settings
+from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, FX_UNMODELLED
+from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
+from app.services.result_ledger import PreregDeclarationRefused, freeze_preregistration, load_preregistration
+from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
+from app.services.strategy_mt1_trial import TRIAL_CONTRACT_VERSION
+from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION, structural_promotion_refusals
+from scripts._prereg_freeze_guard import assert_policy_version_merged, policy_version_report
+
+DECLARED_BY: Final = "scripts/freeze_2437_mt1_declarations.py (#2437)"
+UNIVERSE_BASIS: Final = "survivorship_free"
+
+_Z_0975: Final = 1.959963984540054
+_Z_08: Final = 0.8416212335729143
+_STANDARDISED_EFFECT: Final = 0.5
+_POWER_DERIVED_MONTHS: Final = math.ceil(((_Z_0975 + _Z_08) / _STANDARDISED_EFFECT) ** 2)
+MIN_FORWARD_DECISION_DATES: Final = max(36, _POWER_DERIVED_MONTHS)
+MIN_FORWARD_CALENDAR_WEEKS: Final = math.ceil(MIN_FORWARD_DECISION_DATES * 365.25 / (12 * 7))
+
+_FORWARD_SHADOW_DERIVATION: Final = (
+    "Frozen preregistration power floor: standardised paired monthly effect=0.5, alpha=0.05 two-sided, "
+    "power=0.8; z_0.975=1.959963984540054 and z_0.8=0.8416212335729143. "
+    "n=ceil(((1.959963984540054+0.8416212335729143)/0.5)^2)=32 independent decision months; raised to "
+    "36 months to cover three complete calendar years. Calendar duration="
+    "ceil(36x365.25/(12x7))=157 weeks. Prospective inference still uses the preregistered paired "
+    "moving-block bootstrap; this floor does not assert monthly independence."
+)
+
+
+def _build(*, control: bool) -> PreregDeclaration:
+    identity = (
+        s8_control_identity(universe=UNIVERSE_BASIS, cost_model_id=COST_MODEL_ID)
+        if control
+        else mt1_identity(universe=UNIVERSE_BASIS, cost_model_id=COST_MODEL_ID)
+    )
+    expected = structural_promotion_refusals(
+        universe_basis=UNIVERSE_BASIS,
+        carry_unmodelled=CARRY_UNMODELLED,
+        fx_unmodelled=FX_UNMODELLED,
+    )
+    return PreregDeclaration(
+        strategy_id=identity.strategy_id,
+        strategy_version=identity.version,
+        contract_version=TRIAL_CONTRACT_VERSION,
+        prereg_purpose="falsification_only" if control else "capital_candidate",
+        structural_refusal_policy_version=STRUCTURAL_REFUSAL_POLICY_VERSION,
+        declared_universe_basis=UNIVERSE_BASIS,
+        declared_carry_unmodelled=CARRY_UNMODELLED,
+        declared_fx_unmodelled=FX_UNMODELLED,
+        expected_structural_refusals=expected,
+        forward_shadow=ForwardShadowFloor(
+            min_independent_decision_dates=MIN_FORWARD_DECISION_DATES,
+            min_calendar_weeks=MIN_FORWARD_CALENDAR_WEEKS,
+            derivation=_FORWARD_SHADOW_DERIVATION,
+        ),
+        declared_by=DECLARED_BY,
+    )
+
+
+def build_mt1_declaration() -> PreregDeclaration:
+    return _build(control=False)
+
+
+def build_s8_control_declaration() -> PreregDeclaration:
+    return _build(control=True)
+
+
+def build_declarations() -> tuple[PreregDeclaration, PreregDeclaration]:
+    return build_mt1_declaration(), build_s8_control_declaration()
+
+
+def _summary(declaration: PreregDeclaration) -> dict[str, object]:
+    return {**declaration.digest_payload, "declaration_sha256": declaration.sha256}
+
+
+def _freeze_batch(
+    conn: psycopg.Connection[tuple], declarations: tuple[PreregDeclaration, ...]
+) -> tuple[list[dict[str, object]], bool]:
+    """Freeze every missing row atomically; accept only byte-identical retries."""
+    existing = {
+        (declaration.strategy_id, declaration.strategy_version): load_preregistration(
+            conn, declaration.strategy_id, declaration.strategy_version
+        )
+        for declaration in declarations
+    }
+    conflicts = [
+        declaration
+        for declaration in declarations
+        if (stored := existing[(declaration.strategy_id, declaration.strategy_version)]) is not None
+        and stored.declaration_sha256 != declaration.sha256
+    ]
+    if conflicts:
+        conn.rollback()
+        conflict_reports: list[dict[str, object]] = []
+        for declaration in conflicts:
+            stored = existing[(declaration.strategy_id, declaration.strategy_version)]
+            assert stored is not None
+            conflict_reports.append(
+                {
+                    **_summary(declaration),
+                    "outcome": "conflicting_declaration_already_frozen",
+                    "stored_declaration_sha256": stored.declaration_sha256,
+                    "note": "declarations are immutable; different terms require a new strategy_version",
+                }
+            )
+        return conflict_reports, False
+
+    reports: list[dict[str, object]] = []
+    try:
+        for declaration in declarations:
+            stored = existing[(declaration.strategy_id, declaration.strategy_version)]
+            if stored is not None:
+                reports.append(
+                    {
+                        **_summary(declaration),
+                        "outcome": "already_frozen_identical",
+                        "declaration_id": stored.declaration_id,
+                    }
+                )
+                continue
+            declaration_id = freeze_preregistration(conn, declaration)
+            reports.append({**_summary(declaration), "outcome": "frozen", "declaration_id": declaration_id})
+    except PreregDeclarationRefused as error:
+        conn.rollback()
+        return ([{"outcome": "batch_refused_and_rolled_back", "refusals": list(error.refusals)}], False)
+    except psycopg.errors.UniqueViolation:
+        # A concurrent identical batch is an idempotent success, but only after
+        # this transaction is rolled back and every stored digest is re-read.
+        # Any missing or different row is a failed batch, never guessed safe.
+        conn.rollback()
+        raced = [
+            load_preregistration(conn, declaration.strategy_id, declaration.strategy_version)
+            for declaration in declarations
+        ]
+        raced_pairs = tuple(zip(raced, declarations, strict=True))
+        if all(
+            stored is not None and stored.declaration_sha256 == declaration.sha256
+            for stored, declaration in raced_pairs
+        ):
+            return (
+                [
+                    {
+                        **_summary(declaration),
+                        "outcome": "already_frozen_identical",
+                        "declaration_id": stored.declaration_id,
+                    }
+                    for declaration, stored in zip(declarations, raced, strict=True)
+                    if stored is not None
+                ],
+                True,
+            )
+        return ([{"outcome": "concurrent_batch_conflict_and_rolled_back"}], False)
+    conn.commit()
+    return reports, True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="print both digest payloads without writing")
+    parser.add_argument(
+        "--allow-policy-divergence",
+        action="store_true",
+        help="override the merged-policy guard and record that override in output",
+    )
+    args = parser.parse_args(argv)
+    declarations = build_declarations()
+    if args.dry_run:
+        policy = policy_version_report()
+        for declaration in declarations:
+            payload = {**_summary(declaration), **policy, "outcome": "dry_run"}
+            sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
+        return 0
+
+    policy = assert_policy_version_merged(allow_divergence=args.allow_policy_divergence)
+    with psycopg.connect(settings.database_url) as conn:
+        reports, ok = _freeze_batch(conn, declarations)
+    stream = sys.stdout if ok else sys.stderr
+    for report in reports:
+        stream.write(json.dumps({**report, **policy}, sort_keys=True) + "\n")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "DECLARED_BY",
+    "MIN_FORWARD_CALENDAR_WEEKS",
+    "MIN_FORWARD_DECISION_DATES",
+    "build_declarations",
+    "build_mt1_declaration",
+    "build_s8_control_declaration",
+    "main",
+]

--- a/tests/test_2437_mt1_declarations.py
+++ b/tests/test_2437_mt1_declarations.py
@@ -1,0 +1,129 @@
+"""MT-1 identities and immutable pre-outcome declarations (#2437)."""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, FX_UNMODELLED
+from app.services.equity_curve import EQUITY_CURVE_ENGINE_VERSION
+from app.services.market_calendar import RULE_SET_VERSION as MARKET_CALENDAR_RULE_VERSION
+from app.services.prereg_contract import declaration_refusals
+from app.services.strategies.s8_range_mean_reversion import s8_identity
+from app.services.strategies.s10_relative_strength_leader import s10_identity
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_mt1_books import BOOK_RULE_VERSION
+from app.services.strategy_mt1_identity import (
+    MT1_STRATEGY_ID,
+    S8_CONTROL_STRATEGY_ID,
+    mt1_identity,
+    s8_control_identity,
+)
+from app.services.strategy_mt1_trial import (
+    NEGATIVE_CONTROL_TRIAL_ID,
+    TRIAL_CONTRACT_VERSION,
+    TRIAL_EVALUATOR_VERSION,
+    TRIAL_ID,
+)
+from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION
+from app.services.strategy_volatility_overlay import RULE_SET_VERSION as OVERLAY_RULE_SET_VERSION
+from app.services.trial_register import TRIAL_REGISTER
+from scripts import _prereg_freeze_guard as guard
+from scripts.freeze_2437_mt1_declarations import (
+    MIN_FORWARD_CALENDAR_WEEKS,
+    MIN_FORWARD_DECISION_DATES,
+    build_declarations,
+    build_mt1_declaration,
+    build_s8_control_declaration,
+    main,
+)
+
+UNIVERSE = "survivorship_free"
+
+
+def test_trial_ids_are_the_distinct_strategy_ids_and_registered_exactly() -> None:
+    assert MT1_STRATEGY_ID == TRIAL_ID
+    assert S8_CONTROL_STRATEGY_ID == NEGATIVE_CONTROL_TRIAL_ID
+    assert MT1_STRATEGY_ID != S8_CONTROL_STRATEGY_ID
+    for trial_id in (MT1_STRATEGY_ID, S8_CONTROL_STRATEGY_ID):
+        assert trial_id in TRIAL_REGISTER.trial_ids
+        assert trial_id not in STRATEGY_MANIFEST
+
+
+def test_identities_bind_every_direct_trial_dependency() -> None:
+    mt1 = mt1_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+    control = s8_control_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s10 = s10_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s8 = s8_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+
+    assert mt1.version != control.version
+    assert mt1.version not in {s10.version, s8.version}
+    assert control.version not in {s10.version, s8.version}
+    assert mt1.params["source_strategy_version"] == s10.version
+    assert mt1.params["decision_clock_strategy_version"] == s10.version
+    assert control.params["source_strategy_version"] == s8.version
+    assert control.params["decision_clock_strategy_version"] == s10.version
+    for identity in (mt1, control):
+        assert identity.params["overlay_rule_set_version"] == OVERLAY_RULE_SET_VERSION
+        assert identity.params["four_arm_book_rule_version"] == BOOK_RULE_VERSION
+        assert identity.params["trial_contract_version"] == TRIAL_CONTRACT_VERSION
+        assert identity.params["trial_evaluator_version"] == TRIAL_EVALUATOR_VERSION
+    assert EQUITY_CURVE_ENGINE_VERSION in BOOK_RULE_VERSION
+    assert MARKET_CALENDAR_RULE_VERSION in BOOK_RULE_VERSION
+
+
+def test_identity_moves_with_universe_and_cost_and_refuses_an_empty_cost() -> None:
+    base = mt1_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+    assert base.version != mt1_identity(universe="survivor_only", cost_model_id=COST_MODEL_ID).version
+    assert base.version != mt1_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID + "-changed").version
+    with pytest.raises(ValueError, match="non-empty"):
+        mt1_identity(universe=UNIVERSE, cost_model_id="  ")
+
+
+def test_declarations_are_coherent_and_preserve_the_candidate_control_boundary() -> None:
+    mt1, control = build_declarations()
+    assert mt1 == build_mt1_declaration()
+    assert control == build_s8_control_declaration()
+    assert mt1.prereg_purpose == "capital_candidate"
+    assert control.prereg_purpose == "falsification_only"
+    for declaration in (mt1, control):
+        assert declaration_refusals(declaration) == ()
+        assert declaration.contract_version == TRIAL_CONTRACT_VERSION
+        assert declaration.structural_refusal_policy_version == STRUCTURAL_REFUSAL_POLICY_VERSION
+        assert declaration.declared_universe_basis == UNIVERSE
+        assert declaration.declared_carry_unmodelled is CARRY_UNMODELLED is False
+        assert declaration.declared_fx_unmodelled is FX_UNMODELLED is False
+        assert declaration.expected_structural_refusals == ()
+        assert declaration.recomputed_structural_refusals == ()
+
+
+def test_forward_shadow_floor_is_rederived_from_the_frozen_power_calculation() -> None:
+    derived = math.ceil(((1.959963984540054 + 0.8416212335729143) / 0.5) ** 2)
+    assert derived == 32
+    assert MIN_FORWARD_DECISION_DATES == max(36, derived) == 36
+    assert MIN_FORWARD_CALENDAR_WEEKS == math.ceil(36 * 365.25 / (12 * 7)) == 157
+    for declaration in build_declarations():
+        assert declaration.forward_shadow.min_independent_decision_dates == 36
+        assert declaration.forward_shadow.min_calendar_weeks == 157
+        assert "n=ceil" in declaration.forward_shadow.derivation
+        assert "moving-block bootstrap" in declaration.forward_shadow.derivation
+        assert len(declaration.forward_shadow.derivation) <= 1000
+
+
+def test_dry_run_prints_both_complete_distinct_digest_payloads(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(guard, "refresh_main_ref", lambda: True)
+    monkeypatch.setattr(guard, "policy_version_on_main", lambda: STRUCTURAL_REFUSAL_POLICY_VERSION)
+    assert main(["--dry-run"]) == 0
+    rows = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert len(rows) == 2
+    assert {row["strategy_id"] for row in rows} == {MT1_STRATEGY_ID, S8_CONTROL_STRATEGY_ID}
+    assert len({row["strategy_version"] for row in rows}) == 2
+    assert len({row["declaration_sha256"] for row in rows}) == 2
+    for row, declaration in zip(rows, build_declarations(), strict=True):
+        assert row["outcome"] == "dry_run"
+        assert set(declaration.digest_payload) <= set(row)
+        assert row["declaration_sha256"] == declaration.sha256

--- a/tests/test_2437_mt1_declarations_db.py
+++ b/tests/test_2437_mt1_declarations_db.py
@@ -1,0 +1,45 @@
+"""Database boundary for the atomic MT-1 declaration freeze (#2437)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import psycopg
+
+from app.services.result_ledger import freeze_preregistration, load_preregistration
+from scripts.freeze_2437_mt1_declarations import _freeze_batch, build_declarations
+
+
+def test_both_declarations_freeze_atomically_and_identical_retry_is_safe(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    declarations = build_declarations()
+    reports, ok = _freeze_batch(ebull_test_conn, declarations)
+    assert ok is True
+    assert [report["outcome"] for report in reports] == ["frozen", "frozen"]
+
+    for declaration in declarations:
+        stored = load_preregistration(ebull_test_conn, declaration.strategy_id, declaration.strategy_version)
+        assert stored is not None
+        assert stored.declaration_sha256 == declaration.sha256
+
+    retry_reports, retry_ok = _freeze_batch(ebull_test_conn, declarations)
+    assert retry_ok is True
+    assert [report["outcome"] for report in retry_reports] == [
+        "already_frozen_identical",
+        "already_frozen_identical",
+    ]
+
+
+def test_a_conflicting_first_row_prevents_the_second_row_from_being_written(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    mt1, control = build_declarations()
+    conflicting = replace(mt1, declared_by="a different pre-outcome declaration")
+    freeze_preregistration(ebull_test_conn, conflicting)
+    ebull_test_conn.commit()
+
+    reports, ok = _freeze_batch(ebull_test_conn, (mt1, control))
+    assert ok is False
+    assert reports[0]["outcome"] == "conflicting_declaration_already_frozen"
+    assert load_preregistration(ebull_test_conn, control.strategy_id, control.strategy_version) is None

--- a/tests/test_2631_freeze_policy_guard.py
+++ b/tests/test_2631_freeze_policy_guard.py
@@ -20,6 +20,7 @@ import pytest
 from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
 from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION
 from scripts import _prereg_freeze_guard as guard
+from scripts import freeze_2437_mt1_declarations as mt1_freeze
 from scripts import freeze_2582_schedule13d_declaration as c4_freeze
 from scripts import freeze_2616_precutoff_declarations as precutoff_freeze
 
@@ -119,7 +120,7 @@ def test_digest_payload_is_a_fresh_dict_each_call() -> None:
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("module", [c4_freeze, precutoff_freeze])
+@pytest.mark.parametrize("module", [c4_freeze, precutoff_freeze, mt1_freeze])
 def test_dry_run_prints_the_policy_version_and_every_digest_field(
     module: object, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -290,7 +291,7 @@ def test_every_freeze_script_calls_the_guard() -> None:
     under another name is not covered — recorded here rather than implied away.
     """
     scripts = sorted((_REPO_ROOT / "scripts").glob("freeze_*.py"))
-    assert len(scripts) == 2, f"a new freeze script appeared: {[p.name for p in scripts]}"
+    assert len(scripts) == 3, f"a new freeze script appeared: {[p.name for p in scripts]}"
     for path in scripts:
         source = path.read_text()
         # ⚠ THE CALL, NOT THE NAME. A bare substring check is satisfied by the


### PR DESCRIPTION
Refs #2437

## Outcome
- gives MT-1 and the S-8 negative control distinct dependency-complete strategy identities
- versions the calendar, equity engine, four-arm book, overlay, source strategies, evaluator, contract, universe, and cost model
- adds reproducible 36-decision-month / 157-week declarations with MT-1 capital-candidate and S-8 falsification-only purposes
- freezes the pair atomically and accepts only digest-identical retries
- deliberately keeps both identities out of the ordinary strategy manifest until the dedicated four-arm runner exists

## Safety boundary
This PR does not access outcomes and does not freeze production declarations. Run the dry-run and irreversible freeze only from merged code. No live-money authority is introduced.

## Verification
- repository pre-push gate green
- 8,606 fast tests passed
- focused declaration and atomic database tests passed
- dry-run produced two distinct coherent digests and matched the structural policy on refreshed origin/main