### PR TITLE
feat(strategies): recover MT1 paper-trading operator path

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -48,11 +48,13 @@ from app.services.ops_monitor import (
     get_kill_switch_status,
 )
 from app.services.runtime_config import (
+    RuntimeConfig,
     RuntimeConfigCorrupt,
     RuntimeConfigNoOp,
     get_runtime_config,
     update_runtime_config,
 )
+from app.services.strategy_control_plane import PAPER_ALLOCATOR_ADVISORY_LOCK, load_paper_pool
 
 logger = logging.getLogger(__name__)
 
@@ -221,8 +223,8 @@ def patch_config(
     Returns the post-update runtime config (not the full /config response;
     the caller can re-GET if they need kill switch state too).
     """
-    try:
-        updated = update_runtime_config(
+    def apply_patch() -> RuntimeConfig:
+        return update_runtime_config(
             conn,
             updated_by=body.updated_by,
             reason=body.reason,
@@ -234,6 +236,19 @@ def patch_config(
             llm_model_writer=body.llm_model_writer,
             llm_model_critic=body.llm_model_critic,
         )
+
+    try:
+        if body.enable_live_trading is True:
+            with conn.transaction():
+                conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
+                if load_paper_pool(conn).enabled:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="live trading cannot be enabled while strategy paper automation is enabled",
+                    )
+                updated = apply_patch()
+        else:
+            updated = apply_patch()
     except RuntimeConfigCorrupt as exc:
         # #87: fixed string instead of str(exc) — see GET handler note.
         raise HTTPException(status_code=503, detail="runtime config unavailable") from exc

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -873,7 +873,7 @@ class StrategyInitialPaperSetupRequest(BaseModel):
     max_instrument_exposure_pct: Decimal = Field(gt=0, le=100)
     max_portfolio_exposure_pct: Decimal = Field(gt=0, le=100)
     max_drawdown_pct: Decimal = Field(gt=0, lt=100)
-    min_net_expectancy_pct: Decimal
+    min_net_expectancy_pct: Decimal = Field(ge=0)
     cost_stress_multiplier: Decimal = Field(ge=1)
     reason: str = Field(min_length=1, max_length=1000)
 

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -57,6 +57,7 @@ from app.services.strategy_control_plane import (
     lock_strategy_control,
     mandate_for_profile,
     promote_strategy,
+    validate_paper_promotion_evidence,
 )
 from app.services.strategy_core_eligibility import CoreEligibilityError
 from app.services.strategy_core_mandate import (
@@ -1770,6 +1771,16 @@ def get_strategy_overview(
         fire_rate = fire_rate_by_strategy.get(key, StrategyFireRate())
         pnl = pnl_by_strategy.get(key, StrategyPnl())
         control = control_by_strategy.get(key, StrategyControlState())
+        pinned_evidence_ready = control.pinned_evidence_ready
+        if control.stage in {"paper_enabled", "live_enabled"}:
+            try:
+                validate_paper_promotion_evidence(
+                    conn,
+                    strategy_id=strategy_id,
+                    strategy_version=versions[strategy_id],
+                )
+            except (StrategyControlError, RuntimeError):
+                pinned_evidence_ready = False
         promotion_action = next_promotion_action(control.stage) if entry.purpose == "capital_candidate" else None
         promotion_refusals: list[str] = []
         if promotion_action in {"validate_historical", "start_forward_observation", "approve_paper"}:
@@ -1804,7 +1815,7 @@ def get_strategy_overview(
             allocation_refusals.append("paper_promotion_missing")
         if control.stage in {"paper_enabled", "live_enabled"} and not control.paper_forward_evidence_ready:
             allocation_refusals.append("paper_forward_evidence_missing")
-        if not control.pinned_evidence_ready:
+        if not pinned_evidence_ready:
             allocation_refusals.append("pinned_promotion_evidence_invalid")
         if not control.policy_configured:
             allocation_refusals.append("execution_policy_missing")

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -95,6 +95,7 @@ from app.services.strategy_monitoring import (
     load_owned_pnl,
     realised_pnl_for_keys,
 )
+from app.services.strategy_mt1_read_model import load_mt1_controlled_trial_state
 from app.services.strategy_position_manager import (
     StrategyPositionManagerError,
     manage_owned_position,
@@ -538,6 +539,42 @@ class AccountEquityEvidenceView(BaseModel):
     incomplete_reasons: list[str]
 
 
+class ControlledTrialCellView(BaseModel):
+    ambiguity_arm: str
+    quarantine_arm: str
+    historical_conjuncts_pass: bool
+
+
+class ControlledTrialView(BaseModel):
+    trial_id: str
+    strategy_version: str
+    negative_control_id: str
+    negative_control_version: str
+    state: Literal[
+        "not_run",
+        "structural_refused",
+        "structural_passed_outcomes_pending",
+        "historical_conjuncts_failed",
+        "historical_conjuncts_passed",
+        "evidence_inconsistent",
+    ]
+    structural_attempt_id: int | None
+    trial_result_id: int | None
+    structural_assessed_at: datetime | None
+    evaluated_at: datetime | None
+    structural_cells: int
+    result_cells: list[ControlledTrialCellView]
+    historical_conjuncts_pass: bool | None
+    refusal_code: str | None
+    refusal_detail: str | None
+    integrity_refusals: list[str]
+    holdout_evaluations: int
+    holdout_accesses: int
+    promotion_authority: Literal[False]
+    paper_activation_reachable: Literal[False]
+    live_activation_reachable: Literal[False]
+
+
 class StrategyOverviewResponse(BaseModel):
     as_of: datetime
     demo_connection: bool
@@ -553,6 +590,7 @@ class StrategyOverviewResponse(BaseModel):
     automation_readiness: AutomationReadinessView
     account_equity_evidence: AccountEquityEvidenceView
     evidence_refresh: EvidenceRefreshView
+    controlled_trials: list[ControlledTrialView]
     strategies: list[StrategyOverview]
 
 
@@ -1523,6 +1561,7 @@ def get_strategy_overview(
         conn,
         environment=cast(Literal["demo", "real"], settings.etoro_env),
     )
+    controlled_trial = load_mt1_controlled_trial_state(conn)
 
     results_by_strategy: dict[str, list[dict[str, object]]] = defaultdict(list)
     for row in result_rows:
@@ -1847,6 +1886,30 @@ def get_strategy_overview(
         demo_connection=settings.etoro_env == "demo",
         execution_enabled=entry_block.auto_trading_enabled,
         live_execution_enabled=entry_block.live_trading_enabled,
+        controlled_trials=[
+            ControlledTrialView(
+                trial_id=controlled_trial.trial_id,
+                strategy_version=controlled_trial.strategy_version,
+                negative_control_id=controlled_trial.negative_control_id,
+                negative_control_version=controlled_trial.negative_control_version,
+                state=controlled_trial.state,
+                structural_attempt_id=controlled_trial.structural_attempt_id,
+                trial_result_id=controlled_trial.trial_result_id,
+                structural_assessed_at=controlled_trial.structural_assessed_at,
+                evaluated_at=controlled_trial.evaluated_at,
+                structural_cells=controlled_trial.structural_cells,
+                result_cells=[ControlledTrialCellView(**cell.__dict__) for cell in controlled_trial.result_cells],
+                historical_conjuncts_pass=controlled_trial.historical_conjuncts_pass,
+                refusal_code=controlled_trial.refusal_code,
+                refusal_detail=controlled_trial.refusal_detail,
+                integrity_refusals=list(controlled_trial.integrity_refusals),
+                holdout_evaluations=controlled_trial.holdout_evaluations,
+                holdout_accesses=controlled_trial.holdout_accesses,
+                promotion_authority=False,
+                paper_activation_reachable=False,
+                live_activation_reachable=False,
+            )
+        ],
         entry_block=StrategyEntryBlockView(
             new_entries_blocked=entry_block.new_entries_blocked,
             global_kill_active=entry_block.global_kill_active,

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -38,11 +38,7 @@ from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
-from app.services.runtime_config import (
-    RuntimeConfigCorrupt,
-    RuntimeConfigNoOp,
-    update_runtime_config,
-)
+from app.services.runtime_config import RuntimeConfigCorrupt
 from app.services.strategy_ambiguity_policy import AMBIGUITY_RULE_VERSION
 from app.services.strategy_base_currency import (
     DEPLOYMENT_CURRENCY_UNSUPPORTED,
@@ -2004,7 +2000,7 @@ def get_strategy_overview(
     return StrategyOverviewResponse(
         as_of=as_of,
         demo_connection=settings.etoro_env == "demo",
-        execution_enabled=entry_block.auto_trading_enabled,
+        execution_enabled=paper_pool.enabled,
         live_execution_enabled=entry_block.live_trading_enabled,
         controlled_trials=[
             ControlledTrialView(
@@ -2031,7 +2027,7 @@ def get_strategy_overview(
             )
         ],
         entry_block=StrategyEntryBlockView(
-            new_entries_blocked=entry_block.new_entries_blocked,
+            new_entries_blocked=entry_block.new_entries_blocked or not paper_pool.enabled,
             global_kill_active=entry_block.global_kill_active,
             global_kill_reason=entry_block.global_kill_reason,
             global_kill_activated_at=entry_block.global_kill_activated_at,
@@ -2762,7 +2758,7 @@ def update_strategy_paper_pool(
     session: SessionRow = Depends(require_session),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> StrategyPaperPoolView:
-    """Set the shared strategy ceiling and its higher-level automation flag."""
+    """Set the strategy lane's shared ceiling and independent paper switch."""
     try:
         if body.enabled and settings.etoro_env != "demo":
             raise StrategyControlError("paper automation can only be enabled in the demo environment")
@@ -2770,17 +2766,17 @@ def update_strategy_paper_pool(
         with conn.transaction():
             conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
             runtime_row = conn.execute(
-                """SELECT enable_auto_trading, enable_live_trading
+                """SELECT enable_live_trading
                      FROM runtime_config WHERE id=TRUE FOR UPDATE"""
             ).fetchone()
             if runtime_row is None:
                 raise RuntimeConfigCorrupt("runtime_config singleton row missing")
-            runtime = cast(tuple[object, object], runtime_row)
+            live_trading_enabled = bool(cast(tuple[object], runtime_row)[0])
             current_pool = load_paper_pool(conn)
             readiness = get_strategy_overview(conn).automation_readiness if body.enabled else None
             if body.enabled and not current_pool.enabled and readiness is not None and not readiness.ready:
                 raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
-            if body.enabled and bool(runtime[1]):
+            if body.enabled and live_trading_enabled:
                 raise StrategyControlError(
                     "paper automation cannot be enabled while system-wide live trading is enabled"
                 )
@@ -2790,29 +2786,20 @@ def update_strategy_paper_pool(
                 or current_pool.capital_mode != body.capital_mode
                 or current_pool.mandate.risk_profile != body.risk_profile
             )
-            automation_changed = bool(runtime[0]) != body.enabled
-            if not pool_changed and not automation_changed:
+            if not pool_changed:
                 raise StrategyControlError(
                     "automation change must alter enabled state, capital limit, capital mode, or mandate"
                 )
-            if pool_changed:
-                configure_paper_pool(
-                    conn,
-                    enabled=body.enabled,
-                    capital_limit=body.capital_limit,
-                    capital_mode=body.capital_mode,
-                    risk_profile=body.risk_profile,
-                    changed_by=session.username,
-                    reason=body.reason,
-                )
-            if automation_changed:
-                update_runtime_config(
-                    conn,
-                    updated_by=session.username,
-                    reason=body.reason,
-                    enable_auto_trading=body.enabled,
-                )
-    except (StrategyControlError, RuntimeConfigCorrupt, RuntimeConfigNoOp) as exc:
+            configure_paper_pool(
+                conn,
+                enabled=body.enabled,
+                capital_limit=body.capital_limit,
+                capital_mode=body.capital_mode,
+                risk_profile=body.risk_profile,
+                changed_by=session.username,
+                reason=body.reason,
+            )
+    except (StrategyControlError, RuntimeConfigCorrupt) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return get_strategy_overview(conn).paper_pool
 

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -2083,7 +2083,7 @@ _FIRED_SIGNALS_SQL = """
         GROUP BY sto.strategy_trade_id
     ), entry_order AS (
         SELECT DISTINCT ON (sto.strategy_trade_id)
-               sto.strategy_trade_id, ord.status
+               sto.strategy_trade_id, sto.order_id, ord.status
         FROM strategy_trade_orders sto
         JOIN orders ord ON ord.order_id = sto.order_id
         WHERE sto.purpose = 'entry'
@@ -2187,7 +2187,7 @@ _FIRED_SIGNALS_SQL = """
       ON operation.strategy_trade_id = t.strategy_trade_id
      AND ownership.ownership_count = 1
     LEFT JOIN strategy_order_reconciliation_state reconciliation
-      ON reconciliation.order_id = operation.order_id
+      ON reconciliation.order_id = COALESCE(operation.order_id, eo.order_id)
     LEFT JOIN close_history history ON history.strategy_trade_id = t.strategy_trade_id
     WHERE s.verdict = 'fired'
       AND s.strategy_version = ANY(%(versions)s)
@@ -2233,6 +2233,7 @@ def _trade_lifecycle(row: Mapping[str, object]) -> StrategyTradeLifecycle | None
 
     operation_status = row["lifecycle_operation_status"]
     reconciliation_state = row["lifecycle_reconciliation_state"]
+    reconciliation_scope = "position_operation" if row["lifecycle_operation_order_id"] is not None else "entry_order"
     if operation_status == "rejected":
         reasons.append("position_operation_rejected")
     elif operation_status == "reconcile_required":
@@ -2240,13 +2241,13 @@ def _trade_lifecycle(row: Mapping[str, object]) -> StrategyTradeLifecycle | None
     if row["lifecycle_operation_error"] is not None:
         reasons.append("position_operation_error")
     if reconciliation_state in {"not_found", "ambiguous", "error", "rejected"}:
-        reasons.append(f"position_operation_reconciliation_{reconciliation_state}")
+        reasons.append(f"{reconciliation_scope}_reconciliation_{reconciliation_state}")
     if row["lifecycle_reconciliation_error"] is not None and reconciliation_state not in {
         "not_found",
         "ambiguous",
         "error",
     }:
-        reasons.append("position_operation_reconciliation_error")
+        reasons.append(f"{reconciliation_scope}_reconciliation_error")
     reasons.extend(history_reasons)
 
     if trade_status == "failed" and ownership_count == 0:

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -2643,6 +2643,8 @@ def update_strategy_paper_pool(
 ) -> StrategyPaperPoolView:
     """Set the shared strategy ceiling and its higher-level automation flag."""
     try:
+        if body.enabled and settings.etoro_env != "demo":
+            raise StrategyControlError("paper automation can only be enabled in the demo environment")
         readiness = get_strategy_overview(conn).automation_readiness if body.enabled else None
         conn.rollback()
         with conn.transaction():

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -2773,9 +2773,16 @@ def update_strategy_paper_pool(
                 raise RuntimeConfigCorrupt("runtime_config singleton row missing")
             live_trading_enabled = bool(cast(tuple[object], runtime_row)[0])
             current_pool = load_paper_pool(conn)
-            readiness = get_strategy_overview(conn).automation_readiness if body.enabled else None
-            if body.enabled and not current_pool.enabled and readiness is not None and not readiness.ready:
-                raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
+            risk_authority = {"unconfigured": 0, "cautious": 1, "balanced": 2, "growth": 3}
+            authority_increasing = body.enabled and (
+                not current_pool.enabled
+                or body.capital_limit > current_pool.capital_limit
+                or (current_pool.capital_mode == "fixed" and body.capital_mode == "compound")
+                or risk_authority[body.risk_profile] > risk_authority[current_pool.mandate.risk_profile]
+            )
+            readiness = get_strategy_overview(conn).automation_readiness if authority_increasing else None
+            if authority_increasing and readiness is not None and not readiness.ready:
+                raise StrategyControlError("automation authority cannot be increased: " + ", ".join(readiness.blockers))
             if body.enabled and live_trading_enabled:
                 raise StrategyControlError(
                     "paper automation cannot be enabled while system-wide live trading is enabled"

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -41,7 +41,6 @@ from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERS
 from app.services.runtime_config import (
     RuntimeConfigCorrupt,
     RuntimeConfigNoOp,
-    get_runtime_config,
     update_runtime_config,
 )
 from app.services.strategy_ambiguity_policy import AMBIGUITY_RULE_VERSION
@@ -2646,15 +2645,21 @@ def update_strategy_paper_pool(
     try:
         if body.enabled and settings.etoro_env != "demo":
             raise StrategyControlError("paper automation can only be enabled in the demo environment")
-        readiness = get_strategy_overview(conn).automation_readiness if body.enabled else None
         conn.rollback()
         with conn.transaction():
             conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
+            runtime_row = conn.execute(
+                """SELECT enable_auto_trading, enable_live_trading
+                     FROM runtime_config WHERE id=TRUE FOR UPDATE"""
+            ).fetchone()
+            if runtime_row is None:
+                raise RuntimeConfigCorrupt("runtime_config singleton row missing")
+            runtime = cast(tuple[object, object], runtime_row)
             current_pool = load_paper_pool(conn)
+            readiness = get_strategy_overview(conn).automation_readiness if body.enabled else None
             if body.enabled and not current_pool.enabled and readiness is not None and not readiness.ready:
                 raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
-            runtime = get_runtime_config(conn)
-            if body.enabled and runtime.enable_live_trading:
+            if body.enabled and bool(runtime[1]):
                 raise StrategyControlError(
                     "paper automation cannot be enabled while system-wide live trading is enabled"
                 )
@@ -2664,7 +2669,7 @@ def update_strategy_paper_pool(
                 or current_pool.capital_mode != body.capital_mode
                 or current_pool.mandate.risk_profile != body.risk_profile
             )
-            automation_changed = runtime.enable_auto_trading != body.enabled
+            automation_changed = bool(runtime[0]) != body.enabled
             if not pool_changed and not automation_changed:
                 raise StrategyControlError(
                     "automation change must alter enabled state, capital limit, capital mode, or mandate"

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -2654,6 +2654,10 @@ def update_strategy_paper_pool(
             if body.enabled and not current_pool.enabled and readiness is not None and not readiness.ready:
                 raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
             runtime = get_runtime_config(conn)
+            if body.enabled and runtime.enable_live_trading:
+                raise StrategyControlError(
+                    "paper automation cannot be enabled while system-wide live trading is enabled"
+                )
             pool_changed = (
                 current_pool.enabled != body.enabled
                 or current_pool.capital_limit != body.capital_limit

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -95,6 +95,13 @@ from app.services.strategy_monitoring import (
     realised_pnl_for_keys,
 )
 from app.services.strategy_mt1_read_model import load_mt1_controlled_trial_state
+from app.services.strategy_operator_promotion import (
+    OperatorPromotionRefusal,
+    PromotionAction,
+    advance_strategy_for_operator,
+    load_forward_floor_evidence,
+    next_promotion_action,
+)
 from app.services.strategy_position_manager import (
     StrategyPositionManagerError,
     manage_owned_position,
@@ -322,6 +329,8 @@ class StrategyOverview(BaseModel):
     legacy_result_count: int
     all_recent_evidence_complete: bool
     stage: str | None
+    next_promotion_action: PromotionAction | None
+    promotion_refusals: list[str]
     attribution: StrategyAttributionView
     fire_rate: StrategyFireRateView
     pnl: StrategyPnlView
@@ -852,6 +861,47 @@ class AllocationUpdateResponse(BaseModel):
     revision: int
 
 
+class StrategyInitialPaperSetupRequest(BaseModel):
+    strategy_version: str = Field(min_length=1, max_length=200)
+    capital_limit: Decimal = Field(gt=0, max_digits=18, decimal_places=6)
+    ticket_sizing_mode: Literal["percent", "fixed"]
+    ticket_value: Decimal = Field(gt=0, max_digits=18, decimal_places=6)
+    max_ticket_amount: Decimal = Field(gt=0, max_digits=18, decimal_places=6)
+    stop_loss_pct: Decimal = Field(gt=0, lt=100)
+    take_profit_pct: Decimal = Field(gt=0)
+    max_quote_age_seconds: int = Field(gt=0)
+    max_scan_age_seconds: int = Field(gt=0)
+    max_halt_feed_age_seconds: int = Field(gt=0)
+    max_cost_age_seconds: int = Field(gt=0)
+    max_reconciliation_age_seconds: int = Field(gt=0)
+    max_instrument_exposure_pct: Decimal = Field(gt=0, le=100)
+    max_portfolio_exposure_pct: Decimal = Field(gt=0, le=100)
+    max_drawdown_pct: Decimal = Field(gt=0, lt=100)
+    min_net_expectancy_pct: Decimal
+    cost_stress_multiplier: Decimal = Field(ge=1)
+    reason: str = Field(min_length=1, max_length=1000)
+
+    @model_validator(mode="after")
+    def valid_ticket_shape(self) -> StrategyInitialPaperSetupRequest:
+        if self.ticket_sizing_mode == "percent" and self.ticket_value > 100:
+            raise ValueError("percent ticket value must be in (0, 100]")
+        if self.ticket_sizing_mode == "fixed" and self.ticket_value > self.max_ticket_amount:
+            raise ValueError("fixed ticket value cannot exceed its hard maximum")
+        if self.max_ticket_amount > self.capital_limit:
+            raise ValueError("hard ticket maximum cannot exceed the strategy capital limit")
+        return self
+
+
+class StrategyInitialPaperSetupResponse(BaseModel):
+    strategy_id: str
+    strategy_version: str
+    deployment_id: int
+    deployment_revision: int
+    policy_revision: int
+    capital_limit: Decimal
+    enabled: Literal[False]
+
+
 class StrategySizingUpdateRequest(BaseModel):
     strategy_version: str = Field(min_length=1, max_length=200)
     ticket_sizing_mode: Literal["percent", "fixed"]
@@ -1012,6 +1062,21 @@ class StrategyLifecycleResponse(BaseModel):
     strategy_version: str
     stage: Literal["paused", "retired"]
     promotion_id: int
+
+
+class StrategyPromotionRequest(BaseModel):
+    strategy_version: str = Field(min_length=1, max_length=200)
+    action: PromotionAction
+    reason: str = Field(min_length=1, max_length=1000)
+
+
+class StrategyPromotionResponse(BaseModel):
+    strategy_id: str
+    strategy_version: str
+    stage: str
+    promotion_id: int
+    evidence_ref: str | None
+    created: bool
 
 
 def _live_gate_view(report: LiveGateReport) -> LiveGateResponse:
@@ -1321,6 +1386,7 @@ _LATEST_EVIDENCE_REFRESH_SQL = """
 _CURRENT_FORECAST_ASSESSMENTS_SQL = """
     SELECT p.policy_id,p.max_assessment_age_days,
            c.strategy_id,c.strategy_version,c.checked_at,
+           a.window_start,a.window_end,forward_stage.promoted_at AS forward_started_at,
            a.passed,a.resolved_forecasts,a.target_first_count,a.stop_first_count,a.timeout_count,
            a.normalized_brier_score,a.brier_skill_score,a.max_classwise_calibration_error
     FROM strategy_forecast_assessment_policies p
@@ -1337,6 +1403,10 @@ _CURRENT_FORECAST_ASSESSMENTS_SQL = """
      AND a.exit_policy_version=c.exit_policy_version
      AND a.resolver_version=c.resolver_version
      AND a.input_rule_set_version=c.input_rule_set_version
+    JOIN strategy_promotions forward_stage
+      ON forward_stage.strategy_id=c.strategy_id
+     AND forward_stage.strategy_version=c.strategy_version
+     AND forward_stage.to_stage='forward_observation'
     WHERE p.policy_id = (
         SELECT policy_id FROM strategy_forecast_assessment_policies
         WHERE effective_from <= %(as_of)s
@@ -1612,7 +1682,7 @@ def get_strategy_overview(
                 ("worst_case", "masked"),
                 ("worst_case", "admitted"),
             }
-            arms_complete = arm_keys == expected_arm_keys
+            arms_complete = len(rows) == len(expected_arm_keys) and arm_keys == expected_arm_keys
             ambiguity_complete = all(
                 {(ambiguity, quarantine) for ambiguity in ("best_case", "worst_case")}.issubset(arm_keys)
                 for quarantine in ("masked", "admitted")
@@ -1704,6 +1774,25 @@ def get_strategy_overview(
         fire_rate = fire_rate_by_strategy.get(key, StrategyFireRate())
         pnl = pnl_by_strategy.get(key, StrategyPnl())
         control = control_by_strategy.get(key, StrategyControlState())
+        promotion_action = next_promotion_action(control.stage) if entry.purpose == "capital_candidate" else None
+        promotion_refusals: list[str] = []
+        if promotion_action in {"validate_historical", "start_forward_observation", "approve_paper"}:
+            if not all_complete:
+                promotion_refusals.append("recent_evidence_incomplete")
+            if evidence_refused:
+                promotion_refusals.append("recent_evidence_gate_refused")
+            if evidence_not_positive:
+                promotion_refusals.append("recent_net_expectancy_not_positive")
+        if promotion_action == "approve_paper":
+            try:
+                load_forward_floor_evidence(
+                    conn,
+                    strategy_id=strategy_id,
+                    strategy_version=versions[strategy_id],
+                    now=as_of,
+                )
+            except OperatorPromotionRefusal as exc:
+                promotion_refusals.append(exc.code)
         allocation_refusals: list[str] = []
         if entry.purpose == "harness_validation":
             allocation_refusals.append("harness_validation_only")
@@ -1717,6 +1806,8 @@ def get_strategy_overview(
             allocation_refusals.append("recent_net_expectancy_not_positive")
         if control.stage not in {"paper_enabled", "live_enabled"}:
             allocation_refusals.append("paper_promotion_missing")
+        if control.stage in {"paper_enabled", "live_enabled"} and not control.paper_forward_evidence_ready:
+            allocation_refusals.append("paper_forward_evidence_missing")
         if not control.pinned_evidence_ready:
             allocation_refusals.append("pinned_promotion_evidence_invalid")
         if not control.policy_configured:
@@ -1747,19 +1838,38 @@ def get_strategy_overview(
             current_assessments = assessments_by_strategy[key]
             if assessment_policy_row is None:
                 allocation_refusals.append("prospective_assessment_policy_missing")
+                if promotion_action == "approve_paper":
+                    promotion_refusals.append("prospective_assessment_policy_missing")
             elif not current_assessments:
                 allocation_refusals.append("prospective_assessment_missing")
+                if promotion_action == "approve_paper":
+                    promotion_refusals.append("prospective_assessment_missing")
+            elif len(current_assessments) != 1:
+                allocation_refusals.append("prospective_assessment_ambiguous")
+                if promotion_action == "approve_paper":
+                    promotion_refusals.append("prospective_assessment_ambiguous")
             else:
-                passed_assessments = [row for row in current_assessments if bool(row["passed"])]
-                if not passed_assessments:
+                assessment = current_assessments[0]
+                if cast(date, assessment["window_start"]) <= cast(datetime, assessment["forward_started_at"]).date():
+                    allocation_refusals.append("prospective_assessment_includes_pre_forward_observations")
+                    if promotion_action == "approve_paper":
+                        promotion_refusals.append("prospective_assessment_includes_pre_forward_observations")
+                elif cast(date, assessment["window_end"]) > cast(datetime, assessment["checked_at"]).date():
+                    allocation_refusals.append("prospective_assessment_window_invalid")
+                    if promotion_action == "approve_paper":
+                        promotion_refusals.append("prospective_assessment_window_invalid")
+                elif not bool(assessment["passed"]):
                     allocation_refusals.append("prospective_assessment_not_passed")
-                elif not any(
-                    cast(datetime, row["checked_at"])
-                    >= as_of - timedelta(days=cast(int, row["max_assessment_age_days"]))
-                    and cast(datetime, row["checked_at"]) <= as_of + timedelta(seconds=5)
-                    for row in passed_assessments
+                    if promotion_action == "approve_paper":
+                        promotion_refusals.append("prospective_assessment_not_passed")
+                elif not (
+                    cast(datetime, assessment["checked_at"])
+                    >= as_of - timedelta(days=cast(int, assessment["max_assessment_age_days"]))
+                    and cast(datetime, assessment["checked_at"]) <= as_of + timedelta(seconds=5)
                 ):
                     allocation_refusals.append("prospective_assessment_stale")
+                    if promotion_action == "approve_paper":
+                        promotion_refusals.append("prospective_assessment_stale")
         remaining = max(control.capital_limit - control.reserved_capital, Decimal("0"))
         strategies.append(
             StrategyOverview(
@@ -1778,6 +1888,8 @@ def get_strategy_overview(
                 legacy_result_count=result_counts.get(strategy_id, 0) - sum(len(rows) for rows in exact.values()),
                 all_recent_evidence_complete=all_complete,
                 stage=control.stage,
+                next_promotion_action=promotion_action,
+                promotion_refusals=promotion_refusals,
                 attribution=StrategyAttributionView(**attribution.__dict__),
                 fire_rate=StrategyFireRateView(**fire_rate.__dict__),
                 pnl=StrategyPnlView(
@@ -1841,7 +1953,13 @@ def get_strategy_overview(
     candidate_assessments = [
         row for key, rows in assessments_by_strategy.items() if key in capital_candidate_keys for row in rows
     ]
-    passed_assessments = [row for row in candidate_assessments if bool(row["passed"])]
+    post_forward_assessments = [
+        row
+        for row in candidate_assessments
+        if cast(date, row["window_start"]) > cast(datetime, row["forward_started_at"]).date()
+        and cast(date, row["window_end"]) <= cast(datetime, row["checked_at"]).date()
+    ]
+    passed_assessments = [row for row in post_forward_assessments if bool(row["passed"])]
     fresh_passed_assessments = [
         row
         for row in passed_assessments
@@ -1861,6 +1979,9 @@ def get_strategy_overview(
     elif not candidate_assessments:
         readiness_state = "prospective_evidence_missing"
         readiness_blockers = ["prospective_assessment_missing"]
+    elif not post_forward_assessments:
+        readiness_state = "candidate_evidence_incomplete"
+        readiness_blockers = ["prospective_assessment_includes_pre_forward_observations"]
     elif not passed_assessments:
         readiness_state = "prospective_evidence_failed"
         readiness_blockers = ["prospective_assessment_not_passed"]
@@ -2777,6 +2898,81 @@ def update_core_mandate(
     return _core_mandate_response(mandate)
 
 
+@router.post(
+    "/{strategy_id}/paper-setup",
+    response_model=StrategyInitialPaperSetupResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_strategy_paper_setup(
+    strategy_id: str,
+    body: StrategyInitialPaperSetupRequest,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategyInitialPaperSetupResponse:
+    """Create the first disabled paper deployment and explicit risk policy."""
+    _require_current_strategy_version(strategy_id, body.strategy_version)
+    try:
+        with conn.transaction():
+            lock_strategy_control(conn, strategy_id, body.strategy_version)
+            if current_stage(conn, strategy_id, body.strategy_version) != "paper_enabled":
+                raise StrategyControlError("strategy must be paper-approved before initial setup")
+            overview = get_strategy_overview(conn)
+            strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
+            if strategy.allocation.policy_configured:
+                raise StrategyControlError("paper execution policy is already configured")
+            refusals = [code for code in strategy.allocation_refusals if code != "execution_policy_missing"]
+            if refusals:
+                raise StrategyControlError(f"paper setup prerequisites failed: {', '.join(refusals)}")
+            pool = load_paper_pool(conn)
+            if pool.capital_limit <= 0:
+                raise StrategyControlError("paper pool capital limit must be configured first")
+            if body.capital_limit > pool.capital_limit:
+                raise StrategyControlError("strategy capital limit cannot exceed the paper pool limit")
+            deployment = configure_deployment(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=body.strategy_version,
+                mode="paper",
+                capital_limit=body.capital_limit,
+                enabled=False,
+                changed_by=session.username,
+                reason=body.reason,
+            )
+            policy = configure_execution_policy(
+                conn,
+                deployment_id=deployment.deployment_id,
+                ticket_sizing_mode=body.ticket_sizing_mode,
+                ticket_fraction=(body.ticket_value / Decimal("100") if body.ticket_sizing_mode == "percent" else None),
+                fixed_ticket_amount=(body.ticket_value if body.ticket_sizing_mode == "fixed" else None),
+                max_ticket_amount=body.max_ticket_amount,
+                stop_loss_pct=body.stop_loss_pct,
+                take_profit_pct=body.take_profit_pct,
+                max_quote_age_seconds=body.max_quote_age_seconds,
+                max_scan_age_seconds=body.max_scan_age_seconds,
+                max_halt_feed_age_seconds=body.max_halt_feed_age_seconds,
+                max_cost_age_seconds=body.max_cost_age_seconds,
+                max_reconciliation_age_seconds=body.max_reconciliation_age_seconds,
+                max_instrument_exposure_pct=body.max_instrument_exposure_pct,
+                max_portfolio_exposure_pct=body.max_portfolio_exposure_pct,
+                max_drawdown_pct=body.max_drawdown_pct,
+                min_net_expectancy_pct=body.min_net_expectancy_pct,
+                cost_stress_multiplier=body.cost_stress_multiplier,
+                changed_by=session.username,
+                reason=body.reason,
+            )
+    except StrategyControlError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return StrategyInitialPaperSetupResponse(
+        strategy_id=strategy_id,
+        strategy_version=body.strategy_version,
+        deployment_id=deployment.deployment_id,
+        deployment_revision=deployment.revision,
+        policy_revision=policy.revision,
+        capital_limit=deployment.capital_limit,
+        enabled=False,
+    )
+
+
 @router.put(
     "/{strategy_id}/allocation",
     response_model=AllocationUpdateResponse,
@@ -3051,6 +3247,37 @@ def attempt_live_promotion(
     except StrategyControlError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return LivePromotionAttemptResponse(assessment_id=assessment_id, report=_live_gate_view(report))
+
+
+@router.post("/{strategy_id}/promotion", response_model=StrategyPromotionResponse)
+def advance_strategy_promotion(
+    strategy_id: str,
+    body: StrategyPromotionRequest,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategyPromotionResponse:
+    """Advance one server-selected, evidence-bound pre-live stage."""
+    _require_current_strategy_version(strategy_id, body.strategy_version)
+    try:
+        with conn.transaction():
+            result = advance_strategy_for_operator(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=body.strategy_version,
+                action=body.action,
+                promoted_by=session.username,
+                reason=body.reason,
+            )
+    except StrategyControlError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return StrategyPromotionResponse(
+        strategy_id=strategy_id,
+        strategy_version=body.strategy_version,
+        stage=result.promotion.to_stage,
+        promotion_id=result.promotion.promotion_id,
+        evidence_ref=result.evidence_ref,
+        created=result.created,
+    )
 
 
 @router.post("/{strategy_id}/lifecycle", response_model=StrategyLifecycleResponse)

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from datetime import UTC, date, datetime
-from typing import Literal
+from typing import Any, Literal, cast
 
 import psycopg
 import psycopg.rows
@@ -256,6 +256,7 @@ class JobsProcessSubsystemHealth(BaseModel):
     last_beat_at: datetime | None
     age_seconds: float | None
     is_stale: bool
+    notes: dict[str, Any] | None
 
 
 class JobsProcessHealthResponse(BaseModel):
@@ -502,7 +503,7 @@ def _build_jobs_process_health(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT subsystem, last_beat_at
+            SELECT subsystem, last_beat_at, notes
             FROM job_runtime_heartbeat
             ORDER BY subsystem
             """
@@ -526,6 +527,7 @@ def _build_jobs_process_health(
                 last_beat_at=last_beat,
                 age_seconds=age,
                 is_stale=is_stale,
+                notes=cast(dict[str, Any] | None, row["notes"]),
             )
         )
 

--- a/app/db/pg_settings.py
+++ b/app/db/pg_settings.py
@@ -160,11 +160,25 @@ EXPECTED, not observed: #1472's RCA saw ``credential_health`` LISTEN ×3
 (a duplicate-instance bug PR3 fixes). The budget models the intended
 topology so it never blesses that bug."""
 
-JOBS_NON_SEC_MAX_CONCURRENCY: Final[int] = 2
-"""Maximum scheduled/catch-up/manual executions outside the ``sec_rate``
-lane. ``JobRuntime`` enforces this before opening any job lock or body
-connection. Two lets a long LLM thesis run coexist with portfolio/strategy
-work without reopening the cadence herd."""
+JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY: Final[int] = 1
+"""Maximum general scheduled/catch-up/manual executions outside ``sec_rate``.
+
+Long research, LLM and backfill work shares this slot. Keeping it separate
+from the paper-lifecycle reserve prevents that work from consuming the
+capacity needed to reconcile and protect demo-owned positions."""
+
+JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY: Final[int] = 1
+"""Reserved execution capacity for ``strategy_paper_cycle`` only.
+
+The job remains independently serialised by APScheduler ``max_instances=1``,
+the manual in-flight lock and its source advisory lock. This reservation only
+prevents unrelated general work from starving its connection-budget entry."""
+
+JOBS_NON_SEC_MAX_CONCURRENCY: Final[int] = JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY + JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY
+"""Total modeled non-SEC execution concurrency.
+
+The split remains exactly the prior total of two, so reserving the lifecycle
+slot does not increase PostgreSQL connection demand."""
 
 JOBS_NON_SEC_CONNECTIONS_PER_EXECUTION: Final[int] = 2
 """Worst-case connections held by one non-SEC execution: one session-scoped

--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -74,7 +74,7 @@ from app.jobs.credential_health_listener import (
 from app.jobs.heartbeat import HeartbeatWriter, heartbeat_loop
 from app.jobs.listener import ListenerState, listener_loop
 from app.jobs.locks import JOBS_PROCESS_LOCK_KEY
-from app.jobs.runtime import JobRuntime
+from app.jobs.runtime import JobRuntime, execution_slot_wait_snapshot
 from app.jobs.supervisor import supervise
 from app.security import master_key
 from app.security.secrets_crypto import set_active_key as set_broker_encryption_key
@@ -1222,10 +1222,11 @@ def serve(stop_event: threading.Event | None = None) -> int:
         # it. The fresh beats also overwrite the prior boot's stale rows
         # immediately, so a restart no longer shows a stale pid.
         for subsystem in ("scheduler", "manual_listener", "queue_drainer", "main"):
+            notes_provider = execution_slot_wait_snapshot if subsystem == "scheduler" else None
             t = threading.Thread(
                 target=heartbeat_loop,
                 args=(heartbeat, subsystem, stop_event),
-                kwargs={"tick_seconds": 10.0},
+                kwargs={"tick_seconds": 10.0, "notes_provider": notes_provider},
                 name=f"jobs-heartbeat-{subsystem}",
                 daemon=True,
             )

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -46,8 +46,9 @@ import time
 from collections.abc import Callable, Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Final
+from typing import Any, Final, TypedDict
 
 import psycopg
 import psycopg.sql
@@ -59,7 +60,10 @@ from psycopg_pool import ConnectionPool
 
 from app.config import settings
 from app.db.background_write import background_write_connection
-from app.db.pg_settings import JOBS_NON_SEC_MAX_CONCURRENCY
+from app.db.pg_settings import (
+    JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY,
+    JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY,
+)
 from app.jobs.background_pool import BackgroundConnectionPool
 from app.jobs.locks import JobAlreadyRunning, JobLock
 from app.jobs.sec_lane_gate import SEC_LANE_MAX_CONCURRENCY
@@ -646,7 +650,58 @@ _RECURRING_JOB_ID_PREFIX: Final[str] = "recurring:"
 _MAX_INSTANCES_SKIP_REASON: Final[str] = "max_instances_active"
 
 _SEC_EXECUTION_SLOTS = threading.BoundedSemaphore(SEC_LANE_MAX_CONCURRENCY)
-_NON_SEC_EXECUTION_SLOTS = threading.BoundedSemaphore(JOBS_NON_SEC_MAX_CONCURRENCY)
+_GENERAL_NON_SEC_EXECUTION_SLOTS = threading.BoundedSemaphore(JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY)
+_PAPER_LIFECYCLE_EXECUTION_SLOTS = threading.BoundedSemaphore(JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY)
+
+
+@dataclass(frozen=True, slots=True)
+class _ExecutionSlotWait:
+    job_name: str
+    lane: str
+    waiting_since: datetime
+    started_monotonic: float
+
+
+_EXECUTION_SLOT_WAITS_LOCK = threading.Lock()
+_EXECUTION_SLOT_WAITS: dict[int, _ExecutionSlotWait] = {}
+
+
+class ExecutionSlotWaitView(TypedDict):
+    job_name: str
+    lane: str
+    waiting_since: str
+    wait_age_seconds: float
+
+
+class ExecutionSlotWaitSnapshot(TypedDict):
+    execution_slot_wait_count: int
+    execution_slot_waits: list[ExecutionSlotWaitView]
+
+
+def execution_slot_wait_snapshot() -> ExecutionSlotWaitSnapshot:
+    """Return heartbeat-safe visibility for work waiting before ``job_runs``.
+
+    Slot admission deliberately precedes every database connection, so a
+    waiting fire cannot write a ``job_runs`` row without defeating the
+    connection ceiling. The scheduler heartbeat publishes this process-local
+    snapshot instead; logs also record the wait immediately and on admission.
+    """
+    observed_monotonic = time.monotonic()
+    with _EXECUTION_SLOT_WAITS_LOCK:
+        waits = tuple(_EXECUTION_SLOT_WAITS.values())
+    payload: list[ExecutionSlotWaitView] = [
+        {
+            "job_name": wait.job_name,
+            "lane": wait.lane,
+            "waiting_since": wait.waiting_since.isoformat(),
+            "wait_age_seconds": round(max(0.0, observed_monotonic - wait.started_monotonic), 3),
+        }
+        for wait in sorted(waits, key=lambda item: (item.waiting_since, item.job_name))
+    ]
+    return {
+        "execution_slot_wait_count": len(payload),
+        "execution_slot_waits": payload,
+    }
 
 
 @contextmanager
@@ -660,12 +715,45 @@ def _job_execution_slot(job_name: str) -> Iterator[None]:
         # unknown name.  For connection budgeting, the conservative safe
         # classification is the smaller non-SEC allowance.
         source = None
-    slots = _SEC_EXECUTION_SLOTS if source == "sec_rate" else _NON_SEC_EXECUTION_SLOTS
-    slots.acquire()
+    if source == "sec_rate":
+        slots = _SEC_EXECUTION_SLOTS
+        lane = "sec_rate"
+    elif job_name == JOB_STRATEGY_PAPER_CYCLE:
+        slots = _PAPER_LIFECYCLE_EXECUTION_SLOTS
+        lane = "paper_lifecycle_reserved"
+    else:
+        slots = _GENERAL_NON_SEC_EXECUTION_SLOTS
+        lane = "general_non_sec"
+
+    acquired = slots.acquire(blocking=False)
+    if not acquired:
+        thread_id = threading.get_ident()
+        wait = _ExecutionSlotWait(
+            job_name=job_name,
+            lane=lane,
+            waiting_since=datetime.now(UTC),
+            started_monotonic=time.monotonic(),
+        )
+        with _EXECUTION_SLOT_WAITS_LOCK:
+            _EXECUTION_SLOT_WAITS[thread_id] = wait
+        logger.warning("job %r waiting for %s execution capacity", job_name, lane)
+        try:
+            slots.acquire()
+            acquired = True
+        finally:
+            with _EXECUTION_SLOT_WAITS_LOCK:
+                _EXECUTION_SLOT_WAITS.pop(thread_id, None)
+        logger.info(
+            "job %r acquired %s execution capacity after %.3fs",
+            job_name,
+            lane,
+            time.monotonic() - wait.started_monotonic,
+        )
     try:
         yield
     finally:
-        slots.release()
+        if acquired:
+            slots.release()
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -471,6 +471,13 @@ class NamespaceMeasurement:
     universe_record: ResultUniverseRecord
     position_count: int
     axis_dates: tuple[date, ...]
+    #: The exact costed legs that produced ``metrics``, rebased onto
+    #: ``axis_dates``.  The dedicated MT-1 runner consumes this artifact so it
+    #: cannot rebuild fills through a second, drifting strategy path. ``None``
+    #: is retained only for narrow synthetic fixtures constructed outside the
+    #: corpus evaluator; production measurements always carry the book and a
+    #: downstream evidence runner must refuse its absence.
+    source_book: LegBook | None = None
     #: Criterion 5's label windows, on the panel axis — populated for the
     #: ``in_sample`` namespace and EMPTY for ``hold_out``, which has no split.
     #: ⚠ These are the legs that reached the CURVE, so the census describes the
@@ -1682,6 +1689,7 @@ def _measure_namespace(
         universe_record=opportunity,
         position_count=book.positions,
         axis_dates=dates,
+        source_book=shifted,
         label_starts=book.label_starts,
         label_ends=book.label_ends,
         rebalance_costs=curve.rebalance_costs,

--- a/app/services/market_regime_provider.py
+++ b/app/services/market_regime_provider.py
@@ -254,7 +254,12 @@ class MarketRegimeProvider:
         return cls(regime_by_date=dict(zip(dates, series.values, strict=True)))
 
     @classmethod
-    def load_research(cls, conn: psycopg.Connection[Any]) -> MarketRegimeProvider:
+    def load_research(
+        cls,
+        conn: psycopg.Connection[Any],
+        *,
+        through_date: date | None = None,
+    ) -> MarketRegimeProvider:
         """The BACKTEST's benchmark: ``spy_chain_v1`` over the research corpus.
 
         The live scan keeps ``load`` (``price_daily``); this constructor exists
@@ -274,6 +279,9 @@ class MarketRegimeProvider:
 
         ⚠ Both segment reads happen on the one connection passed in, inside its
         current transaction, so the two queries observe one corpus snapshot.
+        A sealed in-sample caller supplies ``through_date`` so post-boundary
+        benchmark observations are not even read; classification remains a
+        backward-looking prefix of the same frozen chain.
         """
         segments: dict[str, list[tuple[date, float]]] = {}
         for role, (vendor, vendor_symbol), expected_basis in (
@@ -306,12 +314,32 @@ class MarketRegimeProvider:
                 SELECT bar_date, close
                 FROM research_price_daily
                 WHERE series_id = %s AND close IS NOT NULL
+                  AND (%s::date IS NULL OR bar_date <= %s::date)
                 ORDER BY bar_date
                 """,
-                (series_id,),
+                (series_id, through_date, through_date),
             ).fetchall()
             segments[role] = [(row[0], float(row[1])) for row in bar_rows]
-        chained = _chain_closes(segments["primary"], segments["fallback"])
+        if through_date is not None and through_date < CHAIN_SEAM:
+            # The sealed MT-1 window ends before the frozen vendor seam. Reading
+            # the primary seam merely to satisfy the full-chain constructor
+            # would itself cross that outcome boundary. The historical prefix
+            # is therefore exactly the fallback segment returned by the bounded
+            # query, with the same ordering/value refusals as the full chain.
+            chained = segments["fallback"]
+            if not chained:
+                raise BenchmarkUnavailableError(
+                    f"chain fallback has no bars through the sealed boundary {through_date}"
+                )
+            for index, (day, close) in enumerate(chained):
+                if index and day <= chained[index - 1][0]:
+                    raise BenchmarkUnavailableError(f"chain dates are not strictly increasing at {day}")
+                if not math.isfinite(close) or close <= 0:
+                    raise BenchmarkUnavailableError(
+                        f"chain close on {day} is {close!r} — not a positive finite price"
+                    )
+        else:
+            chained = _chain_closes(segments["primary"], segments["fallback"])
         return cls._classify([day for day, _ in chained], [close for _, close in chained], label="spy_chain_v1")
 
     def for_dates(self, dates: tuple[date, ...]) -> RegimeSeries:

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -865,6 +865,8 @@ def configure_execution_policy(
         raise StrategyControlError("max_portfolio_exposure_pct must be in (0, 100]")
     if not (Decimal("0") < max_drawdown_pct < Decimal("100")):
         raise StrategyControlError("max_drawdown_pct must be in (0, 100)")
+    if min_net_expectancy_pct < 0:
+        raise StrategyControlError("min_net_expectancy_pct must be non-negative")
     if cost_stress_multiplier < 1:
         raise StrategyControlError("cost_stress_multiplier must be at least 1")
 

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -430,6 +430,7 @@ def promote_strategy(
     evidence_ref: str | None = None,
     result_ids: Sequence[int] = (),
     gate_version: str = GOVERNANCE_GATE_VERSION,
+    replay_result_evidence: bool = False,
 ) -> Promotion:
     """Append one explicit, ordered promotion event.
 
@@ -482,6 +483,8 @@ def promote_strategy(
         raise StrategyControlError("unregistered strategies cannot advance to evidence-backed deployment stages")
     if evidence_ref is not None:
         _require_text(evidence_ref, "evidence_ref")
+    if replay_result_evidence and to_stage != "paper_enabled":
+        raise StrategyControlError("explicit result-evidence replay is reserved for paper approval")
     if len(set(result_ids)) != len(result_ids):
         raise StrategyControlError("result_ids must be unique")
 
@@ -492,7 +495,7 @@ def promote_strategy(
 
     if to_stage in _EXTERNAL_EVIDENCE_STAGES and evidence_ref is None:
         raise StrategyControlError(f"{to_stage} requires an immutable evidence_ref")
-    if to_stage in _RESULT_EVIDENCE_STAGES and not result_ids:
+    if (to_stage in _RESULT_EVIDENCE_STAGES or replay_result_evidence) and not result_ids:
         raise StrategyControlError(f"{to_stage} requires at least one pinned result_id")
 
     if result_ids:
@@ -512,7 +515,7 @@ def promote_strategy(
             raise StrategyControlError(
                 f"result_ids do not belong to {strategy_id}@{strategy_version}: {sorted(missing)}"
             )
-        if to_stage in _RESULT_EVIDENCE_STAGES:
+        if to_stage in _RESULT_EVIDENCE_STAGES or replay_result_evidence:
             # #2639 — criterion 5's two counts, read ONCE for the whole
             # transition. They are scoped to (strategy_id, strategy_version),
             # which is exactly what this call promotes, so they are a property
@@ -815,6 +818,22 @@ def configure_execution_policy(
     """
     for value, field in ((changed_by, "changed_by"), (reason, "reason")):
         _require_text(value, field)
+    numeric_limits = (
+        max_ticket_amount,
+        stop_loss_pct,
+        take_profit_pct,
+        max_instrument_exposure_pct,
+        max_portfolio_exposure_pct,
+        max_drawdown_pct,
+        min_net_expectancy_pct,
+        cost_stress_multiplier,
+    )
+    if ticket_fraction is not None:
+        numeric_limits += (ticket_fraction,)
+    if fixed_ticket_amount is not None:
+        numeric_limits += (fixed_ticket_amount,)
+    if any(not value.is_finite() for value in numeric_limits):
+        raise StrategyControlError("execution-policy numeric limits must be finite")
     if ticket_sizing_mode == "percent":
         if ticket_fraction is None or not (Decimal("0") < ticket_fraction <= Decimal("1")):
             raise StrategyControlError("percent ticket_fraction must be in (0, 1]")

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -419,6 +419,128 @@ def current_stage(conn: psycopg.Connection[Any], strategy_id: str, strategy_vers
     return cast(Stage, row[0]) if row is not None else None
 
 
+def validate_result_evidence_bundle(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    result_ids: Sequence[int],
+    as_of: date | None = None,
+) -> None:
+    """Replay the complete current promotion policy over exact stored results.
+
+    This is the shared authority check used both when a stage is promoted and
+    immediately before paper execution. A paper approval therefore cannot keep
+    authorising entries after a supersedable rule or dated cost record has
+    become invalid.
+    """
+    if not result_ids:
+        raise StrategyControlError("result evidence bundle is empty")
+    if len(set(result_ids)) != len(result_ids):
+        raise StrategyControlError("result_ids must be unique")
+    rows = conn.execute(
+        """
+        SELECT result_id, profit_factor, evaluated_instrument_count,
+               universe_basis, carry_unmodelled, fx_unmodelled, opportunity_set_digest
+        FROM strategy_results_store
+        WHERE strategy_id = %s AND strategy_version = %s
+          AND result_id = ANY(%s)
+        """,
+        (strategy_id, strategy_version, list(result_ids)),
+    ).fetchall()
+    found = {int(row[0]) for row in rows}
+    missing = set(result_ids) - found
+    if missing:
+        raise StrategyControlError(
+            f"result_ids do not belong to {strategy_id}@{strategy_version}: {sorted(missing)}"
+        )
+
+    counts = holdout_access_counts(conn, strategy_id, strategy_version)
+    holdout_refusals = holdout_count_promotion_refusals(
+        holdout_evaluations=counts.holdout_evaluations,
+        recorded_accesses=counts.recorded_accesses,
+    )
+    profit_factor_by_result = {int(row[0]): None if row[1] is None else Decimal(str(row[1])) for row in rows}
+    evaluated_count_by_result = {int(row[0]): int(row[2]) for row in rows}
+    opportunity_digest_by_result = {int(row[0]): None if row[6] is None else str(row[6]) for row in rows}
+    stamps_by_result = {
+        int(row[0]): (
+            None if row[3] is None else str(row[3]),
+            True if row[4] is None else bool(row[4]),
+            True if row[5] is None else bool(row[5]),
+        )
+        for row in rows
+    }
+    universes = load_result_universes(conn, result_ids)
+    ambiguity_refusals = load_promotion_ambiguity_refusals(conn, result_ids)
+    stored_refusals = stored_result_promotion_refusals_for(conn, result_ids)
+    evidences = load_promotion_evidences(conn, result_ids)
+    observed_on = as_of or date.today()
+    for result_id in result_ids:
+        refusals = list(
+            universe_promotion_refusals(
+                universes.get(result_id),
+                evaluated_instrument_count=evaluated_count_by_result[result_id],
+                expected_opportunity_digest=opportunity_digest_by_result[result_id],
+            )
+        )
+        refusals.extend(ambiguity_refusals[result_id])
+        universe_basis, carry_unmodelled, fx_unmodelled = stamps_by_result[result_id]
+        refusals.extend(
+            structural_promotion_refusals(
+                universe_basis=universe_basis,
+                carry_unmodelled=carry_unmodelled,
+                fx_unmodelled=fx_unmodelled,
+            )
+        )
+        refusals.extend(stored_refusals[result_id])
+        refusals.extend(holdout_refusals)
+        evidence = evidences.get(result_id)
+        if evidence is None:
+            refusals.append("promotion_evidence_missing")
+        else:
+            refusals.extend(
+                evidence_refusals(
+                    evidence,
+                    profit_factor=profit_factor_by_result[result_id],
+                    as_of=observed_on,
+                )
+            )
+        if refusals:
+            raise StrategyControlError(f"result {result_id} fails promotion evidence: {', '.join(refusals)}")
+
+
+def validate_paper_promotion_evidence(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    as_of: date | None = None,
+) -> None:
+    """Replay full authority over the exact result pins of paper approval."""
+    rows = conn.execute(
+        """
+        SELECT pr.result_id
+        FROM strategy_promotions promotion
+        JOIN strategy_promotion_results pr ON pr.promotion_id=promotion.promotion_id
+        WHERE promotion.strategy_id=%s AND promotion.strategy_version=%s
+          AND promotion.to_stage='paper_enabled'
+        ORDER BY pr.result_id
+        """,
+        (strategy_id, strategy_version),
+    ).fetchall()
+    result_ids = [int(row[0]) for row in rows]
+    if not result_ids:
+        raise StrategyControlError("paper promotion has no pinned result evidence")
+    validate_result_evidence_bundle(
+        conn,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        result_ids=result_ids,
+        as_of=as_of,
+    )
+
+
 def promote_strategy(
     conn: psycopg.Connection[Any],
     *,
@@ -499,132 +621,29 @@ def promote_strategy(
         raise StrategyControlError(f"{to_stage} requires at least one pinned result_id")
 
     if result_ids:
-        rows = conn.execute(
-            """
-            SELECT result_id, profit_factor, evaluated_instrument_count,
-                   universe_basis, carry_unmodelled, fx_unmodelled, opportunity_set_digest
-            FROM strategy_results_store
-            WHERE strategy_id = %s AND strategy_version = %s
-              AND result_id = ANY(%s)
-            """,
-            (strategy_id, strategy_version, list(result_ids)),
-        ).fetchall()
-        found = {int(row[0]) for row in rows}
-        missing = set(result_ids) - found
-        if missing:
-            raise StrategyControlError(
-                f"result_ids do not belong to {strategy_id}@{strategy_version}: {sorted(missing)}"
-            )
         if to_stage in _RESULT_EVIDENCE_STAGES or replay_result_evidence:
-            # #2639 — criterion 5's two counts, read ONCE for the whole
-            # transition. They are scoped to (strategy_id, strategy_version),
-            # which is exactly what this call promotes, so they are a property
-            # of the promotion rather than of any one pinned result — and every
-            # result's refusal list carries them so that the raise names them.
-            #
-            # ⚠ AGAINST TODAY'S COUNTS, NOT A FROZEN PAIR. Freezing defeats the
-            # criterion: a pair frozen at result time is blind to a later
-            # unrecorded look at the same version's hold-out, which is the leak
-            # criterion 5 exists to catch. `holdout_access_counts` records
-            # nothing, so asking is safe. Reasoning in
-            # `app.services.strategy_promotion_replay`.
-            counts = holdout_access_counts(conn, strategy_id, strategy_version)
-            holdout_refusals = holdout_count_promotion_refusals(
-                holdout_evaluations=counts.holdout_evaluations,
-                recorded_accesses=counts.recorded_accesses,
+            validate_result_evidence_bundle(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                result_ids=result_ids,
             )
-            profit_factor_by_result = {int(row[0]): None if row[1] is None else Decimal(str(row[1])) for row in rows}
-            evaluated_count_by_result = {int(row[0]): int(row[2]) for row in rows}
-            opportunity_digest_by_result = {int(row[0]): None if row[6] is None else str(row[6]) for row in rows}
-            # ⚠ A NULL COST STAMP READS AS *UNMODELLED*, NEVER AS MODELLED.
-            # `bool(None)` is False, and False means "carry is modelled" — so the
-            # obvious coercion turns an unset stamp into a PASS on the clause it
-            # exists to enforce, which is fail-open on the Tier 1 refusals. Both
-            # columns are NOT NULL today (verified against dev, 2026-08-13), so
-            # this is defence in depth rather than a live bug; it is written this
-            # way because the failure direction is silent and the schema is one
-            # migration away from changing. `universe_basis` needs no such care —
-            # it preserves None, which `structural_promotion_refusals` already
-            # refuses as `universe_basis_absent`.
-            stamps_by_result = {
-                int(row[0]): (
-                    None if row[3] is None else str(row[3]),
-                    True if row[4] is None else bool(row[4]),
-                    True if row[5] is None else bool(row[5]),
+        else:
+            rows = conn.execute(
+                """
+                SELECT result_id
+                FROM strategy_results_store
+                WHERE strategy_id = %s AND strategy_version = %s
+                  AND result_id = ANY(%s)
+                """,
+                (strategy_id, strategy_version, list(result_ids)),
+            ).fetchall()
+            found = {int(row[0]) for row in rows}
+            missing = set(result_ids) - found
+            if missing:
+                raise StrategyControlError(
+                    f"result_ids do not belong to {strategy_id}@{strategy_version}: {sorted(missing)}"
                 )
-                for row in rows
-            }
-            # #2641 — every per-result record type is read for the WHOLE batch
-            # before the loop, one statement each, where the loop previously
-            # issued five round trips per pinned result. ⚠ The reordering this
-            # buys is named on `stored_result_promotion_refusals_for`: a corrupt
-            # record anywhere in the batch now raises before ANY result's
-            # refusals are gathered. Within a result nothing moves.
-            universes = load_result_universes(conn, result_ids)
-            ambiguity_refusals = load_promotion_ambiguity_refusals(conn, result_ids)
-            stored_refusals = stored_result_promotion_refusals_for(conn, result_ids)
-            evidences = load_promotion_evidences(conn, result_ids)
-            for result_id in result_ids:
-                # #2621 — the transition REPLAYS the universe check from the
-                # frozen record instead of trusting the write-time refusal that
-                # died with ``WrittenRow``. Frozen at result time, deliberately:
-                # today's date enters this gate only where a validity window was
-                # declared (the cost staleness clause inside
-                # ``evidence_refusals``); the universe declares none, and the
-                # order-time rule against the CURRENT universe is the execution
-                # guard's, not promotion's. Both refusal lists are gathered
-                # before raising so one missing input cannot mask the other.
-                refusals = list(
-                    universe_promotion_refusals(
-                        universes.get(result_id),
-                        evaluated_instrument_count=evaluated_count_by_result[result_id],
-                        expected_opportunity_digest=opportunity_digest_by_result[result_id],
-                    )
-                )
-                # #2625 — the §3.4 ambiguity comparison, re-derived from the
-                # frozen record rather than trusted. Same shape and the same
-                # argument as the universe replay above; the record stores the
-                # comparison's INPUTS so the verdict can be disagreed with.
-                refusals.extend(ambiguity_refusals[result_id])
-                # #2625 — the row's own STRUCTURAL stamps. ⚠ These were
-                # persisted and never replayed: before this, a result stamped
-                # `survivor_only` / `carry_unmodelled` / `fx_unmodelled` — which
-                # is all 324 rows in dev — could be pinned to a promotion
-                # without the transition ever looking. Routed through the SHARED
-                # `structural_promotion_refusals`, the single copy #2599's
-                # preregistration freeze also calls, so the freeze's expectation
-                # and the transition's verdict cannot drift apart.
-                universe_basis, carry_unmodelled, fx_unmodelled = stamps_by_result[result_id]
-                refusals.extend(
-                    structural_promotion_refusals(
-                        universe_basis=universe_basis,
-                        carry_unmodelled=carry_unmodelled,
-                        fx_unmodelled=fx_unmodelled,
-                    )
-                )
-                # #2639 — the row's OWN remaining clauses: its stamped purpose,
-                # criteria 6 and 3, criterion 9's arm pair and §9's acceptance.
-                # Every one is a column on the row already pinned above, and
-                # every one was trusting the write-time verdict that died with
-                # `WrittenRow`. ⚠ Deliberately does NOT return the structural
-                # stamps — see `stored_result_promotion_refusals` for why the
-                # read directly above is kept rather than sourced from the
-                # rebuilt object.
-                refusals.extend(stored_refusals[result_id])
-                refusals.extend(holdout_refusals)
-                evidence = evidences.get(result_id)
-                if evidence is None:
-                    refusals.append("promotion_evidence_missing")
-                else:
-                    refusals.extend(
-                        evidence_refusals(
-                            evidence,
-                            profit_factor=profit_factor_by_result[result_id],
-                            as_of=date.today(),
-                        )
-                    )
-                if refusals:
-                    raise StrategyControlError(f"result {result_id} fails promotion evidence: {', '.join(refusals)}")
 
     row = conn.execute(
         """
@@ -1229,4 +1248,6 @@ __all__ = [
     "registered_strategy_purpose",
     "record_order_position_execution",
     "release_exact_position",
+    "validate_paper_promotion_evidence",
+    "validate_result_evidence_bundle",
 ]

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -116,6 +116,7 @@ class StrategyPnl:
 class StrategyControlState:
     stage: str | None = None
     pinned_evidence_ready: bool = False
+    paper_forward_evidence_ready: bool = False
     deployment_id: int | None = None
     capital_limit: Decimal = Decimal("0")
     currency: str = "USD"
@@ -629,6 +630,11 @@ _CONTROL_SQL = """
         SELECT strategy_id, strategy_version
         FROM strategy_deployments
         WHERE strategy_version = ANY(%(versions)s) AND mode = 'paper'
+    ), paper_approval AS (
+        SELECT p.strategy_id, p.strategy_version, p.promotion_id
+        FROM strategy_promotions p
+        WHERE p.strategy_version = ANY(%(versions)s)
+          AND p.to_stage = 'paper_enabled'
     ), pinned AS (
         SELECT p.strategy_id, p.strategy_version,
                COUNT(*) AS result_count,
@@ -665,6 +671,7 @@ _CONTROL_SQL = """
     SELECT keys.strategy_id, keys.strategy_version, cs.to_stage,
            COALESCE(pin.result_count, 0) AS result_count,
            COALESCE(pin.qualified_result_count, 0) AS qualified_result_count,
+           (forward_evidence.promotion_id IS NOT NULL) AS paper_forward_evidence_ready,
            d.deployment_id, d.capital_limit, d.currency, d.enabled, d.revision,
            COALESCE(res.amount, 0) AS reserved_capital,
            (pol.deployment_id IS NOT NULL) AS policy_configured,
@@ -673,7 +680,10 @@ _CONTROL_SQL = """
            pol.fixed_ticket_amount, pol.max_ticket_amount
     FROM strategy_keys keys
     LEFT JOIN current_stage cs USING (strategy_id, strategy_version)
+    LEFT JOIN paper_approval paper USING (strategy_id, strategy_version)
     LEFT JOIN pinned pin USING (strategy_id, strategy_version)
+    LEFT JOIN strategy_promotion_forward_evidence forward_evidence
+      ON forward_evidence.promotion_id = paper.promotion_id
     LEFT JOIN strategy_deployments d
       ON d.strategy_id = keys.strategy_id AND d.strategy_version = keys.strategy_version
      AND d.mode = 'paper'
@@ -694,6 +704,7 @@ def load_control_state(
             pinned_evidence_ready=(
                 int(row["result_count"]) > 0 and int(row["qualified_result_count"]) == int(row["result_count"])
             ),
+            paper_forward_evidence_ready=bool(row["paper_forward_evidence_ready"]),
             deployment_id=int(row["deployment_id"]) if row["deployment_id"] is not None else None,
             capital_limit=Decimal(str(row["capital_limit"] or 0)),
             currency=str(row["currency"] or "USD"),

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -143,7 +143,7 @@ class StrategyEntryBlockState:
 
     @property
     def new_entries_blocked(self) -> bool:
-        return self.global_kill_active or bool(self.execution_block_reasons) or not self.auto_trading_enabled
+        return self.global_kill_active or bool(self.execution_block_reasons)
 
 
 _ATTRIBUTION_SQL = """
@@ -742,8 +742,6 @@ def load_entry_block_state(conn: psycopg.Connection[Any]) -> StrategyEntryBlockS
         return StrategyEntryBlockState(True, "kill switch state unavailable", None, None, blocks, False, False)
     if runtime is None:
         blocks = (*blocks, "runtime configuration unavailable")
-    elif not bool(runtime["enable_auto_trading"]):
-        blocks = (*blocks, "automatic trading disabled")
     return StrategyEntryBlockState(
         global_kill_active=bool(kill["is_active"]),
         global_kill_reason=str(kill["reason"]) if kill["reason"] is not None else None,

--- a/app/services/strategy_mt1_preregistration.py
+++ b/app/services/strategy_mt1_preregistration.py
@@ -1,0 +1,90 @@
+"""Immutable preregistration terms for the MT-1/S-8 controlled trial.
+
+The terms live in application code because both the one-time freeze CLI and
+the paved evaluator must independently reconstruct them.  ``DECLARED_BY``
+intentionally retains the original script identity so this extraction leaves
+the already-frozen declaration digests byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Final
+
+from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, FX_UNMODELLED
+from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
+from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
+from app.services.strategy_mt1_trial import TRIAL_CONTRACT_VERSION
+from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION, structural_promotion_refusals
+
+DECLARED_BY: Final = "scripts/freeze_2437_mt1_declarations.py (#2437)"
+UNIVERSE_BASIS: Final = "survivorship_free"
+
+_Z_0975: Final = 1.959963984540054
+_Z_08: Final = 0.8416212335729143
+_STANDARDISED_EFFECT: Final = 0.5
+_POWER_DERIVED_MONTHS: Final = math.ceil(((_Z_0975 + _Z_08) / _STANDARDISED_EFFECT) ** 2)
+MIN_FORWARD_DECISION_DATES: Final = max(36, _POWER_DERIVED_MONTHS)
+MIN_FORWARD_CALENDAR_WEEKS: Final = math.ceil(MIN_FORWARD_DECISION_DATES * 365.25 / (12 * 7))
+
+_FORWARD_SHADOW_DERIVATION: Final = (
+    "Frozen preregistration power floor: standardised paired monthly effect=0.5, alpha=0.05 two-sided, "
+    "power=0.8; z_0.975=1.959963984540054 and z_0.8=0.8416212335729143. "
+    "n=ceil(((1.959963984540054+0.8416212335729143)/0.5)^2)=32 independent decision months; raised to "
+    "36 months to cover three complete calendar years. Calendar duration="
+    "ceil(36x365.25/(12x7))=157 weeks. Prospective inference still uses the preregistered paired "
+    "moving-block bootstrap; this floor does not assert monthly independence."
+)
+
+
+def _build(*, control: bool) -> PreregDeclaration:
+    identity = (
+        s8_control_identity(universe=UNIVERSE_BASIS, cost_model_id=COST_MODEL_ID)
+        if control
+        else mt1_identity(universe=UNIVERSE_BASIS, cost_model_id=COST_MODEL_ID)
+    )
+    expected = structural_promotion_refusals(
+        universe_basis=UNIVERSE_BASIS,
+        carry_unmodelled=CARRY_UNMODELLED,
+        fx_unmodelled=FX_UNMODELLED,
+    )
+    return PreregDeclaration(
+        strategy_id=identity.strategy_id,
+        strategy_version=identity.version,
+        contract_version=TRIAL_CONTRACT_VERSION,
+        prereg_purpose="falsification_only" if control else "capital_candidate",
+        structural_refusal_policy_version=STRUCTURAL_REFUSAL_POLICY_VERSION,
+        declared_universe_basis=UNIVERSE_BASIS,
+        declared_carry_unmodelled=CARRY_UNMODELLED,
+        declared_fx_unmodelled=FX_UNMODELLED,
+        expected_structural_refusals=expected,
+        forward_shadow=ForwardShadowFloor(
+            min_independent_decision_dates=MIN_FORWARD_DECISION_DATES,
+            min_calendar_weeks=MIN_FORWARD_CALENDAR_WEEKS,
+            derivation=_FORWARD_SHADOW_DERIVATION,
+        ),
+        declared_by=DECLARED_BY,
+    )
+
+
+def build_mt1_declaration() -> PreregDeclaration:
+    return _build(control=False)
+
+
+def build_s8_control_declaration() -> PreregDeclaration:
+    return _build(control=True)
+
+
+def build_declarations() -> tuple[PreregDeclaration, PreregDeclaration]:
+    return build_mt1_declaration(), build_s8_control_declaration()
+
+
+__all__ = [
+    "DECLARED_BY",
+    "MIN_FORWARD_CALENDAR_WEEKS",
+    "MIN_FORWARD_DECISION_DATES",
+    "UNIVERSE_BASIS",
+    "build_declarations",
+    "build_mt1_declaration",
+    "build_s8_control_declaration",
+]

--- a/app/services/strategy_mt1_read_model.py
+++ b/app/services/strategy_mt1_read_model.py
@@ -1,0 +1,190 @@
+"""Outcome-minimal operator read model for the MT-1 controlled trial (#2769)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal, cast
+
+import psycopg
+import psycopg.rows
+
+from app.services.backtest_run import BACKTEST_UNIVERSE
+from app.services.cost_model import COST_MODEL_ID
+from app.services.research_price_structure_store import QuarantineArm
+from app.services.result_ledger import holdout_access_counts
+from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
+from app.services.strategy_result import AmbiguityArm
+
+MT1ControlledTrialState = Literal[
+    "not_run",
+    "structural_refused",
+    "structural_passed_outcomes_pending",
+    "historical_conjuncts_failed",
+    "historical_conjuncts_passed",
+    "evidence_inconsistent",
+]
+
+_EXPECTED_FAN = {
+    ("best_case", "masked"),
+    ("best_case", "admitted"),
+    ("worst_case", "masked"),
+    ("worst_case", "admitted"),
+}
+
+
+@dataclass(frozen=True)
+class MT1ControlledTrialCellState:
+    ambiguity_arm: AmbiguityArm
+    quarantine_arm: QuarantineArm
+    historical_conjuncts_pass: bool
+
+
+@dataclass(frozen=True)
+class MT1ControlledTrialReadModel:
+    trial_id: str
+    strategy_version: str
+    negative_control_id: str
+    negative_control_version: str
+    state: MT1ControlledTrialState
+    structural_attempt_id: int | None
+    trial_result_id: int | None
+    structural_assessed_at: datetime | None
+    evaluated_at: datetime | None
+    structural_cells: int
+    result_cells: tuple[MT1ControlledTrialCellState, ...]
+    historical_conjuncts_pass: bool | None
+    refusal_code: str | None
+    refusal_detail: str | None
+    integrity_refusals: tuple[str, ...]
+    holdout_evaluations: int
+    holdout_accesses: int
+    promotion_authority: Literal[False] = False
+    paper_activation_reachable: Literal[False] = False
+    live_activation_reachable: Literal[False] = False
+
+
+def load_mt1_controlled_trial_state(conn: psycopg.Connection[Any]) -> MT1ControlledTrialReadModel:
+    """Read state/verdicts only; never expose return values or make mutation reachable."""
+    mt1 = mt1_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s8 = s8_control_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    mt1_exposure = holdout_access_counts(conn, mt1.strategy_id, mt1.version)
+    s8_exposure = holdout_access_counts(conn, s8.strategy_id, s8.version)
+    holdout_evaluations = mt1_exposure.holdout_evaluations + s8_exposure.holdout_evaluations
+    holdout_accesses = mt1_exposure.recorded_accesses + s8_exposure.recorded_accesses
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT a.structural_attempt_id, a.passed, a.refusal_code, a.refusal_detail,
+                   a.assessed_at, count(sc.structural_attempt_id) AS structural_cells,
+                   r.mt1_trial_result_id, r.historical_conjuncts_pass, r.evaluated_at
+              FROM strategy_mt1_structural_attempts a
+              LEFT JOIN strategy_mt1_structural_cells sc
+                ON sc.structural_attempt_id = a.structural_attempt_id
+              LEFT JOIN strategy_mt1_trial_results r
+                ON r.structural_attempt_id = a.structural_attempt_id
+             WHERE a.mt1_strategy_version = %s AND a.s8_strategy_version = %s
+             GROUP BY a.structural_attempt_id, r.mt1_trial_result_id
+            """,
+            (mt1.version, s8.version),
+        )
+        attempt = cur.fetchone()
+        result_rows: list[dict[str, object]] = []
+        if attempt is not None and attempt["mt1_trial_result_id"] is not None:
+            cur.execute(
+                """
+                SELECT ambiguity_arm, quarantine_arm, historical_conjuncts_pass
+                  FROM strategy_mt1_trial_result_cells
+                 WHERE mt1_trial_result_id = %s
+                 ORDER BY ambiguity_arm, quarantine_arm
+                """,
+                (attempt["mt1_trial_result_id"],),
+            )
+            result_rows = list(cur.fetchall())
+
+    integrity: list[str] = []
+    if holdout_evaluations:
+        integrity.append("holdout_evaluations_exist")
+    if holdout_accesses:
+        integrity.append("holdout_accesses_exist")
+    if attempt is None:
+        return MT1ControlledTrialReadModel(
+            trial_id=mt1.strategy_id,
+            strategy_version=mt1.version,
+            negative_control_id=s8.strategy_id,
+            negative_control_version=s8.version,
+            state="evidence_inconsistent" if integrity else "not_run",
+            structural_attempt_id=None,
+            trial_result_id=None,
+            structural_assessed_at=None,
+            evaluated_at=None,
+            structural_cells=0,
+            result_cells=(),
+            historical_conjuncts_pass=None,
+            refusal_code=None,
+            refusal_detail=None,
+            integrity_refusals=tuple(integrity),
+            holdout_evaluations=holdout_evaluations,
+            holdout_accesses=holdout_accesses,
+        )
+
+    structural_passed = bool(attempt["passed"])
+    structural_cells = int(attempt["structural_cells"])
+    result_id = cast(int | None, attempt["mt1_trial_result_id"])
+    cells = tuple(
+        MT1ControlledTrialCellState(
+            ambiguity_arm=cast(AmbiguityArm, row["ambiguity_arm"]),
+            quarantine_arm=cast(QuarantineArm, row["quarantine_arm"]),
+            historical_conjuncts_pass=bool(row["historical_conjuncts_pass"]),
+        )
+        for row in result_rows
+    )
+    keys = {(cell.ambiguity_arm, cell.quarantine_arm) for cell in cells}
+    if structural_passed and structural_cells != 4:
+        integrity.append("structural_fan_incomplete")
+    if not structural_passed and structural_cells:
+        integrity.append("refused_attempt_has_structural_cells")
+    if result_id is not None and (not structural_passed or keys != _EXPECTED_FAN):
+        integrity.append("result_fan_inconsistent")
+    declared_conjunction = cast(bool | None, attempt["historical_conjuncts_pass"])
+    if result_id is not None and declared_conjunction is not all(cell.historical_conjuncts_pass for cell in cells):
+        integrity.append("result_conjunction_inconsistent")
+
+    if integrity:
+        state: MT1ControlledTrialState = "evidence_inconsistent"
+    elif not structural_passed:
+        state = "structural_refused"
+    elif result_id is None:
+        state = "structural_passed_outcomes_pending"
+    elif declared_conjunction:
+        state = "historical_conjuncts_passed"
+    else:
+        state = "historical_conjuncts_failed"
+    return MT1ControlledTrialReadModel(
+        trial_id=mt1.strategy_id,
+        strategy_version=mt1.version,
+        negative_control_id=s8.strategy_id,
+        negative_control_version=s8.version,
+        state=state,
+        structural_attempt_id=int(attempt["structural_attempt_id"]),
+        trial_result_id=result_id,
+        structural_assessed_at=cast(datetime, attempt["assessed_at"]),
+        evaluated_at=cast(datetime | None, attempt["evaluated_at"]),
+        structural_cells=structural_cells,
+        result_cells=cells,
+        historical_conjuncts_pass=declared_conjunction,
+        refusal_code=cast(str | None, attempt["refusal_code"]),
+        refusal_detail=cast(str | None, attempt["refusal_detail"]),
+        integrity_refusals=tuple(integrity),
+        holdout_evaluations=holdout_evaluations,
+        holdout_accesses=holdout_accesses,
+    )
+
+
+__all__ = [
+    "MT1ControlledTrialCellState",
+    "MT1ControlledTrialReadModel",
+    "MT1ControlledTrialState",
+    "load_mt1_controlled_trial_state",
+]

--- a/app/services/strategy_mt1_runner.py
+++ b/app/services/strategy_mt1_runner.py
@@ -1,0 +1,173 @@
+"""Paved assembly boundary for the MT-1 in-sample controlled trial (#2769).
+
+The generic backtester remains the only owner of causal signal, fill,
+termination, ambiguity, quarantine and cost construction.  This module accepts
+only the complete in-memory source measurements from that engine and composes
+the frozen four-arm MT-1 statistic.
+
+The ambiguity/quarantine fan is conjunctive under the trial register.  All
+four cells must construct and pass their outcome-free structural gates before
+the first cell is handed to the return evaluator; a favourable cell can never
+be selected from an incomplete fan.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from typing import Final
+
+from app.services.backtest_run import (
+    AMBIGUITY_ARM_ORDER,
+    QUARANTINE_ARM_ORDER,
+    ArmMeasurement,
+    NamespaceMeasurement,
+)
+from app.services.research_price_structure_store import QuarantineArm
+from app.services.strategy_mt1_books import MT1FourArmBooks, build_mt1_four_arm_books
+from app.services.strategy_mt1_trial import MT1TrialResult, evaluate_mt1_trial
+from app.services.strategy_result import AmbiguityArm
+from app.services.strategy_result_universe import ResultUniverseRecord
+
+MT1_SOURCE_STRATEGY_ID: Final = "s10-relative-strength-leader"
+S8_SOURCE_STRATEGY_ID: Final = "s8-range-mean-reversion"
+
+RobustnessKey = tuple[AmbiguityArm, QuarantineArm]
+_EXPECTED_KEYS: Final[tuple[RobustnessKey, ...]] = tuple(
+    (ambiguity, quarantine) for ambiguity in AMBIGUITY_ARM_ORDER for quarantine in QUARANTINE_ARM_ORDER
+)
+
+
+class MT1RunnerRefused(ValueError):
+    """The supplied source pass is not the complete frozen MT-1 experiment."""
+
+
+@dataclass(frozen=True)
+class MT1RobustnessCell:
+    ambiguity_arm: AmbiguityArm
+    quarantine_arm: QuarantineArm
+    books: MT1FourArmBooks
+    result: MT1TrialResult
+
+
+@dataclass(frozen=True)
+class MT1HistoricalBundle:
+    """All conjunctive cells from one source-derived in-sample invocation."""
+
+    cells: tuple[MT1RobustnessCell, ...]
+    axis_dates: tuple[date, ...]
+    opportunity_record: ResultUniverseRecord
+
+    @property
+    def historical_statistical_conjuncts_pass(self) -> bool:
+        return all(cell.result.historical_statistical_conjuncts_pass for cell in self.cells)
+
+
+def _source_cells(
+    measurements: Sequence[ArmMeasurement],
+    *,
+    expected_strategy_id: str,
+) -> dict[RobustnessKey, NamespaceMeasurement]:
+    cells: dict[RobustnessKey, NamespaceMeasurement] = {}
+    for measurement in measurements:
+        if measurement.strategy_id != expected_strategy_id:
+            raise MT1RunnerRefused(
+                f"expected only {expected_strategy_id!r} source measurements; received {measurement.strategy_id!r}"
+            )
+        if measurement.ambiguity_arm is None:
+            raise MT1RunnerRefused(
+                f"{expected_strategy_id}: a survivorship-free source measurement must carry an ambiguity arm"
+            )
+        key = (measurement.ambiguity_arm, measurement.quarantine_arm)
+        if key in cells:
+            raise MT1RunnerRefused(f"{expected_strategy_id}: duplicate robustness cell {key}")
+        if set(measurement.namespaces) != {"in_sample"}:
+            raise MT1RunnerRefused(
+                f"{expected_strategy_id}/{key}: MT-1 accepts exactly the in_sample namespace; "
+                f"received {sorted(measurement.namespaces)}"
+            )
+        namespace = measurement.namespaces["in_sample"]
+        if namespace.source_book is None:
+            raise MT1RunnerRefused(f"{expected_strategy_id}/{key}: causal source book is missing")
+        cells[key] = namespace
+    expected = set(_EXPECTED_KEYS)
+    if set(cells) != expected:
+        raise MT1RunnerRefused(
+            f"{expected_strategy_id}: robustness fan is incomplete; "
+            f"missing={sorted(expected - set(cells))} unexpected={sorted(set(cells) - expected)}"
+        )
+    return cells
+
+
+def assemble_mt1_in_sample_bundle(
+    *,
+    mt1_source_measurements: Sequence[ArmMeasurement],
+    s8_source_measurements: Sequence[ArmMeasurement],
+) -> MT1HistoricalBundle:
+    """Construct and evaluate the complete frozen fan, structural gates first."""
+    mt1 = _source_cells(mt1_source_measurements, expected_strategy_id=MT1_SOURCE_STRATEGY_ID)
+    s8 = _source_cells(s8_source_measurements, expected_strategy_id=S8_SOURCE_STRATEGY_ID)
+
+    namespaces = tuple((*mt1.values(), *s8.values()))
+    axes = {namespace.axis_dates for namespace in namespaces}
+    if len(axes) != 1:
+        raise MT1RunnerRefused("MT-1 and S-8 robustness cells do not share one exact in-sample metric axis")
+    axis_dates = next(iter(axes))
+    if not axis_dates:
+        raise MT1RunnerRefused("the shared in-sample metric axis is empty")
+    opportunities = {namespace.universe_record for namespace in namespaces}
+    if len(opportunities) != 1:
+        raise MT1RunnerRefused("MT-1 and S-8 robustness cells do not share one pre-mask opportunity population")
+    opportunity = next(iter(opportunities))
+    first_month = date(axis_dates[0].year, axis_dates[0].month, 1)
+
+    # Phase 1 is intentionally complete before phase 2 begins.  The book
+    # constructor applies the outcome-free structural clock/exposure/turnover
+    # gate.  If cell four refuses, no return evaluator has seen cells one-three.
+    prepared: list[tuple[RobustnessKey, MT1FourArmBooks]] = []
+    for key in _EXPECTED_KEYS:
+        mt1_book = mt1[key].source_book
+        s8_book = s8[key].source_book
+        assert mt1_book is not None and s8_book is not None  # narrowed by _source_cells
+        prepared.append(
+            (
+                key,
+                build_mt1_four_arm_books(
+                    mt1_book=mt1_book,
+                    s8_book=s8_book,
+                    dates=axis_dates,
+                    expected_first_month=first_month,
+                ),
+            )
+        )
+
+    cells: list[MT1RobustnessCell] = []
+    for (ambiguity, quarantine), books in prepared:
+        result = evaluate_mt1_trial(
+            mt1_scaled=books.mt1.scaled,
+            mt1_unscaled=books.mt1.unscaled,
+            s8_scaled=books.s8.scaled,
+            s8_unscaled=books.s8.unscaled,
+            mt1_structural=books.mt1.structural,
+            s8_structural=books.s8.structural,
+        )
+        cells.append(
+            MT1RobustnessCell(
+                ambiguity_arm=ambiguity,
+                quarantine_arm=quarantine,
+                books=books,
+                result=result,
+            )
+        )
+    return MT1HistoricalBundle(cells=tuple(cells), axis_dates=axis_dates, opportunity_record=opportunity)
+
+
+__all__ = [
+    "MT1_SOURCE_STRATEGY_ID",
+    "S8_SOURCE_STRATEGY_ID",
+    "MT1HistoricalBundle",
+    "MT1RobustnessCell",
+    "MT1RunnerRefused",
+    "assemble_mt1_in_sample_bundle",
+]

--- a/app/services/strategy_mt1_runner.py
+++ b/app/services/strategy_mt1_runner.py
@@ -38,10 +38,14 @@ from app.services.prereg_contract import changed_supersession_terms, declaration
 from app.services.research_price_structure_store import QuarantineArm
 from app.services.result_ledger import FrozenPreregistration, holdout_access_counts, load_preregistration
 from app.services.strategy_manifest import STRATEGY_MANIFEST
-from app.services.strategy_mt1_books import MT1FourArmBooks, build_mt1_four_arm_books
+from app.services.strategy_mt1_books import (
+    MT1BookConstructionRefused,
+    MT1FourArmBooks,
+    build_mt1_four_arm_books,
+)
 from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
 from app.services.strategy_mt1_preregistration import build_declarations
-from app.services.strategy_mt1_trial import MT1TrialResult, evaluate_mt1_trial
+from app.services.strategy_mt1_trial import MT1TrialRefused, MT1TrialResult, evaluate_mt1_trial
 from app.services.strategy_result import EVALUATION_WINDOW_START, HOLDOUT_BOUNDARY, AmbiguityArm
 from app.services.strategy_result_universe import ResultUniverseRecord
 
@@ -62,12 +66,36 @@ class MT1RunnerRefused(ValueError):
     """The supplied source pass is not the complete frozen MT-1 experiment."""
 
 
+class _MT1BundleStructuralRefused(MT1RunnerRefused):
+    def __init__(self, detail: str, axis_dates: tuple[date, ...], opportunity: ResultUniverseRecord) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.axis_dates = axis_dates
+        self.opportunity = opportunity
+
+
 @dataclass(frozen=True)
 class MT1PreregistrationAuthority:
     strategy_id: str
     strategy_version: str
     declaration_id: int
     declaration_sha256: str
+
+
+@dataclass(frozen=True)
+class MT1PreparedCell:
+    ambiguity_arm: AmbiguityArm
+    quarantine_arm: QuarantineArm
+    books: MT1FourArmBooks
+
+
+@dataclass(frozen=True)
+class MT1PreparedBundle:
+    """Complete outcome-free structural fan, ready for one frozen evaluation."""
+
+    cells: tuple[MT1PreparedCell, ...]
+    axis_dates: tuple[date, ...]
+    opportunity_record: ResultUniverseRecord
 
 
 @dataclass(frozen=True)
@@ -100,6 +128,36 @@ class MT1InSampleEvaluation:
     mt1_source_strategy_version: str
     s8_source_strategy_version: str
     corpus_version: str
+
+
+@dataclass(frozen=True)
+class MT1InSamplePreparation:
+    authorities: tuple[MT1PreregistrationAuthority, MT1PreregistrationAuthority]
+    prepared: MT1PreparedBundle
+    mt1_strategy_version: str
+    s8_control_strategy_version: str
+    mt1_source_strategy_version: str
+    s8_source_strategy_version: str
+    corpus_version: str
+
+
+@dataclass(frozen=True)
+class MT1InSampleStructuralRefusal:
+    authorities: tuple[MT1PreregistrationAuthority, MT1PreregistrationAuthority]
+    axis_dates: tuple[date, ...]
+    opportunity_record: ResultUniverseRecord
+    detail: str
+    mt1_strategy_version: str
+    s8_control_strategy_version: str
+    mt1_source_strategy_version: str
+    s8_source_strategy_version: str
+    corpus_version: str
+
+
+class MT1InSampleStructuralRefused(MT1RunnerRefused):
+    def __init__(self, evidence: MT1InSampleStructuralRefusal) -> None:
+        super().__init__(evidence.detail)
+        self.evidence = evidence
 
 
 def validate_mt1_preregistrations(
@@ -179,12 +237,12 @@ def _source_cells(
     return cells
 
 
-def assemble_mt1_in_sample_bundle(
+def prepare_mt1_in_sample_bundle(
     *,
     mt1_source_measurements: Sequence[ArmMeasurement],
     s8_source_measurements: Sequence[ArmMeasurement],
-) -> MT1HistoricalBundle:
-    """Construct and evaluate the complete frozen fan, structural gates first."""
+) -> MT1PreparedBundle:
+    """Construct the complete frozen fan without calculating a return statistic."""
     mt1 = _source_cells(mt1_source_measurements, expected_strategy_id=MT1_SOURCE_STRATEGY_ID)
     s8 = _source_cells(s8_source_measurements, expected_strategy_id=S8_SOURCE_STRATEGY_ID)
 
@@ -204,25 +262,37 @@ def assemble_mt1_in_sample_bundle(
     # Phase 1 is intentionally complete before phase 2 begins.  The book
     # constructor applies the outcome-free structural clock/exposure/turnover
     # gate.  If cell four refuses, no return evaluator has seen cells one-three.
-    prepared: list[tuple[RobustnessKey, MT1FourArmBooks]] = []
-    for key in _EXPECTED_KEYS:
-        mt1_book = mt1[key].source_book
-        s8_book = s8[key].source_book
-        assert mt1_book is not None and s8_book is not None  # narrowed by _source_cells
-        prepared.append(
-            (
-                key,
-                build_mt1_four_arm_books(
-                    mt1_book=mt1_book,
-                    s8_book=s8_book,
-                    dates=axis_dates,
-                    expected_first_month=first_month,
-                ),
+    prepared: list[MT1PreparedCell] = []
+    try:
+        for key in _EXPECTED_KEYS:
+            mt1_book = mt1[key].source_book
+            s8_book = s8[key].source_book
+            assert mt1_book is not None and s8_book is not None  # narrowed by _source_cells
+            prepared.append(
+                MT1PreparedCell(
+                    ambiguity_arm=key[0],
+                    quarantine_arm=key[1],
+                    books=build_mt1_four_arm_books(
+                        mt1_book=mt1_book,
+                        s8_book=s8_book,
+                        dates=axis_dates,
+                        expected_first_month=first_month,
+                    ),
+                )
             )
-        )
+    except (MT1BookConstructionRefused, MT1TrialRefused) as exc:
+        raise _MT1BundleStructuralRefused(str(exc), axis_dates, opportunity) from exc
+    return MT1PreparedBundle(cells=tuple(prepared), axis_dates=axis_dates, opportunity_record=opportunity)
+
+
+def evaluate_mt1_prepared_bundle(prepared: MT1PreparedBundle) -> MT1HistoricalBundle:
+    """Evaluate every cell of one already-complete structural fan."""
+    if tuple((cell.ambiguity_arm, cell.quarantine_arm) for cell in prepared.cells) != _EXPECTED_KEYS:
+        raise MT1RunnerRefused("prepared MT-1 robustness fan is incomplete or out of frozen order")
 
     cells: list[MT1RobustnessCell] = []
-    for (ambiguity, quarantine), books in prepared:
+    for prepared_cell in prepared.cells:
+        books = prepared_cell.books
         result = evaluate_mt1_trial(
             mt1_scaled=books.mt1.scaled,
             mt1_unscaled=books.mt1.unscaled,
@@ -233,21 +303,39 @@ def assemble_mt1_in_sample_bundle(
         )
         cells.append(
             MT1RobustnessCell(
-                ambiguity_arm=ambiguity,
-                quarantine_arm=quarantine,
+                ambiguity_arm=prepared_cell.ambiguity_arm,
+                quarantine_arm=prepared_cell.quarantine_arm,
                 books=books,
                 result=result,
             )
         )
-    return MT1HistoricalBundle(cells=tuple(cells), axis_dates=axis_dates, opportunity_record=opportunity)
+    return MT1HistoricalBundle(
+        cells=tuple(cells),
+        axis_dates=prepared.axis_dates,
+        opportunity_record=prepared.opportunity_record,
+    )
 
 
-def run_mt1_in_sample_evaluation(
+def assemble_mt1_in_sample_bundle(
+    *,
+    mt1_source_measurements: Sequence[ArmMeasurement],
+    s8_source_measurements: Sequence[ArmMeasurement],
+) -> MT1HistoricalBundle:
+    """Compatibility composition: complete all structural cells, then evaluate."""
+    return evaluate_mt1_prepared_bundle(
+        prepare_mt1_in_sample_bundle(
+            mt1_source_measurements=mt1_source_measurements,
+            s8_source_measurements=s8_source_measurements,
+        )
+    )
+
+
+def prepare_mt1_in_sample_evaluation(
     conn: psycopg.Connection[Any],
     *,
     progress: ProgressCallback | None = None,
-) -> MT1InSampleEvaluation:
-    """Run the one full-population in-sample MT-1 experiment; never holdout."""
+) -> MT1InSamplePreparation:
+    """Build the one full-population in-sample structural fan; never holdout."""
     # This is deliberately the first DB-facing call. Tests pin the ordering so
     # a future convenience corpus preload cannot burn the pre-outcome boundary.
     authorities = validate_mt1_preregistrations(conn)
@@ -305,18 +393,51 @@ def run_mt1_in_sample_evaluation(
                 )
             )
 
-    bundle = assemble_mt1_in_sample_bundle(
-        mt1_source_measurements=measured[MT1_SOURCE_STRATEGY_ID],
-        s8_source_measurements=measured[S8_SOURCE_STRATEGY_ID],
-    )
-    return MT1InSampleEvaluation(
+    try:
+        prepared = prepare_mt1_in_sample_bundle(
+            mt1_source_measurements=measured[MT1_SOURCE_STRATEGY_ID],
+            s8_source_measurements=measured[S8_SOURCE_STRATEGY_ID],
+        )
+    except _MT1BundleStructuralRefused as exc:
+        raise MT1InSampleStructuralRefused(
+            MT1InSampleStructuralRefusal(
+                authorities=authorities,
+                axis_dates=exc.axis_dates,
+                opportunity_record=exc.opportunity,
+                detail=exc.detail,
+                mt1_strategy_version=mt1_trial_identity.version,
+                s8_control_strategy_version=s8_trial_identity.version,
+                mt1_source_strategy_version=source_identities[MT1_SOURCE_STRATEGY_ID].version,
+                s8_source_strategy_version=source_identities[S8_SOURCE_STRATEGY_ID].version,
+                corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
+            )
+        ) from exc
+    return MT1InSamplePreparation(
         authorities=authorities,
-        bundle=bundle,
+        prepared=prepared,
         mt1_strategy_version=mt1_trial_identity.version,
         s8_control_strategy_version=s8_trial_identity.version,
         mt1_source_strategy_version=source_identities[MT1_SOURCE_STRATEGY_ID].version,
         s8_source_strategy_version=source_identities[S8_SOURCE_STRATEGY_ID].version,
         corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
+    )
+
+
+def run_mt1_in_sample_evaluation(
+    conn: psycopg.Connection[Any],
+    *,
+    progress: ProgressCallback | None = None,
+) -> MT1InSampleEvaluation:
+    """Build and evaluate in memory; durable callers must use the two-phase store."""
+    preparation = prepare_mt1_in_sample_evaluation(conn, progress=progress)
+    return MT1InSampleEvaluation(
+        authorities=preparation.authorities,
+        bundle=evaluate_mt1_prepared_bundle(preparation.prepared),
+        mt1_strategy_version=preparation.mt1_strategy_version,
+        s8_control_strategy_version=preparation.s8_control_strategy_version,
+        mt1_source_strategy_version=preparation.mt1_source_strategy_version,
+        s8_source_strategy_version=preparation.s8_source_strategy_version,
+        corpus_version=preparation.corpus_version,
     )
 
 
@@ -326,10 +447,18 @@ __all__ = [
     "S8_SOURCE_STRATEGY_ID",
     "MT1HistoricalBundle",
     "MT1InSampleEvaluation",
+    "MT1InSamplePreparation",
+    "MT1InSampleStructuralRefusal",
+    "MT1InSampleStructuralRefused",
+    "MT1PreparedBundle",
+    "MT1PreparedCell",
     "MT1PreregistrationAuthority",
     "MT1RobustnessCell",
     "MT1RunnerRefused",
     "assemble_mt1_in_sample_bundle",
+    "evaluate_mt1_prepared_bundle",
+    "prepare_mt1_in_sample_bundle",
+    "prepare_mt1_in_sample_evaluation",
     "run_mt1_in_sample_evaluation",
     "validate_mt1_preregistrations",
 ]

--- a/app/services/strategy_mt1_runner.py
+++ b/app/services/strategy_mt1_runner.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
-from typing import Final
+from typing import Any, Final
+
+import psycopg
 
 from app.services.backtest_run import (
     AMBIGUITY_ARM_ORDER,
@@ -24,8 +26,11 @@ from app.services.backtest_run import (
     ArmMeasurement,
     NamespaceMeasurement,
 )
+from app.services.prereg_contract import changed_supersession_terms, declaration_refusals
 from app.services.research_price_structure_store import QuarantineArm
+from app.services.result_ledger import FrozenPreregistration, holdout_access_counts, load_preregistration
 from app.services.strategy_mt1_books import MT1FourArmBooks, build_mt1_four_arm_books
+from app.services.strategy_mt1_preregistration import build_declarations
 from app.services.strategy_mt1_trial import MT1TrialResult, evaluate_mt1_trial
 from app.services.strategy_result import AmbiguityArm
 from app.services.strategy_result_universe import ResultUniverseRecord
@@ -41,6 +46,14 @@ _EXPECTED_KEYS: Final[tuple[RobustnessKey, ...]] = tuple(
 
 class MT1RunnerRefused(ValueError):
     """The supplied source pass is not the complete frozen MT-1 experiment."""
+
+
+@dataclass(frozen=True)
+class MT1PreregistrationAuthority:
+    strategy_id: str
+    strategy_version: str
+    declaration_id: int
+    declaration_sha256: str
 
 
 @dataclass(frozen=True)
@@ -62,6 +75,47 @@ class MT1HistoricalBundle:
     @property
     def historical_statistical_conjuncts_pass(self) -> bool:
         return all(cell.result.historical_statistical_conjuncts_pass for cell in self.cells)
+
+
+def validate_mt1_preregistrations(
+    conn: psycopg.Connection[Any],
+) -> tuple[MT1PreregistrationAuthority, MT1PreregistrationAuthority]:
+    """Require both current, intact, term-exact declarations before corpus I/O."""
+    authorities: list[MT1PreregistrationAuthority] = []
+    refusals: list[str] = []
+    for expected in build_declarations():
+        frozen: FrozenPreregistration | None = load_preregistration(
+            conn,
+            expected.strategy_id,
+            expected.strategy_version,
+        )
+        if frozen is None:
+            refusals.append(f"{expected.strategy_id}:preregistration_missing")
+            continue
+        if not frozen.digest_intact:
+            refusals.append(f"{expected.strategy_id}:declaration_digest_mismatch")
+        changed = changed_supersession_terms(frozen.declaration, expected)
+        if changed:
+            refusals.append(f"{expected.strategy_id}:declaration_terms_changed={','.join(changed)}")
+        refusals.extend(f"{expected.strategy_id}:{code}" for code in declaration_refusals(frozen.declaration))
+        exposure = holdout_access_counts(conn, expected.strategy_id, expected.strategy_version)
+        if exposure.holdout_evaluations:
+            refusals.append(f"{expected.strategy_id}:holdout_evaluations_already_exist={exposure.holdout_evaluations}")
+        if exposure.recorded_accesses:
+            refusals.append(f"{expected.strategy_id}:holdout_accesses_already_exist={exposure.recorded_accesses}")
+        authorities.append(
+            MT1PreregistrationAuthority(
+                strategy_id=expected.strategy_id,
+                strategy_version=expected.strategy_version,
+                declaration_id=frozen.declaration_id,
+                declaration_sha256=frozen.declaration_sha256,
+            )
+        )
+    if refusals:
+        raise MT1RunnerRefused("MT-1 preregistration authority refused: " + "; ".join(refusals))
+    if len(authorities) != 2:  # pragma: no cover - missing declarations append refusals above
+        raise MT1RunnerRefused("MT-1 preregistration authority is incomplete")
+    return authorities[0], authorities[1]
 
 
 def _source_cells(
@@ -167,7 +221,9 @@ __all__ = [
     "MT1_SOURCE_STRATEGY_ID",
     "S8_SOURCE_STRATEGY_ID",
     "MT1HistoricalBundle",
+    "MT1PreregistrationAuthority",
     "MT1RobustnessCell",
     "MT1RunnerRefused",
     "assemble_mt1_in_sample_bundle",
+    "validate_mt1_preregistrations",
 ]

--- a/app/services/strategy_mt1_runner.py
+++ b/app/services/strategy_mt1_runner.py
@@ -15,28 +15,42 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from typing import Any, Final
 
 import psycopg
 
 from app.services.backtest_run import (
     AMBIGUITY_ARM_ORDER,
+    BACKTEST_UNIVERSE,
     QUARANTINE_ARM_ORDER,
     ArmMeasurement,
     NamespaceMeasurement,
+    ProgressCallback,
+    corpus_version_for,
+    evaluate_level_arms,
+    load_corpus,
 )
+from app.services.cost_model import COST_MODEL_ID
+from app.services.market_regime_provider import MarketRegimeProvider
+from app.services.position_builder import Window
 from app.services.prereg_contract import changed_supersession_terms, declaration_refusals
 from app.services.research_price_structure_store import QuarantineArm
 from app.services.result_ledger import FrozenPreregistration, holdout_access_counts, load_preregistration
+from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_mt1_books import MT1FourArmBooks, build_mt1_four_arm_books
+from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
 from app.services.strategy_mt1_preregistration import build_declarations
 from app.services.strategy_mt1_trial import MT1TrialResult, evaluate_mt1_trial
-from app.services.strategy_result import AmbiguityArm
+from app.services.strategy_result import EVALUATION_WINDOW_START, HOLDOUT_BOUNDARY, AmbiguityArm
 from app.services.strategy_result_universe import ResultUniverseRecord
 
 MT1_SOURCE_STRATEGY_ID: Final = "s10-relative-strength-leader"
 S8_SOURCE_STRATEGY_ID: Final = "s8-range-mean-reversion"
+MT1_IN_SAMPLE_WINDOW: Final = Window(
+    start=EVALUATION_WINDOW_START,
+    end=HOLDOUT_BOUNDARY - timedelta(days=1),
+)
 
 RobustnessKey = tuple[AmbiguityArm, QuarantineArm]
 _EXPECTED_KEYS: Final[tuple[RobustnessKey, ...]] = tuple(
@@ -75,6 +89,17 @@ class MT1HistoricalBundle:
     @property
     def historical_statistical_conjuncts_pass(self) -> bool:
         return all(cell.result.historical_statistical_conjuncts_pass for cell in self.cells)
+
+
+@dataclass(frozen=True)
+class MT1InSampleEvaluation:
+    authorities: tuple[MT1PreregistrationAuthority, MT1PreregistrationAuthority]
+    bundle: MT1HistoricalBundle
+    mt1_strategy_version: str
+    s8_control_strategy_version: str
+    mt1_source_strategy_version: str
+    s8_source_strategy_version: str
+    corpus_version: str
 
 
 def validate_mt1_preregistrations(
@@ -217,13 +242,94 @@ def assemble_mt1_in_sample_bundle(
     return MT1HistoricalBundle(cells=tuple(cells), axis_dates=axis_dates, opportunity_record=opportunity)
 
 
+def run_mt1_in_sample_evaluation(
+    conn: psycopg.Connection[Any],
+    *,
+    progress: ProgressCallback | None = None,
+) -> MT1InSampleEvaluation:
+    """Run the one full-population in-sample MT-1 experiment; never holdout."""
+    # This is deliberately the first DB-facing call. Tests pin the ordering so
+    # a future convenience corpus preload cannot burn the pre-outcome boundary.
+    authorities = validate_mt1_preregistrations(conn)
+
+    corpus = load_corpus(
+        conn,
+        universe_basis=BACKTEST_UNIVERSE,
+        evaluation_window=MT1_IN_SAMPLE_WINDOW,
+    )
+    if corpus.universe_basis != "survivorship_free":  # pragma: no cover - fixed argument and loader contract
+        raise MT1RunnerRefused(f"MT-1 corpus returned unexpected universe {corpus.universe_basis!r}")
+    regime_provider = MarketRegimeProvider.load_research(conn)
+
+    source_entries = {
+        MT1_SOURCE_STRATEGY_ID: STRATEGY_MANIFEST[MT1_SOURCE_STRATEGY_ID],
+        S8_SOURCE_STRATEGY_ID: STRATEGY_MANIFEST[S8_SOURCE_STRATEGY_ID],
+    }
+    source_identities = {
+        strategy_id: entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+        for strategy_id, entry in source_entries.items()
+    }
+    mt1_trial_identity = mt1_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s8_trial_identity = s8_control_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    if mt1_trial_identity.params.get("source_strategy_version") != source_identities[MT1_SOURCE_STRATEGY_ID].version:
+        raise MT1RunnerRefused("MT-1 trial identity is not bound to the current S-10 source version")
+    if (
+        mt1_trial_identity.params.get("decision_clock_strategy_version")
+        != source_identities[MT1_SOURCE_STRATEGY_ID].version
+    ):
+        raise MT1RunnerRefused("MT-1 trial identity is not bound to the current S-10 decision clock")
+    if s8_trial_identity.params.get("source_strategy_version") != source_identities[S8_SOURCE_STRATEGY_ID].version:
+        raise MT1RunnerRefused("S-8 control identity is not bound to the current S-8 source version")
+    if (
+        s8_trial_identity.params.get("decision_clock_strategy_version")
+        != source_identities[MT1_SOURCE_STRATEGY_ID].version
+    ):
+        raise MT1RunnerRefused("S-8 control identity is not bound to the current S-10 decision clock")
+
+    measured: dict[str, list[ArmMeasurement]] = {
+        MT1_SOURCE_STRATEGY_ID: [],
+        S8_SOURCE_STRATEGY_ID: [],
+    }
+    for strategy_id in (MT1_SOURCE_STRATEGY_ID, S8_SOURCE_STRATEGY_ID):
+        for quarantine in QUARANTINE_ARM_ORDER:
+            measured[strategy_id].extend(
+                evaluate_level_arms(
+                    conn,
+                    source_entries[strategy_id],
+                    corpus=corpus,
+                    quarantine_arm=quarantine,
+                    identity=source_identities[strategy_id],
+                    namespaces=("in_sample",),
+                    progress=progress,
+                    regime_provider=regime_provider,
+                )
+            )
+
+    bundle = assemble_mt1_in_sample_bundle(
+        mt1_source_measurements=measured[MT1_SOURCE_STRATEGY_ID],
+        s8_source_measurements=measured[S8_SOURCE_STRATEGY_ID],
+    )
+    return MT1InSampleEvaluation(
+        authorities=authorities,
+        bundle=bundle,
+        mt1_strategy_version=mt1_trial_identity.version,
+        s8_control_strategy_version=s8_trial_identity.version,
+        mt1_source_strategy_version=source_identities[MT1_SOURCE_STRATEGY_ID].version,
+        s8_source_strategy_version=source_identities[S8_SOURCE_STRATEGY_ID].version,
+        corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
+    )
+
+
 __all__ = [
     "MT1_SOURCE_STRATEGY_ID",
+    "MT1_IN_SAMPLE_WINDOW",
     "S8_SOURCE_STRATEGY_ID",
     "MT1HistoricalBundle",
+    "MT1InSampleEvaluation",
     "MT1PreregistrationAuthority",
     "MT1RobustnessCell",
     "MT1RunnerRefused",
     "assemble_mt1_in_sample_bundle",
+    "run_mt1_in_sample_evaluation",
     "validate_mt1_preregistrations",
 ]

--- a/app/services/strategy_mt1_runner.py
+++ b/app/services/strategy_mt1_runner.py
@@ -433,30 +433,6 @@ def prepare_mt1_in_sample_evaluation(
     )
 
 
-def run_mt1_in_sample_evaluation(
-    conn: psycopg.Connection[Any],
-    *,
-    runner_source_head: str,
-    progress: ProgressCallback | None = None,
-) -> MT1InSampleEvaluation:
-    """Build and evaluate in memory; durable callers must use the two-phase store."""
-    preparation = prepare_mt1_in_sample_evaluation(
-        conn,
-        runner_source_head=runner_source_head,
-        progress=progress,
-    )
-    return MT1InSampleEvaluation(
-        authorities=preparation.authorities,
-        bundle=evaluate_mt1_prepared_bundle(preparation.prepared),
-        mt1_strategy_version=preparation.mt1_strategy_version,
-        s8_control_strategy_version=preparation.s8_control_strategy_version,
-        mt1_source_strategy_version=preparation.mt1_source_strategy_version,
-        s8_source_strategy_version=preparation.s8_source_strategy_version,
-        corpus_version=preparation.corpus_version,
-        runner_source_head=preparation.runner_source_head,
-    )
-
-
 __all__ = [
     "MT1_SOURCE_STRATEGY_ID",
     "MT1_IN_SAMPLE_WINDOW",
@@ -475,6 +451,5 @@ __all__ = [
     "evaluate_mt1_prepared_bundle",
     "prepare_mt1_in_sample_bundle",
     "prepare_mt1_in_sample_evaluation",
-    "run_mt1_in_sample_evaluation",
     "validate_mt1_preregistrations",
 ]

--- a/app/services/strategy_mt1_runner.py
+++ b/app/services/strategy_mt1_runner.py
@@ -355,7 +355,7 @@ def prepare_mt1_in_sample_evaluation(
     )
     if corpus.universe_basis != "survivorship_free":  # pragma: no cover - fixed argument and loader contract
         raise MT1RunnerRefused(f"MT-1 corpus returned unexpected universe {corpus.universe_basis!r}")
-    regime_provider = MarketRegimeProvider.load_research(conn)
+    regime_provider = MarketRegimeProvider.load_research(conn, through_date=MT1_IN_SAMPLE_WINDOW.end)
 
     source_entries = {
         MT1_SOURCE_STRATEGY_ID: STRATEGY_MANIFEST[MT1_SOURCE_STRATEGY_ID],

--- a/app/services/strategy_mt1_runner.py
+++ b/app/services/strategy_mt1_runner.py
@@ -13,6 +13,7 @@ be selected from an incomplete fan.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, timedelta
@@ -55,6 +56,7 @@ MT1_IN_SAMPLE_WINDOW: Final = Window(
     start=EVALUATION_WINDOW_START,
     end=HOLDOUT_BOUNDARY - timedelta(days=1),
 )
+_GIT_OBJECT_ID: Final = re.compile(r"^[0-9a-f]{40}$")
 
 RobustnessKey = tuple[AmbiguityArm, QuarantineArm]
 _EXPECTED_KEYS: Final[tuple[RobustnessKey, ...]] = tuple(
@@ -128,6 +130,7 @@ class MT1InSampleEvaluation:
     mt1_source_strategy_version: str
     s8_source_strategy_version: str
     corpus_version: str
+    runner_source_head: str
 
 
 @dataclass(frozen=True)
@@ -139,6 +142,7 @@ class MT1InSamplePreparation:
     mt1_source_strategy_version: str
     s8_source_strategy_version: str
     corpus_version: str
+    runner_source_head: str
 
 
 @dataclass(frozen=True)
@@ -152,6 +156,7 @@ class MT1InSampleStructuralRefusal:
     mt1_source_strategy_version: str
     s8_source_strategy_version: str
     corpus_version: str
+    runner_source_head: str
 
 
 class MT1InSampleStructuralRefused(MT1RunnerRefused):
@@ -333,9 +338,12 @@ def assemble_mt1_in_sample_bundle(
 def prepare_mt1_in_sample_evaluation(
     conn: psycopg.Connection[Any],
     *,
+    runner_source_head: str,
     progress: ProgressCallback | None = None,
 ) -> MT1InSamplePreparation:
     """Build the one full-population in-sample structural fan; never holdout."""
+    if _GIT_OBJECT_ID.fullmatch(runner_source_head) is None:
+        raise MT1RunnerRefused("MT-1 runner source head must be one exact lower-case Git object ID")
     # This is deliberately the first DB-facing call. Tests pin the ordering so
     # a future convenience corpus preload cannot burn the pre-outcome boundary.
     authorities = validate_mt1_preregistrations(conn)
@@ -410,6 +418,7 @@ def prepare_mt1_in_sample_evaluation(
                 mt1_source_strategy_version=source_identities[MT1_SOURCE_STRATEGY_ID].version,
                 s8_source_strategy_version=source_identities[S8_SOURCE_STRATEGY_ID].version,
                 corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
+                runner_source_head=runner_source_head,
             )
         ) from exc
     return MT1InSamplePreparation(
@@ -420,16 +429,22 @@ def prepare_mt1_in_sample_evaluation(
         mt1_source_strategy_version=source_identities[MT1_SOURCE_STRATEGY_ID].version,
         s8_source_strategy_version=source_identities[S8_SOURCE_STRATEGY_ID].version,
         corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
+        runner_source_head=runner_source_head,
     )
 
 
 def run_mt1_in_sample_evaluation(
     conn: psycopg.Connection[Any],
     *,
+    runner_source_head: str,
     progress: ProgressCallback | None = None,
 ) -> MT1InSampleEvaluation:
     """Build and evaluate in memory; durable callers must use the two-phase store."""
-    preparation = prepare_mt1_in_sample_evaluation(conn, progress=progress)
+    preparation = prepare_mt1_in_sample_evaluation(
+        conn,
+        runner_source_head=runner_source_head,
+        progress=progress,
+    )
     return MT1InSampleEvaluation(
         authorities=preparation.authorities,
         bundle=evaluate_mt1_prepared_bundle(preparation.prepared),
@@ -438,6 +453,7 @@ def run_mt1_in_sample_evaluation(
         mt1_source_strategy_version=preparation.mt1_source_strategy_version,
         s8_source_strategy_version=preparation.s8_source_strategy_version,
         corpus_version=preparation.corpus_version,
+        runner_source_head=preparation.runner_source_head,
     )
 
 

--- a/app/services/strategy_mt1_store.py
+++ b/app/services/strategy_mt1_store.py
@@ -61,6 +61,32 @@ def _digest(payload: dict[str, object]) -> str:
     return hashlib.sha256(_canonical(payload)).hexdigest()
 
 
+def _stored_cells_match(
+    stored_rows: list[tuple[object, ...]],
+    expected: list[tuple[str, str, str, dict[str, object]]],
+) -> bool:
+    """Require every ordered child digest to authenticate its exact JSON."""
+    if len(stored_rows) != len(expected):
+        return False
+    for row, expected_row in zip(stored_rows, expected, strict=True):
+        if len(row) != 4:
+            return False
+        ambiguity, quarantine, stored_sha, raw_payload = row
+        if not isinstance(raw_payload, dict):
+            return False
+        payload = dict(raw_payload)
+        expected_ambiguity, expected_quarantine, expected_sha, expected_payload = expected_row
+        if (
+            str(ambiguity) != expected_ambiguity
+            or str(quarantine) != expected_quarantine
+            or str(stored_sha) != expected_sha
+            or payload != expected_payload
+            or _digest(payload) != str(stored_sha)
+        ):
+            return False
+    return True
+
+
 def _number(value: float) -> str:
     if not math.isfinite(value):
         raise ValueError("MT-1 evidence contains a non-finite number")
@@ -133,13 +159,13 @@ def _existing_structural_attempt(
         return None
     stored_sha = str(existing[1])
     stored_payload = dict(existing[2])
-    expected_cells = [
-        (cell.ambiguity_arm, cell.quarantine_arm, _digest(_structural_cell_payload(cell)))
-        for cell in preparation.prepared.cells
-    ]
+    expected_cells = []
+    for cell in preparation.prepared.cells:
+        payload = _structural_cell_payload(cell)
+        expected_cells.append((cell.ambiguity_arm, cell.quarantine_arm, _digest(payload), payload))
     stored_cells = conn.execute(
         """
-        SELECT ambiguity_arm, quarantine_arm, evidence_sha256
+        SELECT ambiguity_arm, quarantine_arm, evidence_sha256, evidence_json
           FROM strategy_mt1_structural_cells WHERE structural_attempt_id = %s
          ORDER BY ambiguity_arm, quarantine_arm
         """,
@@ -148,7 +174,7 @@ def _existing_structural_attempt(
     if (
         stored_sha != expected_sha
         or _digest(stored_payload) != stored_sha
-        or [(str(row[0]), str(row[1]), str(row[2])) for row in stored_cells] != expected_cells
+        or not _stored_cells_match(stored_cells, expected_cells)
     ):
         raise MT1EvidenceConflict("the MT-1 strategy versions already own different structural evidence")
     return int(existing[0])
@@ -410,20 +436,20 @@ def store_mt1_trial_bundle(
     if existing is not None:
         stored_cells = conn.execute(
             """
-            SELECT ambiguity_arm, quarantine_arm, evidence_sha256
+            SELECT ambiguity_arm, quarantine_arm, evidence_sha256, evidence_json
               FROM strategy_mt1_trial_result_cells WHERE mt1_trial_result_id = %s
              ORDER BY ambiguity_arm, quarantine_arm
             """,
             (int(existing[0]),),
         ).fetchall()
         expected_cells = [
-            (cell.ambiguity_arm, cell.quarantine_arm, _digest(payload))
+            (cell.ambiguity_arm, cell.quarantine_arm, _digest(payload), payload)
             for cell, payload in zip(bundle.cells, cell_payloads, strict=True)
         ]
         if (
             str(existing[1]) != header_sha
             or _digest(dict(existing[2])) != str(existing[1])
-            or [(str(row[0]), str(row[1]), str(row[2])) for row in stored_cells] != expected_cells
+            or not _stored_cells_match(stored_cells, expected_cells)
         ):
             raise MT1EvidenceConflict("the structural attempt already owns different MT-1 outcome evidence")
         conn.commit()
@@ -503,21 +529,21 @@ def store_mt1_trial_bundle(
     ).fetchone()
     readback_cells = conn.execute(
         """
-        SELECT ambiguity_arm, quarantine_arm, evidence_sha256
+        SELECT ambiguity_arm, quarantine_arm, evidence_sha256, evidence_json
           FROM strategy_mt1_trial_result_cells WHERE mt1_trial_result_id = %s
          ORDER BY ambiguity_arm, quarantine_arm
         """,
         (result_id,),
     ).fetchall()
     expected_cells = [
-        (cell.ambiguity_arm, cell.quarantine_arm, _digest(payload))
+        (cell.ambiguity_arm, cell.quarantine_arm, _digest(payload), payload)
         for cell, payload in zip(bundle.cells, cell_payloads, strict=True)
     ]
     if (
         readback is None
         or str(readback[0]) != header_sha
         or _digest(dict(readback[1])) != header_sha
-        or [(str(row[0]), str(row[1]), str(row[2])) for row in readback_cells] != expected_cells
+        or not _stored_cells_match(readback_cells, expected_cells)
     ):
         raise MT1EvidenceConflict("the committed MT-1 outcome evidence did not read back exactly")
     return result_id

--- a/app/services/strategy_mt1_store.py
+++ b/app/services/strategy_mt1_store.py
@@ -132,6 +132,7 @@ def _structural_header_payload(preparation: MT1InSamplePreparation) -> dict[str,
         "mt1_strategy_version": preparation.mt1_strategy_version,
         "opportunity_set_digest": record_sha256(preparation.prepared.opportunity_record),
         "passed": True,
+        "runner_source_head": preparation.runner_source_head,
         "s8_control_strategy_version": preparation.s8_control_strategy_version,
         "s8_source_strategy_version": preparation.s8_source_strategy_version,
         "structural_cell_digests": cell_digests,
@@ -200,10 +201,11 @@ def store_mt1_structural_preparation(conn: psycopg.Connection[Any], preparation:
             trial_register_version, trial_contract_version, book_rule_version,
             evaluator_version, metric_axis_rule_version, metric_axis_dates,
             metric_axis_start, metric_axis_end, metric_axis_digest,
-            opportunity_set_digest, passed, structural_evidence_sha256, structural_evidence_json
+            opportunity_set_digest, runner_source_head, passed,
+            structural_evidence_sha256, structural_evidence_json
         ) VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s, 'survivorship_free', %s, %s, %s,
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, %s, %s
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, %s, %s
         ) RETURNING structural_attempt_id
         """,
         (
@@ -227,6 +229,7 @@ def store_mt1_structural_preparation(conn: psycopg.Connection[Any], preparation:
             axis[-1],
             metric_axis_sha256(axis),
             record_sha256(preparation.prepared.opportunity_record),
+            preparation.runner_source_head,
             evidence_sha,
             Jsonb(payload),
         ),
@@ -293,6 +296,7 @@ def store_mt1_structural_refusal(conn: psycopg.Connection[Any], refusal: MT1InSa
         "opportunity_set_digest": record_sha256(refusal.opportunity_record),
         "passed": False,
         "refusal_code": "structural_gate_refused",
+        "runner_source_head": refusal.runner_source_head,
         "s8_control_strategy_version": refusal.s8_control_strategy_version,
         "s8_source_strategy_version": refusal.s8_source_strategy_version,
         "structural_cell_digests": [],
@@ -335,11 +339,11 @@ def store_mt1_structural_refusal(conn: psycopg.Connection[Any], refusal: MT1InSa
             trial_register_version, trial_contract_version, book_rule_version,
             evaluator_version, metric_axis_rule_version, metric_axis_dates,
             metric_axis_start, metric_axis_end, metric_axis_digest,
-            opportunity_set_digest, passed, refusal_code, refusal_detail,
+            opportunity_set_digest, runner_source_head, passed, refusal_code, refusal_detail,
             structural_evidence_sha256, structural_evidence_json
         ) VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s, 'survivorship_free', %s, %s, %s,
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE,
             'structural_gate_refused', %s, %s, %s
         ) RETURNING structural_attempt_id
         """,
@@ -364,6 +368,7 @@ def store_mt1_structural_refusal(conn: psycopg.Connection[Any], refusal: MT1InSa
             axis[-1],
             metric_axis_sha256(axis),
             record_sha256(refusal.opportunity_record),
+            refusal.runner_source_head,
             refusal.detail,
             evidence_sha,
             Jsonb(payload),
@@ -550,11 +555,15 @@ def store_mt1_trial_bundle(
 
 
 def run_and_store_mt1_in_sample_evaluation(
-    conn: psycopg.Connection[Any], *, progress: ProgressCallback | None = None
+    conn: psycopg.Connection[Any], *, runner_source_head: str, progress: ProgressCallback | None = None
 ) -> MT1StoredEvaluation | MT1StoredRefusal:
     """Paved runner: structural commit, outcome calculation, atomic result commit."""
     try:
-        preparation = prepare_mt1_in_sample_evaluation(conn, progress=progress)
+        preparation = prepare_mt1_in_sample_evaluation(
+            conn,
+            runner_source_head=runner_source_head,
+            progress=progress,
+        )
     except MT1InSampleStructuralRefused as exc:
         attempt_id = store_mt1_structural_refusal(conn, exc.evidence)
         return MT1StoredRefusal(structural_attempt_id=attempt_id, detail=exc.evidence.detail)
@@ -573,6 +582,7 @@ def run_and_store_mt1_in_sample_evaluation(
         mt1_source_strategy_version=preparation.mt1_source_strategy_version,
         s8_source_strategy_version=preparation.s8_source_strategy_version,
         corpus_version=preparation.corpus_version,
+        runner_source_head=preparation.runner_source_head,
     )
     return MT1StoredEvaluation(structural_attempt_id, trial_result_id, evaluation)
 

--- a/app/services/strategy_mt1_store.py
+++ b/app/services/strategy_mt1_store.py
@@ -1,0 +1,562 @@
+"""Two-phase durable store for the sealed MT-1 in-sample trial (#2769)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+from app.services.cost_model import COST_MODEL_ID
+from app.services.strategy_mt1_books import BOOK_RULE_VERSION
+from app.services.strategy_mt1_runner import (
+    MT1HistoricalBundle,
+    MT1InSampleEvaluation,
+    MT1InSamplePreparation,
+    MT1InSampleStructuralRefusal,
+    MT1InSampleStructuralRefused,
+    MT1PreparedCell,
+    ProgressCallback,
+    evaluate_mt1_prepared_bundle,
+    prepare_mt1_in_sample_evaluation,
+)
+from app.services.strategy_mt1_trial import TRIAL_CONTRACT_VERSION, TRIAL_EVALUATOR_VERSION, MT1TrialResult
+from app.services.strategy_result import METRIC_AXIS_RULE_VERSION, metric_axis_sha256
+from app.services.strategy_result_universe import record_sha256
+from app.services.trial_register import TRIAL_REGISTER_VERSION
+
+
+class MT1EvidenceConflict(RuntimeError):
+    """An immutable version already owns different controlled-trial evidence."""
+
+
+@dataclass(frozen=True)
+class MT1StoredEvaluation:
+    structural_attempt_id: int
+    trial_result_id: int
+    evaluation: MT1InSampleEvaluation
+
+
+@dataclass(frozen=True)
+class MT1StoredRefusal:
+    structural_attempt_id: int
+    detail: str
+
+
+def _canonical(payload: dict[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode()
+
+
+def _digest(payload: dict[str, object]) -> str:
+    return hashlib.sha256(_canonical(payload)).hexdigest()
+
+
+def _number(value: float) -> str:
+    if not math.isfinite(value):
+        raise ValueError("MT-1 evidence contains a non-finite number")
+    return repr(value)
+
+
+def _structural_cell_payload(cell: MT1PreparedCell) -> dict[str, object]:
+    mt1 = cell.books.mt1.structural
+    s8 = cell.books.s8.structural
+    return {
+        "ambiguity_arm": cell.ambiguity_arm,
+        "book_rule_version": cell.books.rule_version,
+        "mt1_annualised_turnover": _number(mt1.annualised_turnover),
+        "mt1_decision_dates": [item.isoformat() for item in mt1.decision_dates],
+        "mt1_traded_notional": _number(mt1.traded_notional),
+        "quarantine_arm": cell.quarantine_arm,
+        "s8_annualised_turnover": _number(s8.annualised_turnover),
+        "s8_decision_dates": [item.isoformat() for item in s8.decision_dates],
+        "s8_traded_notional": _number(s8.traded_notional),
+        "exposure_reconciled": mt1.exposure_reconciled and s8.exposure_reconciled,
+    }
+
+
+def _structural_header_payload(preparation: MT1InSamplePreparation) -> dict[str, object]:
+    cell_digests = [_digest(_structural_cell_payload(cell)) for cell in preparation.prepared.cells]
+    return {
+        "book_rule_version": BOOK_RULE_VERSION,
+        "corpus_version": preparation.corpus_version,
+        "cost_model_id": COST_MODEL_ID,
+        "declarations": [
+            {
+                "declaration_id": authority.declaration_id,
+                "declaration_sha256": authority.declaration_sha256,
+                "strategy_id": authority.strategy_id,
+                "strategy_version": authority.strategy_version,
+            }
+            for authority in preparation.authorities
+        ],
+        "evaluator_version": TRIAL_EVALUATOR_VERSION,
+        "metric_axis_digest": metric_axis_sha256(preparation.prepared.axis_dates),
+        "metric_axis_rule_version": METRIC_AXIS_RULE_VERSION,
+        "mt1_source_strategy_version": preparation.mt1_source_strategy_version,
+        "mt1_strategy_version": preparation.mt1_strategy_version,
+        "opportunity_set_digest": record_sha256(preparation.prepared.opportunity_record),
+        "passed": True,
+        "s8_control_strategy_version": preparation.s8_control_strategy_version,
+        "s8_source_strategy_version": preparation.s8_source_strategy_version,
+        "structural_cell_digests": cell_digests,
+        "trial_contract_version": TRIAL_CONTRACT_VERSION,
+        "trial_register_version": TRIAL_REGISTER_VERSION,
+        "universe_basis": "survivorship_free",
+    }
+
+
+def _existing_structural_attempt(
+    conn: psycopg.Connection[Any],
+    preparation: MT1InSamplePreparation,
+    *,
+    expected_sha: str,
+) -> int | None:
+    existing = conn.execute(
+        """
+        SELECT structural_attempt_id, structural_evidence_sha256, structural_evidence_json
+          FROM strategy_mt1_structural_attempts
+         WHERE mt1_strategy_version = %s AND s8_strategy_version = %s
+        """,
+        (preparation.mt1_strategy_version, preparation.s8_control_strategy_version),
+    ).fetchone()
+    if existing is None:
+        return None
+    stored_sha = str(existing[1])
+    stored_payload = dict(existing[2])
+    expected_cells = [
+        (cell.ambiguity_arm, cell.quarantine_arm, _digest(_structural_cell_payload(cell)))
+        for cell in preparation.prepared.cells
+    ]
+    stored_cells = conn.execute(
+        """
+        SELECT ambiguity_arm, quarantine_arm, evidence_sha256
+          FROM strategy_mt1_structural_cells WHERE structural_attempt_id = %s
+         ORDER BY ambiguity_arm, quarantine_arm
+        """,
+        (int(existing[0]),),
+    ).fetchall()
+    if (
+        stored_sha != expected_sha
+        or _digest(stored_payload) != stored_sha
+        or [(str(row[0]), str(row[1]), str(row[2])) for row in stored_cells] != expected_cells
+    ):
+        raise MT1EvidenceConflict("the MT-1 strategy versions already own different structural evidence")
+    return int(existing[0])
+
+
+def store_mt1_structural_preparation(conn: psycopg.Connection[Any], preparation: MT1InSamplePreparation) -> int:
+    """Atomically commit the complete structural fan before outcome evaluation."""
+    payload = _structural_header_payload(preparation)
+    evidence_sha = _digest(payload)
+    existing_id = _existing_structural_attempt(conn, preparation, expected_sha=evidence_sha)
+    if existing_id is not None:
+        conn.commit()
+        return existing_id
+
+    mt1_authority, s8_authority = preparation.authorities
+    axis = preparation.prepared.axis_dates
+    row = conn.execute(
+        """
+        INSERT INTO strategy_mt1_structural_attempts (
+            mt1_declaration_id, s8_declaration_id, mt1_strategy_id, mt1_strategy_version,
+            s8_strategy_id, s8_strategy_version, mt1_source_strategy_version,
+            s8_source_strategy_version, universe_basis, corpus_version, cost_model_id,
+            trial_register_version, trial_contract_version, book_rule_version,
+            evaluator_version, metric_axis_rule_version, metric_axis_dates,
+            metric_axis_start, metric_axis_end, metric_axis_digest,
+            opportunity_set_digest, passed, structural_evidence_sha256, structural_evidence_json
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, 'survivorship_free', %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, %s, %s
+        ) RETURNING structural_attempt_id
+        """,
+        (
+            mt1_authority.declaration_id,
+            s8_authority.declaration_id,
+            mt1_authority.strategy_id,
+            preparation.mt1_strategy_version,
+            s8_authority.strategy_id,
+            preparation.s8_control_strategy_version,
+            preparation.mt1_source_strategy_version,
+            preparation.s8_source_strategy_version,
+            preparation.corpus_version,
+            COST_MODEL_ID,
+            TRIAL_REGISTER_VERSION,
+            TRIAL_CONTRACT_VERSION,
+            BOOK_RULE_VERSION,
+            TRIAL_EVALUATOR_VERSION,
+            METRIC_AXIS_RULE_VERSION,
+            list(axis),
+            axis[0],
+            axis[-1],
+            metric_axis_sha256(axis),
+            record_sha256(preparation.prepared.opportunity_record),
+            evidence_sha,
+            Jsonb(payload),
+        ),
+    ).fetchone()
+    assert row is not None
+    attempt_id = int(row[0])
+    for cell in preparation.prepared.cells:
+        cell_payload = _structural_cell_payload(cell)
+        mt1 = cell.books.mt1.structural
+        s8 = cell.books.s8.structural
+        conn.execute(
+            """
+            INSERT INTO strategy_mt1_structural_cells (
+                structural_attempt_id, ambiguity_arm, quarantine_arm, mt1_decision_dates,
+                s8_decision_dates, mt1_annualised_turnover, s8_annualised_turnover,
+                mt1_traded_notional, s8_traded_notional, exposure_reconciled,
+                evidence_sha256, evidence_json
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, %s, %s)
+            """,
+            (
+                attempt_id,
+                cell.ambiguity_arm,
+                cell.quarantine_arm,
+                list(mt1.decision_dates),
+                list(s8.decision_dates),
+                mt1.annualised_turnover,
+                s8.annualised_turnover,
+                mt1.traded_notional,
+                s8.traded_notional,
+                _digest(cell_payload),
+                Jsonb(cell_payload),
+            ),
+        )
+    conn.commit()
+    readback_id = _existing_structural_attempt(conn, preparation, expected_sha=evidence_sha)
+    if readback_id != attempt_id:  # pragma: no cover - the committed row was just returned
+        raise MT1EvidenceConflict("the committed MT-1 structural evidence did not read back exactly")
+    return attempt_id
+
+
+def store_mt1_structural_refusal(conn: psycopg.Connection[Any], refusal: MT1InSampleStructuralRefusal) -> int:
+    """Commit one outcome-free structural refusal with no child cells."""
+    if not refusal.detail.strip() or len(refusal.detail) > 2000:
+        raise ValueError("MT-1 structural refusal detail must contain 1..2000 characters")
+    payload: dict[str, object] = {
+        "book_rule_version": BOOK_RULE_VERSION,
+        "corpus_version": refusal.corpus_version,
+        "cost_model_id": COST_MODEL_ID,
+        "declarations": [
+            {
+                "declaration_id": authority.declaration_id,
+                "declaration_sha256": authority.declaration_sha256,
+                "strategy_id": authority.strategy_id,
+                "strategy_version": authority.strategy_version,
+            }
+            for authority in refusal.authorities
+        ],
+        "detail": refusal.detail,
+        "evaluator_version": TRIAL_EVALUATOR_VERSION,
+        "metric_axis_digest": metric_axis_sha256(refusal.axis_dates),
+        "metric_axis_rule_version": METRIC_AXIS_RULE_VERSION,
+        "mt1_source_strategy_version": refusal.mt1_source_strategy_version,
+        "mt1_strategy_version": refusal.mt1_strategy_version,
+        "opportunity_set_digest": record_sha256(refusal.opportunity_record),
+        "passed": False,
+        "refusal_code": "structural_gate_refused",
+        "s8_control_strategy_version": refusal.s8_control_strategy_version,
+        "s8_source_strategy_version": refusal.s8_source_strategy_version,
+        "structural_cell_digests": [],
+        "trial_contract_version": TRIAL_CONTRACT_VERSION,
+        "trial_register_version": TRIAL_REGISTER_VERSION,
+        "universe_basis": "survivorship_free",
+    }
+    evidence_sha = _digest(payload)
+    existing = conn.execute(
+        """
+        SELECT a.structural_attempt_id, a.structural_evidence_sha256,
+               a.structural_evidence_json, a.passed, count(c.structural_attempt_id)
+          FROM strategy_mt1_structural_attempts a
+          LEFT JOIN strategy_mt1_structural_cells c
+            ON c.structural_attempt_id = a.structural_attempt_id
+         WHERE mt1_strategy_version = %s AND s8_strategy_version = %s
+         GROUP BY a.structural_attempt_id
+        """,
+        (refusal.mt1_strategy_version, refusal.s8_control_strategy_version),
+    ).fetchone()
+    if existing is not None:
+        if (
+            str(existing[1]) != evidence_sha
+            or _digest(dict(existing[2])) != evidence_sha
+            or bool(existing[3])
+            or int(existing[4]) != 0
+        ):
+            raise MT1EvidenceConflict("the MT-1 strategy versions already own different structural evidence")
+        conn.commit()
+        return int(existing[0])
+
+    mt1_authority, s8_authority = refusal.authorities
+    axis = refusal.axis_dates
+    row = conn.execute(
+        """
+        INSERT INTO strategy_mt1_structural_attempts (
+            mt1_declaration_id, s8_declaration_id, mt1_strategy_id, mt1_strategy_version,
+            s8_strategy_id, s8_strategy_version, mt1_source_strategy_version,
+            s8_source_strategy_version, universe_basis, corpus_version, cost_model_id,
+            trial_register_version, trial_contract_version, book_rule_version,
+            evaluator_version, metric_axis_rule_version, metric_axis_dates,
+            metric_axis_start, metric_axis_end, metric_axis_digest,
+            opportunity_set_digest, passed, refusal_code, refusal_detail,
+            structural_evidence_sha256, structural_evidence_json
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, 'survivorship_free', %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE,
+            'structural_gate_refused', %s, %s, %s
+        ) RETURNING structural_attempt_id
+        """,
+        (
+            mt1_authority.declaration_id,
+            s8_authority.declaration_id,
+            mt1_authority.strategy_id,
+            refusal.mt1_strategy_version,
+            s8_authority.strategy_id,
+            refusal.s8_control_strategy_version,
+            refusal.mt1_source_strategy_version,
+            refusal.s8_source_strategy_version,
+            refusal.corpus_version,
+            COST_MODEL_ID,
+            TRIAL_REGISTER_VERSION,
+            TRIAL_CONTRACT_VERSION,
+            BOOK_RULE_VERSION,
+            TRIAL_EVALUATOR_VERSION,
+            METRIC_AXIS_RULE_VERSION,
+            list(axis),
+            axis[0],
+            axis[-1],
+            metric_axis_sha256(axis),
+            record_sha256(refusal.opportunity_record),
+            refusal.detail,
+            evidence_sha,
+            Jsonb(payload),
+        ),
+    ).fetchone()
+    assert row is not None
+    attempt_id = int(row[0])
+    conn.commit()
+    readback_id = store_mt1_structural_refusal(conn, refusal)
+    if readback_id != attempt_id:  # pragma: no cover - the committed row was just returned
+        raise MT1EvidenceConflict("the committed MT-1 structural refusal did not read back exactly")
+    return attempt_id
+
+
+def _risk_payload(result: MT1TrialResult) -> dict[str, object]:
+    def risk(report: Any) -> dict[str, str]:
+        return {
+            "certainty_equivalent": _number(report.certainty_equivalent),
+            "expected_shortfall_5": _number(report.expected_shortfall_5),
+            "maximum_drawdown": _number(report.maximum_drawdown),
+        }
+
+    return {
+        "bootstrap_block_length": result.bootstrap_block_length,
+        "bootstrap_resamples": result.bootstrap_resamples,
+        "bootstrap_seed": result.bootstrap_seed,
+        "common_months": [item.isoformat() for item in result.common_months],
+        "evaluator_version": result.evaluator_version,
+        "excluded_months_by_arm": list(result.excluded_months_by_arm),
+        "historical_statistical_conjuncts_pass": result.historical_statistical_conjuncts_pass,
+        "mt1_delta_cer": _number(result.mt1_delta_cer),
+        "mt1_delta_interval": {
+            "high": _number(result.mt1_delta_interval.high),
+            "low": _number(result.mt1_delta_interval.low),
+        },
+        "mt1_drawdown_improved": result.mt1_drawdown_improved,
+        "mt1_expected_shortfall_improved": result.mt1_expected_shortfall_improved,
+        "mt1_lower_bound_positive": result.mt1_lower_bound_positive,
+        "mt1_scaled": risk(result.mt1_scaled),
+        "mt1_unscaled": risk(result.mt1_unscaled),
+        "primary_difference_in_differences": _number(result.primary_difference_in_differences),
+        "primary_interval": {
+            "high": _number(result.primary_interval.high),
+            "low": _number(result.primary_interval.low),
+        },
+        "primary_lower_bound_positive": result.primary_lower_bound_positive,
+        "s8_delta_cer": _number(result.s8_delta_cer),
+        "s8_scaled": risk(result.s8_scaled),
+        "s8_unscaled": risk(result.s8_unscaled),
+    }
+
+
+def store_mt1_trial_bundle(
+    conn: psycopg.Connection[Any], *, structural_attempt_id: int, bundle: MT1HistoricalBundle
+) -> int:
+    """Atomically commit all four outcome cells and their conjunction header."""
+    cell_payloads = [_risk_payload(cell.result) for cell in bundle.cells]
+    header_payload: dict[str, object] = {
+        "historical_conjuncts_pass": bundle.historical_statistical_conjuncts_pass,
+        "result_cell_digests": [_digest(payload) for payload in cell_payloads],
+    }
+    header_sha = _digest(header_payload)
+    existing = conn.execute(
+        """
+        SELECT mt1_trial_result_id, evidence_sha256, evidence_json
+          FROM strategy_mt1_trial_results WHERE structural_attempt_id = %s
+        """,
+        (structural_attempt_id,),
+    ).fetchone()
+    if existing is not None:
+        stored_cells = conn.execute(
+            """
+            SELECT ambiguity_arm, quarantine_arm, evidence_sha256
+              FROM strategy_mt1_trial_result_cells WHERE mt1_trial_result_id = %s
+             ORDER BY ambiguity_arm, quarantine_arm
+            """,
+            (int(existing[0]),),
+        ).fetchall()
+        expected_cells = [
+            (cell.ambiguity_arm, cell.quarantine_arm, _digest(payload))
+            for cell, payload in zip(bundle.cells, cell_payloads, strict=True)
+        ]
+        if (
+            str(existing[1]) != header_sha
+            or _digest(dict(existing[2])) != str(existing[1])
+            or [(str(row[0]), str(row[1]), str(row[2])) for row in stored_cells] != expected_cells
+        ):
+            raise MT1EvidenceConflict("the structural attempt already owns different MT-1 outcome evidence")
+        conn.commit()
+        return int(existing[0])
+
+    row = conn.execute(
+        """
+        INSERT INTO strategy_mt1_trial_results (
+            structural_attempt_id, historical_conjuncts_pass, evidence_sha256, evidence_json
+        ) VALUES (%s, %s, %s, %s) RETURNING mt1_trial_result_id
+        """,
+        (structural_attempt_id, bundle.historical_statistical_conjuncts_pass, header_sha, Jsonb(header_payload)),
+    ).fetchone()
+    assert row is not None
+    result_id = int(row[0])
+    for cell, payload in zip(bundle.cells, cell_payloads, strict=True):
+        result = cell.result
+        conn.execute(
+            """
+            INSERT INTO strategy_mt1_trial_result_cells (
+                mt1_trial_result_id, ambiguity_arm, quarantine_arm, common_months,
+                excluded_months_by_arm, mt1_scaled_certainty_equivalent,
+                mt1_scaled_maximum_drawdown, mt1_scaled_expected_shortfall_5,
+                mt1_unscaled_certainty_equivalent, mt1_unscaled_maximum_drawdown,
+                mt1_unscaled_expected_shortfall_5, s8_scaled_certainty_equivalent,
+                s8_scaled_maximum_drawdown, s8_scaled_expected_shortfall_5,
+                s8_unscaled_certainty_equivalent, s8_unscaled_maximum_drawdown,
+                s8_unscaled_expected_shortfall_5, mt1_delta_cer, s8_delta_cer,
+                primary_difference_in_differences, mt1_interval_low, mt1_interval_high,
+                primary_interval_low, primary_interval_high, primary_lower_bound_positive,
+                mt1_lower_bound_positive, mt1_drawdown_improved,
+                mt1_expected_shortfall_improved, historical_conjuncts_pass,
+                evidence_sha256, evidence_json
+            ) VALUES (
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                result_id,
+                cell.ambiguity_arm,
+                cell.quarantine_arm,
+                list(result.common_months),
+                list(result.excluded_months_by_arm),
+                result.mt1_scaled.certainty_equivalent,
+                result.mt1_scaled.maximum_drawdown,
+                result.mt1_scaled.expected_shortfall_5,
+                result.mt1_unscaled.certainty_equivalent,
+                result.mt1_unscaled.maximum_drawdown,
+                result.mt1_unscaled.expected_shortfall_5,
+                result.s8_scaled.certainty_equivalent,
+                result.s8_scaled.maximum_drawdown,
+                result.s8_scaled.expected_shortfall_5,
+                result.s8_unscaled.certainty_equivalent,
+                result.s8_unscaled.maximum_drawdown,
+                result.s8_unscaled.expected_shortfall_5,
+                result.mt1_delta_cer,
+                result.s8_delta_cer,
+                result.primary_difference_in_differences,
+                result.mt1_delta_interval.low,
+                result.mt1_delta_interval.high,
+                result.primary_interval.low,
+                result.primary_interval.high,
+                result.primary_lower_bound_positive,
+                result.mt1_lower_bound_positive,
+                result.mt1_drawdown_improved,
+                result.mt1_expected_shortfall_improved,
+                result.historical_statistical_conjuncts_pass,
+                _digest(payload),
+                Jsonb(payload),
+            ),
+        )
+    conn.commit()
+    readback = conn.execute(
+        "SELECT evidence_sha256, evidence_json FROM strategy_mt1_trial_results WHERE mt1_trial_result_id = %s",
+        (result_id,),
+    ).fetchone()
+    readback_cells = conn.execute(
+        """
+        SELECT ambiguity_arm, quarantine_arm, evidence_sha256
+          FROM strategy_mt1_trial_result_cells WHERE mt1_trial_result_id = %s
+         ORDER BY ambiguity_arm, quarantine_arm
+        """,
+        (result_id,),
+    ).fetchall()
+    expected_cells = [
+        (cell.ambiguity_arm, cell.quarantine_arm, _digest(payload))
+        for cell, payload in zip(bundle.cells, cell_payloads, strict=True)
+    ]
+    if (
+        readback is None
+        or str(readback[0]) != header_sha
+        or _digest(dict(readback[1])) != header_sha
+        or [(str(row[0]), str(row[1]), str(row[2])) for row in readback_cells] != expected_cells
+    ):
+        raise MT1EvidenceConflict("the committed MT-1 outcome evidence did not read back exactly")
+    return result_id
+
+
+def run_and_store_mt1_in_sample_evaluation(
+    conn: psycopg.Connection[Any], *, progress: ProgressCallback | None = None
+) -> MT1StoredEvaluation | MT1StoredRefusal:
+    """Paved runner: structural commit, outcome calculation, atomic result commit."""
+    try:
+        preparation = prepare_mt1_in_sample_evaluation(conn, progress=progress)
+    except MT1InSampleStructuralRefused as exc:
+        attempt_id = store_mt1_structural_refusal(conn, exc.evidence)
+        return MT1StoredRefusal(structural_attempt_id=attempt_id, detail=exc.evidence.detail)
+    structural_attempt_id = store_mt1_structural_preparation(conn, preparation)
+    bundle = evaluate_mt1_prepared_bundle(preparation.prepared)
+    trial_result_id = store_mt1_trial_bundle(
+        conn,
+        structural_attempt_id=structural_attempt_id,
+        bundle=bundle,
+    )
+    evaluation = MT1InSampleEvaluation(
+        authorities=preparation.authorities,
+        bundle=bundle,
+        mt1_strategy_version=preparation.mt1_strategy_version,
+        s8_control_strategy_version=preparation.s8_control_strategy_version,
+        mt1_source_strategy_version=preparation.mt1_source_strategy_version,
+        s8_source_strategy_version=preparation.s8_source_strategy_version,
+        corpus_version=preparation.corpus_version,
+    )
+    return MT1StoredEvaluation(structural_attempt_id, trial_result_id, evaluation)
+
+
+__all__ = [
+    "MT1EvidenceConflict",
+    "MT1StoredEvaluation",
+    "MT1StoredRefusal",
+    "run_and_store_mt1_in_sample_evaluation",
+    "store_mt1_structural_preparation",
+    "store_mt1_structural_refusal",
+    "store_mt1_trial_bundle",
+]

--- a/app/services/strategy_operator_promotion.py
+++ b/app/services/strategy_operator_promotion.py
@@ -179,6 +179,41 @@ def _load_complete_result_bundle(
     return tuple(item["result_id"] for item in payload), _canonical_ref("strategy-result-bundle", payload)
 
 
+def _require_preserved_result_bundle(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    stage: Literal["historical_validated", "forward_observation", "paper_enabled"],
+    result_ids: tuple[int, ...],
+    evidence_ref: str,
+) -> None:
+    """Prove a later transition still names the exact earlier denominator."""
+    rows = conn.execute(
+        """
+        SELECT p.promotion_id,p.evidence_ref,pr.result_id
+        FROM strategy_promotions p
+        LEFT JOIN strategy_promotion_results pr ON pr.promotion_id=p.promotion_id
+        WHERE p.strategy_id=%s AND p.strategy_version=%s AND p.to_stage=%s
+        ORDER BY p.promotion_id,pr.result_id
+        """,
+        (strategy_id, strategy_version, stage),
+    ).fetchall()
+    if not rows:
+        raise StrategyControlError(f"{stage} evidence event is missing")
+    promotion_ids = {int(row[0]) for row in rows}
+    if len(promotion_ids) != 1:
+        raise StrategyControlError(f"{stage} evidence event is ambiguous")
+    pinned_ids = tuple(int(row[2]) for row in rows if row[2] is not None)
+    if pinned_ids != tuple(sorted(result_ids)):
+        raise StrategyControlError(f"{stage} does not preserve the exact current historical evidence bundle")
+    # Paper approval has a composite evidence reference that includes the
+    # forward floor and prospective assessment. Earlier stages must retain the
+    # canonical result-bundle reference itself.
+    if stage != "paper_enabled" and str(rows[0][1]) != evidence_ref:
+        raise StrategyControlError(f"{stage} evidence reference does not match its pinned result bundle")
+
+
 def load_forward_floor_evidence(
     conn: psycopg.Connection[Any],
     *,
@@ -384,6 +419,41 @@ def advance_strategy_for_operator(
     lock_strategy_control(conn, strategy_id, strategy_version)
     stage = current_stage(conn, strategy_id, strategy_version)
     if stage == target:
+        current_ids: tuple[int, ...] = ()
+        current_ref = ""
+        if target in {"historical_validated", "forward_observation", "paper_enabled"}:
+            current_ids, current_ref = _load_complete_result_bundle(
+                conn, strategy_id=strategy_id, strategy_version=strategy_version
+            )
+            _require_preserved_result_bundle(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                stage=cast(
+                    Literal["historical_validated", "forward_observation", "paper_enabled"],
+                    target,
+                ),
+                result_ids=current_ids,
+                evidence_ref=current_ref,
+            )
+        if target in {"forward_observation", "paper_enabled"}:
+            _require_preserved_result_bundle(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                stage="historical_validated",
+                result_ids=current_ids,
+                evidence_ref=current_ref,
+            )
+        if target == "paper_enabled":
+            _require_preserved_result_bundle(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                stage="forward_observation",
+                result_ids=current_ids,
+                evidence_ref=current_ref,
+            )
         row = conn.execute(
             """
             SELECT promotion_id,from_stage,evidence_ref
@@ -407,6 +477,7 @@ def advance_strategy_for_operator(
         raise StrategyControlError(f"action {action!r} is not allowed from stage {stage!r}")
 
     result_ids: tuple[int, ...] = ()
+    result_ref = ""
     evidence_ref: str | None = None
     prospective: ProspectiveEvidence | None = None
     forward_floor: ForwardFloorEvidence | None = None
@@ -416,7 +487,24 @@ def advance_strategy_for_operator(
             conn, strategy_id=strategy_id, strategy_version=strategy_version
         )
         evidence_ref = result_ref
+    if action in {"start_forward_observation", "approve_paper"}:
+        _require_preserved_result_bundle(
+            conn,
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            stage="historical_validated",
+            result_ids=result_ids,
+            evidence_ref=result_ref,
+        )
     if action == "approve_paper":
+        _require_preserved_result_bundle(
+            conn,
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            stage="forward_observation",
+            result_ids=result_ids,
+            evidence_ref=result_ref,
+        )
         observed_at = (now or datetime.now(UTC)).astimezone(UTC)
         forward_floor = load_forward_floor_evidence(
             conn,

--- a/app/services/strategy_operator_promotion.py
+++ b/app/services/strategy_operator_promotion.py
@@ -1,0 +1,485 @@
+"""Evidence-bound operator transitions from research registration to paper.
+
+The browser names an action, never a destination stage, result id, assessment
+id, or verdict.  This module resolves the complete authoritative evidence set
+under the strategy lock and gives ``promote_strategy`` only server-selected
+immutable identities.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, Final, Literal, cast
+
+import psycopg
+import psycopg.rows
+
+from app.services.backtest_run import BACKTEST_UNIVERSE, RESULT_SCOPE, corpus_version_for
+from app.services.cost_model import COST_MODEL_ID
+from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
+from app.services.prereg_contract import declaration_refusals
+from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.result_ledger import load_preregistration
+from app.services.strategy_ambiguity_policy import AMBIGUITY_RULE_VERSION
+from app.services.strategy_control_plane import (
+    Promotion,
+    Stage,
+    StrategyControlError,
+    current_stage,
+    lock_strategy_control,
+    promote_strategy,
+    registered_strategy_purpose,
+)
+from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+from app.services.strategy_result import TOTAL_RETURN_BASIS
+
+PromotionAction = Literal[
+    "register_candidate",
+    "validate_historical",
+    "start_forward_observation",
+    "approve_paper",
+]
+
+_TARGET_BY_ACTION: Final[dict[PromotionAction, Stage]] = {
+    "register_candidate": "research_candidate",
+    "validate_historical": "historical_validated",
+    "start_forward_observation": "forward_observation",
+    "approve_paper": "paper_enabled",
+}
+_ACTION_BY_STAGE: Final[dict[str | None, PromotionAction]] = {
+    None: "register_candidate",
+    "research_candidate": "validate_historical",
+    "historical_validated": "start_forward_observation",
+    "forward_observation": "approve_paper",
+}
+_ARMS: Final = (
+    ("best_case", "masked"),
+    ("best_case", "admitted"),
+    ("worst_case", "masked"),
+    ("worst_case", "admitted"),
+)
+
+
+@dataclass(frozen=True)
+class OperatorPromotion:
+    promotion: Promotion
+    evidence_ref: str | None
+    created: bool
+
+
+@dataclass(frozen=True)
+class ProspectiveEvidence:
+    assessment_id: int
+    evidence_ref: str
+
+
+@dataclass(frozen=True)
+class ForwardFloorEvidence:
+    declaration_id: int
+    resolved_signals: int
+    decision_dates: int
+    elapsed_days: int
+    assessed_at: datetime
+    evidence_ref: str
+
+
+class OperatorPromotionRefusal(StrategyControlError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def next_promotion_action(stage: str | None) -> PromotionAction | None:
+    return _ACTION_BY_STAGE.get(stage)
+
+
+def _canonical_ref(kind: str, payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    return f"{kind}:sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _load_complete_result_bundle(
+    conn: psycopg.Connection[Any], *, strategy_id: str, strategy_version: str
+) -> tuple[tuple[int, ...], str]:
+    window_starts = [item.window.start for item in RECENT_EVIDENCE_WINDOWS.values()]
+    window_ends = [item.window.end for item in RECENT_EVIDENCE_WINDOWS.values()]
+    rows = conn.execute(
+        """
+        SELECT result_id,result_version,window_start,window_end,evidence_window_id,
+               ambiguity_arm,quarantine_arm
+        FROM strategy_results_store
+        WHERE strategy_id=%(strategy_id)s AND strategy_version=%(strategy_version)s
+          AND result_scope=%(result_scope)s
+          AND namespace='hold_out'
+          AND corpus_version=%(corpus_version)s
+          AND cost_model_id=%(cost_model_id)s
+          AND sizing_rule=%(sizing_rule)s
+          AND benchmark_rule=%(benchmark_rule)s
+          AND return_basis=%(return_basis)s
+          AND ambiguity_rule_version=%(ambiguity_rule_version)s
+          AND position_rule_set_version=%(position_version)s
+          AND outcome_rule_set_version=%(outcome_version)s
+          AND input_rule_set_version=%(input_version)s
+          AND (window_start,window_end) IN (
+              SELECT * FROM unnest(%(window_starts)s::date[], %(window_ends)s::date[])
+          )
+        ORDER BY window_start,window_end,evidence_window_id,ambiguity_arm,quarantine_arm,result_id
+        """,
+        {
+            "strategy_id": strategy_id,
+            "strategy_version": strategy_version,
+            "result_scope": RESULT_SCOPE,
+            "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
+            "cost_model_id": COST_MODEL_ID,
+            "sizing_rule": SIZING_RULE_ID,
+            "benchmark_rule": BENCHMARK_RULE_ID,
+            "return_basis": TOTAL_RETURN_BASIS,
+            "ambiguity_rule_version": AMBIGUITY_RULE_VERSION,
+            "position_version": POSITION_RULE_SET_VERSION,
+            "outcome_version": OUTCOME_RULE_SET_VERSION,
+            "input_version": QUARANTINE_RULE_SET_VERSION,
+            "window_starts": window_starts,
+            "window_ends": window_ends,
+        },
+    ).fetchall()
+    expected = {
+        (item.window.start, item.window.end, item.window_id, ambiguity, quarantine)
+        for item in RECENT_EVIDENCE_WINDOWS.values()
+        for ambiguity, quarantine in _ARMS
+    }
+    observed = [(row[2], row[3], row[4], str(row[5]), str(row[6])) for row in rows]
+    counts = {key: observed.count(key) for key in set(observed)}
+    missing = sorted(expected - set(observed), key=str)
+    duplicate = sorted((key for key, count in counts.items() if count != 1), key=str)
+    unexpected = sorted(set(observed) - expected, key=str)
+    if missing or duplicate or unexpected or len(rows) != len(expected):
+        raise StrategyControlError(
+            "authoritative recent evidence denominator is incomplete or ambiguous "
+            f"(expected={len(expected)}, found={len(rows)}, missing={len(missing)}, "
+            f"duplicate={len(duplicate)}, unexpected={len(unexpected)})"
+        )
+    payload = [
+        {
+            "result_id": int(row[0]),
+            "result_version": str(row[1]),
+            "result_scope": RESULT_SCOPE,
+            "window_start": row[2].isoformat(),
+            "window_end": row[3].isoformat(),
+            "evidence_window_id": str(row[4]),
+            "ambiguity_arm": str(row[5]),
+            "quarantine_arm": str(row[6]),
+        }
+        for row in rows
+    ]
+    return tuple(item["result_id"] for item in payload), _canonical_ref("strategy-result-bundle", payload)
+
+
+def load_forward_floor_evidence(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    now: datetime,
+) -> ForwardFloorEvidence:
+    frozen = load_preregistration(conn, strategy_id, strategy_version)
+    if frozen is None:
+        raise OperatorPromotionRefusal(
+            "preregistration_declaration_missing",
+            "paper approval requires a frozen preregistration declaration",
+        )
+    if not frozen.digest_intact:
+        raise OperatorPromotionRefusal(
+            "declaration_digest_mismatch",
+            "paper approval declaration digest does not match its stored payload",
+        )
+    refusals = declaration_refusals(frozen.declaration)
+    if refusals:
+        raise OperatorPromotionRefusal(
+            "declaration_no_longer_coherent",
+            f"paper approval declaration is incoherent: {', '.join(refusals)}",
+        )
+    if frozen.declaration.prereg_purpose != "capital_candidate":
+        raise OperatorPromotionRefusal(
+            "declaration_not_capital_candidate",
+            "paper approval requires a capital-candidate declaration",
+        )
+    stage_row = conn.execute(
+        """
+        SELECT promoted_at
+        FROM strategy_promotions
+        WHERE strategy_id=%s AND strategy_version=%s AND to_stage='forward_observation'
+        """,
+        (strategy_id, strategy_version),
+    ).fetchone()
+    if stage_row is None:
+        raise OperatorPromotionRefusal("forward_observation_missing", "forward-observation audit event is missing")
+    forward_started_at = cast(datetime, stage_row[0])
+    observed_at = now.astimezone(UTC)
+    if forward_started_at > observed_at:
+        raise OperatorPromotionRefusal(
+            "forward_observation_future_dated",
+            "forward-observation audit event is future-dated",
+        )
+    evidence_row = conn.execute(
+        """
+        SELECT count(*) AS resolved_signals,
+               count(DISTINCT s.signal_bar_date) AS decision_dates
+        FROM strategy_signals s
+        JOIN strategy_outcomes o
+          ON o.signal_id=s.signal_id
+         AND o.rule_set_version=%(outcome_version)s
+         AND o.input_rule_set_version=%(input_version)s
+        WHERE s.strategy_id=%(strategy_id)s AND s.strategy_version=%(strategy_version)s
+          AND s.signal_kind='entry' AND s.verdict='fired'
+          AND o.gross_return_pct IS NOT NULL
+          AND s.created_at >= %(forward_started_at)s
+          AND s.created_at <= %(observed_at)s
+          AND s.signal_bar_date >= %(forward_date)s
+        """,
+        {
+            "strategy_id": strategy_id,
+            "strategy_version": strategy_version,
+            "outcome_version": OUTCOME_RULE_SET_VERSION,
+            "input_version": QUARANTINE_RULE_SET_VERSION,
+            "forward_started_at": forward_started_at,
+            "observed_at": observed_at,
+            "forward_date": forward_started_at.date(),
+        },
+    ).fetchone()
+    assert evidence_row is not None
+    resolved_signals = int(evidence_row[0])
+    decision_dates = int(evidence_row[1])
+    elapsed_days = max((observed_at - forward_started_at).days, 0)
+    floor = frozen.declaration.forward_shadow
+    if decision_dates < floor.min_independent_decision_dates:
+        raise OperatorPromotionRefusal(
+            "forward_decision_dates_insufficient",
+            "forward independent decision-date floor is not satisfied",
+        )
+    if elapsed_days < 7 * floor.min_calendar_weeks:
+        raise OperatorPromotionRefusal(
+            "forward_calendar_weeks_insufficient",
+            "forward calendar-week floor is not satisfied",
+        )
+    payload = {
+        "declaration_id": frozen.declaration_id,
+        "declaration_sha256": frozen.declaration_sha256,
+        "resolved_signals": resolved_signals,
+        "decision_dates": decision_dates,
+        "elapsed_days": elapsed_days,
+        "assessed_at": observed_at.isoformat(),
+    }
+    return ForwardFloorEvidence(
+        declaration_id=frozen.declaration_id,
+        resolved_signals=resolved_signals,
+        decision_dates=decision_dates,
+        elapsed_days=elapsed_days,
+        assessed_at=observed_at,
+        evidence_ref=_canonical_ref("strategy-forward-floor", payload),
+    )
+
+
+def _load_current_prospective_evidence(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    now: datetime,
+) -> ProspectiveEvidence:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT a.assessment_id,a.evidence_hash,a.passed,a.reason_codes,
+                   a.window_start,a.window_end,c.checked_at,p.policy_id,p.evidence_ref,
+                   p.max_assessment_age_days,forward_stage.promoted_at AS forward_started_at
+            FROM strategy_forecast_assessment_policies p
+            JOIN strategy_forecast_assessment_current c ON c.policy_id=p.policy_id
+            JOIN strategy_forecast_assessments a
+              ON a.assessment_id=c.assessment_id
+             AND a.policy_id=c.policy_id
+             AND a.strategy_id=c.strategy_id
+             AND a.strategy_version=c.strategy_version
+             AND a.forecast_policy_version=c.forecast_policy_version
+             AND a.model_version=c.model_version
+             AND a.calibration_id=c.calibration_id
+             AND a.setup_version=c.setup_version
+             AND a.exit_policy_version=c.exit_policy_version
+             AND a.resolver_version=c.resolver_version
+             AND a.input_rule_set_version=c.input_rule_set_version
+            JOIN strategy_promotions forward_stage
+              ON forward_stage.strategy_id=c.strategy_id
+             AND forward_stage.strategy_version=c.strategy_version
+             AND forward_stage.to_stage='forward_observation'
+            WHERE p.policy_id=(
+                SELECT policy_id FROM strategy_forecast_assessment_policies
+                WHERE effective_from <= %(now)s ORDER BY effective_from DESC LIMIT 1
+            )
+              AND c.strategy_id=%(strategy_id)s AND c.strategy_version=%(strategy_version)s
+            ORDER BY a.assessment_id
+            """,
+            {"now": now, "strategy_id": strategy_id, "strategy_version": strategy_version},
+        )
+        rows = list(cur.fetchall())
+    if not rows:
+        raise StrategyControlError("current prospective assessment is missing")
+    if len(rows) != 1:
+        raise StrategyControlError("current prospective assessment scope is ambiguous")
+    row = rows[0]
+    if not bool(row["passed"]):
+        raise StrategyControlError("current prospective assessment did not pass")
+    checked_at = cast(datetime, row["checked_at"])
+    forward_started_at = cast(datetime, row["forward_started_at"])
+    if cast(date, row["window_start"]) <= forward_started_at.date():
+        raise StrategyControlError("current prospective assessment includes pre-forward observations")
+    if cast(date, row["window_end"]) > checked_at.date():
+        raise StrategyControlError("current prospective assessment window ends after it was checked")
+    if checked_at <= forward_started_at:
+        raise StrategyControlError("current prospective assessment predates forward observation")
+    if checked_at > now + timedelta(seconds=5):
+        raise StrategyControlError("current prospective assessment is future-dated")
+    if checked_at < now - timedelta(days=int(row["max_assessment_age_days"])):
+        raise StrategyControlError("current prospective assessment is stale")
+    assessment_id = int(row["assessment_id"])
+    return ProspectiveEvidence(
+        assessment_id=assessment_id,
+        evidence_ref=_canonical_ref(
+            "strategy-prospective-assessment",
+            {
+                "assessment_id": assessment_id,
+                "evidence_hash": str(row["evidence_hash"]),
+                "policy_id": str(row["policy_id"]),
+                "policy_evidence_ref": str(row["evidence_ref"]),
+            },
+        ),
+    )
+
+
+def advance_strategy_for_operator(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    action: PromotionAction,
+    promoted_by: str,
+    reason: str,
+    now: datetime | None = None,
+) -> OperatorPromotion:
+    """Apply one explicit positive transition using only authoritative evidence."""
+    for value, field in (
+        (strategy_id, "strategy_id"),
+        (strategy_version, "strategy_version"),
+        (promoted_by, "promoted_by"),
+        (reason, "reason"),
+    ):
+        if not value.strip():
+            raise StrategyControlError(f"{field} must be non-empty")
+    if registered_strategy_purpose(strategy_id) != "capital_candidate":
+        raise StrategyControlError("only registered capital-candidate strategies can advance")
+    target = _TARGET_BY_ACTION[action]
+    lock_strategy_control(conn, strategy_id, strategy_version)
+    stage = current_stage(conn, strategy_id, strategy_version)
+    if stage == target:
+        row = conn.execute(
+            """
+            SELECT promotion_id,from_stage,evidence_ref
+            FROM strategy_promotions
+            WHERE strategy_id=%s AND strategy_version=%s AND to_stage=%s
+            ORDER BY promotion_id DESC LIMIT 1
+            """,
+            (strategy_id, strategy_version, target),
+        ).fetchone()
+        assert row is not None
+        if target == "paper_enabled":
+            link = conn.execute(
+                "SELECT assessment_id FROM strategy_promotion_forward_evidence WHERE promotion_id=%s",
+                (int(row[0]),),
+            ).fetchone()
+            if link is None:
+                raise StrategyControlError("paper promotion prospective evidence link is missing")
+        promotion = Promotion(int(row[0]), strategy_id, strategy_version, cast(Stage | None, row[1]), target)
+        return OperatorPromotion(promotion, None if row[2] is None else str(row[2]), False)
+    if next_promotion_action(stage) != action:
+        raise StrategyControlError(f"action {action!r} is not allowed from stage {stage!r}")
+
+    result_ids: tuple[int, ...] = ()
+    evidence_ref: str | None = None
+    prospective: ProspectiveEvidence | None = None
+    forward_floor: ForwardFloorEvidence | None = None
+    replay = False
+    if action in {"validate_historical", "start_forward_observation", "approve_paper"}:
+        result_ids, result_ref = _load_complete_result_bundle(
+            conn, strategy_id=strategy_id, strategy_version=strategy_version
+        )
+        evidence_ref = result_ref
+    if action == "approve_paper":
+        observed_at = (now or datetime.now(UTC)).astimezone(UTC)
+        forward_floor = load_forward_floor_evidence(
+            conn,
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            now=observed_at,
+        )
+        prospective = _load_current_prospective_evidence(
+            conn,
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            now=observed_at,
+        )
+        evidence_ref = _canonical_ref(
+            "strategy-paper-approval",
+            {
+                "historical_bundle": evidence_ref,
+                "forward_floor": forward_floor.evidence_ref,
+                "prospective_assessment": prospective.evidence_ref,
+            },
+        )
+        replay = True
+    promotion = promote_strategy(
+        conn,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        to_stage=target,
+        promoted_by=promoted_by,
+        reason=reason,
+        evidence_ref=evidence_ref,
+        result_ids=result_ids,
+        replay_result_evidence=replay,
+    )
+    if prospective is not None and forward_floor is not None:
+        conn.execute(
+            """
+            INSERT INTO strategy_promotion_forward_evidence (
+                promotion_id,strategy_id,strategy_version,declaration_id,assessment_id,forward_resolved_signals,
+                forward_decision_dates,forward_elapsed_days,assessed_at
+            ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            """,
+            (
+                promotion.promotion_id,
+                strategy_id,
+                strategy_version,
+                forward_floor.declaration_id,
+                prospective.assessment_id,
+                forward_floor.resolved_signals,
+                forward_floor.decision_dates,
+                forward_floor.elapsed_days,
+                forward_floor.assessed_at,
+            ),
+        )
+    return OperatorPromotion(promotion, evidence_ref, True)
+
+
+__all__ = [
+    "OperatorPromotion",
+    "ForwardFloorEvidence",
+    "OperatorPromotionRefusal",
+    "ProspectiveEvidence",
+    "PromotionAction",
+    "advance_strategy_for_operator",
+    "load_forward_floor_evidence",
+    "next_promotion_action",
+]

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -35,6 +35,7 @@ from app.services.broker_settlement_arms import select_underlying_long_arms
 from app.services.cost_model import COST_MODEL_ID
 from app.services.market_calendar import us_market_status
 from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
+from app.services.result_ledger import holdout_access_counts, stored_result_promotion_refusals_for
 from app.services.runtime_config import RuntimeConfigCorrupt, get_runtime_config
 from app.services.strategy_base_currency import (
     DEPLOYMENT_CURRENCY_UNSUPPORTED,
@@ -61,6 +62,7 @@ from app.services.strategy_order_reconciliation import (
     ensure_strategy_request_id,
     reconcile_strategy_order,
 )
+from app.services.strategy_result import holdout_count_promotion_refusals
 
 _NY = ZoneInfo("America/New_York")
 _CENT = Decimal("0.01")
@@ -430,6 +432,13 @@ def _load_intent(
         row = cur.fetchone()
     if row is None:
         return None, "signal_not_fired_entry", False
+    pinned_refusal = _pinned_result_evidence_refusal(
+        conn,
+        strategy_id=str(row["strategy_id"]),
+        strategy_version=str(row["strategy_version"]),
+    )
+    if pinned_refusal is not None:
+        return None, pinned_refusal, True
     checks = (
         (bool(row["is_tradable"]), "instrument_not_tradable"),
         (row["asset_class"] == "us_equity", "unsupported_market_session"),
@@ -663,6 +672,42 @@ def _persist_rejection(
             ),
         )
     return PaperExecutionResult(signal_id, "rejected", reason_code)
+
+
+def _pinned_result_evidence_refusal(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+) -> str | None:
+    """Replay current result policy over the exact paper-promotion pins."""
+    rows = conn.execute(
+        """
+        SELECT pr.result_id
+        FROM strategy_promotions promotion
+        JOIN strategy_promotion_results pr ON pr.promotion_id=promotion.promotion_id
+        WHERE promotion.strategy_id=%s AND promotion.strategy_version=%s
+          AND promotion.to_stage='paper_enabled'
+        ORDER BY pr.result_id
+        """,
+        (strategy_id, strategy_version),
+    ).fetchall()
+    result_ids = [int(row[0]) for row in rows]
+    if not result_ids:
+        return "pinned_promotion_evidence_invalid"
+    exposure = holdout_access_counts(conn, strategy_id, strategy_version)
+    if holdout_count_promotion_refusals(
+        holdout_evaluations=exposure.holdout_evaluations,
+        recorded_accesses=exposure.recorded_accesses,
+    ):
+        return "pinned_promotion_evidence_invalid"
+    try:
+        refusals = stored_result_promotion_refusals_for(conn, result_ids)
+    except RuntimeError:
+        return "pinned_promotion_evidence_invalid"
+    if any(refusals[result_id] for result_id in result_ids):
+        return "pinned_promotion_evidence_invalid"
+    return None
 
 
 def _eligibility_reason(response: BrokerEligibilityResponse, intent: _Intent, amount: Decimal) -> str | None:

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -1138,6 +1138,8 @@ def _execute_fired_paper_signal_locked(
         return _persist_rejection(conn, signal_id=signal_id, reason_code="runtime_config_corrupt", now=evaluated_at)
     if not runtime.enable_auto_trading:
         return _persist_rejection(conn, signal_id=signal_id, reason_code="auto_trading_disabled", now=evaluated_at)
+    if runtime.enable_live_trading:
+        return _persist_rejection(conn, signal_id=signal_id, reason_code="live_trading_enabled", now=evaluated_at)
     if kill_row is None or bool(kill_row[0]):
         return _persist_rejection(
             conn, signal_id=signal_id, reason_code="kill_switch_active_or_missing", now=evaluated_at

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -610,6 +610,8 @@ def _persist_rejection(
     intent: _Intent | None = None,
     risk: BrokerAccountRiskSnapshot | None = None,
     halt_identity_evaluated: bool = False,
+    costs_at: datetime | None = None,
+    cost_assessment: _CostAssessment | None = None,
 ) -> PaperExecutionResult:
     existing = _existing_result(conn, signal_id)
     conn.commit()
@@ -623,9 +625,14 @@ def _persist_rejection(
                 signal_id, deployment_id, policy_revision, forecast_id, ranking_member_id,
                 verdict, reason_code,
                 evaluated_at, quote_at, scan_at, halt_feed_at, halt_identity_rule_version,
+                costs_at,
                 broker_available_cash, account_equity, account_invested,
-                instrument_invested, gross_expectancy_ci_low_pct
-            ) VALUES (%s, %s, %s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                instrument_invested, gross_expectancy_ci_low_pct,
+                stressed_cost_amount, net_expectancy_pct, cost_basis
+            ) VALUES (
+                %s, %s, %s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s,
+                %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
             """,
             (
                 signal_id,
@@ -639,6 +646,7 @@ def _persist_rejection(
                 intent.scan_at if intent else None,
                 intent.halt_feed_at if intent else None,
                 HALT_IDENTITY_RULE_VERSION if intent is not None or halt_identity_evaluated else None,
+                costs_at,
                 risk.available_cash if risk else None,
                 risk.equity if risk else None,
                 risk.total_invested if risk else None,
@@ -649,6 +657,9 @@ def _persist_rejection(
                 if risk and intent
                 else None,
                 intent.gross_expectancy_ci_low_pct if intent else None,
+                cost_assessment.stressed if cost_assessment else None,
+                cost_assessment.net if cost_assessment else None,
+                cost_assessment.basis if cost_assessment else None,
             ),
         )
     return PaperExecutionResult(signal_id, "rejected", reason_code)
@@ -1228,6 +1239,17 @@ def _execute_fired_paper_signal_locked(
             conn, signal_id=signal_id, reason_code=assessed, now=evaluated_at, intent=intent, risk=risk
         )
     stressed_cost, net_expectancy = assessed.stressed, assessed.net
+    if net_expectancy <= 0:
+        return _persist_rejection(
+            conn,
+            signal_id=signal_id,
+            reason_code="net_expectancy_not_positive",
+            now=evaluated_at,
+            intent=intent,
+            risk=risk,
+            costs_at=costs.last_updated,
+            cost_assessment=assessed,
+        )
     if net_expectancy < intent.min_net_expectancy_pct:
         return _persist_rejection(
             conn,
@@ -1236,6 +1258,8 @@ def _execute_fired_paper_signal_locked(
             now=evaluated_at,
             intent=intent,
             risk=risk,
+            costs_at=costs.last_updated,
+            cost_assessment=assessed,
         )
     stop_rate = (intent.ask * (Decimal("1") - intent.stop_loss_pct / Decimal("100"))).quantize(
         Decimal("0.000001"), rounding=ROUND_DOWN

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -293,6 +293,11 @@ def _load_intent(
                    current_assessment.checked_at AS prospective_assessment_checked_at,
                    prospective_assessment.assessment_id AS prospective_assessment_id,
                    prospective_assessment.passed AS prospective_assessment_passed,
+                   prospective_assessment.window_start AS prospective_assessment_window_start,
+                   prospective_assessment.window_end AS prospective_assessment_window_end,
+                   current_stage.to_stage AS current_stage,
+                   paper_approval.forward_started_at,
+                   paper_approval.forward_evidence_ready,
                    ranking.ranking_member_id,ranking.selected AS ranking_selected,
                    ranking_batch.ranking_policy_version,
                    ranking_batch.strategy_paper_pool_event_id AS ranking_pool_event_id
@@ -303,6 +308,29 @@ def _load_intent(
               ON d.strategy_id = s.strategy_id AND d.strategy_version = s.strategy_version
              AND d.mode = 'paper'
             LEFT JOIN strategy_execution_policies p ON p.deployment_id = d.deployment_id
+            LEFT JOIN LATERAL (
+                SELECT promotion.to_stage
+                FROM strategy_promotions promotion
+                WHERE promotion.strategy_id=s.strategy_id
+                  AND promotion.strategy_version=s.strategy_version
+                ORDER BY promotion.promotion_id DESC
+                LIMIT 1
+            ) current_stage ON true
+            LEFT JOIN LATERAL (
+                SELECT forward_promotion.promoted_at AS forward_started_at,
+                       (forward_evidence.promotion_id IS NOT NULL) AS forward_evidence_ready
+                FROM strategy_promotions paper_promotion
+                JOIN strategy_promotions forward_promotion
+                  ON forward_promotion.strategy_id=paper_promotion.strategy_id
+                 AND forward_promotion.strategy_version=paper_promotion.strategy_version
+                 AND forward_promotion.to_stage='forward_observation'
+                LEFT JOIN strategy_promotion_forward_evidence forward_evidence
+                  ON forward_evidence.promotion_id=paper_promotion.promotion_id
+                WHERE paper_promotion.strategy_id=s.strategy_id
+                  AND paper_promotion.strategy_version=s.strategy_version
+                  AND paper_promotion.to_stage='paper_enabled'
+                LIMIT 1
+            ) paper_approval ON true
             LEFT JOIN LATERAL (
                 SELECT strategy_paper_pool_event_id,enabled,capital_limit,capital_mode,risk_profile,
                        max_portfolio_drawdown_pct,max_loss_per_position_pct,
@@ -419,6 +447,8 @@ def _load_intent(
             "portfolio_mandate_incomplete",
         ),
         (bool(row["enabled"]), "paper_deployment_disabled"),
+        (row["current_stage"] in {"paper_enabled", "live_enabled"}, "paper_stage_required"),
+        (bool(row["forward_evidence_ready"]), "paper_forward_evidence_missing"),
         (row["currency"] in SUPPORTED_DEPLOYMENT_CURRENCIES, DEPLOYMENT_CURRENCY_UNSUPPORTED),
         (row["policy_revision"] is not None, "execution_policy_missing"),
         (row["forecast_id"] is not None, "opportunity_forecast_missing"),
@@ -499,6 +529,19 @@ def _load_intent(
         max_seconds=int(row["max_assessment_age_days"]) * 86_400,
     ):
         return None, "opportunity_assessment_stale", True
+    assessment_checked_at = cast(datetime, row["prospective_assessment_checked_at"])
+    assessment_window_start = cast(date | None, row["prospective_assessment_window_start"])
+    assessment_window_end = cast(date | None, row["prospective_assessment_window_end"])
+    forward_started_at = cast(datetime | None, row["forward_started_at"])
+    if (
+        assessment_window_start is None
+        or assessment_window_end is None
+        or forward_started_at is None
+        or assessment_window_start <= forward_started_at.date()
+        or assessment_window_end > assessment_checked_at.date()
+        or assessment_checked_at <= forward_started_at
+    ):
+        return None, "opportunity_assessment_pre_forward", True
     if not _session_is_open(now):
         return None, "market_session_closed", True
     return (

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -1141,8 +1141,6 @@ def _execute_fired_paper_signal_locked(
         conn.commit()
     except RuntimeConfigCorrupt:
         return _persist_rejection(conn, signal_id=signal_id, reason_code="runtime_config_corrupt", now=evaluated_at)
-    if not runtime.enable_auto_trading:
-        return _persist_rejection(conn, signal_id=signal_id, reason_code="auto_trading_disabled", now=evaluated_at)
     if runtime.enable_live_trading:
         return _persist_rejection(conn, signal_id=signal_id, reason_code="live_trading_enabled", now=evaluated_at)
     if kill_row is None or bool(kill_row[0]):

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -188,12 +188,13 @@ def _existing_result(conn: psycopg.Connection[Any], signal_id: int) -> PaperExec
         cur.execute(
             """
             SELECT d.verdict, d.reason_code, d.amount, t.strategy_trade_id,
-                   o.order_id, o.status, o.broker_order_ref
+                   o.order_id, o.status, o.broker_order_ref, r.last_error_code
             FROM strategy_funding_decisions d
             LEFT JOIN strategy_trades t ON t.funding_decision_id = d.funding_decision_id
             LEFT JOIN strategy_trade_orders sto
               ON sto.strategy_trade_id = t.strategy_trade_id AND sto.purpose = 'entry'
             LEFT JOIN orders o ON o.order_id = sto.order_id
+            LEFT JOIN strategy_order_reconciliation_state r ON r.order_id = o.order_id
             WHERE d.signal_id = %s
             """,
             (signal_id,),
@@ -203,16 +204,20 @@ def _existing_result(conn: psycopg.Connection[Any], signal_id: int) -> PaperExec
         return None
     if row["verdict"] == "rejected":
         verdict: Literal["rejected", "submitted", "submission_uncertain", "broker_rejected"] = "rejected"
+        reason_code = str(row["reason_code"])
     elif row["status"] == "rejected":
         verdict = "broker_rejected"
+        reason_code = str(row["last_error_code"] or "broker_order_rejected")
     elif row["status"] == "submitted" and row["broker_order_ref"] is None:
         verdict = "submission_uncertain"
+        reason_code = "submission_uncertain"
     else:
         verdict = "submitted"
+        reason_code = "broker_accepted"
     return PaperExecutionResult(
         signal_id=signal_id,
         verdict=verdict,
-        reason_code=str(row["reason_code"]),
+        reason_code=reason_code,
         amount=Decimal(str(row["amount"])) if row["amount"] is not None else None,
         strategy_trade_id=int(row["strategy_trade_id"]) if row["strategy_trade_id"] is not None else None,
         order_id=int(row["order_id"]) if row["order_id"] is not None else None,

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -35,7 +35,6 @@ from app.services.broker_settlement_arms import select_underlying_long_arms
 from app.services.cost_model import COST_MODEL_ID
 from app.services.market_calendar import us_market_status
 from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
-from app.services.result_ledger import holdout_access_counts, stored_result_promotion_refusals_for
 from app.services.runtime_config import RuntimeConfigCorrupt, get_runtime_config
 from app.services.strategy_base_currency import (
     DEPLOYMENT_CURRENCY_UNSUPPORTED,
@@ -48,6 +47,7 @@ from app.services.strategy_control_plane import (
     decide_funding,
     link_strategy_order,
     registered_strategy_purpose,
+    validate_paper_promotion_evidence,
 )
 from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
 from app.services.strategy_halt_identity import (
@@ -62,7 +62,6 @@ from app.services.strategy_order_reconciliation import (
     ensure_strategy_request_id,
     reconcile_strategy_order,
 )
-from app.services.strategy_result import holdout_count_promotion_refusals
 
 _NY = ZoneInfo("America/New_York")
 _CENT = Decimal("0.01")
@@ -432,13 +431,14 @@ def _load_intent(
         row = cur.fetchone()
     if row is None:
         return None, "signal_not_fired_entry", False
-    pinned_refusal = _pinned_result_evidence_refusal(
-        conn,
-        strategy_id=str(row["strategy_id"]),
-        strategy_version=str(row["strategy_version"]),
-    )
-    if pinned_refusal is not None:
-        return None, pinned_refusal, True
+    try:
+        validate_paper_promotion_evidence(
+            conn,
+            strategy_id=str(row["strategy_id"]),
+            strategy_version=str(row["strategy_version"]),
+        )
+    except (StrategyControlError, RuntimeError):
+        return None, "pinned_promotion_evidence_invalid", True
     checks = (
         (bool(row["is_tradable"]), "instrument_not_tradable"),
         (row["asset_class"] == "us_equity", "unsupported_market_session"),
@@ -672,42 +672,6 @@ def _persist_rejection(
             ),
         )
     return PaperExecutionResult(signal_id, "rejected", reason_code)
-
-
-def _pinned_result_evidence_refusal(
-    conn: psycopg.Connection[Any],
-    *,
-    strategy_id: str,
-    strategy_version: str,
-) -> str | None:
-    """Replay current result policy over the exact paper-promotion pins."""
-    rows = conn.execute(
-        """
-        SELECT pr.result_id
-        FROM strategy_promotions promotion
-        JOIN strategy_promotion_results pr ON pr.promotion_id=promotion.promotion_id
-        WHERE promotion.strategy_id=%s AND promotion.strategy_version=%s
-          AND promotion.to_stage='paper_enabled'
-        ORDER BY pr.result_id
-        """,
-        (strategy_id, strategy_version),
-    ).fetchall()
-    result_ids = [int(row[0]) for row in rows]
-    if not result_ids:
-        return "pinned_promotion_evidence_invalid"
-    exposure = holdout_access_counts(conn, strategy_id, strategy_version)
-    if holdout_count_promotion_refusals(
-        holdout_evaluations=exposure.holdout_evaluations,
-        recorded_accesses=exposure.recorded_accesses,
-    ):
-        return "pinned_promotion_evidence_invalid"
-    try:
-        refusals = stored_result_promotion_refusals_for(conn, result_ids)
-    except RuntimeError:
-        return "pinned_promotion_evidence_invalid"
-    if any(refusals[result_id] for result_id in result_ids):
-        return "pinned_promotion_evidence_invalid"
-    return None
 
 
 def _eligibility_reason(response: BrokerEligibilityResponse, intent: _Intent, amount: Decimal) -> str | None:

--- a/docs/proposals/ta/2026-08-15-metric-axis-integrity-implementation-plan.md
+++ b/docs/proposals/ta/2026-08-15-metric-axis-integrity-implementation-plan.md
@@ -124,8 +124,10 @@ Spec: `docs/proposals/ta/2026-08-15-metric-axis-integrity.md`.
 
 ## 6. Gate, review, merge and rerun
 
-1. After worker 98349 releases the database lock/CPU window, run
-   `scripts.audit_2697_legacy_metric_axis` first. It reads identity/provenance
+1. After the legacy worker releases the database lock/CPU window, run
+   `scripts.audit_2697_legacy_metric_axis --run-id <completed-run-id>` first.
+   The run ID is mandatory so a failed/orphaned attempt cannot be silently
+   substituted. It reads invocation identity plus result identity/provenance
    fields only, requires the exact 40-row population, and proves every legacy
    row is refused as `metric_axis_unproven` without consulting a metric. Then
    run focused pure/DB tests, migration smoke, the full in-sample A/B, its
@@ -135,8 +137,9 @@ Spec: `docs/proposals/ta/2026-08-15-metric-axis-integrity.md`.
 2. Self-review, run the required semantic diff review, push, read every CI/bot
    response, resolve each explicitly, re-run affected gates and merge only on
    the latest approved green commit.
-3. Record run 98349 as legacy development evidence that is structurally refused
-   by `metric_axis_unproven`; do not interpret its performance.
+3. Record failed run 98349 and its exact-payload retry separately. Only a
+   successful retry may become legacy development evidence, and it remains
+   structurally refused by `metric_axis_unproven`; do not interpret performance.
 4. The MT-1/S-8 declarations were frozen under policy v3 while this known v4
    change was still in flight. Immediately after merge and before either trial
    accesses an outcome, run the policy-only atomic supersession from merged

--- a/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
+++ b/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
@@ -17,7 +17,7 @@ claim is valid until the ordered research gates below complete.
 | Purpose | Branch / exact head | PR | State |
 | --- | --- | --- | --- |
 | Causal metric-axis correction | `fix/2697-metric-axis-integrity` / `7b87e567d90707fe41d8ae3ee0577c887f1e3f56` | #2757, base `main` | Pushed, clean, draft; hosted CI green; hosted review skipped because draft |
-| Backtest scale gate and compact synthetic controls | `fix/2772-backtest-scale-gate` / `f358fc9d78688557481c63df9e25032f4c1ad8b1` | #2773, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; exact-head local pre-push gate green; main-only hosted workflows intentionally do not run on this base |
+| Backtest scale gate and compact synthetic controls | `fix/2772-backtest-scale-gate` / `510cd60bc7aac491edba5e30b4521c672177f2b3` | #2773, base `fix/2697-metric-axis-integrity` | Pushed, clean, merge-clean stacked draft; exact-head local pre-push gate green; no review/bot response yet; main-only hosted workflows intentionally do not run on this base |
 | Recovered MT-1 and operator paper lane | `integration/ta-demo-mt1-operator`; implementation baseline `ca1ca82bd7bc00e7fc1d1551ebe42db708884000`, with this handover added at the branch tip | #2771, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; main-only hosted workflows intentionally do not run on this base |
 
 `/Users/lukebradford/Dev/eBull` remains the exact detached legacy execution
@@ -79,31 +79,38 @@ Draft PR #2773 now implements the code-level relaunch guardrails:
   throughput, peak RSS, decoded bars, placement size, and reference
   equivalence without querying the database or exposing strategy outcomes;
 - operational backtest logs have a static guard against outcome terms.
+- every new control durably records its placement space, matched trade count,
+  reasoned exclusion/no-slack census, placed-series count, exposure and turnover;
+- promotion fails closed independently on missing/unknown match evidence and on
+  population, exposure or turnover residuals under the exact versioned policy;
+- PostgreSQL enforces the thirteen-field block and its derived exact verdict;
+  legacy controls remain readable but cannot promote, while failed matches
+  remain storable as negative evidence.
 
 The fixed local benchmark passed exact equivalence at all four declared sizes;
 its largest case measured 131,072 trades per member and three members. This is
 a compute-layout baseline, not a full-corpus forecast or strategy result.
 
-The audit after the first slice found four gates that must precede the actual
-production pilot: durable fail-closed match-quality evidence; a production
-memory refusal; measurement of spawned-worker startup, input copying, worker
-RSS, and observed parallel scaling; and an outcome-blind differential over
-stratified real-corpus shapes. Repeated strategy-by-strategy PostgreSQL reads
-and Decimal/object reconstruction also remain outside the current projection.
-A digest-bound reusable corpus representation with `load_arms` equivalence is
-therefore required before the pilot, not deferred until after a refusal. No
-full-population run has been launched.
+The durable match-quality gate is now complete. The next bounded slice must add
+a production memory refusal and measure spawned-worker startup, collector/input
+transfer, worker RSS, observed parallel scaling, and the existing
+strategy-by-strategy PostgreSQL read/Decimal reconstruction cost. It must stop
+after fixed small members and publish structural/resource evidence only. That
+measurement decides whether the current read path can be documented as inside
+budget or a digest-bound reusable corpus representation with `load_arms`
+equivalence must land first. An outcome-blind differential over stratified
+real-corpus shapes also remains. No full-population run has been launched.
 
 ## Ordered #2757 completion
 
-1. Persist the synthetic cohort's unmatchable/no-slack census and exposure/
-   turnover match residual, and make unacceptable or absent structural evidence
-   refuse promotion rather than disappear from the durable result.
-2. Add a production memory budget and a parallel canary that measures process
-   startup, collector transfer, worker RSS, and observed scaling.
-3. Build a digest-bound reusable corpus representation, prove `load_arms`
-   equivalence on deterministic and stratified real-corpus samples, and include
-   its read/decode cost in the launch projection.
+1. Add a production memory budget and a bounded parallel canary that measures
+   process startup, collector transfer/input copying, worker RSS, observed
+   scaling, and current PostgreSQL read/decode cost without exposing outcomes.
+2. Use that fixed measurement to either document the current read path inside
+   budget or build a digest-bound reusable corpus representation; in the latter
+   case prove `load_arms` equivalence on deterministic and stratified
+   real-corpus samples and include read/decode cost in the projection.
+3. Complete the outcome-blind differential on stratified real-corpus shapes.
 4. Review and merge stacked #2773 onto #2757, preserving exact-head local and
    hosted gates when its base becomes eligible, then run only the exact
    three-member production pilot. Stop at the first correctness or time/memory
@@ -173,8 +180,11 @@ The stacked integration provides:
 
 - All three branch heads are clean and pushed.
 - #2757 exact-head local pre-push gate and hosted CI are green.
-- #2773 exact-head local pre-push gate is green; its fixed scale benchmark
-  passed exact slow/compact equivalence, and the synthetic/statistics/equity/
+- #2773 exact head `510cd60bc7aac491edba5e30b4521c672177f2b3`
+  passed the full local pre-push gate with 303 global mutation anchors; 309
+  focused result/backtest/ledger/synthetic-control tests and 138 real-Postgres
+  namespace/result-table tests are green. Its fixed scale benchmark passed
+  exact slow/compact equivalence, and the synthetic/statistics/equity/
   metric-axis mutation probes caught 7/7, 31/31, and 7/7 mutations respectively.
 - #2757 result-model mutation probe caught 28/28 mutations; its dedicated
   metric-axis probe caught 7/7 structural reverts; 291 global probe anchors pass.
@@ -193,7 +203,7 @@ The stacked integration provides:
 | Ticket | Remaining disposition |
 | --- | --- |
 | #2697 | Close only through reviewed and merged #2757 after legacy audit and exact-head A/B |
-| #2772 | Draft #2773 implements observability, compact controls, time budgets, exact fixture differential proof, and fail-closed mark spans; durable match evidence, production memory/parallel measurement, reusable corpus reads, and stratified differential proof remain before review/merge or pilot |
+| #2772 | Draft #2773 implements observability, compact controls, time budgets, exact fixture differential proof, fail-closed mark spans, and durable exact match evidence; production memory/parallel/read-cost measurement and stratified differential proof remain, with reusable corpus work conditional on the bounded measurement |
 | #2766 | Implemented in #2771; close only after final-base review verifies first paper enable and independent master switch |
 | #2767 | Implemented in #2771; close only after final-base worker-capacity verification |
 | #2768 | Implemented in #2771; close only after final-base real-Postgres lifecycle acceptance |

--- a/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
+++ b/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
@@ -17,7 +17,7 @@ claim is valid until the ordered research gates below complete.
 | Purpose | Branch / exact head | PR | State |
 | --- | --- | --- | --- |
 | Causal metric-axis correction | `fix/2697-metric-axis-integrity` / `7b87e567d90707fe41d8ae3ee0577c887f1e3f56` | #2757, base `main` | Pushed, clean, draft; hosted CI green; hosted review skipped because draft |
-| Backtest scale gate and compact synthetic controls | `fix/2772-backtest-scale-gate` / `42def78b2f35490c0a12afc1aaad4e367011253e` | #2773, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; exact-head local pre-push gate green; main-only hosted workflows intentionally do not run on this base |
+| Backtest scale gate and compact synthetic controls | `fix/2772-backtest-scale-gate` / `f358fc9d78688557481c63df9e25032f4c1ad8b1` | #2773, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; exact-head local pre-push gate green; main-only hosted workflows intentionally do not run on this base |
 | Recovered MT-1 and operator paper lane | `integration/ta-demo-mt1-operator`; implementation baseline `ca1ca82bd7bc00e7fc1d1551ebe42db708884000`, with this handover added at the branch tip | #2771, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; main-only hosted workflows intentionally do not run on this base |
 
 `/Users/lukebradford/Dev/eBull` remains the exact detached legacy execution
@@ -71,6 +71,8 @@ Draft PR #2773 now implements the code-level relaunch guardrails:
   parallel fanout;
 - production synthetic members share immutable mark series instead of copying
   every leg's complete mark history;
+- compact construction fails closed on reversed legs, negative source offsets,
+  truncated mark spans, and non-columnar sources before a curve is evaluated;
 - the compact and slow reference engines have an exact differential over
   entries, exits, prices, returns, dates, curve arrays, and counters;
 - a fixed, digest-bound, outcome-free benchmark records wall time, CPU,
@@ -82,44 +84,51 @@ The fixed local benchmark passed exact equivalence at all four declared sizes;
 its largest case measured 131,072 trades per member and three members. This is
 a compute-layout baseline, not a full-corpus forecast or strategy result.
 
-The remaining boundary is an actual exact three-member production pilot over
-the sealed corpus. Repeated strategy-by-strategy PostgreSQL reads and
-Decimal/object reconstruction have not yet been optimized. If that pilot is
-refused by the new budget, first implement a digest-bound columnar snapshot and
-prove `load_arms` equivalence against the current database/reference path. If
-the pilot is admitted, do not add that complexity before measured evidence
-requires it. No full-population run has been launched.
+The audit after the first slice found four gates that must precede the actual
+production pilot: durable fail-closed match-quality evidence; a production
+memory refusal; measurement of spawned-worker startup, input copying, worker
+RSS, and observed parallel scaling; and an outcome-blind differential over
+stratified real-corpus shapes. Repeated strategy-by-strategy PostgreSQL reads
+and Decimal/object reconstruction also remain outside the current projection.
+A digest-bound reusable corpus representation with `load_arms` equivalence is
+therefore required before the pilot, not deferred until after a refusal. No
+full-population run has been launched.
 
 ## Ordered #2757 completion
 
-1. Review and merge stacked #2773 onto #2757, preserving exact-head local and
-   hosted gates when its base becomes eligible.
-2. Run the exact three-member production pilot over the sealed corpus. Stop at
-   the first correctness or budget refusal; do not expose outcome values.
-3. If the pilot is refused, implement a digest-bound columnar snapshot and
-   differential proof for `load_arms`, then repeat only the pilot. If it is
-   admitted, retain the existing database path until profiling justifies more
-   complexity. Any outcome-informed adjustment is a new declared trial/version.
-4. Launch a new exact legacy structural run only if the measured projection is
+1. Persist the synthetic cohort's unmatchable/no-slack census and exposure/
+   turnover match residual, and make unacceptable or absent structural evidence
+   refuse promotion rather than disappear from the durable result.
+2. Add a production memory budget and a parallel canary that measures process
+   startup, collector transfer, worker RSS, and observed scaling.
+3. Build a digest-bound reusable corpus representation, prove `load_arms`
+   equivalence on deterministic and stratified real-corpus samples, and include
+   its read/decode cost in the launch projection.
+4. Review and merge stacked #2773 onto #2757, preserving exact-head local and
+   hosted gates when its base becomes eligible, then run only the exact
+   three-member production pilot. Stop at the first correctness or time/memory
+   refusal; do not expose outcome values. Any outcome-informed adjustment is a
+   new declared trial/version.
+5. Launch a new exact legacy structural run only if the measured projection is
    inside budget, then pass its structural audit without reading performance.
-5. Run the full-population old/new A/B with output redirected, for example:
+6. Run the full-population old/new A/B with output redirected, for example:
 
    ```bash
    uv run python -m scripts.verify_2697_metric_axis_ab \
      > /tmp/ebull-2697-metric-axis-ab-7b87e567.jsonl
    ```
 
-6. Before reading that output, run its structural auditor:
+7. Before reading that output, run its structural auditor:
 
    ```bash
    uv run python -m scripts.audit_2697_metric_axis_ab \
      /tmp/ebull-2697-metric-axis-ab-7b87e567.jsonl
    ```
 
-7. Require the declared current and legacy populations, sealed in-sample
+8. Require the declared current and legacy populations, sealed in-sample
    corpus/regime window, and final exact-head/clean-tree recheck.
-8. Only after the structural audit passes may the A/B values be interpreted.
-9. Update #2697 and #2757 with exact evidence, mark #2757 ready, wait for the
+9. Only after the structural audit passes may the A/B values be interpreted.
+10. Update #2697 and #2757 with exact evidence, mark #2757 ready, wait for the
    hosted implementation review, address every substantive response, rerun the
    final-SHA gates, and merge only when review and evidence are clean.
 
@@ -166,9 +175,9 @@ The stacked integration provides:
 - #2757 exact-head local pre-push gate and hosted CI are green.
 - #2773 exact-head local pre-push gate is green; its fixed scale benchmark
   passed exact slow/compact equivalence, and the synthetic/statistics/equity/
-  metric-axis mutation probes caught 7/7, 29/29, and 7/7 mutations respectively.
+  metric-axis mutation probes caught 7/7, 31/31, and 7/7 mutations respectively.
 - #2757 result-model mutation probe caught 28/28 mutations; its dedicated
-  metric-axis probe caught 7/7 structural reverts; 289 global probe anchors pass.
+  metric-axis probe caught 7/7 structural reverts; 291 global probe anchors pass.
 - Integration whole-repository Ruff, formatting, and Pyright pass.
 - Integration focused MT-1/promotion/allocation/executor/runtime/API suites pass.
 - All 137 frontend files / 1,537 tests, frontend typecheck, and production build pass.
@@ -184,7 +193,7 @@ The stacked integration provides:
 | Ticket | Remaining disposition |
 | --- | --- |
 | #2697 | Close only through reviewed and merged #2757 after legacy audit and exact-head A/B |
-| #2772 | Draft #2773 implements observability, compact controls, launch budgets, and exact differential proof; review/merge it, run the exact production pilot, and add a digest-bound columnar snapshot only if that pilot is refused |
+| #2772 | Draft #2773 implements observability, compact controls, time budgets, exact fixture differential proof, and fail-closed mark spans; durable match evidence, production memory/parallel measurement, reusable corpus reads, and stratified differential proof remain before review/merge or pilot |
 | #2766 | Implemented in #2771; close only after final-base review verifies first paper enable and independent master switch |
 | #2767 | Implemented in #2771; close only after final-base worker-capacity verification |
 | #2768 | Implemented in #2771; close only after final-base real-Postgres lifecycle acceptance |

--- a/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
+++ b/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
@@ -19,13 +19,13 @@ claim is valid until the ordered research gates below complete.
 | Causal metric-axis correction | `fix/2697-metric-axis-integrity` / `7b87e567d90707fe41d8ae3ee0577c887f1e3f56` | #2757, base `main` | Pushed, clean, draft; hosted CI green; hosted review skipped because draft |
 | Recovered MT-1 and operator paper lane | `integration/ta-demo-mt1-operator`; implementation baseline `ca1ca82bd7bc00e7fc1d1551ebe42db708884000`, with this handover added at the branch tip | #2771, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; main-only hosted workflows intentionally do not run on this base |
 
-Do not edit or reload `/Users/lukebradford/Dev/eBull` while the legacy worker
-below is active. It is an exact detached execution tree, not the development
-worktree.
+`/Users/lukebradford/Dev/eBull` remains the exact detached legacy execution
+tree. The oversized worker has been terminated; do not restart its request or
+use that tree for development.
 
-## In-flight exact legacy run
+## Terminated exact legacy run
 
-- PID: `81457`
+- former PID: `81457` (confirmed absent after exact-PID terminate)
 - command: `/Users/lukebradford/Dev/eBull/.venv/bin/python3 -m app.jobs`
 - detached head: `ef206555d05acf44750a79c35e02513f04c4885d`
 - job run: `99585`
@@ -36,46 +36,58 @@ worktree.
   {"control": {}, "params": {"synthetic_control": true, "trial_register_version": "trial-register-2026-08-15-r6"}}
   ```
 
-This is a long single-process legacy computation. Repeated narration adds no
-evidence. On resume, check the PID once. If it is still active and compute-bound,
-leave it alone and wait outside the coding loop. Do not query result, progress,
-metric, trade, comparator, bootstrap, deflation, or synthetic-control values.
+The operator approved termination on 2026-08-16 after a bounded operational
+audit projected an order-of-weeks completion time and found no usable progress
+telemetry. The durable terminate request was recorded, request `408` was
+rejected before restart, and only the jobs daemon was restarted. Run `99585`
+was reaped to `failure`; its automatic retry was cleared (`next_retry_at` is
+null), no later `strategy_backtest_run` was created, and the old worker ignored
+`SIGTERM` before the two exact orphan PIDs were killed. The stop row is closed
+with `observed_at` null, preserving the external-termination audit sentinel.
 
-After process exit, the **first result-related command** must be run from the
-metric-axis worktree:
+The structural auditor was then run from the metric-axis worktree:
 
 ```bash
 cd /Users/lukebradford/Dev/.ebull-ui
 uv run python -m scripts.audit_2697_legacy_metric_axis --run-id 99585
 ```
 
-The auditor must prove all of the following before any performance value is
-read: exact run/request/payload provenance, atomic success, the complete declared
-40-row identity population, no invented metric-axis fields, and current
-promotion refusal `metric_axis_unproven`. Any failure stops the sequence.
+It exited `2` at the terminal-failure guard and did not read result rows. The
+legacy structural audit and the full old/new A/B therefore remain unfulfilled.
+Do not relaunch either full-population run until #2772's observability,
+multi-size scale benchmark, launch-budget refusal, and optimized/reference
+differential gates pass. The legacy log exposure already recorded on #2697
+also means run `99585` could not have supported blind interpretation.
 
 ## Ordered #2757 completion
 
 1. Confirm `.ebull-ui` is clean and still exactly at `7b87e567d90707fe41d8ae3ee0577c887f1e3f56`.
-2. Pass the legacy structural audit above without reading performance.
-3. Run the full-population old/new A/B with output redirected, for example:
+2. Complete #2772: outcome-free progress/ETA, fixed multi-size scale benchmark,
+   declared runtime/memory launch budget, digest-bound reusable compute layout,
+   and differential equivalence to the slow reference engine.
+3. Validate fixtures, then a fixed wiring smoke, then the scale curve. Stop at
+   the first correctness or budget failure; any outcome-informed adjustment is
+   a new declared trial/version.
+4. Launch a new exact legacy structural run only if the measured projection is
+   inside budget, then pass its structural audit without reading performance.
+5. Run the full-population old/new A/B with output redirected, for example:
 
    ```bash
    uv run python -m scripts.verify_2697_metric_axis_ab \
      > /tmp/ebull-2697-metric-axis-ab-7b87e567.jsonl
    ```
 
-4. Before reading that output, run its structural auditor:
+6. Before reading that output, run its structural auditor:
 
    ```bash
    uv run python -m scripts.audit_2697_metric_axis_ab \
      /tmp/ebull-2697-metric-axis-ab-7b87e567.jsonl
    ```
 
-5. Require the declared current and legacy populations, sealed in-sample
+7. Require the declared current and legacy populations, sealed in-sample
    corpus/regime window, and final exact-head/clean-tree recheck.
-6. Only after the structural audit passes may the A/B values be interpreted.
-7. Update #2697 and #2757 with exact evidence, mark #2757 ready, wait for the
+8. Only after the structural audit passes may the A/B values be interpreted.
+9. Update #2697 and #2757 with exact evidence, mark #2757 ready, wait for the
    hosted implementation review, address every substantive response, rerun the
    final-SHA gates, and merge only when review and evidence are clean.
 
@@ -137,6 +149,7 @@ The stacked integration provides:
 | Ticket | Remaining disposition |
 | --- | --- |
 | #2697 | Close only through reviewed and merged #2757 after legacy audit and exact-head A/B |
+| #2772 | Blocking #2697 full-population relaunch: implement observability, scale gate, compute-layout optimization, and differential proof |
 | #2766 | Implemented in #2771; close only after final-base review verifies first paper enable and independent master switch |
 | #2767 | Implemented in #2771; close only after final-base worker-capacity verification |
 | #2768 | Implemented in #2771; close only after final-base real-Postgres lifecycle acceptance |

--- a/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
+++ b/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
@@ -1,0 +1,152 @@
+# TA paper-trading milestone handover — 2026-08-16
+
+## Objective and current truth
+
+The target is an operator-ready, demo-only strategy lane: evidence-qualified
+strategies can be reviewed, promoted, assigned bounded paper capital, executed
+through broker preflight, and audited through signal, order, position, close,
+fees, and P&L. Real-money activation remains fail-closed.
+
+The plumbing is implemented and pushed, but the milestone is **not complete**.
+There is no evidence-qualified capital candidate yet. Every current catalogue
+entry remains `harness_validation`, and no profitability or promotion-ready
+claim is valid until the ordered research gates below complete.
+
+## Branches and pull requests
+
+| Purpose | Branch / exact head | PR | State |
+| --- | --- | --- | --- |
+| Causal metric-axis correction | `fix/2697-metric-axis-integrity` / `7b87e567d90707fe41d8ae3ee0577c887f1e3f56` | #2757, base `main` | Pushed, clean, draft; hosted CI green; hosted review skipped because draft |
+| Recovered MT-1 and operator paper lane | `integration/ta-demo-mt1-operator`; implementation baseline `ca1ca82bd7bc00e7fc1d1551ebe42db708884000`, with this handover added at the branch tip | #2771, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; main-only hosted workflows intentionally do not run on this base |
+
+Do not edit or reload `/Users/lukebradford/Dev/eBull` while the legacy worker
+below is active. It is an exact detached execution tree, not the development
+worktree.
+
+## In-flight exact legacy run
+
+- PID: `81457`
+- command: `/Users/lukebradford/Dev/eBull/.venv/bin/python3 -m app.jobs`
+- detached head: `ef206555d05acf44750a79c35e02513f04c4885d`
+- job run: `99585`
+- linked request: `408`
+- exact payload:
+
+  ```json
+  {"control": {}, "params": {"synthetic_control": true, "trial_register_version": "trial-register-2026-08-15-r6"}}
+  ```
+
+This is a long single-process legacy computation. Repeated narration adds no
+evidence. On resume, check the PID once. If it is still active and compute-bound,
+leave it alone and wait outside the coding loop. Do not query result, progress,
+metric, trade, comparator, bootstrap, deflation, or synthetic-control values.
+
+After process exit, the **first result-related command** must be run from the
+metric-axis worktree:
+
+```bash
+cd /Users/lukebradford/Dev/.ebull-ui
+uv run python -m scripts.audit_2697_legacy_metric_axis --run-id 99585
+```
+
+The auditor must prove all of the following before any performance value is
+read: exact run/request/payload provenance, atomic success, the complete declared
+40-row identity population, no invented metric-axis fields, and current
+promotion refusal `metric_axis_unproven`. Any failure stops the sequence.
+
+## Ordered #2757 completion
+
+1. Confirm `.ebull-ui` is clean and still exactly at `7b87e567d90707fe41d8ae3ee0577c887f1e3f56`.
+2. Pass the legacy structural audit above without reading performance.
+3. Run the full-population old/new A/B with output redirected, for example:
+
+   ```bash
+   uv run python -m scripts.verify_2697_metric_axis_ab \
+     > /tmp/ebull-2697-metric-axis-ab-7b87e567.jsonl
+   ```
+
+4. Before reading that output, run its structural auditor:
+
+   ```bash
+   uv run python -m scripts.audit_2697_metric_axis_ab \
+     /tmp/ebull-2697-metric-axis-ab-7b87e567.jsonl
+   ```
+
+5. Require the declared current and legacy populations, sealed in-sample
+   corpus/regime window, and final exact-head/clean-tree recheck.
+6. Only after the structural audit passes may the A/B values be interpreted.
+7. Update #2697 and #2757 with exact evidence, mark #2757 ready, wait for the
+   hosted implementation review, address every substantive response, rerun the
+   final-SHA gates, and merge only when review and evidence are clean.
+
+## Ordered programme work after #2757
+
+1. Rebase `integration/ta-demo-mt1-operator` onto accepted `main`; update #2771
+   from its temporary stacked base.
+2. Rerun full pre-push/static/backend/frontend/real-Postgres gates on the final
+   SHA and obtain substantive hosted review.
+3. Run the audited MT-1/S-8 declaration-supersession step; do not reuse stale
+   declarations after the metric-axis contract changed.
+4. Run the corrected preregistered MT-1 in-sample trial through the two-phase
+   structural-commit/outcome path and its structural, invocation, and derivation
+   auditors.
+5. Apply the complete conjunctive decision rule. A failed or incomplete result
+   remains research evidence; do not search around it or tune after seeing it.
+6. Only if warranted, freeze and review a distinct `capital_candidate` version,
+   then advance through registered holdout and prospective forward observation.
+7. Configure explicit disabled-first strategy limits and the shared paper risk
+   mandate, then exercise bounded demo execution and audit the actual generated
+   lifecycle end to end.
+
+## Operator-path implementation already recovered
+
+The stacked integration provides:
+
+- outcome-free MT-1 structural preparation followed by atomic trial-result storage;
+- complete pinned-evidence replay at promotion, operator readiness, and before broker access;
+- authenticated promotion and explicit first paper setup, created disabled;
+- an independent strategy paper master switch that does not enable the legacy auto-order lane;
+- shared and per-strategy capital, sizing, freshness, cost, positive-net-expectancy,
+  exposure, drawdown, daily-loss, concurrency, long-only, and no-leverage checks;
+- one reserved paper lifecycle worker slot without increasing the PostgreSQL connection budget;
+- demo-only order submission, exact strategy-owned position tracking, conservative
+  ambiguous/reconciliation-required states, close history, fees, and P&L;
+- `/strategies` navigation and UI for evidence, controls, generated activity,
+  owned positions, reconciliation, and lifecycle audit;
+- no live activation writer: generic `live_enabled` promotion is refused and the
+  live endpoint records an assessment only.
+
+## Verification already completed
+
+- Both branch heads are clean and pushed.
+- #2757 exact-head local pre-push gate and hosted CI are green.
+- #2757 result-model mutation probe caught 28/28 mutations; its dedicated
+  metric-axis probe caught 7/7 structural reverts; 289 global probe anchors pass.
+- Integration whole-repository Ruff, formatting, and Pyright pass.
+- Integration focused MT-1/promotion/allocation/executor/runtime/API suites pass.
+- All 137 frontend files / 1,537 tests, frontend typecheck, and production build pass.
+- The broad backend run had nine parallel global-state/connection/source-lock
+  failures; every one passed on a clean serial rerun.
+- Real-Postgres lifecycle acceptance covers ranking, funding, broker-priced
+  preflight, exactly one demo submission, reconciliation, exact ownership,
+  lifecycle reads, replay idempotence, and exclusion of a same-instrument manual
+  position. This proves plumbing, not profitability.
+
+## Ticket ownership
+
+| Ticket | Remaining disposition |
+| --- | --- |
+| #2697 | Close only through reviewed and merged #2757 after legacy audit and exact-head A/B |
+| #2766 | Implemented in #2771; close only after final-base review verifies first paper enable and independent master switch |
+| #2767 | Implemented in #2771; close only after final-base worker-capacity verification |
+| #2768 | Implemented in #2771; close only after final-base real-Postgres lifecycle acceptance |
+| #2769 | Paved evaluator implemented in #2771; outcome/evidence gate remains outstanding |
+| #2770 | Operator promotion path implemented in #2771; actual evidence-qualified candidate and demo exercise remain outstanding |
+
+## Explicit non-claims
+
+- No current strategy is known to be profitable.
+- Backtest or controlled-trial output alone does not authorize capital.
+- The operator UI and paper executor prove reachability and safety plumbing, not edge.
+- Live/real-money strategy activation is unavailable and must remain so until a
+  separately validated broker contract and measured live-promotion gate exist.

--- a/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
+++ b/docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md
@@ -17,6 +17,7 @@ claim is valid until the ordered research gates below complete.
 | Purpose | Branch / exact head | PR | State |
 | --- | --- | --- | --- |
 | Causal metric-axis correction | `fix/2697-metric-axis-integrity` / `7b87e567d90707fe41d8ae3ee0577c887f1e3f56` | #2757, base `main` | Pushed, clean, draft; hosted CI green; hosted review skipped because draft |
+| Backtest scale gate and compact synthetic controls | `fix/2772-backtest-scale-gate` / `42def78b2f35490c0a12afc1aaad4e367011253e` | #2773, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; exact-head local pre-push gate green; main-only hosted workflows intentionally do not run on this base |
 | Recovered MT-1 and operator paper lane | `integration/ta-demo-mt1-operator`; implementation baseline `ca1ca82bd7bc00e7fc1d1551ebe42db708884000`, with this handover added at the branch tip | #2771, base `fix/2697-metric-axis-integrity` | Pushed, clean, stacked draft; main-only hosted workflows intentionally do not run on this base |
 
 `/Users/lukebradford/Dev/eBull` remains the exact detached legacy execution
@@ -59,15 +60,46 @@ multi-size scale benchmark, launch-budget refusal, and optimized/reference
 differential gates pass. The legacy log exposure already recorded on #2697
 also means run `99585` could not have supported blind interpretation.
 
+## #2772 scale-readiness slice
+
+Draft PR #2773 now implements the code-level relaunch guardrails:
+
+- outcome-free global progress records include control and member ordinals,
+  elapsed time, processing rate, and ETA;
+- an exact three-member production pilot is retained in each final cohort and
+  must pass declared per-cohort and cumulative projected-wall budgets before
+  parallel fanout;
+- production synthetic members share immutable mark series instead of copying
+  every leg's complete mark history;
+- the compact and slow reference engines have an exact differential over
+  entries, exits, prices, returns, dates, curve arrays, and counters;
+- a fixed, digest-bound, outcome-free benchmark records wall time, CPU,
+  throughput, peak RSS, decoded bars, placement size, and reference
+  equivalence without querying the database or exposing strategy outcomes;
+- operational backtest logs have a static guard against outcome terms.
+
+The fixed local benchmark passed exact equivalence at all four declared sizes;
+its largest case measured 131,072 trades per member and three members. This is
+a compute-layout baseline, not a full-corpus forecast or strategy result.
+
+The remaining boundary is an actual exact three-member production pilot over
+the sealed corpus. Repeated strategy-by-strategy PostgreSQL reads and
+Decimal/object reconstruction have not yet been optimized. If that pilot is
+refused by the new budget, first implement a digest-bound columnar snapshot and
+prove `load_arms` equivalence against the current database/reference path. If
+the pilot is admitted, do not add that complexity before measured evidence
+requires it. No full-population run has been launched.
+
 ## Ordered #2757 completion
 
-1. Confirm `.ebull-ui` is clean and still exactly at `7b87e567d90707fe41d8ae3ee0577c887f1e3f56`.
-2. Complete #2772: outcome-free progress/ETA, fixed multi-size scale benchmark,
-   declared runtime/memory launch budget, digest-bound reusable compute layout,
-   and differential equivalence to the slow reference engine.
-3. Validate fixtures, then a fixed wiring smoke, then the scale curve. Stop at
-   the first correctness or budget failure; any outcome-informed adjustment is
-   a new declared trial/version.
+1. Review and merge stacked #2773 onto #2757, preserving exact-head local and
+   hosted gates when its base becomes eligible.
+2. Run the exact three-member production pilot over the sealed corpus. Stop at
+   the first correctness or budget refusal; do not expose outcome values.
+3. If the pilot is refused, implement a digest-bound columnar snapshot and
+   differential proof for `load_arms`, then repeat only the pilot. If it is
+   admitted, retain the existing database path until profiling justifies more
+   complexity. Any outcome-informed adjustment is a new declared trial/version.
 4. Launch a new exact legacy structural run only if the measured projection is
    inside budget, then pass its structural audit without reading performance.
 5. Run the full-population old/new A/B with output redirected, for example:
@@ -130,8 +162,11 @@ The stacked integration provides:
 
 ## Verification already completed
 
-- Both branch heads are clean and pushed.
+- All three branch heads are clean and pushed.
 - #2757 exact-head local pre-push gate and hosted CI are green.
+- #2773 exact-head local pre-push gate is green; its fixed scale benchmark
+  passed exact slow/compact equivalence, and the synthetic/statistics/equity/
+  metric-axis mutation probes caught 7/7, 29/29, and 7/7 mutations respectively.
 - #2757 result-model mutation probe caught 28/28 mutations; its dedicated
   metric-axis probe caught 7/7 structural reverts; 289 global probe anchors pass.
 - Integration whole-repository Ruff, formatting, and Pyright pass.
@@ -149,7 +184,7 @@ The stacked integration provides:
 | Ticket | Remaining disposition |
 | --- | --- |
 | #2697 | Close only through reviewed and merged #2757 after legacy audit and exact-head A/B |
-| #2772 | Blocking #2697 full-population relaunch: implement observability, scale gate, compute-layout optimization, and differential proof |
+| #2772 | Draft #2773 implements observability, compact controls, launch budgets, and exact differential proof; review/merge it, run the exact production pilot, and add a digest-bound columnar snapshot only if that pilot is refused |
 | #2766 | Implemented in #2771; close only after final-base review verifies first paper enable and independent master switch |
 | #2767 | Implemented in #2771; close only after final-base worker-capacity verification |
 | #2768 | Implemented in #2771; close only after final-base real-Postgres lifecycle acceptance |

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -10,6 +10,10 @@ import type {
   StrategyPnlHistoryResponse,
   StrategyPositionCloseResponse,
   StrategySizingUpdateResponse,
+  StrategyPromotionAction,
+  StrategyPromotionResponse,
+  StrategyInitialPaperSetupRequest,
+  StrategyInitialPaperSetupResponse,
 } from "@/api/types";
 
 export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
@@ -18,6 +22,26 @@ export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
 
 export function requestStrategyEvidenceRefresh(): Promise<StrategyEvidenceRefreshResponse> {
   return apiFetch("/strategies/evidence-refresh", { method: "POST" });
+}
+
+export function advanceStrategyPromotion(
+  strategyId: string,
+  body: { strategy_version: string; action: StrategyPromotionAction; reason: string },
+): Promise<StrategyPromotionResponse> {
+  return apiFetch(`/strategies/${encodeURIComponent(strategyId)}/promotion`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function createStrategyPaperSetup(
+  strategyId: string,
+  body: StrategyInitialPaperSetupRequest,
+): Promise<StrategyInitialPaperSetupResponse> {
+  return apiFetch(`/strategies/${encodeURIComponent(strategyId)}/paper-setup`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
 }
 
 export function fetchFiredSignals(cursor: number | null, strategyId?: string): Promise<FiredSignalsResponse> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2607,6 +2607,43 @@ export interface StrategyEntryBlock {
   execution_block_reasons: string[];
 }
 
+export interface StrategyControlledTrialCell {
+  ambiguity_arm: "best_case" | "worst_case";
+  quarantine_arm: "masked" | "admitted";
+  historical_conjuncts_pass: boolean;
+}
+
+/** Outcome-minimal controlled research state. It intentionally exposes no
+ * return statistic and carries no paper/live mutation capability. */
+export interface StrategyControlledTrial {
+  trial_id: string;
+  strategy_version: string;
+  negative_control_id: string;
+  negative_control_version: string;
+  state:
+    | "not_run"
+    | "structural_refused"
+    | "structural_passed_outcomes_pending"
+    | "historical_conjuncts_failed"
+    | "historical_conjuncts_passed"
+    | "evidence_inconsistent";
+  structural_attempt_id: number | null;
+  trial_result_id: number | null;
+  structural_assessed_at: string | null;
+  evaluated_at: string | null;
+  structural_cells: number;
+  result_cells: StrategyControlledTrialCell[];
+  historical_conjuncts_pass: boolean | null;
+  refusal_code: string | null;
+  refusal_detail: string | null;
+  integrity_refusals: string[];
+  holdout_evaluations: number;
+  holdout_accesses: number;
+  promotion_authority: false;
+  paper_activation_reachable: false;
+  live_activation_reachable: false;
+}
+
 export interface StrategyOverviewResponse {
   as_of: string;
   demo_connection: boolean;
@@ -2615,6 +2652,7 @@ export interface StrategyOverviewResponse {
   live_strategy_activation_available: false;
   live_strategy_activation_blocker: "live_strategy_broker_contract_not_validated";
   storage_policy: "fired_signals_and_material_mutations_only";
+  controlled_trials: StrategyControlledTrial[];
   entry_block: StrategyEntryBlock;
   paper_pool: StrategyPaperPool;
   automation_readiness: {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -169,6 +169,24 @@ export interface JobOverviewResponse {
 export interface JobsListResponse {
   checked_at: string;
   jobs: JobOverviewResponse[];
+  jobs_process: {
+    state: "healthy" | "degraded" | "down";
+    subsystems: Array<{
+      subsystem: string;
+      last_beat_at: string | null;
+      age_seconds: number | null;
+      is_stale: boolean;
+      notes: {
+        execution_slot_wait_count?: number;
+        execution_slot_waits?: Array<{
+          job_name: string;
+          lane: string;
+          waiting_since: string;
+          wait_age_seconds: number;
+        }>;
+      } | null;
+    }>;
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2530,12 +2530,60 @@ export interface StrategyOverview {
   legacy_result_count: number;
   all_recent_evidence_complete: boolean;
   stage: string | null;
+  next_promotion_action: StrategyPromotionAction | null;
+  promotion_refusals: string[];
   attribution: StrategyAttribution;
   fire_rate: StrategyFireRate;
   pnl: StrategyPnl;
   allocation: StrategyAllocation;
   allocation_ready: boolean;
   allocation_refusals: string[];
+}
+
+export type StrategyPromotionAction =
+  | "register_candidate"
+  | "validate_historical"
+  | "start_forward_observation"
+  | "approve_paper";
+
+export interface StrategyPromotionResponse {
+  strategy_id: string;
+  strategy_version: string;
+  stage: string;
+  promotion_id: number;
+  evidence_ref: string | null;
+  created: boolean;
+}
+
+export interface StrategyInitialPaperSetupRequest {
+  strategy_version: string;
+  capital_limit: string;
+  ticket_sizing_mode: "percent" | "fixed";
+  ticket_value: string;
+  max_ticket_amount: string;
+  stop_loss_pct: string;
+  take_profit_pct: string;
+  max_quote_age_seconds: number;
+  max_scan_age_seconds: number;
+  max_halt_feed_age_seconds: number;
+  max_cost_age_seconds: number;
+  max_reconciliation_age_seconds: number;
+  max_instrument_exposure_pct: string;
+  max_portfolio_exposure_pct: string;
+  max_drawdown_pct: string;
+  min_net_expectancy_pct: string;
+  cost_stress_multiplier: string;
+  reason: string;
+}
+
+export interface StrategyInitialPaperSetupResponse {
+  strategy_id: string;
+  strategy_version: string;
+  deployment_id: number;
+  deployment_revision: number;
+  policy_revision: number;
+  capital_limit: string;
+  enabled: false;
 }
 
 /** How often the entry rule fires, from the durable census (#2623 gap 2).

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -141,6 +141,18 @@ function recsEmpty(): RecommendationsListResponse {
 function jobsResponse(): JobsListResponse {
   return {
     checked_at: "2026-04-16T01:00:00Z",
+    jobs_process: {
+      state: "healthy",
+      subsystems: [
+        {
+          subsystem: "scheduler",
+          last_beat_at: "2026-04-16T00:59:59Z",
+          age_seconds: 1,
+          is_stale: false,
+          notes: { execution_slot_wait_count: 0, execution_slot_waits: [] },
+        },
+      ],
+    },
     jobs: [
       {
         name: "orchestrator_full_sync",
@@ -343,6 +355,27 @@ describe("AdminPage — Background tasks collapsible", () => {
     expect(
       screen.queryByRole("button", { name: "Run Orchestrator full sync now" }),
     ).toBeNull();
+  });
+
+  it("shows execution-budget waits with the job, lane and current age", async () => {
+    const response = jobsResponse();
+    response.jobs_process.subsystems[0]!.age_seconds = 2;
+    response.jobs_process.subsystems[0]!.notes = {
+      execution_slot_wait_count: 1,
+      execution_slot_waits: [{
+        job_name: "pg_size_sample",
+        lane: "general_non_sec",
+        waiting_since: "2026-04-16T00:59:50Z",
+        wait_age_seconds: 8.4,
+      }],
+    };
+    mockedJobs.mockResolvedValue(response);
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByRole("button", { name: /Background tasks/ }));
+    expect((await screen.findByText(/pg_size_sample \(10s, general_non_sec\)/)).closest("[role='status']")).toHaveTextContent(
+      "Waiting for execution capacity: pg_size_sample (10s, general_non_sec)",
+    );
   });
 
   it("Run-now happy path: POST + refetch + Queued badge", async () => {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -166,6 +166,12 @@ export function AdminPage() {
   const backgroundJobs = (jobs.data?.jobs ?? []).filter(
     (j) => !ORCHESTRATOR_OWNED.has(j.name),
   );
+  const executionSlotWaits = (jobs.data?.jobs_process.subsystems ?? []).flatMap((subsystem) =>
+    (subsystem.notes?.execution_slot_waits ?? []).map((wait) => ({
+      ...wait,
+      wait_age_seconds: wait.wait_age_seconds + (subsystem.age_seconds ?? 0),
+    })),
+  );
 
   // ProblemsPanel surfaces failing layers with a drill-through; PR6
   // moves the orchestrator detail behind /admin/processes/orchestrator_full_sync
@@ -257,6 +263,17 @@ export function AdminPage() {
               transaction execution, position monitoring, deferred-rec
               retries, and periodic governance.
             </p>
+            {executionSlotWaits.length > 0 ? (
+              <div className="mb-3 border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200" role="status">
+                <strong>Waiting for execution capacity:</strong>{" "}
+                {executionSlotWaits.map((wait, index) => (
+                  <span key={`${wait.job_name}:${wait.waiting_since}`}>
+                    {index > 0 ? "; " : ""}
+                    {wait.job_name} ({Math.max(0, Math.floor(wait.wait_age_seconds))}s, {wait.lane})
+                  </span>
+                ))}
+              </div>
+            ) : null}
             <JobsTable items={backgroundJobs} rowState={rowState} onRun={handleRun} />
           </>
         )}

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -210,6 +210,8 @@ const OVERVIEW: StrategyOverviewResponse = {
     legacy_result_count: 0,
     all_recent_evidence_complete: false,
     stage: null,
+    next_promotion_action: "register_candidate",
+    promotion_refusals: [],
     attribution: {
       fired_entries: 12,
       funded_entries: 0,
@@ -411,6 +413,59 @@ describe("StrategiesPage", () => {
     expect(screen.getAllByText("+1.50%")).toHaveLength(2);
     expect(screen.getByText("Not proven")).toBeInTheDocument();
     expect(screen.getByText("Official account equity starts collecting with the next portfolio sync.")).toBeInTheDocument();
+  });
+
+  it("submits only the server-declared next promotion action with an operator reason", async () => {
+    const advance = vi.spyOn(strategiesApi, "advanceStrategyPromotion").mockResolvedValue({
+      strategy_id: "s1-time-series-momentum",
+      strategy_version: "strategy-registry-v1+abc",
+      stage: "research_candidate",
+      promotion_id: 91,
+      evidence_ref: null,
+      created: true,
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.type(screen.getByLabelText("Operator reason"), "Reviewed preregistered candidate");
+    await userEvent.click(screen.getByRole("button", { name: "Register candidate" }));
+
+    await waitFor(() => expect(advance).toHaveBeenCalledWith("s1-time-series-momentum", {
+      strategy_version: "strategy-registry-v1+abc",
+      action: "register_candidate",
+      reason: "Reviewed preregistered candidate",
+    }));
+  });
+
+  it("requires explicit limits and creates the first paper setup disabled", async () => {
+    const paper = structuredClone(OVERVIEW);
+    paper.strategies[0]!.stage = "paper_enabled";
+    paper.strategies[0]!.next_promotion_action = null;
+    paper.strategies[0]!.promotion_refusals = [];
+    paper.strategies[0]!.allocation_refusals = ["execution_policy_missing"];
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(paper);
+    const setup = vi.spyOn(strategiesApi, "createStrategyPaperSetup").mockResolvedValue({
+      strategy_id: "s1-time-series-momentum",
+      strategy_version: "strategy-registry-v1+abc",
+      deployment_id: 19,
+      deployment_revision: 1,
+      policy_revision: 1,
+      capital_limit: "1",
+      enabled: false,
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(screen.getByText("Set explicit first paper limits"));
+    for (const input of screen.getAllByRole("spinbutton")) await userEvent.type(input, "1");
+    await userEvent.type(screen.getByLabelText("Operator reason"), "Reviewed every paper limit");
+    await userEvent.click(screen.getByRole("button", { name: "Create disabled paper setup" }));
+
+    await waitFor(() => expect(setup).toHaveBeenCalledWith("s1-time-series-momentum", expect.objectContaining({
+      strategy_version: "strategy-registry-v1+abc",
+      capital_limit: "1",
+      cost_stress_multiplier: "1",
+      reason: "Reviewed every paper limit",
+    })));
+    expect(setup.mock.calls[0]![1]).not.toHaveProperty("enabled");
   });
 
   it("shows the controlled-trial verdict as read-only historical evidence", async () => {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -1040,6 +1040,33 @@ describe("StrategiesPage", () => {
     expect(within(row).queryByText(/realised/)).not.toBeInTheDocument();
   });
 
+  it("labels an ambiguous entry-order reconciliation separately from a position operation", async () => {
+    const ambiguousEntry: FiredSignal = {
+      ...FUNDED_SIGNAL,
+      trade_lifecycle: {
+        ...FUNDED_SIGNAL.trade_lifecycle!,
+        latest_operation_type: null,
+        latest_operation_id: null,
+        latest_operation_order_id: null,
+        latest_operation_trigger: null,
+        latest_operation_status: null,
+        latest_operation_created_at: null,
+        latest_operation_submitted_at: null,
+        latest_operation_resolved_at: null,
+        latest_reconciliation_state: "ambiguous",
+        latest_reconciliation_broker_status: "multiple_matches",
+        latest_reconciliation_error: "multiple_position_executions",
+        incomplete_reasons: ["entry_order_reconciliation_ambiguous"],
+      },
+    };
+    vi.mocked(strategiesApi.fetchFiredSignals).mockResolvedValue({ items: [ambiguousEntry], next_cursor: null });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const section = (await screen.findByText("Generated trade activity")).closest("section")!;
+    expect(within(section).getByText("Entry order has ambiguous broker reconciliation")).toBeInTheDocument();
+    expect(within(section).getByText("Reconciliation ambiguous · broker multiple matches")).toBeInTheDocument();
+  });
+
   it("renders failed and reconciliation-required trades as risk states", async () => {
     const failed: FiredSignal = {
       ...FUNDED_SIGNAL,

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -58,6 +58,7 @@ const OVERVIEW: StrategyOverviewResponse = {
   live_strategy_activation_available: false,
   live_strategy_activation_blocker: "live_strategy_broker_contract_not_validated",
   storage_policy: "fired_signals_and_material_mutations_only",
+  controlled_trials: [],
   entry_block: {
     new_entries_blocked: false,
     global_kill_active: false,
@@ -410,6 +411,49 @@ describe("StrategiesPage", () => {
     expect(screen.getAllByText("+1.50%")).toHaveLength(2);
     expect(screen.getByText("Not proven")).toBeInTheDocument();
     expect(screen.getByText("Official account equity starts collecting with the next portfolio sync.")).toBeInTheDocument();
+  });
+
+  it("shows the controlled-trial verdict as read-only historical evidence", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      controlled_trials: [{
+        trial_id: "mt1-capped-volatility-managed-relative-strength-v1",
+        strategy_version: "mt1-version-v1",
+        negative_control_id: "mt1-s8-capped-volatility-negative-control-v1",
+        negative_control_version: "s8-version-v1",
+        state: "historical_conjuncts_failed",
+        structural_attempt_id: 12,
+        trial_result_id: 13,
+        structural_assessed_at: "2026-08-15T12:00:00Z",
+        evaluated_at: "2026-08-15T12:01:00Z",
+        structural_cells: 4,
+        result_cells: [
+          { ambiguity_arm: "best_case", quarantine_arm: "admitted", historical_conjuncts_pass: true },
+          { ambiguity_arm: "best_case", quarantine_arm: "masked", historical_conjuncts_pass: true },
+          { ambiguity_arm: "worst_case", quarantine_arm: "admitted", historical_conjuncts_pass: false },
+          { ambiguity_arm: "worst_case", quarantine_arm: "masked", historical_conjuncts_pass: true },
+        ],
+        historical_conjuncts_pass: false,
+        refusal_code: null,
+        refusal_detail: null,
+        integrity_refusals: [],
+        holdout_evaluations: 0,
+        holdout_accesses: 0,
+        promotion_authority: false,
+        paper_activation_reachable: false,
+        live_activation_reachable: false,
+      }],
+    });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+
+    const panel = (await screen.findByText("Controlled research trials")).closest("section")!;
+    expect(within(panel).getByText("Read only")).toBeInTheDocument();
+    expect(within(panel).getByText("Historical conjuncts failed")).toBeInTheDocument();
+    expect(within(panel).getAllByText("4/4 cells")).toHaveLength(2);
+    expect(within(panel).getAllByText("Conjuncts failed")).toHaveLength(1);
+    expect(within(panel).getByText(/cannot enable paper or live trading/)).toBeInTheDocument();
+    expect(within(panel).queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("shows broker account evidence without presenting it as automated return", async () => {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -651,6 +651,26 @@ describe("StrategiesPage", () => {
     expect(screen.getByRole("checkbox", { name: "Allow new automated entries" })).toBeDisabled();
   });
 
+  it("does not invent an owned position for an enabled strategy whose entry gates later fail", async () => {
+    const approved = approvedOverview();
+    const strategy = approved.strategies[0]!;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...approved,
+      strategies: [{
+        ...strategy,
+        allocation_ready: false,
+        allocation_refusals: ["prospective_assessment_stale"],
+        allocation: { ...strategy.allocation, enabled: true },
+      }],
+    });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+
+    expect(await screen.findByText("New entries blocked")).toBeInTheDocument();
+    expect(screen.queryByText("Managing existing position")).not.toBeInTheDocument();
+    expect(screen.getByText(/later fails a gate remains visible, but cannot open a new position/)).toBeInTheDocument();
+  });
+
   it("renders harness rules as compact controls without allocation actions", async () => {
     const strategy = OVERVIEW.strategies[0]!;
     vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -757,6 +757,19 @@ describe("StrategiesPage", () => {
     expect(screen.getByText("Paper automation can only be enabled while connected to the demo environment.")).toBeInTheDocument();
   });
 
+  it("keeps paper enable disabled while system-wide live trading is enabled", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...approvedOverview(),
+      execution_enabled: false,
+      live_execution_enabled: true,
+      paper_pool: { ...approvedOverview().paper_pool, enabled: false },
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
+    expect(master).toBeDisabled();
+    expect(screen.getByText("Turn off system-wide live trading before enabling paper automation.")).toBeInTheDocument();
+  });
+
   it("shows compact prospective evidence when automation is ready", async () => {
     vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(approvedOverview());
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -709,16 +709,52 @@ describe("StrategiesPage", () => {
     })));
   });
 
-  it("does not present automation as enabled while the system-wide guard is off", async () => {
+  it("uses the atomic paper-pool request for the first enable while the system-wide flag is off", async () => {
+    const update = vi.spyOn(strategiesApi, "updateStrategyPaperPool").mockResolvedValue({
+      ...OVERVIEW.paper_pool,
+      enabled: true,
+    });
     vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
       ...approvedOverview(),
+      execution_enabled: false,
+      paper_pool: { ...approvedOverview().paper_pool, enabled: false },
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
+    expect(master).not.toBeChecked();
+    expect(master).not.toBeDisabled();
+    await userEvent.click(master);
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: true,
+      capital_limit: "1000.000000",
+      risk_profile: "balanced",
+    })));
+  });
+
+  it("keeps first enable disabled when strategy evidence is not ready", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
       execution_enabled: false,
     });
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
     expect(master).not.toBeChecked();
     expect(master).toBeDisabled();
-    expect(screen.getByText("System-wide automatic trading is off. Enable that safety control before allowing new entries.")).toBeInTheDocument();
+    expect(screen.getByText("Automation stays off until at least one strategy passes validation.")).toBeInTheDocument();
+  });
+
+  it("keeps first enable disabled outside the demo environment", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...approvedOverview(),
+      demo_connection: false,
+      execution_enabled: false,
+      paper_pool: { ...approvedOverview().paper_pool, enabled: false },
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
+    expect(master).toBeDisabled();
+    expect(screen.getByText("Paper automation can only be enabled while connected to the demo environment.")).toBeInTheDocument();
   });
 
   it("shows compact prospective evidence when automation is ready", async () => {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -807,6 +807,17 @@ describe("StrategiesPage", () => {
     })));
   });
 
+  it("shows an enabled strategy paper pool independently of the legacy automation flag", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...approvedOverview(),
+      execution_enabled: false,
+    });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+
+    expect(await screen.findByRole("checkbox", { name: "Allow new automated entries" })).toBeChecked();
+  });
+
   it("keeps first enable disabled when strategy evidence is not ready", async () => {
     vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
       ...OVERVIEW,

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -18,6 +18,7 @@ import type {
   FiredSignalsResponse,
   StrategyEvidenceWindow,
   StrategyFireRate,
+  StrategyControlledTrial,
   StrategyOverview,
   StrategyOverviewResponse,
   StrategyOwnedPosition,
@@ -1463,6 +1464,73 @@ function ValidationControl({ strategy }: { strategy: StrategyOverview }) {
   );
 }
 
+const CONTROLLED_TRIAL_STATE: Record<StrategyControlledTrial["state"], string> = {
+  not_run: "Not run",
+  structural_refused: "Structural gate refused",
+  structural_passed_outcomes_pending: "Structure committed; outcomes pending",
+  historical_conjuncts_failed: "Historical conjuncts failed",
+  historical_conjuncts_passed: "Historical conjuncts passed",
+  evidence_inconsistent: "Evidence inconsistent",
+};
+
+function ControlledTrialPanel({ trials }: { trials: StrategyControlledTrial[] }) {
+  return (
+    <section className="border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold">Controlled research trials</h2>
+          <p className="mt-1 max-w-3xl text-xs text-slate-500">
+            Preregistered historical falsification only. These verdicts are not promotion authority and cannot enable paper or live trading.
+          </p>
+        </div>
+        <Badge tone="neutral">Read only</Badge>
+      </div>
+      <div className="mt-4 space-y-4">
+        {trials.map((trial) => {
+          const tone = trial.state === "historical_conjuncts_passed"
+            ? "ok"
+            : trial.state === "not_run" || trial.state === "structural_passed_outcomes_pending"
+              ? "warn"
+              : "risk";
+          return (
+            <article key={`${trial.trial_id}:${trial.strategy_version}`} className="border-t border-slate-200 pt-4 dark:border-slate-800">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <h3 className="text-sm font-medium">MT-1 volatility-managed relative strength</h3>
+                  <p className="mt-1 text-xs text-slate-500">Negative control: S-8 range mean reversion</p>
+                </div>
+                <Badge tone={tone}>{CONTROLLED_TRIAL_STATE[trial.state]}</Badge>
+              </div>
+              <dl className="mt-3 grid gap-3 text-xs sm:grid-cols-4">
+                <div><dt className="text-slate-500">Structural fan</dt><dd className="mt-1 font-medium tabular-nums">{trial.structural_cells}/4 cells</dd></div>
+                <div><dt className="text-slate-500">Outcome fan</dt><dd className="mt-1 font-medium tabular-nums">{trial.result_cells.length}/4 cells</dd></div>
+                <div><dt className="text-slate-500">Holdout evaluations</dt><dd className="mt-1 font-medium tabular-nums">{trial.holdout_evaluations}</dd></div>
+                <div><dt className="text-slate-500">Holdout accesses</dt><dd className="mt-1 font-medium tabular-nums">{trial.holdout_accesses}</dd></div>
+              </dl>
+              {trial.result_cells.length ? (
+                <ul className="mt-3 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
+                  {trial.result_cells.map((cell) => (
+                    <li key={`${cell.ambiguity_arm}:${cell.quarantine_arm}`} className="border border-slate-200 px-3 py-2 dark:border-slate-800">
+                      <span className="block text-slate-500">{cell.ambiguity_arm.replaceAll("_", " ")} · {cell.quarantine_arm}</span>
+                      <strong className={cell.historical_conjuncts_pass ? "text-emerald-700 dark:text-emerald-300" : "text-red-700 dark:text-red-300"}>
+                        {cell.historical_conjuncts_pass ? "Conjuncts passed" : "Conjuncts failed"}
+                      </strong>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              {trial.refusal_detail ? <p className="mt-3 text-xs text-red-700 dark:text-red-300">{trial.refusal_detail}</p> : null}
+              {trial.integrity_refusals.length ? (
+                <p className="mt-3 text-xs text-red-700 dark:text-red-300">Integrity refusal: {trial.integrity_refusals.join(", ")}</p>
+              ) : null}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 export function StrategiesPage() {
   const overview = useAsync(fetchStrategyOverview, []);
   const pnlHistory = useAsync(fetchStrategyPnlHistory, []);
@@ -1573,6 +1641,8 @@ export function StrategiesPage() {
           ) : activity.data ? (
             <StrategyActivity response={activity.data} strategyTitles={strategyTitles} onRetry={activity.refetch} />
           ) : null}
+
+          {overview.data.controlled_trials.length ? <ControlledTrialPanel trials={overview.data.controlled_trials} /> : null}
 
           {forwardCandidates.length ? <SignalValidation overview={overview.data} strategies={forwardCandidates} /> : null}
 

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1038,7 +1038,12 @@ function AutomationControl({
     || parsed !== Number(pool.capital_limit)
     || capitalMode !== pool.capital_mode
     || riskProfile !== pool.mandate.risk_profile;
-  const canEnable = overview.automation_readiness.ready && overview.execution_enabled && riskProfile !== "unconfigured";
+  // This form owns both the paper-pool switch and the system-wide automatic
+  // trading flag through one atomic endpoint. Requiring execution_enabled here
+  // creates a circular first-enable gate: the flag can never become true
+  // because the control that changes it is disabled. The server independently
+  // rechecks evidence readiness and the demo-only boundary on every enable.
+  const canEnable = overview.automation_readiness.ready && overview.demo_connection && riskProfile !== "unconfigured";
   const selectedMandate = riskProfile === pool.mandate.risk_profile && pool.mandate.configured
     ? pool.mandate
     : pool.available_mandates.find((mandate) => mandate.risk_profile === riskProfile) ?? null;
@@ -1149,8 +1154,8 @@ function AutomationControl({
       </dl>
       {!canEnable ? (
         <p className="mt-4 text-xs text-amber-700 dark:text-amber-300">
-          {!overview.execution_enabled
-            ? "System-wide automatic trading is off. Enable that safety control before allowing new entries."
+          {!overview.demo_connection
+            ? "Paper automation can only be enabled while connected to the demo environment."
             : riskProfile === "unconfigured"
               ? "Choose a risk profile before allowing new entries."
             : "Automation stays off until at least one strategy passes validation."}

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -339,6 +339,8 @@ const REFUSAL_LABELS: Record<string, string> = {
   recent_evidence_incomplete: "Recent evidence windows are incomplete",
   recent_evidence_gate_refused: "Recent evidence failed its promotion gate",
   recent_net_expectancy_not_positive: "Net expectancy is not positive",
+  net_expectancy_not_positive: "Broker-priced expectancy is not positive after stressed costs",
+  net_expectancy_below_policy: "Broker-priced expectancy is below the configured minimum",
   paper_promotion_missing: "No approved deployment exists",
   paper_forward_evidence_missing: "Paper approval has no durable forward-evidence record",
   pinned_promotion_evidence_invalid: "Pinned evidence is no longer valid",

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1043,30 +1043,30 @@ function AutomationControl({
   onUpdated: () => void;
 }) {
   const pool = overview.paper_pool;
-  const [enabled, setEnabled] = useState(pool.enabled && overview.execution_enabled);
+  const [enabled, setEnabled] = useState(pool.enabled);
   const [limit, setLimit] = useState(pool.capital_limit);
   const [capitalMode, setCapitalMode] = useState(pool.capital_mode);
   const [riskProfile, setRiskProfile] = useState(pool.mandate.risk_profile);
   const [saving, setSaving] = useState(false);
   const [failed, setFailed] = useState(false);
   useEffect(() => {
-    setEnabled(pool.enabled && overview.execution_enabled);
+    setEnabled(pool.enabled);
     setLimit(pool.capital_limit);
     setCapitalMode(pool.capital_mode);
     setRiskProfile(pool.mandate.risk_profile);
-  }, [pool.enabled, pool.capital_limit, pool.capital_mode, pool.mandate.risk_profile, overview.execution_enabled]);
+  }, [pool.enabled, pool.capital_limit, pool.capital_mode, pool.mandate.risk_profile]);
   const parsed = Number(limit);
   const valid = Number.isFinite(parsed) && parsed >= 0 && (!enabled || parsed > 0);
-  const effectiveEnabled = pool.enabled && overview.execution_enabled;
+  const effectiveEnabled = pool.enabled;
   const dirty = enabled !== effectiveEnabled
     || parsed !== Number(pool.capital_limit)
     || capitalMode !== pool.capital_mode
     || riskProfile !== pool.mandate.risk_profile;
-  // This form owns both the paper-pool switch and the system-wide automatic
-  // trading flag through one atomic endpoint. Requiring execution_enabled here
-  // creates a circular first-enable gate: the flag can never become true
-  // because the control that changes it is disabled. The server independently
-  // rechecks evidence readiness, the demo boundary, and live-off state on every enable.
+  // The paper-pool event is this lane's master switch. It deliberately does
+  // not mutate the legacy system-wide automatic-trading flag, which controls
+  // a separate recommendation/order pipeline outside this bounded sleeve.
+  // The server independently rechecks evidence readiness, the demo boundary,
+  // and live-off state on every enable.
   const canEnable = overview.automation_readiness.ready
     && overview.demo_connection
     && !overview.live_execution_enabled

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -3,7 +3,9 @@ import type { FormEvent } from "react";
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
+  advanceStrategyPromotion,
   closeStrategyOwnedPosition,
+  createStrategyPaperSetup,
   fetchFiredSignals,
   fetchStrategyOverview,
   fetchStrategyOwnedPositions,
@@ -338,6 +340,7 @@ const REFUSAL_LABELS: Record<string, string> = {
   recent_evidence_gate_refused: "Recent evidence failed its promotion gate",
   recent_net_expectancy_not_positive: "Net expectancy is not positive",
   paper_promotion_missing: "No approved deployment exists",
+  paper_forward_evidence_missing: "Paper approval has no durable forward-evidence record",
   pinned_promotion_evidence_invalid: "Pinned evidence is no longer valid",
   execution_policy_missing: "Execution and risk policy is missing",
   universe_basis_not_survivorship_free: "Point-in-time universe is not complete",
@@ -347,8 +350,19 @@ const REFUSAL_LABELS: Record<string, string> = {
   synthetic_control_not_run: "Random-entry control has not passed",
   prospective_assessment_policy_missing: "Prospective forecast acceptance limits are missing",
   prospective_assessment_missing: "No current prospective forecast assessment exists",
+  prospective_assessment_ambiguous: "More than one current prospective assessment scope exists",
+  prospective_assessment_includes_pre_forward_observations: "Prospective evidence includes observations from before forward admission",
+  prospective_assessment_window_invalid: "Prospective assessment window is temporally inconsistent",
   prospective_assessment_not_passed: "Recent forecast probabilities failed validation",
   prospective_assessment_stale: "Prospective forecast validation is stale",
+  preregistration_declaration_missing: "The capital candidate has no frozen preregistration",
+  declaration_digest_mismatch: "The frozen preregistration failed its integrity check",
+  declaration_no_longer_coherent: "The frozen preregistration no longer matches the evidence contract",
+  declaration_not_capital_candidate: "The frozen preregistration is not for a capital candidate",
+  forward_observation_missing: "Forward observation has not started",
+  forward_observation_future_dated: "Forward observation is future-dated",
+  forward_decision_dates_insufficient: "The preregistered forward decision-date floor is not met",
+  forward_calendar_weeks_insufficient: "The preregistered forward calendar-time floor is not met",
   funding_not_reconciled_to_trade: "Funded decision has not reconciled to a strategy trade",
   trade_not_reconciled_to_position: "Strategy trade has not reconciled to a broker position",
   position_ownership_ambiguous: "More than one broker-position ownership record exists",
@@ -1426,13 +1440,131 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
   );
 }
 
-function ResearchCandidate({ strategy }: { strategy: StrategyOverview }) {
+const PROMOTION_ACTION_LABEL = {
+  register_candidate: "Register candidate",
+  validate_historical: "Approve historical evidence",
+  start_forward_observation: "Start forward observation",
+  approve_paper: "Approve for paper trading",
+} as const;
+
+type PaperSetupValues = {
+  capital_limit: string;
+  ticket_sizing_mode: "percent" | "fixed";
+  ticket_value: string;
+  max_ticket_amount: string;
+  stop_loss_pct: string;
+  take_profit_pct: string;
+  max_quote_age_seconds: string;
+  max_scan_age_seconds: string;
+  max_halt_feed_age_seconds: string;
+  max_cost_age_seconds: string;
+  max_reconciliation_age_seconds: string;
+  max_instrument_exposure_pct: string;
+  max_portfolio_exposure_pct: string;
+  max_drawdown_pct: string;
+  min_net_expectancy_pct: string;
+  cost_stress_multiplier: string;
+  reason: string;
+};
+
+const EMPTY_PAPER_SETUP: PaperSetupValues = {
+  capital_limit: "", ticket_sizing_mode: "percent", ticket_value: "", max_ticket_amount: "",
+  stop_loss_pct: "", take_profit_pct: "", max_quote_age_seconds: "", max_scan_age_seconds: "",
+  max_halt_feed_age_seconds: "", max_cost_age_seconds: "", max_reconciliation_age_seconds: "",
+  max_instrument_exposure_pct: "", max_portfolio_exposure_pct: "", max_drawdown_pct: "",
+  min_net_expectancy_pct: "", cost_stress_multiplier: "", reason: "",
+};
+
+const PAPER_SETUP_FIELDS: { key: Exclude<keyof PaperSetupValues, "ticket_sizing_mode" | "reason">; label: string; step?: string }[] = [
+  { key: "capital_limit", label: "Strategy capital limit (USD)", step: "0.01" },
+  { key: "ticket_value", label: "Per-signal size (% or USD)", step: "0.01" },
+  { key: "max_ticket_amount", label: "Hard ticket maximum (USD)", step: "0.01" },
+  { key: "stop_loss_pct", label: "Stop loss (%)", step: "0.01" },
+  { key: "take_profit_pct", label: "Take profit (%)", step: "0.01" },
+  { key: "max_quote_age_seconds", label: "Maximum quote age (seconds)" },
+  { key: "max_scan_age_seconds", label: "Maximum scan age (seconds)" },
+  { key: "max_halt_feed_age_seconds", label: "Maximum halt-feed age (seconds)" },
+  { key: "max_cost_age_seconds", label: "Maximum cost age (seconds)" },
+  { key: "max_reconciliation_age_seconds", label: "Maximum reconciliation age (seconds)" },
+  { key: "max_instrument_exposure_pct", label: "Maximum instrument exposure (%)", step: "0.01" },
+  { key: "max_portfolio_exposure_pct", label: "Maximum portfolio exposure (%)", step: "0.01" },
+  { key: "max_drawdown_pct", label: "Maximum drawdown (%)", step: "0.01" },
+  { key: "min_net_expectancy_pct", label: "Minimum net expectancy (%)", step: "0.01" },
+  { key: "cost_stress_multiplier", label: "Cost stress multiplier", step: "0.01" },
+];
+
+function InitialPaperSetup({ strategy, onUpdated }: { strategy: StrategyOverview; onUpdated: () => void }) {
+  const [values, setValues] = useState<PaperSetupValues>(EMPTY_PAPER_SETUP);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const complete = Object.entries(values).every(([key, value]) => key === "ticket_sizing_mode" || value.trim());
+  async function save(event: FormEvent) {
+    event.preventDefault();
+    if (!complete || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await createStrategyPaperSetup(strategy.strategy_id, {
+        strategy_version: strategy.strategy_version,
+        ...values,
+        max_quote_age_seconds: Number(values.max_quote_age_seconds),
+        max_scan_age_seconds: Number(values.max_scan_age_seconds),
+        max_halt_feed_age_seconds: Number(values.max_halt_feed_age_seconds),
+        max_cost_age_seconds: Number(values.max_cost_age_seconds),
+        max_reconciliation_age_seconds: Number(values.max_reconciliation_age_seconds),
+      });
+      onUpdated();
+    } catch (caught) {
+      setError(caught instanceof ApiError ? caught.message : "Initial paper limits were not created.");
+    } finally {
+      setSaving(false);
+    }
+  }
+  return (
+    <details className="border-t border-slate-200 p-4 dark:border-slate-800">
+      <summary className="cursor-pointer text-xs font-semibold">Set explicit first paper limits</summary>
+      <p className="mt-2 text-xs text-slate-500">Every field is an operator decision. Saving creates a disabled deployment; it does not start trading.</p>
+      <form onSubmit={(event) => void save(event)} className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <label className="text-xs">Sizing method<select value={values.ticket_sizing_mode} onChange={(event) => setValues((current) => ({ ...current, ticket_sizing_mode: event.target.value as "percent" | "fixed" }))} className="mt-1 block min-h-10 w-full border border-slate-300 bg-white px-2 dark:border-slate-700 dark:bg-slate-950"><option value="percent">Percent of sleeve</option><option value="fixed">Fixed USD</option></select></label>
+        {PAPER_SETUP_FIELDS.map((field) => (
+          <label key={field.key} className="text-xs">{field.label}<input type="number" step={field.step ?? "1"} value={values[field.key]} onChange={(event) => setValues((current) => ({ ...current, [field.key]: event.target.value }))} className="mt-1 block min-h-10 w-full border border-slate-300 bg-white px-2 dark:border-slate-700 dark:bg-slate-950" /></label>
+        ))}
+        <label className="text-xs sm:col-span-2 lg:col-span-3">Operator reason<input value={values.reason} maxLength={1000} onChange={(event) => setValues((current) => ({ ...current, reason: event.target.value }))} className="mt-1 block min-h-10 w-full border border-slate-300 bg-white px-2 dark:border-slate-700 dark:bg-slate-950" /></label>
+        <button type="submit" disabled={!complete || saving} className="min-h-10 border border-slate-300 px-3 text-xs font-medium disabled:opacity-40 dark:border-slate-700">{saving ? "Saving explicit limits…" : "Create disabled paper setup"}</button>
+      </form>
+      {error ? <p className="mt-2 text-xs text-red-700 dark:text-red-300">{error}</p> : null}
+    </details>
+  );
+}
+
+function ResearchCandidate({ strategy, onUpdated }: { strategy: StrategyOverview; onUpdated: () => void }) {
   const [expanded, setExpanded] = useState(false);
+  const [reason, setReason] = useState("");
+  const [promoting, setPromoting] = useState(false);
+  const [promotionError, setPromotionError] = useState<string | null>(null);
   const arm = representativeArm(strategy);
   const validation = validationState(strategy);
   const ci = arm && arm.expectancy_ci_low_pct !== null && arm.expectancy_ci_high_pct !== null
     ? `${pctPoints(arm.expectancy_ci_low_pct)} to ${pctPoints(arm.expectancy_ci_high_pct)}`
     : "—";
+  async function promote() {
+    if (!strategy.next_promotion_action || !reason.trim()) return;
+    setPromoting(true);
+    setPromotionError(null);
+    try {
+      await advanceStrategyPromotion(strategy.strategy_id, {
+        strategy_version: strategy.strategy_version,
+        action: strategy.next_promotion_action,
+        reason: reason.trim(),
+      });
+      setReason("");
+      onUpdated();
+    } catch (error) {
+      setPromotionError(error instanceof ApiError ? error.message : "Strategy was not advanced.");
+    } finally {
+      setPromoting(false);
+    }
+  }
   return (
     <article className="border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
       <div className="grid gap-4 p-4 lg:grid-cols-[minmax(16rem,1.5fr)_repeat(3,minmax(7rem,0.7fr))_auto] lg:items-center">
@@ -1449,6 +1581,23 @@ function ResearchCandidate({ strategy }: { strategy: StrategyOverview }) {
         </button>
       </div>
       {expanded ? <EvidenceDetail strategy={strategy} /> : null}
+      {strategy.next_promotion_action ? (
+        <div className="border-t border-slate-200 p-4 dark:border-slate-800">
+          <div className="flex flex-wrap items-end gap-3">
+            <label className="min-w-64 flex-1 text-xs text-slate-600 dark:text-slate-300">
+              Operator reason
+              <input value={reason} onChange={(event) => setReason(event.target.value)} maxLength={1000} className="mt-1 block min-h-10 w-full border border-slate-300 bg-white px-2 dark:border-slate-700 dark:bg-slate-950" />
+            </label>
+            <button type="button" onClick={() => void promote()} disabled={promoting || !reason.trim() || strategy.promotion_refusals.length > 0} className="min-h-10 border border-slate-300 px-3 text-xs font-medium disabled:opacity-40 dark:border-slate-700">
+              {promoting ? "Checking evidence…" : PROMOTION_ACTION_LABEL[strategy.next_promotion_action]}
+            </button>
+          </div>
+          {strategy.promotion_refusals.length ? <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">Cannot advance: {strategy.promotion_refusals.map(refusalLabel).join(" · ")}</p> : null}
+          {promotionError ? <p className="mt-2 text-xs text-red-700 dark:text-red-300">{promotionError}</p> : null}
+          <p className="mt-2 text-[10px] text-slate-500">The server selects and pins the complete evidence bundle. This control cannot enable live trading.</p>
+        </div>
+      ) : null}
+      {strategy.stage === "paper_enabled" && strategy.allocation_refusals.includes("execution_policy_missing") ? <InitialPaperSetup strategy={strategy} onUpdated={onUpdated} /> : null}
     </article>
   );
 }
@@ -1737,7 +1886,7 @@ export function StrategiesPage() {
                   ) : null}
                   <div className="space-y-2">
                     {researchCandidates.length
-                      ? researchCandidates.map((strategy) => <ResearchCandidate key={strategy.strategy_id} strategy={strategy} />)
+                      ? researchCandidates.map((strategy) => <ResearchCandidate key={strategy.strategy_id} strategy={strategy} onUpdated={overview.refetch} />)
                       : <EmptyState title="No capital candidates" description="The current bounded research programme produced no strategy safe enough to allocate capital." />}
                   </div>
                 </section>

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1052,8 +1052,11 @@ function AutomationControl({
   // trading flag through one atomic endpoint. Requiring execution_enabled here
   // creates a circular first-enable gate: the flag can never become true
   // because the control that changes it is disabled. The server independently
-  // rechecks evidence readiness and the demo-only boundary on every enable.
-  const canEnable = overview.automation_readiness.ready && overview.demo_connection && riskProfile !== "unconfigured";
+  // rechecks evidence readiness, the demo boundary, and live-off state on every enable.
+  const canEnable = overview.automation_readiness.ready
+    && overview.demo_connection
+    && !overview.live_execution_enabled
+    && riskProfile !== "unconfigured";
   const selectedMandate = riskProfile === pool.mandate.risk_profile && pool.mandate.configured
     ? pool.mandate
     : pool.available_mandates.find((mandate) => mandate.risk_profile === riskProfile) ?? null;
@@ -1166,6 +1169,8 @@ function AutomationControl({
         <p className="mt-4 text-xs text-amber-700 dark:text-amber-300">
           {!overview.demo_connection
             ? "Paper automation can only be enabled while connected to the demo environment."
+            : overview.live_execution_enabled
+              ? "Turn off system-wide live trading before enabling paper automation."
             : riskProfile === "unconfigured"
               ? "Choose a risk profile before allowing new entries."
             : "Automation stays off until at least one strategy passes validation."}

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -364,6 +364,10 @@ const REFUSAL_LABELS: Record<string, string> = {
   position_operation_reconciliation_not_found: "Latest operation was not found at the broker",
   position_operation_reconciliation_ambiguous: "Latest operation has ambiguous broker reconciliation",
   position_operation_reconciliation_error: "Latest operation reconciliation failed",
+  entry_order_reconciliation_not_found: "Entry order was not found at the broker",
+  entry_order_reconciliation_ambiguous: "Entry order has ambiguous broker reconciliation",
+  entry_order_reconciliation_rejected: "Entry order was rejected by the broker",
+  entry_order_reconciliation_error: "Entry order reconciliation failed",
 };
 
 function refusalLabel(refusal: string): string {
@@ -708,6 +712,9 @@ function StrategyActivity({
               <tbody>
                 {items.map((signal) => {
                   const funding = fundingPresentation(signal);
+                  const operationalLifecycleReasons = (signal.trade_lifecycle?.incomplete_reasons ?? []).filter(
+                    (reason) => reason.startsWith("entry_order_") || reason.startsWith("position_operation_"),
+                  );
                   return (
                     <tr key={signal.signal_id} className="border-t border-slate-200 align-top dark:border-slate-800">
                       <td className="px-4 py-3">
@@ -761,6 +768,9 @@ function StrategyActivity({
                               </span>
                             ) : null}
                             {signal.trade_lifecycle.latest_reconciliation_error ? <span className="block text-red-700 dark:text-red-300">{refusalLabel(signal.trade_lifecycle.latest_reconciliation_error)}</span> : null}
+                            {operationalLifecycleReasons.length > 0 ? (
+                              <span className="block text-red-700 dark:text-red-300">{operationalLifecycleReasons.map(refusalLabel).join(" · ")}</span>
+                            ) : null}
                           </>
                         ) : null}
                       </td>

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1358,7 +1358,7 @@ function ApprovedStrategy({
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-semibold">{strategy.title}</h3>
           <Badge tone={strategy.allocation_ready ? "ok" : "warn"}>
-            {strategy.allocation_ready ? "Approved" : "Managing existing position"}
+            {strategy.allocation_ready ? "Approved" : "New entries blocked"}
           </Badge>
         </div>
         <p className="mt-1 max-w-md text-xs text-slate-500">{strategy.description}</p>
@@ -1820,7 +1820,7 @@ export function StrategiesPage() {
               <div className="mb-3 flex flex-wrap items-end justify-between gap-2">
                 <div>
                   <h2 className="text-sm font-semibold">Approved &amp; managed strategies</h2>
-                  <p className="mt-1 text-xs text-slate-500">Approved strategies may use the shared pot; an invalidated strategy remains visible only while it manages an existing position.</p>
+                  <p className="mt-1 text-xs text-slate-500">Approved strategies may use the shared pot. An enabled strategy that later fails a gate remains visible, but cannot open a new position.</p>
                 </div>
                 <span className="text-xs text-slate-500">{summary.approved} approved</span>
               </div>

--- a/scripts/audit_2697_legacy_metric_axis.py
+++ b/scripts/audit_2697_legacy_metric_axis.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Outcome-blind structural audit of run 98349 for #2697.
+"""Outcome-blind structural audit of an explicitly named legacy run for #2697.
 
 This script deliberately never selects a performance, trade, comparator,
 bootstrap, deflation, or synthetic-control value. It establishes only that the
@@ -10,6 +10,7 @@ current promotion rule as ``metric_axis_unproven``.
 
 from __future__ import annotations
 
+import argparse
 import json
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -31,8 +32,12 @@ from scripts.audit_2745_in_sample_run import (
     EXPECTED_KEYS,
     EXPECTED_STRATEGY_VERSIONS,
     EXPECTED_TRIAL_COUNT,
-    RUN_ID,
 )
+
+_EXPECTED_PARAMS: Final = {
+    "synthetic_control": True,
+    "trial_register_version": "trial-register-2026-08-15-r6",
+}
 
 _AXIS_FIELDS: Final = (
     "metric_axis_rule_version",
@@ -54,12 +59,13 @@ class _NoMetricAccess:
 
 @dataclass(frozen=True)
 class StructuralAudit:
+    run_id: int
     failures: tuple[str, ...]
     result_ids: tuple[int, ...]
 
     def as_dict(self) -> dict[str, object]:
         return {
-            "run_id": RUN_ID,
+            "run_id": self.run_id,
             "audit": "metric-axis-legacy-structural-only",
             "performance_fields_read": False,
             "result_ids": list(self.result_ids),
@@ -91,7 +97,7 @@ def _identity(row: dict[str, Any]) -> ResultIdentity:
     )
 
 
-def audit_rows(rows: list[dict[str, Any]]) -> StructuralAudit:
+def audit_rows(rows: list[dict[str, Any]], *, run_id: int) -> StructuralAudit:
     failures: list[str] = []
     keyed: dict[tuple[str, str, str], dict[str, Any]] = {}
     for row in rows:
@@ -135,6 +141,7 @@ def audit_rows(rows: list[dict[str, Any]]) -> StructuralAudit:
     if extra:
         failures.append(f"unexpected result keys: {extra}")
     return StructuralAudit(
+        run_id=run_id,
         failures=tuple(sorted(set(failures))),
         result_ids=tuple(sorted(int(row["result_id"]) for row in rows)),
     )
@@ -158,27 +165,89 @@ ORDER BY strategy_id, ambiguity_arm, quarantine_arm, result_id
 """
 
 
+def invocation_failures(
+    *,
+    job_name: object,
+    params: object,
+    request_id: object,
+    request: tuple[object, object] | None,
+) -> tuple[str, ...]:
+    """Validate exact run/request provenance without consulting result relations."""
+    failures: list[str] = []
+    if job_name != "strategy_backtest_run":
+        failures.append(f"unexpected job name {job_name!r}")
+    if params != _EXPECTED_PARAMS:
+        failures.append("job params_snapshot is not the exact declared r6 payload")
+    if request is None:
+        failures.append(f"linked request {request_id!r} is missing")
+    else:
+        request_job_name, payload = request
+        if request_job_name != job_name:
+            failures.append("linked request job name differs from run")
+        if payload != {"control": {}, "params": _EXPECTED_PARAMS}:
+            failures.append("linked request is not the exact declared r6 payload")
+    return tuple(failures)
+
+
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", type=int, required=True)
+    args = parser.parse_args()
+    if args.run_id <= 0:
+        parser.error("--run-id must be positive")
+
     with psycopg.connect(settings.database_url) as conn:
         job = conn.execute(
-            "SELECT status, started_at, finished_at, row_count, error_msg FROM job_runs WHERE run_id = %s",
-            (RUN_ID,),
+            """SELECT job_name, status, started_at, finished_at, row_count,
+                      error_msg, linked_request_id, params_snapshot
+               FROM job_runs WHERE run_id = %s""",
+            (args.run_id,),
         ).fetchone()
         if job is None:
-            print(json.dumps({"run_id": RUN_ID, "state": "missing"}, sort_keys=True))
+            print(json.dumps({"run_id": args.run_id, "state": "missing"}, sort_keys=True))
             return 2
-        status, started_at, finished_at, job_row_count, error = job
+        job_name, status, started_at, finished_at, job_row_count, error, request_id, params = job
         if status != "success" or finished_at is None:
-            print(json.dumps({"run_id": RUN_ID, "state": status, "error": error}, sort_keys=True, default=str))
+            print(
+                json.dumps(
+                    {"run_id": args.run_id, "state": status, "error": error},
+                    sort_keys=True,
+                    default=str,
+                )
+            )
             return 2
+        request = conn.execute(
+            "SELECT job_name, payload FROM pending_job_requests WHERE request_id = %s",
+            (request_id,),
+        ).fetchone()
+        provenance_failures = invocation_failures(
+            job_name=job_name,
+            params=params,
+            request_id=request_id,
+            request=request,
+        )
+        if provenance_failures:
+            print(
+                json.dumps(
+                    {
+                        "run_id": args.run_id,
+                        "audit": "metric-axis-legacy-structural-only",
+                        "performance_fields_read": False,
+                        "failures": provenance_failures,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 1
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(_RESULT_SQL, {"started_at": started_at, "finished_at": finished_at})
             rows = list(cursor.fetchall())
-        report = audit_rows(rows)
+        report = audit_rows(rows, run_id=args.run_id)
         failures = list(report.failures)
         if job_row_count != len(EXPECTED_KEYS):
             failures.append(f"job row_count {job_row_count!r} != {len(EXPECTED_KEYS)}")
-            report = StructuralAudit(tuple(sorted(set(failures))), report.result_ids)
+            report = StructuralAudit(args.run_id, tuple(sorted(set(failures))), report.result_ids)
         print(json.dumps(report.as_dict(), indent=2, sort_keys=True))
         return 1 if report.failures else 0
 

--- a/scripts/audit_2769_mt1_invocation.py
+++ b/scripts/audit_2769_mt1_invocation.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import math
 import sys
+from collections.abc import Mapping
+from datetime import date
+from typing import cast
 
 import psycopg
 
@@ -11,6 +16,107 @@ from app.config import settings
 from app.services.strategy_mt1_read_model import load_mt1_controlled_trial_state
 
 _ARM_PREFIXES = {"mt1_scaled", "mt1_unscaled", "s8_scaled", "s8_unscaled"}
+_RISK_KEYS = {"certainty_equivalent", "expected_shortfall_5", "maximum_drawdown"}
+_RESULT_KEYS = {
+    "bootstrap_block_length",
+    "bootstrap_resamples",
+    "bootstrap_seed",
+    "common_months",
+    "evaluator_version",
+    "excluded_months_by_arm",
+    "historical_statistical_conjuncts_pass",
+    "mt1_delta_cer",
+    "mt1_delta_interval",
+    "mt1_drawdown_improved",
+    "mt1_expected_shortfall_improved",
+    "mt1_lower_bound_positive",
+    "mt1_scaled",
+    "mt1_unscaled",
+    "primary_difference_in_differences",
+    "primary_interval",
+    "primary_lower_bound_positive",
+    "s8_delta_cer",
+    "s8_scaled",
+    "s8_unscaled",
+}
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode()
+    ).hexdigest()
+
+
+def _finite_number_string(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        return math.isfinite(float(value))
+    except ValueError:
+        return False
+
+
+def _valid_result_payload(payload: object) -> bool:
+    if not isinstance(payload, dict) or set(payload) != _RESULT_KEYS:
+        return False
+    for role in _ARM_PREFIXES:
+        risk = payload.get(role)
+        if not isinstance(risk, dict) or set(risk) != _RISK_KEYS:
+            return False
+        if not all(_finite_number_string(value) for value in risk.values()):
+            return False
+    intervals = (payload.get("mt1_delta_interval"), payload.get("primary_interval"))
+    if any(
+        not isinstance(interval, dict)
+        or set(interval) != {"low", "high"}
+        or not all(_finite_number_string(value) for value in interval.values())
+        for interval in intervals
+    ):
+        return False
+    scalars = ("mt1_delta_cer", "s8_delta_cer", "primary_difference_in_differences")
+    if not all(_finite_number_string(payload.get(field)) for field in scalars):
+        return False
+    if any(
+        not isinstance(payload.get(field), bool)
+        for field in (
+            "historical_statistical_conjuncts_pass",
+            "mt1_drawdown_improved",
+            "mt1_expected_shortfall_improved",
+            "mt1_lower_bound_positive",
+            "primary_lower_bound_positive",
+        )
+    ):
+        return False
+    if any(
+        not isinstance(payload.get(field), int) or isinstance(payload.get(field), bool) or int(payload[field]) < 1
+        for field in ("bootstrap_block_length", "bootstrap_resamples")
+    ):
+        return False
+    if not isinstance(payload.get("bootstrap_seed"), int) or isinstance(payload.get("bootstrap_seed"), bool):
+        return False
+    if not isinstance(payload.get("evaluator_version"), str) or not str(payload["evaluator_version"]).strip():
+        return False
+    exclusions = payload.get("excluded_months_by_arm")
+    if (
+        not isinstance(exclusions, list)
+        or len(exclusions) != 4
+        or any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in exclusions)
+    ):
+        return False
+    raw_months = payload.get("common_months")
+    if (
+        not isinstance(raw_months, list)
+        or len(raw_months) < 120
+        or not all(isinstance(item, str) for item in raw_months)
+    ):
+        return False
+    try:
+        months = tuple(date.fromisoformat(item) for item in raw_months)
+    except ValueError:
+        return False
+    return all(item.day == 1 for item in months) and all(
+        current > previous for previous, current in zip(months, months[1:])
+    )
 
 
 def main() -> int:
@@ -52,6 +158,21 @@ def main() -> int:
                 (sorted(expected_role_columns),),
             ).fetchall()
         }
+        result_header = None
+        result_evidence: list[tuple[object, ...]] = []
+        if state.trial_result_id is not None:
+            result_header = conn.execute(
+                """SELECT historical_conjuncts_pass, evidence_sha256, evidence_json
+                     FROM strategy_mt1_trial_results WHERE mt1_trial_result_id = %s""",
+                (state.trial_result_id,),
+            ).fetchone()
+            result_evidence = conn.execute(
+                """SELECT ambiguity_arm, quarantine_arm, historical_conjuncts_pass,
+                          evidence_sha256, evidence_json
+                     FROM strategy_mt1_trial_result_cells WHERE mt1_trial_result_id = %s
+                     ORDER BY ambiguity_arm, quarantine_arm""",
+                (state.trial_result_id,),
+            ).fetchall()
 
     attempt_count, result_count, result_cell_count = (int(value) for value in counts)
     differences = list(state.integrity_refusals)
@@ -67,6 +188,34 @@ def main() -> int:
             differences.append(f"result_cell_count={result_cell_count}")
         if role_columns != _ARM_PREFIXES:
             differences.append("four_arm_role_schema_incomplete")
+        if result_header is None:
+            differences.append("result_header_missing")
+        else:
+            declared_pass, header_sha, raw_header = result_header
+            header = cast(dict[str, object], raw_header) if isinstance(raw_header, dict) else None
+            if header is None:
+                differences.append("result_header_shape_invalid")
+            elif _digest(header) != str(header_sha):
+                differences.append("result_header_digest_mismatch")
+            if header is not None and set(header) != {"historical_conjuncts_pass", "result_cell_digests"}:
+                differences.append("result_header_shape_invalid")
+            if header is not None and header.get("historical_conjuncts_pass") is not bool(declared_pass):
+                differences.append("result_header_conjunction_mismatch")
+            cell_digests = [str(row[3]) for row in result_evidence]
+            if header is not None and header.get("result_cell_digests") != cell_digests:
+                differences.append("result_header_child_digest_chain_mismatch")
+        for ambiguity, quarantine, passed, evidence_sha, raw_payload in result_evidence:
+            label = f"{ambiguity}:{quarantine}"
+            if not isinstance(raw_payload, dict):
+                differences.append(f"result_cell_shape_invalid:{label}")
+                continue
+            payload = cast(dict[str, object], raw_payload)
+            if _digest(payload) != str(evidence_sha):
+                differences.append(f"result_cell_digest_mismatch:{label}")
+            if not _valid_result_payload(payload):
+                differences.append(f"result_cell_shape_invalid:{label}")
+            if payload.get("historical_statistical_conjuncts_pass") is not bool(passed):
+                differences.append(f"result_cell_conjunction_mismatch:{label}")
     if state.holdout_evaluations:
         differences.append(f"holdout_evaluations={state.holdout_evaluations}")
     if state.holdout_accesses:

--- a/scripts/audit_2769_mt1_invocation.py
+++ b/scripts/audit_2769_mt1_invocation.py
@@ -1,0 +1,103 @@
+"""Audit one atomic MT-1 invocation without selecting a performance value."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.services.strategy_mt1_read_model import load_mt1_controlled_trial_state
+
+_ARM_PREFIXES = {"mt1_scaled", "mt1_unscaled", "s8_scaled", "s8_unscaled"}
+
+
+def main() -> int:
+    with psycopg.connect(settings.database_url) as conn:
+        state = load_mt1_controlled_trial_state(conn)
+        counts = conn.execute(
+            """
+            SELECT
+                (SELECT count(*) FROM strategy_mt1_structural_attempts
+                  WHERE mt1_strategy_version = %s AND s8_strategy_version = %s),
+                (SELECT count(*) FROM strategy_mt1_trial_results r
+                  JOIN strategy_mt1_structural_attempts a USING (structural_attempt_id)
+                 WHERE a.mt1_strategy_version = %s AND a.s8_strategy_version = %s),
+                (SELECT count(*) FROM strategy_mt1_trial_result_cells c
+                  JOIN strategy_mt1_trial_results r USING (mt1_trial_result_id)
+                  JOIN strategy_mt1_structural_attempts a USING (structural_attempt_id)
+                 WHERE a.mt1_strategy_version = %s AND a.s8_strategy_version = %s)
+            """,
+            (
+                state.strategy_version,
+                state.negative_control_version,
+                state.strategy_version,
+                state.negative_control_version,
+                state.strategy_version,
+                state.negative_control_version,
+            ),
+        ).fetchone()
+        assert counts is not None
+        expected_role_columns = {f"{prefix}_certainty_equivalent": prefix for prefix in _ARM_PREFIXES}
+        role_columns = {
+            expected_role_columns[str(row[0])]
+            for row in conn.execute(
+                """
+                SELECT column_name FROM information_schema.columns
+                 WHERE table_schema = 'public'
+                   AND table_name = 'strategy_mt1_trial_result_cells'
+                   AND column_name = ANY(%s)
+                """,
+                (sorted(expected_role_columns),),
+            ).fetchall()
+        }
+
+    attempt_count, result_count, result_cell_count = (int(value) for value in counts)
+    differences = list(state.integrity_refusals)
+    if attempt_count != 1:
+        differences.append(f"structural_attempt_count={attempt_count}")
+    if state.state == "structural_refused":
+        if result_count or result_cell_count:
+            differences.append("structural_refusal_exposed_results")
+    else:
+        if result_count != 1:
+            differences.append(f"trial_result_count={result_count}")
+        if result_cell_count != 4:
+            differences.append(f"result_cell_count={result_cell_count}")
+        if role_columns != _ARM_PREFIXES:
+            differences.append("four_arm_role_schema_incomplete")
+    if state.holdout_evaluations:
+        differences.append(f"holdout_evaluations={state.holdout_evaluations}")
+    if state.holdout_accesses:
+        differences.append(f"holdout_accesses={state.holdout_accesses}")
+    if state.state in {"not_run", "structural_passed_outcomes_pending", "evidence_inconsistent"}:
+        differences.append(f"terminal_state={state.state}")
+    output = {
+        "arm_roles": result_cell_count * len(role_columns),
+        "differences": sorted(set(differences)),
+        "holdout_accesses": state.holdout_accesses,
+        "holdout_evaluations": state.holdout_evaluations,
+        "result_cells": [
+            {
+                "ambiguity_arm": cell.ambiguity_arm,
+                "historical_conjuncts_pass": cell.historical_conjuncts_pass,
+                "quarantine_arm": cell.quarantine_arm,
+            }
+            for cell in state.result_cells
+        ],
+        "state": state.state,
+        "status": "verified" if not differences else "refused",
+        "structural_attempts": attempt_count,
+        "structural_cells": state.structural_cells,
+        "trial_results": result_count,
+    }
+    (sys.stdout if not differences else sys.stderr).write(json.dumps(output, sort_keys=True) + "\n")
+    return 0 if not differences else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main"]

--- a/scripts/audit_2769_mt1_structural.py
+++ b/scripts/audit_2769_mt1_structural.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import sys
 from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation
 
 import psycopg
 import psycopg.rows
@@ -27,6 +28,13 @@ def _digest(payload: Mapping[str, object]) -> str:
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode()
     ).hexdigest()
+
+
+def _same_number(encoded: object, stored: object) -> bool:
+    try:
+        return isinstance(encoded, str) and Decimal(encoded) == Decimal(str(stored))
+    except InvalidOperation:
+        return False
 
 
 def main() -> int:
@@ -56,6 +64,8 @@ def main() -> int:
                     SELECT ambiguity_arm, quarantine_arm,
                            cardinality(mt1_decision_dates) AS mt1_decision_dates,
                            cardinality(s8_decision_dates) AS s8_decision_dates,
+                           mt1_decision_dates AS _mt1_decision_dates,
+                           s8_decision_dates AS _s8_decision_dates,
                            mt1_annualised_turnover, s8_annualised_turnover,
                            mt1_traded_notional, s8_traded_notional, exposure_reconciled,
                            evidence_sha256, evidence_json
@@ -75,9 +85,60 @@ def main() -> int:
         differences.append("refused_attempt_has_cells")
     if _digest(attempt["structural_evidence_json"]) != attempt["structural_evidence_sha256"]:
         differences.append("structural_header_digest_mismatch")
+    header_payload = attempt["structural_evidence_json"]
+    child_digests = [str(row["evidence_sha256"]) for row in cells]
+    if header_payload.get("structural_cell_digests") != child_digests:
+        differences.append("structural_header_child_digest_chain_mismatch")
+    for field in (
+        "book_rule_version",
+        "corpus_version",
+        "cost_model_id",
+        "evaluator_version",
+        "metric_axis_digest",
+        "metric_axis_rule_version",
+        "opportunity_set_digest",
+        "trial_contract_version",
+        "trial_register_version",
+    ):
+        if header_payload.get(field) != attempt[field]:
+            differences.append(f"structural_header_column_mismatch:{field}")
+    if header_payload.get("passed") is not bool(attempt["passed"]):
+        differences.append("structural_header_column_mismatch:passed")
     for row in cells:
-        if _digest(row["evidence_json"]) != row["evidence_sha256"]:
+        payload = row["evidence_json"]
+        label = f"{row['ambiguity_arm']}:{row['quarantine_arm']}"
+        if _digest(payload) != row["evidence_sha256"]:
             differences.append(f"cell_digest_mismatch:{row['ambiguity_arm']}:{row['quarantine_arm']}")
+        if (
+            payload.get("ambiguity_arm") != row["ambiguity_arm"]
+            or payload.get("quarantine_arm") != row["quarantine_arm"]
+        ):
+            differences.append(f"cell_key_column_mismatch:{label}")
+        mt1_dates = payload.get("mt1_decision_dates")
+        s8_dates = payload.get("s8_decision_dates")
+        stored_mt1_dates = [item.isoformat() for item in row["_mt1_decision_dates"]]
+        stored_s8_dates = [item.isoformat() for item in row["_s8_decision_dates"]]
+        if (
+            not isinstance(mt1_dates, list)
+            or not isinstance(s8_dates, list)
+            or len(mt1_dates) != row["mt1_decision_dates"]
+            or len(s8_dates) != row["s8_decision_dates"]
+            or mt1_dates != stored_mt1_dates
+            or s8_dates != stored_s8_dates
+        ):
+            differences.append(f"cell_clock_column_mismatch:{label}")
+        if payload.get("book_rule_version") != attempt["book_rule_version"]:
+            differences.append(f"cell_book_rule_mismatch:{label}")
+        for field in (
+            "mt1_annualised_turnover",
+            "s8_annualised_turnover",
+            "mt1_traded_notional",
+            "s8_traded_notional",
+        ):
+            if not _same_number(payload.get(field), row[field]):
+                differences.append(f"cell_numeric_column_mismatch:{label}:{field}")
+        if payload.get("exposure_reconciled") is not bool(row["exposure_reconciled"]):
+            differences.append(f"cell_exposure_column_mismatch:{label}")
     output = {
         "differences": sorted(differences),
         "status": "verified" if not differences else "refused",
@@ -86,7 +147,10 @@ def main() -> int:
             for key, value in attempt.items()
             if key != "structural_evidence_json"
         },
-        "structural_cells": [{key: value for key, value in row.items() if key != "evidence_json"} for row in cells],
+        "structural_cells": [
+            {key: value for key, value in row.items() if key != "evidence_json" and not key.startswith("_")}
+            for row in cells
+        ],
     }
     (sys.stdout if not differences else sys.stderr).write(json.dumps(output, sort_keys=True, default=str) + "\n")
     return 0 if not differences else 2

--- a/scripts/audit_2769_mt1_structural.py
+++ b/scripts/audit_2769_mt1_structural.py
@@ -1,0 +1,99 @@
+"""Emit the complete MT-1 structural fan without querying a performance table."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from collections.abc import Mapping
+
+import psycopg
+import psycopg.rows
+
+from app.config import settings
+from app.services.backtest_run import BACKTEST_UNIVERSE
+from app.services.cost_model import COST_MODEL_ID
+from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
+
+_EXPECTED_FAN = {
+    ("best_case", "masked"),
+    ("best_case", "admitted"),
+    ("worst_case", "masked"),
+    ("worst_case", "admitted"),
+}
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode()
+    ).hexdigest()
+
+
+def main() -> int:
+    mt1 = mt1_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s8 = s8_control_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            attempt = cur.execute(
+                """
+                SELECT structural_attempt_id, passed, refusal_code, refusal_detail, assessed_at,
+                       metric_axis_rule_version, cardinality(metric_axis_dates) AS metric_axis_dates,
+                       metric_axis_start, metric_axis_end, metric_axis_digest,
+                       opportunity_set_digest, corpus_version, cost_model_id,
+                       trial_register_version, trial_contract_version, book_rule_version,
+                       evaluator_version, structural_evidence_sha256, structural_evidence_json
+                  FROM strategy_mt1_structural_attempts
+                 WHERE mt1_strategy_version = %s AND s8_strategy_version = %s
+                """,
+                (mt1.version, s8.version),
+            ).fetchone()
+            if attempt is None:
+                sys.stderr.write(json.dumps({"status": "refused", "reason": "structural_attempt_missing"}) + "\n")
+                return 2
+            cells = list(
+                cur.execute(
+                    """
+                    SELECT ambiguity_arm, quarantine_arm,
+                           cardinality(mt1_decision_dates) AS mt1_decision_dates,
+                           cardinality(s8_decision_dates) AS s8_decision_dates,
+                           mt1_annualised_turnover, s8_annualised_turnover,
+                           mt1_traded_notional, s8_traded_notional, exposure_reconciled,
+                           evidence_sha256, evidence_json
+                      FROM strategy_mt1_structural_cells
+                     WHERE structural_attempt_id = %s
+                     ORDER BY ambiguity_arm, quarantine_arm
+                    """,
+                    (attempt["structural_attempt_id"],),
+                ).fetchall()
+            )
+
+    differences: list[str] = []
+    keys = {(str(row["ambiguity_arm"]), str(row["quarantine_arm"])) for row in cells}
+    if bool(attempt["passed"]) and keys != _EXPECTED_FAN:
+        differences.append("structural_fan_incomplete")
+    if not bool(attempt["passed"]) and cells:
+        differences.append("refused_attempt_has_cells")
+    if _digest(attempt["structural_evidence_json"]) != attempt["structural_evidence_sha256"]:
+        differences.append("structural_header_digest_mismatch")
+    for row in cells:
+        if _digest(row["evidence_json"]) != row["evidence_sha256"]:
+            differences.append(f"cell_digest_mismatch:{row['ambiguity_arm']}:{row['quarantine_arm']}")
+    output = {
+        "differences": sorted(differences),
+        "status": "verified" if not differences else "refused",
+        "structural_attempt": {
+            key: value.isoformat() if hasattr(value, "isoformat") else value
+            for key, value in attempt.items()
+            if key != "structural_evidence_json"
+        },
+        "structural_cells": [{key: value for key, value in row.items() if key != "evidence_json"} for row in cells],
+    }
+    (sys.stdout if not differences else sys.stderr).write(json.dumps(output, sort_keys=True, default=str) + "\n")
+    return 0 if not differences else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main"]

--- a/scripts/audit_2769_mt1_structural.py
+++ b/scripts/audit_2769_mt1_structural.py
@@ -48,6 +48,7 @@ def main() -> int:
                        metric_axis_rule_version, cardinality(metric_axis_dates) AS metric_axis_dates,
                        metric_axis_start, metric_axis_end, metric_axis_digest,
                        opportunity_set_digest, corpus_version, cost_model_id,
+                       runner_source_head,
                        trial_register_version, trial_contract_version, book_rule_version,
                        evaluator_version, structural_evidence_sha256, structural_evidence_json
                   FROM strategy_mt1_structural_attempts
@@ -97,6 +98,7 @@ def main() -> int:
         "metric_axis_digest",
         "metric_axis_rule_version",
         "opportunity_set_digest",
+        "runner_source_head",
         "trial_contract_version",
         "trial_register_version",
     ):

--- a/scripts/freeze_2437_mt1_declarations.py
+++ b/scripts/freeze_2437_mt1_declarations.py
@@ -16,81 +16,22 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import sys
-from typing import Final
 
 import psycopg
 
 from app.config import settings
-from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, FX_UNMODELLED
-from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
+from app.services.prereg_contract import PreregDeclaration
 from app.services.result_ledger import PreregDeclarationRefused, freeze_preregistration, load_preregistration
-from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
-from app.services.strategy_mt1_trial import TRIAL_CONTRACT_VERSION
-from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION, structural_promotion_refusals
-from scripts._prereg_freeze_guard import assert_policy_version_merged, policy_version_report
-
-DECLARED_BY: Final = "scripts/freeze_2437_mt1_declarations.py (#2437)"
-UNIVERSE_BASIS: Final = "survivorship_free"
-
-_Z_0975: Final = 1.959963984540054
-_Z_08: Final = 0.8416212335729143
-_STANDARDISED_EFFECT: Final = 0.5
-_POWER_DERIVED_MONTHS: Final = math.ceil(((_Z_0975 + _Z_08) / _STANDARDISED_EFFECT) ** 2)
-MIN_FORWARD_DECISION_DATES: Final = max(36, _POWER_DERIVED_MONTHS)
-MIN_FORWARD_CALENDAR_WEEKS: Final = math.ceil(MIN_FORWARD_DECISION_DATES * 365.25 / (12 * 7))
-
-_FORWARD_SHADOW_DERIVATION: Final = (
-    "Frozen preregistration power floor: standardised paired monthly effect=0.5, alpha=0.05 two-sided, "
-    "power=0.8; z_0.975=1.959963984540054 and z_0.8=0.8416212335729143. "
-    "n=ceil(((1.959963984540054+0.8416212335729143)/0.5)^2)=32 independent decision months; raised to "
-    "36 months to cover three complete calendar years. Calendar duration="
-    "ceil(36x365.25/(12x7))=157 weeks. Prospective inference still uses the preregistered paired "
-    "moving-block bootstrap; this floor does not assert monthly independence."
+from app.services.strategy_mt1_preregistration import (
+    DECLARED_BY,
+    MIN_FORWARD_CALENDAR_WEEKS,
+    MIN_FORWARD_DECISION_DATES,
+    build_declarations,
+    build_mt1_declaration,
+    build_s8_control_declaration,
 )
-
-
-def _build(*, control: bool) -> PreregDeclaration:
-    identity = (
-        s8_control_identity(universe=UNIVERSE_BASIS, cost_model_id=COST_MODEL_ID)
-        if control
-        else mt1_identity(universe=UNIVERSE_BASIS, cost_model_id=COST_MODEL_ID)
-    )
-    expected = structural_promotion_refusals(
-        universe_basis=UNIVERSE_BASIS,
-        carry_unmodelled=CARRY_UNMODELLED,
-        fx_unmodelled=FX_UNMODELLED,
-    )
-    return PreregDeclaration(
-        strategy_id=identity.strategy_id,
-        strategy_version=identity.version,
-        contract_version=TRIAL_CONTRACT_VERSION,
-        prereg_purpose="falsification_only" if control else "capital_candidate",
-        structural_refusal_policy_version=STRUCTURAL_REFUSAL_POLICY_VERSION,
-        declared_universe_basis=UNIVERSE_BASIS,
-        declared_carry_unmodelled=CARRY_UNMODELLED,
-        declared_fx_unmodelled=FX_UNMODELLED,
-        expected_structural_refusals=expected,
-        forward_shadow=ForwardShadowFloor(
-            min_independent_decision_dates=MIN_FORWARD_DECISION_DATES,
-            min_calendar_weeks=MIN_FORWARD_CALENDAR_WEEKS,
-            derivation=_FORWARD_SHADOW_DERIVATION,
-        ),
-        declared_by=DECLARED_BY,
-    )
-
-
-def build_mt1_declaration() -> PreregDeclaration:
-    return _build(control=False)
-
-
-def build_s8_control_declaration() -> PreregDeclaration:
-    return _build(control=True)
-
-
-def build_declarations() -> tuple[PreregDeclaration, PreregDeclaration]:
-    return build_mt1_declaration(), build_s8_control_declaration()
+from scripts._prereg_freeze_guard import assert_policy_version_merged, policy_version_report
 
 
 def _summary(declaration: PreregDeclaration) -> dict[str, object]:

--- a/scripts/run_2769_mt1_in_sample.py
+++ b/scripts/run_2769_mt1_in_sample.py
@@ -59,6 +59,8 @@ def assert_exact_clean_main_source() -> dict[str, object]:
         raise SystemExit("refusing MT-1: the runner worktree is not clean")
     source_head = head.strip()
     main_head = main.strip()
+    if len(source_head) != 40 or any(character not in "0123456789abcdef" for character in source_head):
+        raise SystemExit("refusing MT-1: runner head is not an exact lower-case Git object ID")
     if source_head != main_head:
         raise SystemExit(
             f"refusing MT-1: runner head {source_head} is not exact origin/main {main_head}; merge and update first"
@@ -126,7 +128,11 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 0
 
-        stored = run_and_store_mt1_in_sample_evaluation(conn, progress=_progress)
+        stored = run_and_store_mt1_in_sample_evaluation(
+            conn,
+            runner_source_head=str(source["runner_source_head"]),
+            progress=_progress,
+        )
     if isinstance(stored, MT1StoredRefusal):
         sys.stdout.write(
             json.dumps(

--- a/scripts/run_2769_mt1_in_sample.py
+++ b/scripts/run_2769_mt1_in_sample.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
+from pathlib import Path
 
 import psycopg
 
@@ -24,9 +26,48 @@ from app.services.strategy_mt1_store import (
     MT1StoredRefusal,
     run_and_store_mt1_in_sample_evaluation,
 )
-from scripts._prereg_freeze_guard import assert_policy_version_merged
+from scripts._prereg_freeze_guard import assert_policy_version_merged, refresh_main_ref
 
 ACKNOWLEDGEMENT = "RUN-2769-PREREGISTERED-IN-SAMPLE"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git_output(*args: str) -> str | None:
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed executable and internal arguments
+            ["git", *args],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    return completed.stdout if completed.returncode == 0 else None
+
+
+def assert_exact_clean_main_source() -> dict[str, object]:
+    """Refuse immutable evidence unless this exact clean runner is on main."""
+    if not refresh_main_ref():
+        raise SystemExit("refusing MT-1: origin/main could not be refreshed")
+    status = _git_output("status", "--porcelain")
+    head = _git_output("rev-parse", "HEAD")
+    main = _git_output("rev-parse", "origin/main")
+    if status is None or head is None or main is None:
+        raise SystemExit("refusing MT-1: the exact source head could not be established")
+    if status.strip():
+        raise SystemExit("refusing MT-1: the runner worktree is not clean")
+    source_head = head.strip()
+    main_head = main.strip()
+    if source_head != main_head:
+        raise SystemExit(
+            f"refusing MT-1: runner head {source_head} is not exact origin/main {main_head}; merge and update first"
+        )
+    return {
+        "runner_source_clean": True,
+        "runner_source_head": source_head,
+        "runner_source_matches_main": True,
+    }
 
 
 def _progress(event: BacktestProgressEvent) -> None:
@@ -58,6 +99,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.execute is not None and args.execute != ACKNOWLEDGEMENT:
         parser.error(f"--execute requires the exact acknowledgement {ACKNOWLEDGEMENT!r}")
 
+    source = assert_exact_clean_main_source()
     policy = assert_policy_version_merged()
     with psycopg.connect(settings.database_url) as conn:
         if args.execute is None:
@@ -66,6 +108,7 @@ def main(argv: list[str] | None = None) -> int:
                 json.dumps(
                     {
                         **policy,
+                        **source,
                         "declarations": [
                             {
                                 "declaration_id": item.declaration_id,
@@ -89,6 +132,7 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(
                 {
                     **policy,
+                    **source,
                     "detail": stored.detail,
                     "outcome": "structural_gate_refused_no_performance_stored",
                     "structural_attempt_id": stored.structural_attempt_id,
@@ -103,6 +147,7 @@ def main(argv: list[str] | None = None) -> int:
         json.dumps(
             {
                 **policy,
+                **source,
                 "all_four_historical_conjuncts_pass": (stored.evaluation.bundle.historical_statistical_conjuncts_pass),
                 "outcome": "complete_four_cell_result_stored",
                 "structural_attempt_id": stored.structural_attempt_id,
@@ -119,4 +164,4 @@ if __name__ == "__main__":
     raise SystemExit(main())
 
 
-__all__ = ["ACKNOWLEDGEMENT", "main"]
+__all__ = ["ACKNOWLEDGEMENT", "assert_exact_clean_main_source", "main"]

--- a/scripts/run_2769_mt1_in_sample.py
+++ b/scripts/run_2769_mt1_in_sample.py
@@ -1,0 +1,122 @@
+"""Run the preregistered, in-sample-only MT-1 controlled trial (#2769).
+
+Without ``--execute`` this command validates the exact current declarations
+and confirms that neither holdout outcomes nor holdout access records exist.
+The execution path is deliberately two phase: it commits the complete
+outcome-free structural fan before calculating any return statistic, then
+commits all four robustness cells atomically.  It never loads a post-boundary
+bar and it never selects a favourable ambiguity/quarantine cell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.services.backtest_run import BacktestProgressEvent
+from app.services.strategy_mt1_runner import validate_mt1_preregistrations
+from app.services.strategy_mt1_store import (
+    MT1StoredEvaluation,
+    MT1StoredRefusal,
+    run_and_store_mt1_in_sample_evaluation,
+)
+from scripts._prereg_freeze_guard import assert_policy_version_merged
+
+ACKNOWLEDGEMENT = "RUN-2769-PREREGISTERED-IN-SAMPLE"
+
+
+def _progress(event: BacktestProgressEvent) -> None:
+    sys.stderr.write(
+        json.dumps(
+            {
+                "ambiguity_arm": event.ambiguity_arm,
+                "phase": event.phase,
+                "quarantine_arm": event.quarantine_arm,
+                "series_seen": event.series_seen,
+                "series_total": event.series_total,
+                "strategy_id": event.strategy_id,
+                "type": "progress",
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--execute",
+        metavar="ACKNOWLEDGEMENT",
+        help=f"run the one durable in-sample trial; required literal: {ACKNOWLEDGEMENT}",
+    )
+    args = parser.parse_args(argv)
+    if args.execute is not None and args.execute != ACKNOWLEDGEMENT:
+        parser.error(f"--execute requires the exact acknowledgement {ACKNOWLEDGEMENT!r}")
+
+    policy = assert_policy_version_merged()
+    with psycopg.connect(settings.database_url) as conn:
+        if args.execute is None:
+            authorities = validate_mt1_preregistrations(conn)
+            sys.stdout.write(
+                json.dumps(
+                    {
+                        **policy,
+                        "declarations": [
+                            {
+                                "declaration_id": item.declaration_id,
+                                "declaration_sha256": item.declaration_sha256,
+                                "strategy_id": item.strategy_id,
+                                "strategy_version": item.strategy_version,
+                            }
+                            for item in authorities
+                        ],
+                        "outcome": "authority_ready_no_outcomes_evaluated",
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+            return 0
+
+        stored = run_and_store_mt1_in_sample_evaluation(conn, progress=_progress)
+    if isinstance(stored, MT1StoredRefusal):
+        sys.stdout.write(
+            json.dumps(
+                {
+                    **policy,
+                    "detail": stored.detail,
+                    "outcome": "structural_gate_refused_no_performance_stored",
+                    "structural_attempt_id": stored.structural_attempt_id,
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        return 2
+    assert isinstance(stored, MT1StoredEvaluation)
+    sys.stdout.write(
+        json.dumps(
+            {
+                **policy,
+                "all_four_historical_conjuncts_pass": (stored.evaluation.bundle.historical_statistical_conjuncts_pass),
+                "outcome": "complete_four_cell_result_stored",
+                "structural_attempt_id": stored.structural_attempt_id,
+                "trial_result_id": stored.trial_result_id,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["ACKNOWLEDGEMENT", "main"]

--- a/scripts/verify_2769_mt1_derivation.py
+++ b/scripts/verify_2769_mt1_derivation.py
@@ -1,0 +1,129 @@
+"""Replay MT-1 persisted input provenance without reading an outcome value."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.config import settings
+from app.services.backtest_run import BACKTEST_UNIVERSE, corpus_version_for, load_corpus
+from app.services.cost_model import COST_MODEL_ID
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_mt1_books import BOOK_RULE_VERSION
+from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
+from app.services.strategy_mt1_runner import (
+    MT1_IN_SAMPLE_WINDOW,
+    MT1_SOURCE_STRATEGY_ID,
+    S8_SOURCE_STRATEGY_ID,
+)
+from app.services.strategy_mt1_trial import TRIAL_CONTRACT_VERSION, TRIAL_EVALUATOR_VERSION
+from app.services.strategy_result import METRIC_AXIS_RULE_VERSION, metric_axis_sha256
+from app.services.strategy_result_universe import ResultUniverseRecord, record_sha256
+from app.services.trial_register import TRIAL_REGISTER_VERSION
+
+
+def _canonical_digest(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def verify_persisted_inputs(
+    row: Mapping[str, object],
+    *,
+    derived_axis: tuple[Any, ...],
+    derived_opportunity: ResultUniverseRecord,
+) -> list[str]:
+    """Return exact provenance differences; the caller decides the exit code."""
+    mt1_source = STRATEGY_MANIFEST[MT1_SOURCE_STRATEGY_ID].identity(
+        universe=BACKTEST_UNIVERSE,
+        cost_model_id=COST_MODEL_ID,
+    )
+    s8_source = STRATEGY_MANIFEST[S8_SOURCE_STRATEGY_ID].identity(
+        universe=BACKTEST_UNIVERSE,
+        cost_model_id=COST_MODEL_ID,
+    )
+    mt1 = mt1_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s8 = s8_control_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    expected: dict[str, object] = {
+        "book_rule_version": BOOK_RULE_VERSION,
+        "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
+        "cost_model_id": COST_MODEL_ID,
+        "evaluator_version": TRIAL_EVALUATOR_VERSION,
+        "metric_axis_dates": list(derived_axis),
+        "metric_axis_digest": metric_axis_sha256(derived_axis),
+        "metric_axis_rule_version": METRIC_AXIS_RULE_VERSION,
+        "mt1_source_strategy_version": mt1_source.version,
+        "mt1_strategy_version": mt1.version,
+        "opportunity_set_digest": record_sha256(derived_opportunity),
+        "s8_source_strategy_version": s8_source.version,
+        "s8_strategy_version": s8.version,
+        "trial_contract_version": TRIAL_CONTRACT_VERSION,
+        "trial_register_version": TRIAL_REGISTER_VERSION,
+        "universe_basis": "survivorship_free",
+    }
+    differences = [name for name, value in expected.items() if row.get(name) != value]
+    payload = row.get("structural_evidence_json")
+    if not isinstance(payload, dict) or _canonical_digest(payload) != row.get("structural_evidence_sha256"):
+        differences.append("structural_evidence_digest")
+    return sorted(differences)
+
+
+def main() -> int:
+    mt1 = mt1_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s8 = s8_control_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            row = cur.execute(
+                """
+                SELECT mt1_strategy_version, s8_strategy_version, mt1_source_strategy_version,
+                       s8_source_strategy_version, universe_basis, corpus_version, cost_model_id,
+                       trial_register_version, trial_contract_version, book_rule_version,
+                       evaluator_version, metric_axis_rule_version, metric_axis_dates,
+                       metric_axis_digest, opportunity_set_digest, structural_evidence_sha256,
+                       structural_evidence_json
+                  FROM strategy_mt1_structural_attempts
+                 WHERE mt1_strategy_version = %s AND s8_strategy_version = %s
+                """,
+                (mt1.version, s8.version),
+            ).fetchone()
+        if row is None:
+            sys.stderr.write(json.dumps({"outcome": "refused", "reason": "structural_attempt_missing"}) + "\n")
+            return 2
+        corpus = load_corpus(
+            conn,
+            universe_basis=BACKTEST_UNIVERSE,
+            evaluation_window=MT1_IN_SAMPLE_WINDOW,
+        )
+        differences = verify_persisted_inputs(
+            row,
+            derived_axis=corpus.in_sample_axis,
+            derived_opportunity=corpus.opportunity_records["in_sample"],
+        )
+    output = {
+        "differences": differences,
+        "metric_axis_dates": len(corpus.in_sample_axis),
+        "outcome": "verified" if not differences else "refused",
+        "opportunity_set_digest": record_sha256(corpus.opportunity_records["in_sample"]),
+        "window_end": MT1_IN_SAMPLE_WINDOW.end.isoformat(),
+    }
+    (sys.stdout if not differences else sys.stderr).write(json.dumps(output, sort_keys=True) + "\n")
+    return 0 if not differences else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main", "verify_persisted_inputs"]

--- a/scripts/verify_2769_mt1_derivation.py
+++ b/scripts/verify_2769_mt1_derivation.py
@@ -77,6 +77,15 @@ def verify_persisted_inputs(
     payload = row.get("structural_evidence_json")
     if not isinstance(payload, dict) or _canonical_digest(payload) != row.get("structural_evidence_sha256"):
         differences.append("structural_evidence_digest")
+    source_head = row.get("runner_source_head")
+    if (
+        not isinstance(source_head, str)
+        or len(source_head) != 40
+        or any(character not in "0123456789abcdef" for character in source_head)
+    ):
+        differences.append("runner_source_head_invalid")
+    if isinstance(payload, dict) and payload.get("runner_source_head") != source_head:
+        differences.append("runner_source_head_payload_mismatch")
     return sorted(differences)
 
 
@@ -92,7 +101,7 @@ def main() -> int:
                        trial_register_version, trial_contract_version, book_rule_version,
                        evaluator_version, metric_axis_rule_version, metric_axis_dates,
                        metric_axis_digest, opportunity_set_digest, structural_evidence_sha256,
-                       structural_evidence_json
+                       structural_evidence_json, runner_source_head
                   FROM strategy_mt1_structural_attempts
                  WHERE mt1_strategy_version = %s AND s8_strategy_version = %s
                 """,

--- a/sql/361_mt1_controlled_trial_results.sql
+++ b/sql/361_mt1_controlled_trial_results.sql
@@ -48,6 +48,7 @@ CREATE TABLE strategy_mt1_structural_attempts (
     metric_axis_end             DATE NOT NULL CHECK (metric_axis_end < DATE '2021-06-29'),
     metric_axis_digest          TEXT NOT NULL CHECK (metric_axis_digest ~ '^[0-9a-f]{64}$'),
     opportunity_set_digest      TEXT NOT NULL CHECK (opportunity_set_digest ~ '^[0-9a-f]{64}$'),
+    runner_source_head          TEXT NOT NULL CHECK (runner_source_head ~ '^[0-9a-f]{40}$'),
     passed                      BOOLEAN NOT NULL,
     refusal_code                TEXT CHECK (refusal_code = 'structural_gate_refused'),
     refusal_detail              TEXT CHECK (

--- a/sql/361_mt1_controlled_trial_results.sql
+++ b/sql/361_mt1_controlled_trial_results.sql
@@ -1,0 +1,389 @@
+-- #2769 -- durable, structural-first evidence for the preregistered MT-1/S-8
+-- four-arm controlled experiment.
+--
+-- One immutable strategy version gets one structural attempt. A passed attempt
+-- must own the complete ambiguity x quarantine fan (four cells); a refused
+-- attempt owns none and contains no performance columns. Only a passed,
+-- complete structural attempt may own an outcome bundle, and that bundle must
+-- atomically own the same exact four cells. Deferred constraint triggers make
+-- partial fan commits impossible even for a writer that bypasses Python.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION strategy_mt1_numeric_is_finite(value NUMERIC)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+STRICT
+AS $$
+    SELECT value NOT IN ('NaN'::NUMERIC, 'Infinity'::NUMERIC, '-Infinity'::NUMERIC)
+$$;
+
+CREATE TABLE strategy_mt1_structural_attempts (
+    structural_attempt_id       BIGSERIAL PRIMARY KEY,
+    mt1_declaration_id          BIGINT NOT NULL,
+    s8_declaration_id           BIGINT NOT NULL,
+    mt1_strategy_id             TEXT NOT NULL CHECK (
+        mt1_strategy_id = 'mt1-capped-volatility-managed-relative-strength-v1'
+    ),
+    mt1_strategy_version        TEXT NOT NULL CHECK (btrim(mt1_strategy_version) <> ''),
+    s8_strategy_id              TEXT NOT NULL CHECK (
+        s8_strategy_id = 'mt1-s8-capped-volatility-negative-control-v1'
+    ),
+    s8_strategy_version         TEXT NOT NULL CHECK (btrim(s8_strategy_version) <> ''),
+    mt1_source_strategy_version TEXT NOT NULL CHECK (btrim(mt1_source_strategy_version) <> ''),
+    s8_source_strategy_version  TEXT NOT NULL CHECK (btrim(s8_source_strategy_version) <> ''),
+    universe_basis              TEXT NOT NULL CHECK (universe_basis = 'survivorship_free'),
+    corpus_version              TEXT NOT NULL CHECK (btrim(corpus_version) <> ''),
+    cost_model_id               TEXT NOT NULL CHECK (btrim(cost_model_id) <> ''),
+    trial_register_version      TEXT NOT NULL CHECK (btrim(trial_register_version) <> ''),
+    trial_contract_version      TEXT NOT NULL CHECK (btrim(trial_contract_version) <> ''),
+    book_rule_version           TEXT NOT NULL CHECK (btrim(book_rule_version) <> ''),
+    evaluator_version           TEXT NOT NULL CHECK (btrim(evaluator_version) <> ''),
+    metric_axis_rule_version    TEXT NOT NULL CHECK (
+        metric_axis_rule_version = 'full-namespace-panel-v1'
+    ),
+    metric_axis_dates           DATE[] NOT NULL,
+    metric_axis_start           DATE NOT NULL,
+    metric_axis_end             DATE NOT NULL CHECK (metric_axis_end < DATE '2021-06-29'),
+    metric_axis_digest          TEXT NOT NULL CHECK (metric_axis_digest ~ '^[0-9a-f]{64}$'),
+    opportunity_set_digest      TEXT NOT NULL CHECK (opportunity_set_digest ~ '^[0-9a-f]{64}$'),
+    passed                      BOOLEAN NOT NULL,
+    refusal_code                TEXT CHECK (refusal_code = 'structural_gate_refused'),
+    refusal_detail              TEXT CHECK (
+        refusal_detail IS NULL OR char_length(btrim(refusal_detail)) BETWEEN 1 AND 2000
+    ),
+    structural_evidence_sha256  TEXT NOT NULL CHECK (structural_evidence_sha256 ~ '^[0-9a-f]{64}$'),
+    structural_evidence_json    JSONB NOT NULL CHECK (jsonb_typeof(structural_evidence_json) = 'object'),
+    assessed_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_mt1_structural_attempt_declarations_distinct CHECK (
+        mt1_declaration_id <> s8_declaration_id
+    ),
+    CONSTRAINT strategy_mt1_structural_attempt_axis CHECK (
+        strategy_metric_axis_is_valid(metric_axis_dates, metric_axis_start, metric_axis_end)
+    ),
+    CONSTRAINT strategy_mt1_structural_attempt_state CHECK (
+        (passed AND refusal_code IS NULL AND refusal_detail IS NULL)
+        OR (NOT passed AND refusal_code IS NOT NULL AND refusal_detail IS NOT NULL)
+    ),
+    CONSTRAINT strategy_mt1_structural_attempt_once UNIQUE (
+        mt1_strategy_version, s8_strategy_version
+    ),
+    CONSTRAINT strategy_mt1_structural_mt1_declaration_fk FOREIGN KEY (
+        mt1_declaration_id, mt1_strategy_id, mt1_strategy_version
+    ) REFERENCES strategy_preregistration_declarations (
+        declaration_id, strategy_id, strategy_version
+    ) ON DELETE RESTRICT,
+    CONSTRAINT strategy_mt1_structural_s8_declaration_fk FOREIGN KEY (
+        s8_declaration_id, s8_strategy_id, s8_strategy_version
+    ) REFERENCES strategy_preregistration_declarations (
+        declaration_id, strategy_id, strategy_version
+    ) ON DELETE RESTRICT
+);
+
+CREATE TABLE strategy_mt1_structural_cells (
+    structural_attempt_id       BIGINT NOT NULL
+        REFERENCES strategy_mt1_structural_attempts(structural_attempt_id) ON DELETE RESTRICT,
+    ambiguity_arm               TEXT NOT NULL CHECK (ambiguity_arm IN ('best_case', 'worst_case')),
+    quarantine_arm              TEXT NOT NULL CHECK (quarantine_arm IN ('masked', 'admitted')),
+    mt1_decision_dates          DATE[] NOT NULL,
+    s8_decision_dates           DATE[] NOT NULL,
+    mt1_annualised_turnover     NUMERIC NOT NULL CHECK (
+        mt1_annualised_turnover >= 0 AND mt1_annualised_turnover <= 6
+    ),
+    s8_annualised_turnover      NUMERIC NOT NULL CHECK (
+        s8_annualised_turnover >= 0 AND s8_annualised_turnover <= 6
+    ),
+    mt1_traded_notional         NUMERIC NOT NULL CHECK (mt1_traded_notional >= 0),
+    s8_traded_notional          NUMERIC NOT NULL CHECK (s8_traded_notional >= 0),
+    exposure_reconciled         BOOLEAN NOT NULL CHECK (exposure_reconciled),
+    evidence_sha256             TEXT NOT NULL CHECK (evidence_sha256 ~ '^[0-9a-f]{64}$'),
+    evidence_json               JSONB NOT NULL CHECK (jsonb_typeof(evidence_json) = 'object'),
+    PRIMARY KEY (structural_attempt_id, ambiguity_arm, quarantine_arm),
+    CONSTRAINT strategy_mt1_structural_cell_metrics_finite CHECK (
+        strategy_mt1_numeric_is_finite(mt1_annualised_turnover)
+        AND strategy_mt1_numeric_is_finite(s8_annualised_turnover)
+        AND strategy_mt1_numeric_is_finite(mt1_traded_notional)
+        AND strategy_mt1_numeric_is_finite(s8_traded_notional)
+    ),
+    CONSTRAINT strategy_mt1_structural_cell_clock CHECK (
+        cardinality(mt1_decision_dates) > 0
+        AND mt1_decision_dates = s8_decision_dates
+        AND strategy_metric_axis_is_valid(
+            mt1_decision_dates,
+            mt1_decision_dates[1],
+            mt1_decision_dates[cardinality(mt1_decision_dates)]
+        )
+    )
+);
+
+CREATE TABLE strategy_mt1_trial_results (
+    mt1_trial_result_id         BIGSERIAL PRIMARY KEY,
+    structural_attempt_id       BIGINT NOT NULL UNIQUE
+        REFERENCES strategy_mt1_structural_attempts(structural_attempt_id) ON DELETE RESTRICT,
+    historical_conjuncts_pass  BOOLEAN NOT NULL,
+    evidence_sha256             TEXT NOT NULL CHECK (evidence_sha256 ~ '^[0-9a-f]{64}$'),
+    evidence_json               JSONB NOT NULL CHECK (jsonb_typeof(evidence_json) = 'object'),
+    evaluated_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION strategy_mt1_month_axis_is_valid(months DATE[])
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+STRICT
+AS $$
+    SELECT cardinality(months) >= 120
+       AND strategy_metric_axis_is_valid(
+            months,
+            months[1],
+            months[cardinality(months)]
+       )
+       AND NOT EXISTS (
+            SELECT 1 FROM unnest(months) AS month
+            WHERE extract(day FROM month) <> 1
+       )
+$$;
+
+CREATE TABLE strategy_mt1_trial_result_cells (
+    mt1_trial_result_id             BIGINT NOT NULL
+        REFERENCES strategy_mt1_trial_results(mt1_trial_result_id) ON DELETE RESTRICT,
+    ambiguity_arm                   TEXT NOT NULL CHECK (ambiguity_arm IN ('best_case', 'worst_case')),
+    quarantine_arm                  TEXT NOT NULL CHECK (quarantine_arm IN ('masked', 'admitted')),
+    common_months                   DATE[] NOT NULL CHECK (cardinality(common_months) >= 120),
+    excluded_months_by_arm          INTEGER[] NOT NULL CHECK (
+        cardinality(excluded_months_by_arm) = 4
+        AND 0 <= ALL(excluded_months_by_arm)
+    ),
+    mt1_scaled_certainty_equivalent NUMERIC NOT NULL,
+    mt1_scaled_maximum_drawdown     NUMERIC NOT NULL CHECK (
+        mt1_scaled_maximum_drawdown BETWEEN 0 AND 1
+    ),
+    mt1_scaled_expected_shortfall_5 NUMERIC NOT NULL,
+    mt1_unscaled_certainty_equivalent NUMERIC NOT NULL,
+    mt1_unscaled_maximum_drawdown   NUMERIC NOT NULL CHECK (
+        mt1_unscaled_maximum_drawdown BETWEEN 0 AND 1
+    ),
+    mt1_unscaled_expected_shortfall_5 NUMERIC NOT NULL,
+    s8_scaled_certainty_equivalent  NUMERIC NOT NULL,
+    s8_scaled_maximum_drawdown      NUMERIC NOT NULL CHECK (
+        s8_scaled_maximum_drawdown BETWEEN 0 AND 1
+    ),
+    s8_scaled_expected_shortfall_5  NUMERIC NOT NULL,
+    s8_unscaled_certainty_equivalent NUMERIC NOT NULL,
+    s8_unscaled_maximum_drawdown    NUMERIC NOT NULL CHECK (
+        s8_unscaled_maximum_drawdown BETWEEN 0 AND 1
+    ),
+    s8_unscaled_expected_shortfall_5 NUMERIC NOT NULL,
+    mt1_delta_cer                   NUMERIC NOT NULL,
+    s8_delta_cer                    NUMERIC NOT NULL,
+    primary_difference_in_differences NUMERIC NOT NULL,
+    mt1_interval_low                NUMERIC NOT NULL,
+    mt1_interval_high               NUMERIC NOT NULL CHECK (mt1_interval_high >= mt1_interval_low),
+    primary_interval_low            NUMERIC NOT NULL,
+    primary_interval_high           NUMERIC NOT NULL CHECK (
+        primary_interval_high >= primary_interval_low
+    ),
+    primary_lower_bound_positive    BOOLEAN NOT NULL,
+    mt1_lower_bound_positive        BOOLEAN NOT NULL,
+    mt1_drawdown_improved           BOOLEAN NOT NULL,
+    mt1_expected_shortfall_improved BOOLEAN NOT NULL,
+    historical_conjuncts_pass       BOOLEAN NOT NULL,
+    evidence_sha256                 TEXT NOT NULL CHECK (evidence_sha256 ~ '^[0-9a-f]{64}$'),
+    evidence_json                   JSONB NOT NULL CHECK (jsonb_typeof(evidence_json) = 'object'),
+    PRIMARY KEY (mt1_trial_result_id, ambiguity_arm, quarantine_arm),
+    CONSTRAINT strategy_mt1_result_metrics_finite CHECK (
+        strategy_mt1_numeric_is_finite(mt1_scaled_certainty_equivalent)
+        AND strategy_mt1_numeric_is_finite(mt1_scaled_maximum_drawdown)
+        AND strategy_mt1_numeric_is_finite(mt1_scaled_expected_shortfall_5)
+        AND strategy_mt1_numeric_is_finite(mt1_unscaled_certainty_equivalent)
+        AND strategy_mt1_numeric_is_finite(mt1_unscaled_maximum_drawdown)
+        AND strategy_mt1_numeric_is_finite(mt1_unscaled_expected_shortfall_5)
+        AND strategy_mt1_numeric_is_finite(s8_scaled_certainty_equivalent)
+        AND strategy_mt1_numeric_is_finite(s8_scaled_maximum_drawdown)
+        AND strategy_mt1_numeric_is_finite(s8_scaled_expected_shortfall_5)
+        AND strategy_mt1_numeric_is_finite(s8_unscaled_certainty_equivalent)
+        AND strategy_mt1_numeric_is_finite(s8_unscaled_maximum_drawdown)
+        AND strategy_mt1_numeric_is_finite(s8_unscaled_expected_shortfall_5)
+        AND strategy_mt1_numeric_is_finite(mt1_delta_cer)
+        AND strategy_mt1_numeric_is_finite(s8_delta_cer)
+        AND strategy_mt1_numeric_is_finite(primary_difference_in_differences)
+        AND strategy_mt1_numeric_is_finite(mt1_interval_low)
+        AND strategy_mt1_numeric_is_finite(mt1_interval_high)
+        AND strategy_mt1_numeric_is_finite(primary_interval_low)
+        AND strategy_mt1_numeric_is_finite(primary_interval_high)
+    ),
+    CONSTRAINT strategy_mt1_result_common_month_clock CHECK (
+        strategy_mt1_month_axis_is_valid(common_months)
+    )
+);
+
+CREATE OR REPLACE FUNCTION enforce_strategy_mt1_structural_fan()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    owner_id BIGINT := COALESCE(NEW.structural_attempt_id, OLD.structural_attempt_id);
+    owner_passed BOOLEAN;
+    owner_axis DATE[];
+    cell_count INTEGER;
+BEGIN
+    SELECT passed, metric_axis_dates INTO owner_passed, owner_axis
+      FROM strategy_mt1_structural_attempts
+     WHERE structural_attempt_id = owner_id;
+    IF owner_passed IS NULL THEN
+        RETURN NULL;
+    END IF;
+    SELECT count(*) INTO cell_count
+      FROM strategy_mt1_structural_cells
+     WHERE structural_attempt_id = owner_id;
+    IF (owner_passed AND cell_count <> 4) OR (NOT owner_passed AND cell_count <> 0) THEN
+        RAISE EXCEPTION
+            'MT-1 structural attempt % passed=% requires exactly % cells, found %',
+            owner_id, owner_passed, CASE WHEN owner_passed THEN 4 ELSE 0 END, cell_count;
+    END IF;
+    IF owner_passed AND EXISTS (
+        SELECT 1
+          FROM strategy_mt1_structural_cells cell,
+               unnest(cell.mt1_decision_dates) AS decision_date
+         WHERE cell.structural_attempt_id = owner_id
+           AND NOT decision_date = ANY(owner_axis)
+    ) THEN
+        RAISE EXCEPTION
+            'MT-1 structural attempt % has a decision outside its frozen metric axis', owner_id;
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+CREATE CONSTRAINT TRIGGER trg_strategy_mt1_structural_attempt_fan
+AFTER INSERT ON strategy_mt1_structural_attempts
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION enforce_strategy_mt1_structural_fan();
+
+CREATE CONSTRAINT TRIGGER trg_strategy_mt1_structural_cell_fan
+AFTER INSERT ON strategy_mt1_structural_cells
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION enforce_strategy_mt1_structural_fan();
+
+CREATE OR REPLACE FUNCTION enforce_strategy_mt1_result_fan()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    result_id BIGINT := COALESCE(NEW.mt1_trial_result_id, OLD.mt1_trial_result_id);
+    attempt_id BIGINT;
+    attempt_passed BOOLEAN;
+    structural_count INTEGER;
+    result_count INTEGER;
+    declared_pass BOOLEAN;
+    derived_pass BOOLEAN;
+    distinct_common_axes INTEGER;
+BEGIN
+    SELECT r.structural_attempt_id, a.passed, r.historical_conjuncts_pass
+      INTO attempt_id, attempt_passed, declared_pass
+      FROM strategy_mt1_trial_results r
+      JOIN strategy_mt1_structural_attempts a
+        ON a.structural_attempt_id = r.structural_attempt_id
+     WHERE r.mt1_trial_result_id = result_id;
+    IF attempt_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+    SELECT count(*) INTO structural_count
+      FROM strategy_mt1_structural_cells WHERE structural_attempt_id = attempt_id;
+    SELECT count(*), bool_and(historical_conjuncts_pass)
+      INTO result_count, derived_pass
+      FROM strategy_mt1_trial_result_cells WHERE mt1_trial_result_id = result_id;
+    SELECT count(DISTINCT common_months) INTO distinct_common_axes
+      FROM strategy_mt1_trial_result_cells WHERE mt1_trial_result_id = result_id;
+    IF NOT attempt_passed OR structural_count <> 4 OR result_count <> 4 THEN
+        RAISE EXCEPTION
+            'MT-1 result % requires one passed four-cell structural attempt and four result cells', result_id;
+    END IF;
+    IF declared_pass IS DISTINCT FROM derived_pass THEN
+        RAISE EXCEPTION
+            'MT-1 result % declares pass=% but its four-cell conjunction is %',
+            result_id, declared_pass, derived_pass;
+    END IF;
+    IF distinct_common_axes <> 1 OR EXISTS (
+        SELECT 1
+          FROM strategy_mt1_trial_result_cells cell
+          JOIN strategy_mt1_trial_results result
+            ON result.mt1_trial_result_id = cell.mt1_trial_result_id
+          JOIN strategy_mt1_structural_attempts attempt
+            ON attempt.structural_attempt_id = result.structural_attempt_id,
+               unnest(cell.common_months) AS common_month
+         WHERE cell.mt1_trial_result_id = result_id
+           AND NOT EXISTS (
+               SELECT 1 FROM unnest(attempt.metric_axis_dates) AS axis_date
+                WHERE date_trunc('month', axis_date)::DATE = common_month
+           )
+    ) THEN
+        RAISE EXCEPTION
+            'MT-1 result % common-month axes differ or escape the frozen metric axis', result_id;
+    END IF;
+    IF EXISTS (
+        SELECT ambiguity_arm, quarantine_arm
+          FROM strategy_mt1_structural_cells
+         WHERE structural_attempt_id = attempt_id
+        EXCEPT
+        SELECT ambiguity_arm, quarantine_arm
+          FROM strategy_mt1_trial_result_cells
+         WHERE mt1_trial_result_id = result_id
+    ) OR EXISTS (
+        SELECT ambiguity_arm, quarantine_arm
+          FROM strategy_mt1_trial_result_cells
+         WHERE mt1_trial_result_id = result_id
+        EXCEPT
+        SELECT ambiguity_arm, quarantine_arm
+          FROM strategy_mt1_structural_cells
+         WHERE structural_attempt_id = attempt_id
+    ) THEN
+        RAISE EXCEPTION 'MT-1 result % fan keys differ from its structural attempt', result_id;
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+CREATE CONSTRAINT TRIGGER trg_strategy_mt1_result_header_fan
+AFTER INSERT ON strategy_mt1_trial_results
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION enforce_strategy_mt1_result_fan();
+
+CREATE CONSTRAINT TRIGGER trg_strategy_mt1_result_cell_fan
+AFTER INSERT ON strategy_mt1_trial_result_cells
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION enforce_strategy_mt1_result_fan();
+
+CREATE OR REPLACE FUNCTION reject_strategy_mt1_evidence_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'MT-1 controlled-trial evidence is immutable; mint a new strategy version';
+END;
+$$;
+
+CREATE TRIGGER trg_strategy_mt1_structural_attempt_immutable
+BEFORE UPDATE OR DELETE ON strategy_mt1_structural_attempts
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_mt1_evidence_change();
+CREATE TRIGGER trg_strategy_mt1_structural_cell_immutable
+BEFORE UPDATE OR DELETE ON strategy_mt1_structural_cells
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_mt1_evidence_change();
+CREATE TRIGGER trg_strategy_mt1_result_immutable
+BEFORE UPDATE OR DELETE ON strategy_mt1_trial_results
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_mt1_evidence_change();
+CREATE TRIGGER trg_strategy_mt1_result_cell_immutable
+BEFORE UPDATE OR DELETE ON strategy_mt1_trial_result_cells
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_mt1_evidence_change();
+
+COMMENT ON TABLE strategy_mt1_structural_attempts IS
+    'One immutable pre-performance MT-1/S-8 structural assessment per exact strategy-version pair.';
+COMMENT ON TABLE strategy_mt1_structural_cells IS
+    'The complete four-cell ambiguity/quarantine structural fan; contains no return or performance statistic.';
+COMMENT ON TABLE strategy_mt1_trial_results IS
+    'One immutable outcome bundle authorised by a committed passed four-cell structural attempt.';
+COMMENT ON TABLE strategy_mt1_trial_result_cells IS
+    'Four conjunctive MT-1 controlled-result cells; no favourable ambiguity/quarantine cell is selectable.';
+
+COMMIT;

--- a/sql/362_strategy_promotion_forecast_assessment.sql
+++ b/sql/362_strategy_promotion_forecast_assessment.sql
@@ -1,0 +1,95 @@
+-- 362_strategy_promotion_forecast_assessment.sql
+--
+-- #2770: a paper approval must pin the exact immutable declaration and
+-- prospective assessment it consumed, plus the forward-shadow facts checked
+-- against that declaration.  The source rows remain directly resolvable and
+-- neither can be deleted behind the audit event.  The redundant identity
+-- columns make cross-trial substitution impossible at the FK layer rather
+-- than trusting every writer to join the three sources correctly.
+
+ALTER TABLE strategy_promotions
+    ADD CONSTRAINT strategy_promotions_forward_evidence_identity
+    UNIQUE (promotion_id,strategy_id,strategy_version,to_stage);
+
+ALTER TABLE strategy_forecast_assessments
+    ADD CONSTRAINT strategy_forecast_assessments_forward_evidence_identity
+    UNIQUE (assessment_id,strategy_id,strategy_version);
+
+-- These tables were documented and consumed as append-only evidence, but the
+-- original migrations did not enforce that claim. A mutable promotion time
+-- could move the forward boundary after approval; a mutable assessment could
+-- flip the exact verdict the approval pins.
+CREATE OR REPLACE FUNCTION reject_strategy_promotion_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'strategy promotions are append-only';
+END;
+$$;
+
+CREATE TRIGGER trg_strategy_promotions_immutable
+BEFORE UPDATE OR DELETE ON strategy_promotions
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_promotion_change();
+
+CREATE OR REPLACE FUNCTION reject_strategy_forecast_assessment_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'strategy forecast assessments are immutable';
+END;
+$$;
+
+CREATE TRIGGER trg_strategy_forecast_assessments_immutable
+BEFORE UPDATE OR DELETE ON strategy_forecast_assessments
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_forecast_assessment_change();
+
+CREATE TABLE IF NOT EXISTS strategy_promotion_forward_evidence (
+    promotion_id BIGINT PRIMARY KEY,
+    strategy_id TEXT NOT NULL,
+    strategy_version TEXT NOT NULL,
+    promotion_stage TEXT NOT NULL DEFAULT 'paper_enabled'
+        CHECK (promotion_stage = 'paper_enabled'),
+    declaration_id BIGINT NOT NULL,
+    assessment_id BIGINT NOT NULL,
+    forward_resolved_signals INTEGER NOT NULL CHECK (forward_resolved_signals >= 0),
+    forward_decision_dates INTEGER NOT NULL CHECK (forward_decision_dates >= 0),
+    forward_elapsed_days INTEGER NOT NULL CHECK (forward_elapsed_days >= 0),
+    assessed_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT strategy_promotion_forward_evidence_promotion_fk
+        FOREIGN KEY (promotion_id,strategy_id,strategy_version,promotion_stage)
+        REFERENCES strategy_promotions(promotion_id,strategy_id,strategy_version,to_stage)
+        ON DELETE RESTRICT,
+    CONSTRAINT strategy_promotion_forward_evidence_declaration_fk
+        FOREIGN KEY (declaration_id,strategy_id,strategy_version)
+        REFERENCES strategy_preregistration_declarations(declaration_id,strategy_id,strategy_version)
+        ON DELETE RESTRICT,
+    CONSTRAINT strategy_promotion_forward_evidence_assessment_fk
+        FOREIGN KEY (assessment_id,strategy_id,strategy_version)
+        REFERENCES strategy_forecast_assessments(assessment_id,strategy_id,strategy_version)
+        ON DELETE RESTRICT,
+    CONSTRAINT strategy_promotion_forward_evidence_identity_nonempty
+        CHECK (strategy_id <> '' AND strategy_version <> '')
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_promotion_forward_evidence_declaration
+    ON strategy_promotion_forward_evidence(declaration_id);
+CREATE INDEX IF NOT EXISTS idx_strategy_promotion_forward_evidence_assessment
+    ON strategy_promotion_forward_evidence(assessment_id);
+
+COMMENT ON TABLE strategy_promotion_forward_evidence IS
+    'Exact preregistration, prospective assessment and frozen forward-shadow facts consumed by a #2770 paper approval.';
+
+CREATE OR REPLACE FUNCTION reject_strategy_promotion_forward_evidence_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'paper-promotion forward evidence is immutable';
+END;
+$$;
+
+CREATE TRIGGER trg_strategy_promotion_forward_evidence_immutable
+BEFORE UPDATE OR DELETE ON strategy_promotion_forward_evidence
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_promotion_forward_evidence_change();

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -380,11 +380,18 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "report_snapshots",
 )
 
-# DELETE intentionally cannot remove these immutable audit children. Test DB
-# cleanup is allowed to empty them, but must do so explicitly before deleting
-# their parents; otherwise every test that stores real promotion evidence falls
-# through to the much slower whole-schema TRUNCATE recovery path (#2737).
-_TRUNCATE_BEFORE_DELETE: frozenset[str] = frozenset({"strategy_result_universe"})
+# DELETE intentionally cannot remove these immutable audit roots/children.
+# Test DB cleanup is allowed to empty them, but must do so explicitly before
+# deleting their parents; otherwise every evidence test falls through to the
+# much slower whole-schema TRUNCATE recovery path (#2737, #2769).  The grouped
+# CASCADE below is confined to the asserted per-worker test database.
+_TRUNCATE_BEFORE_DELETE: frozenset[str] = frozenset(
+    {
+        "strategy_mt1_structural_attempts",
+        "strategy_preregistration_declarations",
+        "strategy_result_universe",
+    }
+)
 
 
 # #1401 — worker-DB relation-count tripwire ceiling.
@@ -1240,9 +1247,14 @@ def _reset_planner_tables(conn: psycopg.Connection[tuple]) -> None:
         with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
             cur.execute(plan.probe_sql)
             dirty = {row[0] for row in cur.fetchall()}
-            for table in sorted(_TRUNCATE_BEFORE_DELETE & dirty):
-                cur.execute(sql.SQL("TRUNCATE TABLE {}").format(sql.Identifier(table)))
-                dirty.remove(table)
+            truncate_first = sorted(_TRUNCATE_BEFORE_DELETE & dirty)
+            if truncate_first:
+                cur.execute(
+                    sql.SQL("TRUNCATE TABLE {} CASCADE").format(
+                        sql.SQL(", ").join(sql.Identifier(table) for table in truncate_first)
+                    )
+                )
+                dirty.difference_update(truncate_first)
             for table in plan.delete_order:
                 if table in dirty:
                     cur.execute(sql.SQL("DELETE FROM {}").format(sql.Identifier(table)))

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -388,6 +388,8 @@ _PLANNER_TABLES: tuple[str, ...] = (
 _TRUNCATE_BEFORE_DELETE: frozenset[str] = frozenset(
     {
         "strategy_mt1_structural_attempts",
+        "strategy_forecast_assessments",
+        "strategy_promotions",
         "strategy_preregistration_declarations",
         "strategy_result_universe",
     }

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -390,7 +390,9 @@ _TRUNCATE_BEFORE_DELETE: frozenset[str] = frozenset(
         "strategy_mt1_structural_attempts",
         "strategy_forecast_assessments",
         "strategy_promotions",
+        "strategy_promotion_evidence",
         "strategy_preregistration_declarations",
+        "strategy_result_ambiguity",
         "strategy_result_universe",
     }
 )

--- a/tests/test_2437_mt1_declarations.py
+++ b/tests/test_2437_mt1_declarations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+from dataclasses import replace
 
 import pytest
 
@@ -39,6 +40,7 @@ from scripts.freeze_2437_mt1_declarations import (
     build_s8_control_declaration,
     main,
 )
+from scripts.supersede_2437_mt1_declarations import PREDECESSOR_POLICY_VERSION
 
 UNIVERSE = "survivorship_free"
 
@@ -97,6 +99,18 @@ def test_declarations_are_coherent_and_preserve_the_candidate_control_boundary()
         assert declaration.declared_fx_unmodelled is FX_UNMODELLED is False
         assert declaration.expected_structural_refusals == ()
         assert declaration.recomputed_structural_refusals == ()
+
+
+def test_application_contract_reconstructs_the_exact_already_frozen_root_digests() -> None:
+    expected = (
+        "11aeefa42edc47b553a1f90329f4b961e728988b596eab08345f571500f8604a",
+        "ebdee0b9645a8b070e10bc9dad2c0d8fe57e523285774b513cafa8479efa5334",
+    )
+    reconstructed = tuple(
+        replace(declaration, structural_refusal_policy_version=PREDECESSOR_POLICY_VERSION).sha256
+        for declaration in build_declarations()
+    )
+    assert reconstructed == expected
 
 
 def test_forward_shadow_floor_is_rederived_from_the_frozen_power_calculation() -> None:

--- a/tests/test_2769_mt1_auditors.py
+++ b/tests/test_2769_mt1_auditors.py
@@ -17,6 +17,7 @@ from app.services.strategy_mt1_trial import TRIAL_CONTRACT_VERSION, TRIAL_EVALUA
 from app.services.strategy_result import METRIC_AXIS_RULE_VERSION, metric_axis_sha256
 from app.services.strategy_result_universe import ResultUniverseRecord, record_sha256
 from app.services.trial_register import TRIAL_REGISTER_VERSION
+from scripts.audit_2769_mt1_invocation import _valid_result_payload
 from scripts.verify_2769_mt1_derivation import verify_persisted_inputs
 
 _ROOT = Path(__file__).resolve().parents[1]
@@ -76,3 +77,38 @@ def test_structural_auditor_cannot_query_the_result_tables() -> None:
     assert "certainty_equivalent" not in source
     assert "maximum_drawdown" not in source
     assert "expected_shortfall" not in source
+
+
+def test_invocation_auditor_requires_the_complete_canonical_result_payload() -> None:
+    risk = {
+        "certainty_equivalent": "0.1",
+        "expected_shortfall_5": "-0.1",
+        "maximum_drawdown": "0.1",
+    }
+    months = [date(2010 + offset // 12, offset % 12 + 1, 1).isoformat() for offset in range(120)]
+    payload: dict[str, object] = {
+        "bootstrap_block_length": 12,
+        "bootstrap_resamples": 1000,
+        "bootstrap_seed": 2769,
+        "common_months": months,
+        "evaluator_version": "mt1-evaluator-v1",
+        "excluded_months_by_arm": [0, 0, 0, 0],
+        "historical_statistical_conjuncts_pass": False,
+        "mt1_delta_cer": "0.01",
+        "mt1_delta_interval": {"low": "-0.01", "high": "0.02"},
+        "mt1_drawdown_improved": True,
+        "mt1_expected_shortfall_improved": True,
+        "mt1_lower_bound_positive": False,
+        "mt1_scaled": risk,
+        "mt1_unscaled": risk,
+        "primary_difference_in_differences": "0.01",
+        "primary_interval": {"low": "-0.01", "high": "0.02"},
+        "primary_lower_bound_positive": False,
+        "s8_delta_cer": "0.0",
+        "s8_scaled": risk,
+        "s8_unscaled": risk,
+    }
+    assert _valid_result_payload(payload)
+    assert not _valid_result_payload({**payload, "common_months": months[:-1]})
+    assert not _valid_result_payload({**payload, "mt1_scaled": {**risk, "certainty_equivalent": "NaN"}})
+    assert not _valid_result_payload({**payload, "unexpected": True})

--- a/tests/test_2769_mt1_auditors.py
+++ b/tests/test_2769_mt1_auditors.py
@@ -44,7 +44,7 @@ def test_derivation_replay_requires_every_source_dependent_input_pin() -> None:
     )
     mt1 = mt1_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
     s8 = s8_control_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
-    payload: dict[str, object] = {"structural": "header"}
+    payload: dict[str, object] = {"runner_source_head": "a" * 40, "structural": "header"}
     row: dict[str, object] = {
         "book_rule_version": BOOK_RULE_VERSION,
         "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
@@ -56,6 +56,7 @@ def test_derivation_replay_requires_every_source_dependent_input_pin() -> None:
         "mt1_source_strategy_version": mt1_source.version,
         "mt1_strategy_version": mt1.version,
         "opportunity_set_digest": record_sha256(opportunity),
+        "runner_source_head": "a" * 40,
         "s8_source_strategy_version": s8_source.version,
         "s8_strategy_version": s8.version,
         "structural_evidence_json": payload,

--- a/tests/test_2769_mt1_auditors.py
+++ b/tests/test_2769_mt1_auditors.py
@@ -1,0 +1,78 @@
+"""Outcome-free verifier/auditor contracts for #2769."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+from pathlib import Path
+
+from app.services.backtest_run import BACKTEST_UNIVERSE, corpus_version_for
+from app.services.cost_model import COST_MODEL_ID
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_mt1_books import BOOK_RULE_VERSION
+from app.services.strategy_mt1_identity import mt1_identity, s8_control_identity
+from app.services.strategy_mt1_runner import MT1_SOURCE_STRATEGY_ID, S8_SOURCE_STRATEGY_ID
+from app.services.strategy_mt1_trial import TRIAL_CONTRACT_VERSION, TRIAL_EVALUATOR_VERSION
+from app.services.strategy_result import METRIC_AXIS_RULE_VERSION, metric_axis_sha256
+from app.services.strategy_result_universe import ResultUniverseRecord, record_sha256
+from app.services.trial_register import TRIAL_REGISTER_VERSION
+from scripts.verify_2769_mt1_derivation import verify_persisted_inputs
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _sha(payload: dict[str, object]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode()
+    ).hexdigest()
+
+
+def test_derivation_replay_requires_every_source_dependent_input_pin() -> None:
+    axis = (date(2020, 1, 2), date(2020, 1, 3))
+    opportunity = ResultUniverseRecord(
+        universe_rule_version="test-universe-v1",
+        evaluated_instrument_ids=frozenset({1}),
+        validated_universe_ids=frozenset({1}),
+    )
+    mt1_source = STRATEGY_MANIFEST[MT1_SOURCE_STRATEGY_ID].identity(
+        universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID
+    )
+    s8_source = STRATEGY_MANIFEST[S8_SOURCE_STRATEGY_ID].identity(
+        universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID
+    )
+    mt1 = mt1_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s8 = s8_control_identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    payload: dict[str, object] = {"structural": "header"}
+    row: dict[str, object] = {
+        "book_rule_version": BOOK_RULE_VERSION,
+        "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
+        "cost_model_id": COST_MODEL_ID,
+        "evaluator_version": TRIAL_EVALUATOR_VERSION,
+        "metric_axis_dates": list(axis),
+        "metric_axis_digest": metric_axis_sha256(axis),
+        "metric_axis_rule_version": METRIC_AXIS_RULE_VERSION,
+        "mt1_source_strategy_version": mt1_source.version,
+        "mt1_strategy_version": mt1.version,
+        "opportunity_set_digest": record_sha256(opportunity),
+        "s8_source_strategy_version": s8_source.version,
+        "s8_strategy_version": s8.version,
+        "structural_evidence_json": payload,
+        "structural_evidence_sha256": _sha(payload),
+        "trial_contract_version": TRIAL_CONTRACT_VERSION,
+        "trial_register_version": TRIAL_REGISTER_VERSION,
+        "universe_basis": "survivorship_free",
+    }
+    assert verify_persisted_inputs(row, derived_axis=axis, derived_opportunity=opportunity) == []
+
+    row["metric_axis_digest"] = "0" * 64
+    assert verify_persisted_inputs(row, derived_axis=axis, derived_opportunity=opportunity) == ["metric_axis_digest"]
+
+
+def test_structural_auditor_cannot_query_the_result_tables() -> None:
+    source = (_ROOT / "scripts" / "audit_2769_mt1_structural.py").read_text()
+    assert "FROM strategy_mt1_trial_result" not in source
+    assert "JOIN strategy_mt1_trial_result" not in source
+    assert "certainty_equivalent" not in source
+    assert "maximum_drawdown" not in source
+    assert "expected_shortfall" not in source

--- a/tests/test_2769_mt1_result_ledger_db.py
+++ b/tests/test_2769_mt1_result_ledger_db.py
@@ -1,0 +1,254 @@
+"""Database invariants for the sealed MT-1 controlled-trial ledger (#2769)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.result_ledger import freeze_preregistration
+from app.services.strategy_mt1_preregistration import build_declarations
+
+_FAN = (("best_case", "masked"), ("best_case", "admitted"), ("worst_case", "masked"), ("worst_case", "admitted"))
+_SHA = "0" * 64
+_DECISION_DATES = [date(2020, 1, 2), date(2020, 2, 3)]
+
+
+def _months(count: int = 120) -> list[date]:
+    return [date(2010 + offset // 12, offset % 12 + 1, 1) for offset in range(count)]
+
+
+def _freeze_pair(conn: psycopg.Connection[tuple]) -> tuple[int, int, str, str]:
+    mt1, s8 = build_declarations()
+    mt1_id = freeze_preregistration(conn, mt1)
+    s8_id = freeze_preregistration(conn, s8)
+    conn.commit()
+    return mt1_id, s8_id, mt1.strategy_version, s8.strategy_version
+
+
+def _insert_attempt(conn: psycopg.Connection[tuple], *, passed: bool) -> int:
+    mt1_id, s8_id, mt1_version, s8_version = _freeze_pair(conn)
+    row = conn.execute(
+        """
+        INSERT INTO strategy_mt1_structural_attempts (
+            mt1_declaration_id, s8_declaration_id, mt1_strategy_id, mt1_strategy_version,
+            s8_strategy_id, s8_strategy_version, mt1_source_strategy_version,
+            s8_source_strategy_version, universe_basis, corpus_version, cost_model_id,
+            trial_register_version, trial_contract_version, book_rule_version,
+            evaluator_version, metric_axis_rule_version, metric_axis_dates,
+            metric_axis_start, metric_axis_end, metric_axis_digest,
+            opportunity_set_digest, passed, refusal_code, refusal_detail,
+            structural_evidence_sha256, structural_evidence_json
+        ) VALUES (
+            %s, %s, 'mt1-capped-volatility-managed-relative-strength-v1', %s,
+            'mt1-s8-capped-volatility-negative-control-v1', %s, 'source-mt1', 'source-s8',
+            'survivorship_free', 'corpus-v1', 'cost-v1', 'register-v1', 'contract-v1',
+            'book-v1', 'evaluator-v1', 'full-namespace-panel-v1', %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, '{}'::jsonb
+        ) RETURNING structural_attempt_id
+        """,
+        (
+            mt1_id,
+            s8_id,
+            mt1_version,
+            s8_version,
+            [*_months(121), *_DECISION_DATES],
+            _months()[0],
+            _DECISION_DATES[-1],
+            _SHA,
+            _SHA,
+            passed,
+            None if passed else "structural_gate_refused",
+            None if passed else "synthetic structural refusal",
+            _SHA,
+        ),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _insert_structural_cells(
+    conn: psycopg.Connection[tuple], attempt_id: int, *, decision_dates: list[date] | None = None
+) -> None:
+    clock = _DECISION_DATES if decision_dates is None else decision_dates
+    for ambiguity_arm, quarantine_arm in _FAN:
+        conn.execute(
+            """
+            INSERT INTO strategy_mt1_structural_cells (
+                structural_attempt_id, ambiguity_arm, quarantine_arm, mt1_decision_dates,
+                s8_decision_dates, mt1_annualised_turnover, s8_annualised_turnover,
+                mt1_traded_notional, s8_traded_notional, exposure_reconciled,
+                evidence_sha256, evidence_json
+            ) VALUES (%s, %s, %s, %s, %s, 1, 1, 100, 100, TRUE, %s, '{}'::jsonb)
+            """,
+            (attempt_id, ambiguity_arm, quarantine_arm, clock, clock, _SHA),
+        )
+
+
+def _complete_structural_attempt(conn: psycopg.Connection[tuple]) -> int:
+    attempt_id = _insert_attempt(conn, passed=True)
+    _insert_structural_cells(conn, attempt_id)
+    conn.commit()
+    return attempt_id
+
+
+def _insert_result_header(conn: psycopg.Connection[tuple], attempt_id: int, *, passed: bool) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO strategy_mt1_trial_results (
+            structural_attempt_id, historical_conjuncts_pass, evidence_sha256, evidence_json
+        ) VALUES (%s, %s, %s, '{}'::jsonb) RETURNING mt1_trial_result_id
+        """,
+        (attempt_id, passed, _SHA),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _insert_result_cell(
+    conn: psycopg.Connection[tuple],
+    result_id: int,
+    arms: tuple[str, str],
+    *,
+    passed: bool,
+    cer: object = 0,
+    common_months: list[date] | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO strategy_mt1_trial_result_cells (
+            mt1_trial_result_id, ambiguity_arm, quarantine_arm, common_months,
+            excluded_months_by_arm, mt1_scaled_certainty_equivalent,
+            mt1_scaled_maximum_drawdown, mt1_scaled_expected_shortfall_5,
+            mt1_unscaled_certainty_equivalent, mt1_unscaled_maximum_drawdown,
+            mt1_unscaled_expected_shortfall_5, s8_scaled_certainty_equivalent,
+            s8_scaled_maximum_drawdown, s8_scaled_expected_shortfall_5,
+            s8_unscaled_certainty_equivalent, s8_unscaled_maximum_drawdown,
+            s8_unscaled_expected_shortfall_5, mt1_delta_cer, s8_delta_cer,
+            primary_difference_in_differences, mt1_interval_low, mt1_interval_high,
+            primary_interval_low, primary_interval_high, primary_lower_bound_positive,
+            mt1_lower_bound_positive, mt1_drawdown_improved,
+            mt1_expected_shortfall_improved, historical_conjuncts_pass,
+            evidence_sha256, evidence_json
+        ) VALUES (
+            %s, %s, %s, %s, ARRAY[0,0,0,0], %s, 0.1, -0.1, 0, 0.1, -0.1,
+            0, 0.1, -0.1, 0, 0.1, -0.1, 0, 0, 0, -0.1, 0.1, -0.1, 0.1,
+            %s, %s, %s, %s, %s, %s, '{}'::jsonb
+        )
+        """,
+        (
+            result_id,
+            arms[0],
+            arms[1],
+            _months() if common_months is None else common_months,
+            cer,
+            passed,
+            passed,
+            passed,
+            passed,
+            passed,
+            _SHA,
+        ),
+    )
+
+
+def test_passed_structural_attempt_cannot_commit_without_complete_fan(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _insert_attempt(ebull_test_conn, passed=True)
+    with pytest.raises(psycopg.errors.RaiseException, match="requires exactly 4 cells"):
+        ebull_test_conn.commit()
+    ebull_test_conn.rollback()
+
+
+def test_refused_structural_attempt_has_zero_cells_and_cannot_own_results(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    attempt_id = _insert_attempt(ebull_test_conn, passed=False)
+    ebull_test_conn.commit()
+    _insert_result_header(ebull_test_conn, attempt_id, passed=False)
+    with pytest.raises(psycopg.errors.RaiseException, match="passed four-cell structural attempt"):
+        ebull_test_conn.commit()
+    ebull_test_conn.rollback()
+
+
+def test_partial_result_fan_cannot_commit(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    attempt_id = _complete_structural_attempt(ebull_test_conn)
+    result_id = _insert_result_header(ebull_test_conn, attempt_id, passed=False)
+    for arms in _FAN[:3]:
+        _insert_result_cell(ebull_test_conn, result_id, arms, passed=False)
+    with pytest.raises(psycopg.errors.RaiseException, match="four result cells"):
+        ebull_test_conn.commit()
+    ebull_test_conn.rollback()
+
+
+def test_structural_decisions_must_belong_to_the_parent_metric_axis(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    attempt_id = _insert_attempt(ebull_test_conn, passed=True)
+    _insert_structural_cells(
+        ebull_test_conn,
+        attempt_id,
+        decision_dates=[date(2020, 1, 2), date(2020, 3, 2)],
+    )
+    with pytest.raises(psycopg.errors.RaiseException, match="decision outside its frozen metric axis"):
+        ebull_test_conn.commit()
+    ebull_test_conn.rollback()
+
+
+def test_all_result_cells_must_share_one_parent_backed_month_axis(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    attempt_id = _complete_structural_attempt(ebull_test_conn)
+    result_id = _insert_result_header(ebull_test_conn, attempt_id, passed=False)
+    for index, arms in enumerate(_FAN):
+        months = _months(121)[1:] if index == 0 else _months()
+        _insert_result_cell(ebull_test_conn, result_id, arms, passed=False, common_months=months)
+    with pytest.raises(psycopg.errors.RaiseException, match="common-month axes differ"):
+        ebull_test_conn.commit()
+    ebull_test_conn.rollback()
+
+
+def test_header_is_the_conjunction_of_all_four_cells(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    attempt_id = _complete_structural_attempt(ebull_test_conn)
+    result_id = _insert_result_header(ebull_test_conn, attempt_id, passed=True)
+    for index, arms in enumerate(_FAN):
+        _insert_result_cell(ebull_test_conn, result_id, arms, passed=index != 0)
+    with pytest.raises(psycopg.errors.RaiseException, match="four-cell conjunction is f"):
+        ebull_test_conn.commit()
+    ebull_test_conn.rollback()
+
+
+@pytest.mark.parametrize("non_finite", [Decimal("NaN"), Decimal("Infinity"), Decimal("-Infinity")])
+def test_result_cells_refuse_non_finite_metrics(
+    ebull_test_conn: psycopg.Connection[tuple], non_finite: Decimal
+) -> None:
+    attempt_id = _complete_structural_attempt(ebull_test_conn)
+    result_id = _insert_result_header(ebull_test_conn, attempt_id, passed=False)
+    with pytest.raises(psycopg.errors.CheckViolation, match="metrics_finite"):
+        _insert_result_cell(ebull_test_conn, result_id, _FAN[0], passed=False, cer=non_finite)
+    ebull_test_conn.rollback()
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "UPDATE strategy_mt1_structural_attempts SET corpus_version = 'changed'",
+        "DELETE FROM strategy_mt1_structural_cells",
+        "UPDATE strategy_mt1_trial_results SET historical_conjuncts_pass = FALSE",
+        "DELETE FROM strategy_mt1_trial_result_cells",
+    ],
+)
+def test_committed_trial_evidence_is_immutable(ebull_test_conn: psycopg.Connection[tuple], statement: str) -> None:
+    attempt_id = _complete_structural_attempt(ebull_test_conn)
+    result_id = _insert_result_header(ebull_test_conn, attempt_id, passed=True)
+    for arms in _FAN:
+        _insert_result_cell(ebull_test_conn, result_id, arms, passed=True)
+    ebull_test_conn.commit()
+    with pytest.raises(psycopg.errors.RaiseException, match="evidence is immutable"):
+        ebull_test_conn.execute(statement)
+    ebull_test_conn.rollback()

--- a/tests/test_2769_mt1_result_ledger_db.py
+++ b/tests/test_2769_mt1_result_ledger_db.py
@@ -13,6 +13,7 @@ from app.services.strategy_mt1_preregistration import build_declarations
 
 _FAN = (("best_case", "masked"), ("best_case", "admitted"), ("worst_case", "masked"), ("worst_case", "admitted"))
 _SHA = "0" * 64
+_RUNNER_HEAD = "a" * 40
 _DECISION_DATES = [date(2020, 1, 2), date(2020, 2, 3)]
 
 
@@ -39,13 +40,13 @@ def _insert_attempt(conn: psycopg.Connection[tuple], *, passed: bool) -> int:
             trial_register_version, trial_contract_version, book_rule_version,
             evaluator_version, metric_axis_rule_version, metric_axis_dates,
             metric_axis_start, metric_axis_end, metric_axis_digest,
-            opportunity_set_digest, passed, refusal_code, refusal_detail,
+            opportunity_set_digest, runner_source_head, passed, refusal_code, refusal_detail,
             structural_evidence_sha256, structural_evidence_json
         ) VALUES (
             %s, %s, 'mt1-capped-volatility-managed-relative-strength-v1', %s,
             'mt1-s8-capped-volatility-negative-control-v1', %s, 'source-mt1', 'source-s8',
             'survivorship_free', 'corpus-v1', 'cost-v1', 'register-v1', 'contract-v1',
-            'book-v1', 'evaluator-v1', 'full-namespace-panel-v1', %s, %s, %s, %s, %s,
+            'book-v1', 'evaluator-v1', 'full-namespace-panel-v1', %s, %s, %s, %s, %s, %s,
             %s, %s, %s, %s, '{}'::jsonb
         ) RETURNING structural_attempt_id
         """,
@@ -59,6 +60,7 @@ def _insert_attempt(conn: psycopg.Connection[tuple], *, passed: bool) -> int:
             _DECISION_DATES[-1],
             _SHA,
             _SHA,
+            _RUNNER_HEAD,
             passed,
             None if passed else "structural_gate_refused",
             None if passed else "synthetic structural refusal",
@@ -287,5 +289,5 @@ def test_committed_trial_evidence_is_immutable(ebull_test_conn: psycopg.Connecti
         _insert_result_cell(ebull_test_conn, result_id, arms, passed=True)
     ebull_test_conn.commit()
     with pytest.raises(psycopg.errors.RaiseException, match="evidence is immutable"):
-        ebull_test_conn.execute(statement)
+        ebull_test_conn.execute(statement)  # type: ignore[arg-type] - fixed test-only SQL cases above
     ebull_test_conn.rollback()

--- a/tests/test_2769_mt1_result_ledger_db.py
+++ b/tests/test_2769_mt1_result_ledger_db.py
@@ -161,6 +161,32 @@ def test_passed_structural_attempt_cannot_commit_without_complete_fan(
     with pytest.raises(psycopg.errors.RaiseException, match="requires exactly 4 cells"):
         ebull_test_conn.commit()
     ebull_test_conn.rollback()
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_mt1_structural_attempts").fetchone() == (0,)
+
+
+def test_duplicate_structural_fan_cell_is_refused(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    attempt_id = _insert_attempt(ebull_test_conn, passed=True)
+    arms = _FAN[0]
+    for _ in range(2):
+        try:
+            ebull_test_conn.execute(
+                """
+                INSERT INTO strategy_mt1_structural_cells (
+                    structural_attempt_id, ambiguity_arm, quarantine_arm, mt1_decision_dates,
+                    s8_decision_dates, mt1_annualised_turnover, s8_annualised_turnover,
+                    mt1_traded_notional, s8_traded_notional, exposure_reconciled,
+                    evidence_sha256, evidence_json
+                ) VALUES (%s, %s, %s, %s, %s, 1, 1, 100, 100, TRUE, %s, '{}'::jsonb)
+                """,
+                (attempt_id, arms[0], arms[1], _DECISION_DATES, _DECISION_DATES, _SHA),
+            )
+        except psycopg.errors.UniqueViolation:
+            break
+    else:  # pragma: no cover - the primary key must reject the second row
+        raise AssertionError("duplicate fan cell was accepted")
+    ebull_test_conn.rollback()
 
 
 def test_refused_structural_attempt_has_zero_cells_and_cannot_own_results(
@@ -181,6 +207,17 @@ def test_partial_result_fan_cannot_commit(ebull_test_conn: psycopg.Connection[tu
         _insert_result_cell(ebull_test_conn, result_id, arms, passed=False)
     with pytest.raises(psycopg.errors.RaiseException, match="four result cells"):
         ebull_test_conn.commit()
+    ebull_test_conn.rollback()
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_mt1_trial_results").fetchone() == (0,)
+
+
+def test_partial_four_arm_result_cell_is_refused(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    attempt_id = _complete_structural_attempt(ebull_test_conn)
+    result_id = _insert_result_header(ebull_test_conn, attempt_id, passed=False)
+    with pytest.raises(psycopg.errors.NotNullViolation):
+        _insert_result_cell(ebull_test_conn, result_id, _FAN[0], passed=False, cer=None)
     ebull_test_conn.rollback()
 
 

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -204,9 +204,12 @@ class TestPatchConfig:
 
     def test_enable_live_with_confirm_succeeds(self) -> None:
         _override_conn(_mock_conn())
-        with patch(
-            "app.api.config.update_runtime_config",
-            return_value=_runtime(auto=True, live=True),
+        with (
+            patch("app.api.config.load_paper_pool", return_value=MagicMock(enabled=False)),
+            patch(
+                "app.api.config.update_runtime_config",
+                return_value=_runtime(auto=True, live=True),
+            ),
         ):
             resp = client.patch(
                 "/config",
@@ -219,6 +222,28 @@ class TestPatchConfig:
             )
         assert resp.status_code == 200
         assert resp.json()["enable_live_trading"] is True
+
+    def test_enable_live_refuses_while_strategy_paper_automation_is_enabled(self) -> None:
+        _override_conn(_mock_conn())
+        with (
+            patch("app.api.config.load_paper_pool", return_value=MagicMock(enabled=True)),
+            patch("app.api.config.update_runtime_config") as mock_update,
+        ):
+            resp = client.patch(
+                "/config",
+                json={
+                    "updated_by": "op",
+                    "reason": "go live",
+                    "enable_live_trading": True,
+                    "confirm_live_enable": True,
+                },
+            )
+
+        assert resp.status_code == 409
+        assert resp.json()["detail"] == (
+            "live trading cannot be enabled while strategy paper automation is enabled"
+        )
+        mock_update.assert_not_called()
 
     def test_disable_live_does_not_require_confirm(self) -> None:
         _override_conn(_mock_conn())

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -451,6 +451,13 @@ def test_empty_ledgers_still_return_all_manifest_strategies(
     assert overview.automation_readiness.resolved_forecasts == 0
     assert overview.account_equity_evidence.status == "unavailable"
     assert overview.account_equity_evidence.days_collected == 0
+    assert len(overview.controlled_trials) == 1
+    controlled = overview.controlled_trials[0]
+    assert controlled.state == "not_run"
+    assert (controlled.holdout_evaluations, controlled.holdout_accesses) == (0, 0)
+    assert controlled.promotion_authority is False
+    assert controlled.paper_activation_reachable is False
+    assert controlled.live_activation_reachable is False
     s4 = next(item for item in overview.strategies if item.strategy_id == "s4-volatility-compression-breakout")
     assert s4.runnable
     assert s4.exclusion_reason is None

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -846,3 +846,34 @@ def test_derive_overall_status_engine_up_unchanged() -> None:
     # Engine up + everything clean → ok (default arg also engine-up).
     assert _derive_overall_status(layers, jobs, False, set(), jobs_process_down=False) == "ok"
     assert _derive_overall_status(layers, jobs, False, set()) == "ok"
+
+
+def test_jobs_process_health_preserves_execution_slot_wait_notes() -> None:
+    from app.api.system import _build_jobs_process_health
+
+    conn = _mock_conn()
+    cursor = conn.cursor.return_value.__enter__.return_value
+    cursor.fetchall.return_value = [
+        {
+            "subsystem": "scheduler",
+            "last_beat_at": _NOW - timedelta(seconds=3),
+            "notes": {
+                "execution_slot_wait_count": 1,
+                "execution_slot_waits": [
+                    {
+                        "job_name": "pg_size_sample",
+                        "lane": "general_non_sec",
+                        "waiting_since": (_NOW - timedelta(seconds=12)).isoformat(),
+                        "wait_age_seconds": 9.0,
+                    }
+                ],
+            },
+        }
+    ]
+
+    health = _build_jobs_process_health(conn, _NOW)
+
+    assert health.state == "healthy"
+    assert health.subsystems[0].age_seconds == 3
+    assert health.subsystems[0].notes is not None
+    assert health.subsystems[0].notes["execution_slot_waits"][0]["job_name"] == "pg_size_sample"

--- a/tests/test_audit_2697_legacy_metric_axis.py
+++ b/tests/test_audit_2697_legacy_metric_axis.py
@@ -4,7 +4,7 @@ from datetime import date
 from typing import Any
 
 from app.services.strategy_result import ResultIdentity
-from scripts.audit_2697_legacy_metric_axis import _AXIS_FIELDS, audit_rows
+from scripts.audit_2697_legacy_metric_axis import _AXIS_FIELDS, audit_rows, invocation_failures
 from scripts.audit_2745_in_sample_run import (
     AMBIGUITY_ARMS,
     EXPECTED_IDENTITY,
@@ -66,7 +66,8 @@ def _complete() -> list[dict[str, Any]]:
 
 
 def test_complete_legacy_population_is_structurally_refused_without_metrics() -> None:
-    report = audit_rows(_complete())
+    report = audit_rows(_complete(), run_id=99585)
+    assert report.run_id == 99585
     assert report.failures == ()
     assert len(report.result_ids) == 40
 
@@ -74,11 +75,48 @@ def test_complete_legacy_population_is_structurally_refused_without_metrics() ->
 def test_one_invented_axis_field_fails_the_structural_audit() -> None:
     rows = _complete()
     rows[0]["metric_axis_rule_version"] = "full-namespace-panel-v1"
-    report = audit_rows(rows)
+    report = audit_rows(rows, run_id=99585)
     assert any("invented metric-axis fields" in failure for failure in report.failures)
 
 
 def test_missing_arm_is_an_integrity_failure() -> None:
-    report = audit_rows(_complete()[:-1])
+    report = audit_rows(_complete()[:-1], run_id=99585)
     assert any("published 39 rows" in failure for failure in report.failures)
     assert any("missing result keys" in failure for failure in report.failures)
+
+
+def test_retry_invocation_requires_exact_run_and_request_payloads() -> None:
+    expected = {
+        "synthetic_control": True,
+        "trial_register_version": "trial-register-2026-08-15-r6",
+    }
+    assert (
+        invocation_failures(
+            job_name="strategy_backtest_run",
+            params=expected,
+            request_id=408,
+            request=("strategy_backtest_run", {"control": {}, "params": expected}),
+        )
+        == ()
+    )
+
+    failures = invocation_failures(
+        job_name="strategy_backtest_run",
+        params={**expected, "synthetic_control": False},
+        request_id=408,
+        request=("strategy_backtest_run", {"control": {}, "params": expected}),
+    )
+    assert failures == ("job params_snapshot is not the exact declared r6 payload",)
+
+
+def test_retry_invocation_refuses_missing_linked_request() -> None:
+    failures = invocation_failures(
+        job_name="strategy_backtest_run",
+        params={
+            "synthetic_control": True,
+            "trial_register_version": "trial-register-2026-08-15-r6",
+        },
+        request_id=408,
+        request=None,
+    )
+    assert failures == ("linked request 408 is missing",)

--- a/tests/test_audit_2697_metric_axis_ab.py
+++ b/tests/test_audit_2697_metric_axis_ab.py
@@ -11,7 +11,7 @@ from scripts.audit_2697_metric_axis_ab import _CONTROL, _CONTROL_DELTA, _METRICS
 _HEAD = "a" * 40
 
 
-def _numbers(keys: frozenset[str]) -> dict[str, float]:
+def _numbers(keys: frozenset[str]) -> dict[str, object]:
     return {key: float(index + 1) for index, key in enumerate(sorted(keys))}
 
 

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -1233,6 +1233,8 @@ class TestNamespaceAxis:
         assert outcome.metrics.trade_count == 0
         assert outcome.metrics.total_return_pct == 0.0
         assert outcome.metrics.effective_sample_size is None
+        assert outcome.source_book is not None
+        assert len(outcome.source_book) == 0
 
     def test_the_axis_keeps_cash_on_both_sides_of_the_namespaces_legs(self) -> None:
         axis = tuple(date(2010, 1, day) for day in range(1, 11))
@@ -1276,6 +1278,12 @@ class TestNamespaceAxis:
         assert outcome is not None
         assert outcome.axis_dates == axis
         assert outcome.metrics.effective_sample_size is not None
+        assert outcome.source_book is not None
+        assert outcome.source_book.entry_index == [3]
+        assert outcome.source_book.exit_index == [6]
+        assert outcome.source_book.entry_price == [1.0]
+        assert outcome.source_book.exit_price == [1.2]
+        assert outcome.source_book.marks.tolist() == [1.0, 1.1, 1.15, 1.2]
 
     def test_moving_only_the_first_firing_and_last_exit_cannot_move_axis_identity(self) -> None:
         axis = tuple(date(2010, 1, day) for day in range(1, 11))

--- a/tests/test_connection_budget_sec_lane.py
+++ b/tests/test_connection_budget_sec_lane.py
@@ -33,5 +33,10 @@ def test_demand_plus_reserve_exactly_fits_usable():
 
 def test_execution_gates_fit_the_modeled_cadence_burst():
     assert pg_settings.JOBS_NON_SEC_MAX_CONCURRENCY == 2
+    assert pg_settings.JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY == 1
+    assert pg_settings.JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY == 1
+    assert pg_settings.JOBS_NON_SEC_MAX_CONCURRENCY == (
+        pg_settings.JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY + pg_settings.JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY
+    )
     assert pg_settings.JOBS_NON_SEC_CONNECTIONS_PER_EXECUTION == 2
     assert pg_settings.JOBS_BACKTEST_PROGRESS_CONNECTIONS == 1

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -233,8 +233,8 @@ class TestDistinctJobConcurrency:
 
 
 class TestConnectionBudgetExecutionGate:
-    def test_third_non_sec_execution_waits_without_opening_a_connection(self) -> None:
-        from app.jobs.runtime import _job_execution_slot
+    def test_paper_lifecycle_enters_while_general_work_waits(self) -> None:
+        from app.jobs.runtime import _job_execution_slot, execution_slot_wait_snapshot
 
         release = threading.Event()
         entered = [threading.Event() for _ in range(3)]
@@ -245,22 +245,58 @@ class TestConnectionBudgetExecutionGate:
                 release.wait(timeout=2.0)
 
         threads = [
-            threading.Thread(target=hold, args=("strategy_paper_cycle", entered[0]), daemon=True),
-            threading.Thread(target=hold, args=("thesis_refresh", entered[1]), daemon=True),
-            threading.Thread(target=hold, args=("pg_size_sample", entered[2]), daemon=True),
+            threading.Thread(target=hold, args=("thesis_refresh", entered[0]), daemon=True),
+            threading.Thread(target=hold, args=("pg_size_sample", entered[1]), daemon=True),
+            threading.Thread(target=hold, args=("strategy_paper_cycle", entered[2]), daemon=True),
         ]
         try:
             threads[0].start()
-            threads[1].start()
             assert entered[0].wait(timeout=1.0)
-            assert entered[1].wait(timeout=1.0)
+            threads[1].start()
+            assert not entered[1].wait(timeout=0.1), "second general job bypassed the one-slot budget"
+            snapshot = execution_slot_wait_snapshot()
+            assert snapshot["execution_slot_wait_count"] == 1
+            assert snapshot["execution_slot_waits"] == [
+                {
+                    "job_name": "pg_size_sample",
+                    "lane": "general_non_sec",
+                    "waiting_since": snapshot["execution_slot_waits"][0]["waiting_since"],
+                    "wait_age_seconds": snapshot["execution_slot_waits"][0]["wait_age_seconds"],
+                }
+            ]
+            assert snapshot["execution_slot_waits"][0]["wait_age_seconds"] >= 0
             threads[2].start()
-            assert not entered[2].wait(timeout=0.1)
+            assert entered[2].wait(timeout=1.0), "paper lifecycle was starved by general jobs"
+        finally:
+            release.set()
+            for thread in threads:
+                if thread.ident is not None:
+                    thread.join(timeout=1.0)
+        assert entered[1].is_set()
+        assert execution_slot_wait_snapshot()["execution_slot_waits"] == []
+
+    def test_second_paper_lifecycle_waits_for_reserved_slot(self) -> None:
+        from app.jobs.runtime import _job_execution_slot
+
+        release = threading.Event()
+        entered = [threading.Event(), threading.Event()]
+
+        def hold(marker: threading.Event) -> None:
+            with _job_execution_slot("strategy_paper_cycle"):
+                marker.set()
+                release.wait(timeout=2.0)
+
+        threads = [threading.Thread(target=hold, args=(marker,), daemon=True) for marker in entered]
+        try:
+            threads[0].start()
+            assert entered[0].wait(timeout=1.0)
+            threads[1].start()
+            assert not entered[1].wait(timeout=0.1)
         finally:
             release.set()
             for thread in threads:
                 thread.join(timeout=1.0)
-        assert entered[2].is_set()
+        assert entered[1].is_set()
 
     def test_fifth_sec_execution_waits_for_one_of_four_slots(self) -> None:
         from app.jobs.runtime import _job_execution_slot

--- a/tests/test_run_2769_mt1_in_sample.py
+++ b/tests/test_run_2769_mt1_in_sample.py
@@ -61,7 +61,7 @@ def test_default_command_checks_authority_without_running_outcomes(
 def test_execution_requires_literal_and_reports_structural_refusal(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(command, "assert_exact_clean_main_source", lambda: {"source": "merged"})
+    monkeypatch.setattr(command, "assert_exact_clean_main_source", lambda: {"runner_source_head": "a" * 40})
     monkeypatch.setattr(command, "assert_policy_version_merged", lambda: {"policy": "merged"})
     monkeypatch.setattr(command.psycopg, "connect", lambda _url: _Connection())
     monkeypatch.setattr(
@@ -81,8 +81,8 @@ def test_exact_source_guard_refuses_an_unmerged_runner(monkeypatch: pytest.Monke
     monkeypatch.setattr(command, "refresh_main_ref", lambda: True)
     outputs = {
         ("status", "--porcelain"): "",
-        ("rev-parse", "HEAD"): "candidate-head\n",
-        ("rev-parse", "origin/main"): "merged-head\n",
+        ("rev-parse", "HEAD"): "a" * 40 + "\n",
+        ("rev-parse", "origin/main"): "b" * 40 + "\n",
     }
     monkeypatch.setattr(command, "_git_output", lambda *args: outputs[args])
 
@@ -94,14 +94,14 @@ def test_exact_source_guard_accepts_only_clean_exact_main(monkeypatch: pytest.Mo
     monkeypatch.setattr(command, "refresh_main_ref", lambda: True)
     outputs = {
         ("status", "--porcelain"): "",
-        ("rev-parse", "HEAD"): "merged-head\n",
-        ("rev-parse", "origin/main"): "merged-head\n",
+        ("rev-parse", "HEAD"): "a" * 40 + "\n",
+        ("rev-parse", "origin/main"): "a" * 40 + "\n",
     }
     monkeypatch.setattr(command, "_git_output", lambda *args: outputs[args])
 
     assert command.assert_exact_clean_main_source() == {
         "runner_source_clean": True,
-        "runner_source_head": "merged-head",
+        "runner_source_head": "a" * 40,
         "runner_source_matches_main": True,
     }
 

--- a/tests/test_run_2769_mt1_in_sample.py
+++ b/tests/test_run_2769_mt1_in_sample.py
@@ -25,6 +25,11 @@ def test_wrong_execution_acknowledgement_refuses_before_policy_or_database(
         "assert_policy_version_merged",
         lambda: (_ for _ in ()).throw(AssertionError("policy guard must not run")),
     )
+    monkeypatch.setattr(
+        command,
+        "assert_exact_clean_main_source",
+        lambda: (_ for _ in ()).throw(AssertionError("source guard must not run")),
+    )
     with pytest.raises(SystemExit, match="2"):
         command.main(["--execute", "wrong"])
 
@@ -38,6 +43,7 @@ def test_default_command_checks_authority_without_running_outcomes(
         strategy_id="mt1",
         strategy_version="v1",
     )
+    monkeypatch.setattr(command, "assert_exact_clean_main_source", lambda: {"source": "merged"})
     monkeypatch.setattr(command, "assert_policy_version_merged", lambda: {"policy": "merged"})
     monkeypatch.setattr(command.psycopg, "connect", lambda _url: _Connection())
     monkeypatch.setattr(command, "validate_mt1_preregistrations", lambda _conn: (authority, authority))
@@ -55,6 +61,7 @@ def test_default_command_checks_authority_without_running_outcomes(
 def test_execution_requires_literal_and_reports_structural_refusal(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    monkeypatch.setattr(command, "assert_exact_clean_main_source", lambda: {"source": "merged"})
     monkeypatch.setattr(command, "assert_policy_version_merged", lambda: {"policy": "merged"})
     monkeypatch.setattr(command.psycopg, "connect", lambda _url: _Connection())
     monkeypatch.setattr(
@@ -68,3 +75,47 @@ def test_execution_requires_literal_and_reports_structural_refusal(
     output = capsys.readouterr().out
     assert "structural_gate_refused_no_performance_stored" in output
     assert '"structural_attempt_id": 42' in output
+
+
+def test_exact_source_guard_refuses_an_unmerged_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command, "refresh_main_ref", lambda: True)
+    outputs = {
+        ("status", "--porcelain"): "",
+        ("rev-parse", "HEAD"): "candidate-head\n",
+        ("rev-parse", "origin/main"): "merged-head\n",
+    }
+    monkeypatch.setattr(command, "_git_output", lambda *args: outputs[args])
+
+    with pytest.raises(SystemExit, match="is not exact origin/main"):
+        command.assert_exact_clean_main_source()
+
+
+def test_exact_source_guard_accepts_only_clean_exact_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command, "refresh_main_ref", lambda: True)
+    outputs = {
+        ("status", "--porcelain"): "",
+        ("rev-parse", "HEAD"): "merged-head\n",
+        ("rev-parse", "origin/main"): "merged-head\n",
+    }
+    monkeypatch.setattr(command, "_git_output", lambda *args: outputs[args])
+
+    assert command.assert_exact_clean_main_source() == {
+        "runner_source_clean": True,
+        "runner_source_head": "merged-head",
+        "runner_source_matches_main": True,
+    }
+
+
+def test_source_refusal_happens_before_database_access(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        command,
+        "assert_exact_clean_main_source",
+        lambda: (_ for _ in ()).throw(SystemExit("unmerged runner")),
+    )
+    monkeypatch.setattr(
+        command.psycopg,
+        "connect",
+        lambda _url: (_ for _ in ()).throw(AssertionError("database must remain unopened")),
+    )
+    with pytest.raises(SystemExit, match="unmerged runner"):
+        command.main([])

--- a/tests/test_run_2769_mt1_in_sample.py
+++ b/tests/test_run_2769_mt1_in_sample.py
@@ -1,0 +1,70 @@
+"""CLI safety boundary for the one MT-1 in-sample invocation (#2769)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import scripts.run_2769_mt1_in_sample as command
+
+
+class _Connection:
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def test_wrong_execution_acknowledgement_refuses_before_policy_or_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        command,
+        "assert_policy_version_merged",
+        lambda: (_ for _ in ()).throw(AssertionError("policy guard must not run")),
+    )
+    with pytest.raises(SystemExit, match="2"):
+        command.main(["--execute", "wrong"])
+
+
+def test_default_command_checks_authority_without_running_outcomes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    authority = SimpleNamespace(
+        declaration_id=8,
+        declaration_sha256="a" * 64,
+        strategy_id="mt1",
+        strategy_version="v1",
+    )
+    monkeypatch.setattr(command, "assert_policy_version_merged", lambda: {"policy": "merged"})
+    monkeypatch.setattr(command.psycopg, "connect", lambda _url: _Connection())
+    monkeypatch.setattr(command, "validate_mt1_preregistrations", lambda _conn: (authority, authority))
+    monkeypatch.setattr(
+        command,
+        "run_and_store_mt1_in_sample_evaluation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("outcomes must remain sealed")),
+    )
+
+    assert command.main([]) == 0
+
+    assert "authority_ready_no_outcomes_evaluated" in capsys.readouterr().out
+
+
+def test_execution_requires_literal_and_reports_structural_refusal(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(command, "assert_policy_version_merged", lambda: {"policy": "merged"})
+    monkeypatch.setattr(command.psycopg, "connect", lambda _url: _Connection())
+    monkeypatch.setattr(
+        command,
+        "run_and_store_mt1_in_sample_evaluation",
+        lambda *_args, **_kwargs: command.MT1StoredRefusal(42, "turnover refused"),
+    )
+
+    assert command.main(["--execute", command.ACKNOWLEDGEMENT]) == 2
+
+    output = capsys.readouterr().out
+    assert "structural_gate_refused_no_performance_stored" in output
+    assert '"structural_attempt_id": 42' in output

--- a/tests/test_strategy_live_gate.py
+++ b/tests/test_strategy_live_gate.py
@@ -55,7 +55,7 @@ def _session() -> SessionRow:
     return SessionRow("live-gate-session", uuid4(), "operator", now + timedelta(hours=1), now)
 
 
-def _forward_stage(conn: psycopg.Connection[Any]) -> None:
+def _forward_stage(conn: psycopg.Connection[Any], *, forward_days: int = 38) -> None:
     conn.execute(
         """
         INSERT INTO strategy_promotions (
@@ -66,9 +66,9 @@ def _forward_stage(conn: psycopg.Connection[Any]) -> None:
           (%s,%s,'research_candidate','historical_validated','test-v1',
            'hist','test','history',now()-interval '39 days'),
           (%s,%s,'historical_validated','forward_observation','test-v1',
-           'forward','test','observe',now()-interval '38 days')
+           'forward','test','observe',now()-(%s * interval '1 day'))
         """,
-        (_STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION),
+        (_STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION, forward_days),
     )
 
 
@@ -414,15 +414,8 @@ def test_paper_duration_uses_observation_time_not_pre_2000_signal_bar(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:
     conn = ebull_test_conn
-    _forward_stage(conn)
+    _forward_stage(conn, forward_days=5)
     _policy(conn)
-    conn.execute(
-        """
-        UPDATE strategy_promotions SET promoted_at=now()-interval '5 days'
-        WHERE strategy_id=%s AND to_stage='forward_observation'
-        """,
-        (_STRATEGY_ID,),
-    )
     promote_strategy(
         conn,
         strategy_id=_STRATEGY_ID,

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -15,6 +15,7 @@ import psycopg
 import pytest
 from fastapi import HTTPException, Request
 
+from app.api.config import ConfigPatchRequest, patch_config
 from app.api.strategies import (
     AllocationUpdateRequest,
     StrategyPaperPoolUpdateRequest,
@@ -1487,6 +1488,65 @@ def test_paper_enable_waits_for_concurrent_live_update_then_refuses(
                     if current.enable_live_trading != runtime_before.enable_live_trading
                     else None
                 ),
+            )
+        conn.commit()
+
+
+def test_live_enable_waits_for_concurrent_paper_enable_then_refuses(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    runtime_before = get_runtime_config(conn)
+    if runtime_before.enable_live_trading:
+        update_runtime_config(
+            conn,
+            updated_by="test-precondition",
+            reason="establish live-off reciprocal-race precondition",
+            enable_live_trading=False,
+        )
+    conn.commit()
+    blocker = psycopg.connect(test_database_url())
+    worker = psycopg.connect(test_database_url())
+    configure_paper_pool(
+        blocker,
+        enabled=True,
+        capital_limit=Decimal("750"),
+        risk_profile="balanced",
+        changed_by="paper-operator",
+        reason="concurrent bounded strategy enable",
+    )
+    request = ConfigPatchRequest(
+        updated_by="live-operator",
+        reason="must serialize behind strategy paper enable",
+        enable_live_trading=True,
+        confirm_live_enable=True,
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(patch_config, request, worker)
+            with pytest.raises(FutureTimeoutError):
+                future.result(timeout=0.1)
+            blocker.commit()
+            with pytest.raises(HTTPException) as exc_info:
+                future.result(timeout=5)
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == (
+            "live trading cannot be enabled while strategy paper automation is enabled"
+        )
+        assert not get_runtime_config(conn).enable_live_trading
+    finally:
+        blocker.rollback()
+        worker.rollback()
+        blocker.close()
+        worker.close()
+        conn.rollback()
+        current = get_runtime_config(conn)
+        if current.enable_live_trading != runtime_before.enable_live_trading:
+            update_runtime_config(
+                conn,
+                updated_by="test-cleanup",
+                reason="restore runtime live flag after reciprocal-race proof",
+                enable_live_trading=runtime_before.enable_live_trading,
             )
         conn.commit()
 

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -1286,6 +1286,75 @@ def test_shared_paper_pool_refuses_activation_outside_demo(
     assert get_runtime_config(conn) == runtime_before
 
 
+def test_shared_paper_pool_refuses_activation_while_live_trading_is_enabled(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    actual_overview = get_strategy_overview
+
+    def ready_overview(connection: psycopg.Connection[object]):
+        overview = actual_overview(connection)
+        overview.automation_readiness = overview.automation_readiness.model_copy(
+            update={"ready": True, "state": "ready", "blockers": []}
+        )
+        return overview
+
+    monkeypatch.setattr("app.api.strategies.get_strategy_overview", ready_overview)
+    runtime_before = get_runtime_config(conn)
+    if runtime_before.enable_auto_trading or not runtime_before.enable_live_trading:
+        update_runtime_config(
+            conn,
+            updated_by="test-precondition",
+            reason="prove paper enable refuses live state",
+            enable_auto_trading=False if runtime_before.enable_auto_trading else None,
+            enable_live_trading=True if not runtime_before.enable_live_trading else None,
+        )
+    conn.commit()
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            update_strategy_paper_pool(
+                StrategyPaperPoolUpdateRequest(
+                    enabled=True,
+                    capital_limit=Decimal("750"),
+                    capital_mode="fixed",
+                    risk_profile="balanced",
+                    reason="must remain paper-only",
+                ),
+                _session(),
+                conn,
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == ("paper automation cannot be enabled while system-wide live trading is enabled")
+        assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
+        assert conn.execute(
+            "SELECT enable_auto_trading,enable_live_trading FROM runtime_config WHERE id=TRUE"
+        ).fetchone() == (False, True)
+    finally:
+        current = get_runtime_config(conn)
+        if (
+            current.enable_auto_trading != runtime_before.enable_auto_trading
+            or current.enable_live_trading != runtime_before.enable_live_trading
+        ):
+            update_runtime_config(
+                conn,
+                updated_by="test-cleanup",
+                reason="restore runtime flags after live-state refusal proof",
+                enable_auto_trading=(
+                    runtime_before.enable_auto_trading
+                    if current.enable_auto_trading != runtime_before.enable_auto_trading
+                    else None
+                ),
+                enable_live_trading=(
+                    runtime_before.enable_live_trading
+                    if current.enable_live_trading != runtime_before.enable_live_trading
+                    else None
+                ),
+            )
+        conn.commit()
+
+
 def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -33,7 +33,7 @@ from app.security.sessions import SessionRow
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.runtime_config import get_runtime_config, update_runtime_config
-from app.services.strategy_control_plane import configure_paper_pool
+from app.services.strategy_control_plane import configure_paper_pool, load_paper_pool
 from app.services.strategy_monitoring import (
     load_attribution,
     load_control_state,
@@ -1580,6 +1580,87 @@ def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(
     assert exc_info.value.status_code == 409
     assert "no_capital_candidates" in str(exc_info.value.detail)
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
+
+
+def test_enabled_paper_pool_refuses_more_authority_while_readiness_is_degraded(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("500"),
+        capital_mode="fixed",
+        risk_profile="cautious",
+        changed_by="test-precondition",
+        reason="establish bounded enabled pool",
+    )
+    conn.commit()
+    monkeypatch.setattr(
+        "app.api.strategies.get_strategy_overview",
+        lambda _conn: SimpleNamespace(
+            automation_readiness=SimpleNamespace(ready=False, blockers=["prospective_assessment_stale"])
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_strategy_paper_pool(
+            StrategyPaperPoolUpdateRequest(
+                enabled=True,
+                capital_limit=Decimal("750"),
+                capital_mode="compound",
+                risk_profile="balanced",
+                reason="must not enlarge dormant authority",
+            ),
+            _session(),
+            conn,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "prospective_assessment_stale" in str(exc_info.value.detail)
+    assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (1,)
+
+
+def test_enabled_paper_pool_allows_risk_reduction_while_readiness_is_degraded(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("750"),
+        capital_mode="compound",
+        risk_profile="balanced",
+        changed_by="test-precondition",
+        reason="establish enabled pool",
+    )
+    conn.commit()
+    monkeypatch.setattr(
+        "app.api.strategies.get_strategy_overview",
+        lambda _conn: SimpleNamespace(
+            automation_readiness=SimpleNamespace(ready=False, blockers=["prospective_assessment_stale"]),
+            paper_pool=load_paper_pool(_conn),
+        ),
+    )
+
+    response = update_strategy_paper_pool(
+        StrategyPaperPoolUpdateRequest(
+            enabled=True,
+            capital_limit=Decimal("500"),
+            capital_mode="fixed",
+            risk_profile="cautious",
+            reason="reduce authority while evidence is stale",
+        ),
+        _session(),
+        conn,
+    )
+
+    assert response.enabled
+    assert response.capital_limit == Decimal("500")
+    assert response.capital_mode == "fixed"
+    assert response.mandate.risk_profile == "cautious"
 
 
 def test_evidence_refresh_queues_one_fixed_pinned_request(

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -1187,7 +1187,8 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     # runtime_config is a deliberately persistent singleton, unlike the
     # per-test pool event stream. Establish the transition this test asserts
     # when an earlier executor test enabled automation.
-    if get_runtime_config(conn).enable_auto_trading:
+    runtime_before = get_runtime_config(conn)
+    if runtime_before.enable_auto_trading:
         update_runtime_config(
             conn,
             updated_by="test-precondition",
@@ -1227,7 +1228,9 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     assert conn.execute(
         "SELECT enabled,capital_limit,capital_mode,changed_by,reason FROM strategy_paper_pool_events"
     ).fetchone() == (True, Decimal("750.000000"), "compound", "allocation-operator", "bounded paper workspace")
-    assert conn.execute("SELECT enable_auto_trading FROM runtime_config WHERE id=TRUE").fetchone() == (True,)
+    assert conn.execute(
+        "SELECT enable_auto_trading,enable_live_trading FROM runtime_config WHERE id=TRUE"
+    ).fetchone() == (True, runtime_before.enable_live_trading)
     assert conn.execute(
         """
         SELECT old_value,new_value,changed_by,reason
@@ -1253,6 +1256,33 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
         )
     assert exc_info.value.status_code == 409
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (1,)
+
+
+def test_shared_paper_pool_refuses_activation_outside_demo(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    runtime_before = get_runtime_config(conn)
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "real")
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_strategy_paper_pool(
+            StrategyPaperPoolUpdateRequest(
+                enabled=True,
+                capital_limit=Decimal("750"),
+                capital_mode="fixed",
+                risk_profile="balanced",
+                reason="must remain demo-only",
+            ),
+            _session(),
+            conn,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "paper automation can only be enabled in the demo environment"
+    assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
+    assert get_runtime_config(conn) == runtime_before
 
 
 def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
@@ -37,6 +39,7 @@ from app.services.strategy_monitoring import (
     load_owned_pnl,
 )
 from app.services.strategy_position_manager import PositionManagerResult
+from tests.fixtures.ebull_test_db import test_database_url
 
 
 def _instrument(conn: psycopg.Connection[Any], instrument_id: int) -> None:
@@ -1341,6 +1344,75 @@ def test_shared_paper_pool_refuses_activation_while_live_trading_is_enabled(
                 conn,
                 updated_by="test-cleanup",
                 reason="restore runtime flags after live-state refusal proof",
+                enable_auto_trading=(
+                    runtime_before.enable_auto_trading
+                    if current.enable_auto_trading != runtime_before.enable_auto_trading
+                    else None
+                ),
+                enable_live_trading=(
+                    runtime_before.enable_live_trading
+                    if current.enable_live_trading != runtime_before.enable_live_trading
+                    else None
+                ),
+            )
+        conn.commit()
+
+
+def test_paper_enable_waits_for_concurrent_live_update_then_refuses(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    runtime_before = get_runtime_config(conn)
+    if runtime_before.enable_auto_trading or runtime_before.enable_live_trading:
+        update_runtime_config(
+            conn,
+            updated_by="test-precondition",
+            reason="establish live-off concurrency precondition",
+            enable_auto_trading=False if runtime_before.enable_auto_trading else None,
+            enable_live_trading=False if runtime_before.enable_live_trading else None,
+        )
+    conn.commit()
+    monkeypatch.setattr(
+        "app.api.strategies.get_strategy_overview",
+        lambda _conn: SimpleNamespace(automation_readiness=SimpleNamespace(ready=True, blockers=[])),
+    )
+    blocker = psycopg.connect(test_database_url())
+    worker = psycopg.connect(test_database_url())
+    blocker.execute("UPDATE runtime_config SET enable_live_trading=TRUE WHERE id=TRUE")
+    request = StrategyPaperPoolUpdateRequest(
+        enabled=True,
+        capital_limit=Decimal("750"),
+        capital_mode="fixed",
+        risk_profile="balanced",
+        reason="must serialize behind live update",
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(update_strategy_paper_pool, request, _session(), worker)
+            with pytest.raises(FutureTimeoutError):
+                future.result(timeout=0.1)
+            blocker.commit()
+            with pytest.raises(HTTPException) as exc_info:
+                future.result(timeout=5)
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == ("paper automation cannot be enabled while system-wide live trading is enabled")
+        assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
+    finally:
+        blocker.rollback()
+        worker.rollback()
+        blocker.close()
+        worker.close()
+        conn.rollback()
+        current = get_runtime_config(conn)
+        if (
+            current.enable_auto_trading != runtime_before.enable_auto_trading
+            or current.enable_live_trading != runtime_before.enable_live_trading
+        ):
+            update_runtime_config(
+                conn,
+                updated_by="test-cleanup",
+                reason="restore runtime flags after concurrency proof",
                 enable_auto_trading=(
                     runtime_before.enable_auto_trading
                     if current.enable_auto_trading != runtime_before.enable_auto_trading

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -1188,12 +1188,13 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     # per-test pool event stream. Establish the transition this test asserts
     # when an earlier executor test enabled automation.
     runtime_before = get_runtime_config(conn)
-    if runtime_before.enable_auto_trading:
+    if runtime_before.enable_auto_trading or runtime_before.enable_live_trading:
         update_runtime_config(
             conn,
             updated_by="test-precondition",
-            reason="establish disabled automation precondition",
-            enable_auto_trading=False,
+            reason="establish paper-only automation precondition",
+            enable_auto_trading=False if runtime_before.enable_auto_trading else None,
+            enable_live_trading=False if runtime_before.enable_live_trading else None,
         )
     conn.commit()
     response = update_strategy_paper_pool(
@@ -1230,7 +1231,7 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     ).fetchone() == (True, Decimal("750.000000"), "compound", "allocation-operator", "bounded paper workspace")
     assert conn.execute(
         "SELECT enable_auto_trading,enable_live_trading FROM runtime_config WHERE id=TRUE"
-    ).fetchone() == (True, runtime_before.enable_live_trading)
+    ).fetchone() == (True, False)
     assert conn.execute(
         """
         SELECT old_value,new_value,changed_by,reason

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -32,6 +32,7 @@ from app.security.sessions import SessionRow
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.runtime_config import get_runtime_config, update_runtime_config
+from app.services.strategy_control_plane import configure_paper_pool
 from app.services.strategy_monitoring import (
     load_attribution,
     load_control_state,
@@ -1234,16 +1235,16 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     ).fetchone() == (True, Decimal("750.000000"), "compound", "allocation-operator", "bounded paper workspace")
     assert conn.execute(
         "SELECT enable_auto_trading,enable_live_trading FROM runtime_config WHERE id=TRUE"
-    ).fetchone() == (True, False)
+    ).fetchone() == (False, False)
     assert conn.execute(
         """
-        SELECT old_value,new_value,changed_by,reason
+        SELECT count(*)
         FROM runtime_config_audit
         WHERE field='enable_auto_trading'
-        ORDER BY audit_id DESC
-        LIMIT 1
+          AND changed_by='allocation-operator'
+          AND reason='bounded paper workspace'
         """
-    ).fetchone() == ("false", "true", "allocation-operator", "bounded paper workspace")
+    ).fetchone() == (0,)
     conn.commit()
 
     with pytest.raises(HTTPException) as exc_info:
@@ -1260,6 +1261,69 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
         )
     assert exc_info.value.status_code == 409
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (1,)
+
+
+def test_disabling_strategy_paper_does_not_disable_legacy_automation(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    runtime_before = get_runtime_config(conn)
+    if not runtime_before.enable_auto_trading or runtime_before.enable_live_trading:
+        update_runtime_config(
+            conn,
+            updated_by="test-precondition",
+            reason="establish independently enabled legacy lane",
+            enable_auto_trading=True if not runtime_before.enable_auto_trading else None,
+            enable_live_trading=False if runtime_before.enable_live_trading else None,
+        )
+    configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("750"),
+        risk_profile="balanced",
+        changed_by="test-precondition",
+        reason="establish enabled strategy lane",
+    )
+    conn.commit()
+    try:
+        response = update_strategy_paper_pool(
+            StrategyPaperPoolUpdateRequest(
+                enabled=False,
+                capital_limit=Decimal("750"),
+                capital_mode="fixed",
+                risk_profile="balanced",
+                reason="disable only the bounded strategy lane",
+            ),
+            _session(),
+            conn,
+        )
+
+        assert not response.enabled
+        assert conn.execute(
+            "SELECT enable_auto_trading,enable_live_trading FROM runtime_config WHERE id=TRUE"
+        ).fetchone() == (True, False)
+    finally:
+        current = get_runtime_config(conn)
+        if (
+            current.enable_auto_trading != runtime_before.enable_auto_trading
+            or current.enable_live_trading != runtime_before.enable_live_trading
+        ):
+            update_runtime_config(
+                conn,
+                updated_by="test-cleanup",
+                reason="restore runtime flags after lane-isolation proof",
+                enable_auto_trading=(
+                    runtime_before.enable_auto_trading
+                    if current.enable_auto_trading != runtime_before.enable_auto_trading
+                    else None
+                ),
+                enable_live_trading=(
+                    runtime_before.enable_live_trading
+                    if current.enable_live_trading != runtime_before.enable_live_trading
+                    else None
+                ),
+            )
+        conn.commit()
 
 
 def test_shared_paper_pool_refuses_activation_outside_demo(
@@ -1580,15 +1644,15 @@ def test_missing_runtime_singleton_is_visible_as_an_entry_block(
     assert not state.auto_trading_enabled
 
 
-def test_disabled_automatic_trading_is_visible_as_an_entry_block(
+def test_legacy_automatic_trading_switch_does_not_block_the_strategy_lane(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     ebull_test_conn.execute("UPDATE runtime_config SET enable_auto_trading=false")
 
     state = load_entry_block_state(ebull_test_conn)
 
-    assert state.new_entries_blocked
-    assert "automatic trading disabled" in state.execution_block_reasons
+    assert not state.new_entries_blocked
+    assert "automatic trading disabled" not in state.execution_block_reasons
     assert not state.auto_trading_enabled
 
 

--- a/tests/test_strategy_mt1_runner.py
+++ b/tests/test_strategy_mt1_runner.py
@@ -249,3 +249,83 @@ def test_source_fans_must_share_the_exact_axis_and_opportunity_population() -> N
             mt1_source_measurements=_fan(runner.MT1_SOURCE_STRATEGY_ID),
             s8_source_measurements=tuple(wrong_population),
         )
+
+
+def test_paved_run_checks_authority_before_corpus_and_builds_only_the_complete_in_sample_fan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[object] = []
+    authority = (
+        runner.MT1PreregistrationAuthority("mt1", "v1", 10, "a" * 64),
+        runner.MT1PreregistrationAuthority("s8", "v1", 11, "b" * 64),
+    )
+
+    def validate(_conn: object):
+        events.append("authority")
+        return authority
+
+    def load_corpus(_conn: object, **kwargs: object):
+        events.append(("corpus", kwargs))
+        return SimpleNamespace(universe_basis="survivorship_free")
+
+    def load_regime(_conn: object):
+        events.append("regime")
+        return object()
+
+    def evaluate(_conn: object, entry: object, **kwargs: object):
+        strategy_id = cast(str, getattr(entry, "strategy_id"))
+        quarantine = cast(str, kwargs["quarantine_arm"])
+        events.append(("evaluate", strategy_id, quarantine, kwargs["namespaces"]))
+        return tuple(_measurement(strategy_id, ambiguity, quarantine) for ambiguity in ("best_case", "worst_case"))
+
+    bundle = cast(runner.MT1HistoricalBundle, object())
+
+    def assemble(**kwargs: object):
+        events.append(
+            (
+                "assemble",
+                len(cast(tuple[object, ...], kwargs["mt1_source_measurements"])),
+                len(cast(tuple[object, ...], kwargs["s8_source_measurements"])),
+            )
+        )
+        return bundle
+
+    monkeypatch.setattr(runner, "validate_mt1_preregistrations", validate)
+    monkeypatch.setattr(runner, "load_corpus", load_corpus)
+    monkeypatch.setattr(runner.MarketRegimeProvider, "load_research", load_regime)
+    monkeypatch.setattr(runner, "evaluate_level_arms", evaluate)
+    monkeypatch.setattr(runner, "assemble_mt1_in_sample_bundle", assemble)
+
+    result = runner.run_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]
+
+    assert result.authorities == authority
+    assert result.bundle is bundle
+    assert events[0] == "authority"
+    assert events[1] == (
+        "corpus",
+        {"universe_basis": "survivorship_free", "evaluation_window": runner.MT1_IN_SAMPLE_WINDOW},
+    )
+    assert runner.MT1_IN_SAMPLE_WINDOW.end < runner.HOLDOUT_BOUNDARY
+    assert events[2] == "regime"
+    assert events[3:7] == [
+        ("evaluate", runner.MT1_SOURCE_STRATEGY_ID, "admitted", ("in_sample",)),
+        ("evaluate", runner.MT1_SOURCE_STRATEGY_ID, "masked", ("in_sample",)),
+        ("evaluate", runner.S8_SOURCE_STRATEGY_ID, "admitted", ("in_sample",)),
+        ("evaluate", runner.S8_SOURCE_STRATEGY_ID, "masked", ("in_sample",)),
+    ]
+    assert events[7] == ("assemble", 4, 4)
+
+
+def test_paved_run_loads_no_corpus_when_preregistration_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        runner,
+        "validate_mt1_preregistrations",
+        lambda _conn: (_ for _ in ()).throw(runner.MT1RunnerRefused("authority refused")),
+    )
+    monkeypatch.setattr(
+        runner,
+        "load_corpus",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("corpus must remain sealed")),
+    )
+    with pytest.raises(runner.MT1RunnerRefused, match="authority refused"):
+        runner.run_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]

--- a/tests/test_strategy_mt1_runner.py
+++ b/tests/test_strategy_mt1_runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import date
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -297,7 +297,9 @@ def test_paved_run_checks_authority_before_corpus_and_builds_only_the_complete_i
     monkeypatch.setattr(runner, "prepare_mt1_in_sample_bundle", prepare)
     monkeypatch.setattr(runner, "evaluate_mt1_prepared_bundle", lambda value: cast(runner.MT1HistoricalBundle, value))
 
-    result = runner.run_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]
+    result = runner.run_mt1_in_sample_evaluation(  # type: ignore[arg-type]
+        cast(Any, object()), runner_source_head="a" * 40
+    )
 
     assert result.authorities == authority
     assert result.bundle is cast(runner.MT1HistoricalBundle, prepared)
@@ -329,4 +331,21 @@ def test_paved_run_loads_no_corpus_when_preregistration_refuses(monkeypatch: pyt
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("corpus must remain sealed")),
     )
     with pytest.raises(runner.MT1RunnerRefused, match="authority refused"):
-        runner.run_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]
+        runner.run_mt1_in_sample_evaluation(  # type: ignore[arg-type]
+            cast(Any, object()), runner_source_head="a" * 40
+        )
+
+
+def test_paved_run_refuses_unpinned_source_before_authority_or_corpus(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        runner,
+        "validate_mt1_preregistrations",
+        lambda _conn: (_ for _ in ()).throw(AssertionError("authority must remain unread")),
+    )
+    monkeypatch.setattr(
+        runner,
+        "load_corpus",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("corpus must remain sealed")),
+    )
+    with pytest.raises(runner.MT1RunnerRefused, match="exact lower-case Git object ID"):
+        runner.run_mt1_in_sample_evaluation(cast(Any, object()), runner_source_head="not-a-git-head")

--- a/tests/test_strategy_mt1_runner.py
+++ b/tests/test_strategy_mt1_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date
 from types import SimpleNamespace
 from typing import cast
@@ -11,6 +12,8 @@ import pytest
 import app.services.strategy_mt1_runner as runner
 from app.services.backtest_run import ArmMeasurement, NamespaceMeasurement
 from app.services.equity_curve import LegBook
+from app.services.result_ledger import FrozenPreregistration, HoldoutAccessCounts
+from app.services.strategy_mt1_preregistration import build_declarations
 from app.services.strategy_result import AmbiguityArm
 from app.services.strategy_result_universe import ResultUniverseRecord
 from app.services.strategy_statistics import StrategyMetrics
@@ -62,6 +65,85 @@ def _measurement(
 
 def _fan(strategy_id: str) -> tuple[ArmMeasurement, ...]:
     return tuple(_measurement(strategy_id, ambiguity, quarantine) for ambiguity, quarantine in _KEYS)
+
+
+def _frozen(index: int, *, declaration=None, digest: str | None = None) -> FrozenPreregistration:
+    current = declaration or build_declarations()[index]
+    return FrozenPreregistration(
+        declaration_id=100 + index,
+        declaration=current,
+        declaration_sha256=current.sha256 if digest is None else digest,
+        chain_declaration_ids=(8 + index, 100 + index),
+        supersedes_declaration_id=8 + index,
+        supersession_reason="structural_refusal_policy_superseded",
+        supersession_attestation="no outcome access",
+    )
+
+
+def test_preregistration_authority_requires_both_current_exact_unexposed_declarations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frozen = [_frozen(0), _frozen(1)]
+    monkeypatch.setattr(
+        runner,
+        "load_preregistration",
+        lambda _conn, strategy_id, _version: (
+            frozen[0] if strategy_id == frozen[0].declaration.strategy_id else frozen[1]
+        ),
+    )
+    monkeypatch.setattr(runner, "holdout_access_counts", lambda *_args: HoldoutAccessCounts(0, 0))
+
+    authority = runner.validate_mt1_preregistrations(cast(object, object()))  # type: ignore[arg-type]
+
+    assert tuple(item.declaration_id for item in authority) == (100, 101)
+    assert tuple(item.declaration_sha256 for item in authority) == tuple(item.declaration_sha256 for item in frozen)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    (
+        ("missing", "preregistration_missing"),
+        ("digest", "declaration_digest_mismatch"),
+        ("terms", "declaration_terms_changed=forward_shadow"),
+        ("policy", "structural_refusal_policy_superseded"),
+        ("exposed", "holdout_evaluations_already_exist=1"),
+    ),
+)
+def test_preregistration_authority_refuses_every_pre_outcome_boundary_breach(
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+    message: str,
+) -> None:
+    declarations = build_declarations()
+    first: FrozenPreregistration | None = _frozen(0)
+    if mutation == "missing":
+        first = None
+    elif mutation == "digest":
+        first = _frozen(0, digest="0" * 64)
+    elif mutation == "terms":
+        changed = replace(
+            declarations[0],
+            forward_shadow=replace(declarations[0].forward_shadow, min_calendar_weeks=158),
+        )
+        first = _frozen(0, declaration=changed)
+    elif mutation == "policy":
+        changed = replace(declarations[0], structural_refusal_policy_version="stale-policy")
+        first = _frozen(0, declaration=changed)
+
+    def load(_conn: object, strategy_id: str, _version: str) -> FrozenPreregistration | None:
+        return first if strategy_id == declarations[0].strategy_id else _frozen(1)
+
+    def counts(_conn: object, strategy_id: str, _version: str) -> HoldoutAccessCounts:
+        return (
+            HoldoutAccessCounts(1, 0)
+            if mutation == "exposed" and strategy_id == declarations[0].strategy_id
+            else HoldoutAccessCounts(0, 0)
+        )
+
+    monkeypatch.setattr(runner, "load_preregistration", load)
+    monkeypatch.setattr(runner, "holdout_access_counts", counts)
+    with pytest.raises(runner.MT1RunnerRefused, match=message):
+        runner.validate_mt1_preregistrations(cast(object, object()))  # type: ignore[arg-type]
 
 
 def test_missing_robustness_cell_refuses_before_any_book_construction(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_strategy_mt1_runner.py
+++ b/tests/test_strategy_mt1_runner.py
@@ -268,8 +268,8 @@ def test_paved_run_checks_authority_before_corpus_and_builds_only_the_complete_i
         events.append(("corpus", kwargs))
         return SimpleNamespace(universe_basis="survivorship_free")
 
-    def load_regime(_conn: object):
-        events.append("regime")
+    def load_regime(_conn: object, *, through_date: date | None = None):
+        events.append(("regime", through_date))
         return object()
 
     def evaluate(_conn: object, entry: object, **kwargs: object):
@@ -309,7 +309,7 @@ def test_paved_run_checks_authority_before_corpus_and_builds_only_the_complete_i
         {"universe_basis": "survivorship_free", "evaluation_window": runner.MT1_IN_SAMPLE_WINDOW},
     )
     assert runner.MT1_IN_SAMPLE_WINDOW.end < runner.HOLDOUT_BOUNDARY
-    assert events[2] == "regime"
+    assert events[2] == ("regime", runner.MT1_IN_SAMPLE_WINDOW.end)
     assert events[3:7] == [
         ("evaluate", runner.MT1_SOURCE_STRATEGY_ID, "admitted", ("in_sample",)),
         ("evaluate", runner.MT1_SOURCE_STRATEGY_ID, "masked", ("in_sample",)),

--- a/tests/test_strategy_mt1_runner.py
+++ b/tests/test_strategy_mt1_runner.py
@@ -278,28 +278,29 @@ def test_paved_run_checks_authority_before_corpus_and_builds_only_the_complete_i
         events.append(("evaluate", strategy_id, quarantine, kwargs["namespaces"]))
         return tuple(_measurement(strategy_id, ambiguity, quarantine) for ambiguity in ("best_case", "worst_case"))
 
-    bundle = cast(runner.MT1HistoricalBundle, object())
+    prepared = cast(runner.MT1PreparedBundle, object())
 
-    def assemble(**kwargs: object):
+    def prepare(**kwargs: object):
         events.append(
             (
-                "assemble",
+                "prepare",
                 len(cast(tuple[object, ...], kwargs["mt1_source_measurements"])),
                 len(cast(tuple[object, ...], kwargs["s8_source_measurements"])),
             )
         )
-        return bundle
+        return prepared
 
     monkeypatch.setattr(runner, "validate_mt1_preregistrations", validate)
     monkeypatch.setattr(runner, "load_corpus", load_corpus)
     monkeypatch.setattr(runner.MarketRegimeProvider, "load_research", load_regime)
     monkeypatch.setattr(runner, "evaluate_level_arms", evaluate)
-    monkeypatch.setattr(runner, "assemble_mt1_in_sample_bundle", assemble)
+    monkeypatch.setattr(runner, "prepare_mt1_in_sample_bundle", prepare)
+    monkeypatch.setattr(runner, "evaluate_mt1_prepared_bundle", lambda value: cast(runner.MT1HistoricalBundle, value))
 
     result = runner.run_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]
 
     assert result.authorities == authority
-    assert result.bundle is bundle
+    assert result.bundle is cast(runner.MT1HistoricalBundle, prepared)
     assert events[0] == "authority"
     assert events[1] == (
         "corpus",
@@ -313,7 +314,7 @@ def test_paved_run_checks_authority_before_corpus_and_builds_only_the_complete_i
         ("evaluate", runner.S8_SOURCE_STRATEGY_ID, "admitted", ("in_sample",)),
         ("evaluate", runner.S8_SOURCE_STRATEGY_ID, "masked", ("in_sample",)),
     ]
-    assert events[7] == ("assemble", 4, 4)
+    assert events[7] == ("prepare", 4, 4)
 
 
 def test_paved_run_loads_no_corpus_when_preregistration_refuses(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_strategy_mt1_runner.py
+++ b/tests/test_strategy_mt1_runner.py
@@ -1,0 +1,169 @@
+"""#2769 complete-fan and structural-first MT-1 assembly tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import app.services.strategy_mt1_runner as runner
+from app.services.backtest_run import ArmMeasurement, NamespaceMeasurement
+from app.services.equity_curve import LegBook
+from app.services.strategy_result import AmbiguityArm
+from app.services.strategy_result_universe import ResultUniverseRecord
+from app.services.strategy_statistics import StrategyMetrics
+
+_AXIS = (date(2000, 1, 3), date(2000, 1, 4))
+_OPPORTUNITY = ResultUniverseRecord(
+    universe_rule_version="test-universe-v1",
+    evaluated_instrument_ids=frozenset({1}),
+    validated_universe_ids=frozenset({1}),
+)
+_KEYS = (
+    ("best_case", "admitted"),
+    ("best_case", "masked"),
+    ("worst_case", "admitted"),
+    ("worst_case", "masked"),
+)
+
+
+def _measurement(
+    strategy_id: str,
+    ambiguity: str,
+    quarantine: str,
+    *,
+    axis: tuple[date, ...] = _AXIS,
+    opportunity: ResultUniverseRecord = _OPPORTUNITY,
+) -> ArmMeasurement:
+    namespace = NamespaceMeasurement(
+        namespace="in_sample",
+        metrics=cast(StrategyMetrics, object()),
+        moments=None,
+        daily_returns={},
+        universe_record=opportunity,
+        position_count=0,
+        axis_dates=axis,
+        source_book=LegBook(),
+    )
+    return ArmMeasurement(
+        strategy_id=strategy_id,
+        strategy_version="source-v1",
+        ambiguity_arm=cast(AmbiguityArm, ambiguity),
+        quarantine_arm=quarantine,  # type: ignore[arg-type]
+        namespaces={"in_sample": namespace},
+        holdout_positions_discarded=0,
+        close_sources={},
+        series_evaluated=1,
+        elapsed_s=0.0,
+    )
+
+
+def _fan(strategy_id: str) -> tuple[ArmMeasurement, ...]:
+    return tuple(_measurement(strategy_id, ambiguity, quarantine) for ambiguity, quarantine in _KEYS)
+
+
+def test_missing_robustness_cell_refuses_before_any_book_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    def forbidden_build(**_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        raise AssertionError("book construction must not start")
+
+    monkeypatch.setattr(runner, "build_mt1_four_arm_books", forbidden_build)
+    with pytest.raises(runner.MT1RunnerRefused, match="robustness fan is incomplete"):
+        runner.assemble_mt1_in_sample_bundle(
+            mt1_source_measurements=_fan(runner.MT1_SOURCE_STRATEGY_ID)[:-1],
+            s8_source_measurements=_fan(runner.S8_SOURCE_STRATEGY_ID),
+        )
+    assert called is False
+
+
+def test_all_four_structural_cells_finish_before_the_first_outcome_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_order: list[int] = []
+    evaluation_build_counts: list[int] = []
+
+    def build(**_kwargs: object) -> object:
+        build_order.append(len(build_order) + 1)
+        arm = SimpleNamespace(scaled=object(), unscaled=object(), structural=object())
+        return SimpleNamespace(mt1=arm, s8=arm)
+
+    def evaluate(**_kwargs: object) -> object:
+        evaluation_build_counts.append(len(build_order))
+        return SimpleNamespace(historical_statistical_conjuncts_pass=True)
+
+    monkeypatch.setattr(runner, "build_mt1_four_arm_books", build)
+    monkeypatch.setattr(runner, "evaluate_mt1_trial", evaluate)
+    bundle = runner.assemble_mt1_in_sample_bundle(
+        mt1_source_measurements=_fan(runner.MT1_SOURCE_STRATEGY_ID),
+        s8_source_measurements=_fan(runner.S8_SOURCE_STRATEGY_ID),
+    )
+
+    assert build_order == [1, 2, 3, 4]
+    assert evaluation_build_counts == [4, 4, 4, 4]
+    assert [(cell.ambiguity_arm, cell.quarantine_arm) for cell in bundle.cells] == list(_KEYS)
+    assert bundle.historical_statistical_conjuncts_pass is True
+
+
+def test_a_late_structural_refusal_exposes_no_earlier_cell_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
+    builds = 0
+    evaluations = 0
+
+    def build(**_kwargs: object) -> object:
+        nonlocal builds
+        builds += 1
+        if builds == 4:
+            raise ValueError("fourth structural cell refused")
+        return object()
+
+    def evaluate(**_kwargs: object) -> object:
+        nonlocal evaluations
+        evaluations += 1
+        return object()
+
+    monkeypatch.setattr(runner, "build_mt1_four_arm_books", build)
+    monkeypatch.setattr(runner, "evaluate_mt1_trial", evaluate)
+    with pytest.raises(ValueError, match="fourth structural cell refused"):
+        runner.assemble_mt1_in_sample_bundle(
+            mt1_source_measurements=_fan(runner.MT1_SOURCE_STRATEGY_ID),
+            s8_source_measurements=_fan(runner.S8_SOURCE_STRATEGY_ID),
+        )
+    assert builds == 4
+    assert evaluations == 0
+
+
+def test_source_fans_must_share_the_exact_axis_and_opportunity_population() -> None:
+    wrong_axis = list(_fan(runner.S8_SOURCE_STRATEGY_ID))
+    wrong_axis[-1] = _measurement(
+        runner.S8_SOURCE_STRATEGY_ID,
+        "worst_case",
+        "masked",
+        axis=(date(2000, 1, 3), date(2000, 1, 5)),
+    )
+    with pytest.raises(runner.MT1RunnerRefused, match="one exact in-sample metric axis"):
+        runner.assemble_mt1_in_sample_bundle(
+            mt1_source_measurements=_fan(runner.MT1_SOURCE_STRATEGY_ID),
+            s8_source_measurements=tuple(wrong_axis),
+        )
+
+    other = ResultUniverseRecord(
+        universe_rule_version="test-universe-v1",
+        evaluated_instrument_ids=frozenset({2}),
+        validated_universe_ids=frozenset({2}),
+    )
+    wrong_population = list(_fan(runner.S8_SOURCE_STRATEGY_ID))
+    wrong_population[-1] = _measurement(
+        runner.S8_SOURCE_STRATEGY_ID,
+        "worst_case",
+        "masked",
+        opportunity=other,
+    )
+    with pytest.raises(runner.MT1RunnerRefused, match="one pre-mask opportunity population"):
+        runner.assemble_mt1_in_sample_bundle(
+            mt1_source_measurements=_fan(runner.MT1_SOURCE_STRATEGY_ID),
+            s8_source_measurements=tuple(wrong_population),
+        )

--- a/tests/test_strategy_mt1_runner.py
+++ b/tests/test_strategy_mt1_runner.py
@@ -295,14 +295,12 @@ def test_paved_run_checks_authority_before_corpus_and_builds_only_the_complete_i
     monkeypatch.setattr(runner.MarketRegimeProvider, "load_research", load_regime)
     monkeypatch.setattr(runner, "evaluate_level_arms", evaluate)
     monkeypatch.setattr(runner, "prepare_mt1_in_sample_bundle", prepare)
-    monkeypatch.setattr(runner, "evaluate_mt1_prepared_bundle", lambda value: cast(runner.MT1HistoricalBundle, value))
-
-    result = runner.run_mt1_in_sample_evaluation(  # type: ignore[arg-type]
+    result = runner.prepare_mt1_in_sample_evaluation(  # type: ignore[arg-type]
         cast(Any, object()), runner_source_head="a" * 40
     )
 
     assert result.authorities == authority
-    assert result.bundle is cast(runner.MT1HistoricalBundle, prepared)
+    assert result.prepared is prepared
     assert events[0] == "authority"
     assert events[1] == (
         "corpus",
@@ -331,7 +329,7 @@ def test_paved_run_loads_no_corpus_when_preregistration_refuses(monkeypatch: pyt
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("corpus must remain sealed")),
     )
     with pytest.raises(runner.MT1RunnerRefused, match="authority refused"):
-        runner.run_mt1_in_sample_evaluation(  # type: ignore[arg-type]
+        runner.prepare_mt1_in_sample_evaluation(  # type: ignore[arg-type]
             cast(Any, object()), runner_source_head="a" * 40
         )
 
@@ -348,4 +346,4 @@ def test_paved_run_refuses_unpinned_source_before_authority_or_corpus(monkeypatc
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("corpus must remain sealed")),
     )
     with pytest.raises(runner.MT1RunnerRefused, match="exact lower-case Git object ID"):
-        runner.run_mt1_in_sample_evaluation(cast(Any, object()), runner_source_head="not-a-git-head")
+        runner.prepare_mt1_in_sample_evaluation(cast(Any, object()), runner_source_head="not-a-git-head")

--- a/tests/test_strategy_mt1_store.py
+++ b/tests/test_strategy_mt1_store.py
@@ -1,0 +1,256 @@
+"""Two-phase persistence tests for the paved MT-1 runner (#2769)."""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from typing import cast
+
+import psycopg
+import pytest
+
+import app.services.strategy_mt1_store as store
+from app.services.result_ledger import freeze_preregistration
+from app.services.strategy_mt1_books import BOOK_RULE_VERSION, MT1FourArmBooks
+from app.services.strategy_mt1_preregistration import build_declarations
+from app.services.strategy_mt1_runner import (
+    MT1HistoricalBundle,
+    MT1InSamplePreparation,
+    MT1InSampleStructuralRefusal,
+    MT1InSampleStructuralRefused,
+    MT1PreparedBundle,
+    MT1PreparedCell,
+    MT1PreregistrationAuthority,
+    MT1RobustnessCell,
+)
+from app.services.strategy_mt1_trial import (
+    ArmRiskReport,
+    MT1TrialResult,
+    PercentileInterval,
+    ScaledBookStructuralAudit,
+    StructuralGateReport,
+)
+from app.services.strategy_result_universe import ResultUniverseRecord
+
+_KEYS = (
+    ("best_case", "admitted"),
+    ("best_case", "masked"),
+    ("worst_case", "admitted"),
+    ("worst_case", "masked"),
+)
+_COMMON_MONTHS = tuple(date(2010 + offset // 12, offset % 12 + 1, 1) for offset in range(120))
+_DECISION_DATES = (date(2020, 1, 2), date(2020, 2, 3))
+_AXIS = (*_COMMON_MONTHS, *_DECISION_DATES)
+
+
+def _months() -> tuple[date, ...]:
+    return _COMMON_MONTHS
+
+
+def _book() -> MT1FourArmBooks:
+    audit = ScaledBookStructuralAudit(
+        decision_dates=_DECISION_DATES,
+        expected_decision_dates=_DECISION_DATES,
+        annualised_turnover=1.0,
+        traded_notional=100.0,
+        exposure_reconciled=True,
+    )
+    source = SimpleNamespace(structural=audit)
+    return cast(
+        MT1FourArmBooks,
+        SimpleNamespace(mt1=source, s8=source, rule_version=BOOK_RULE_VERSION),
+    )
+
+
+def _result(*, passed: bool = True) -> MT1TrialResult:
+    risk = ArmRiskReport(certainty_equivalent=0.1, maximum_drawdown=0.1, expected_shortfall_5=-0.1)
+    return MT1TrialResult(
+        common_months=_months(),
+        excluded_months_by_arm=(0, 0, 0, 0),
+        structural=StructuralGateReport(2, 2, 1.0, 1.0, 100.0, 100.0),
+        mt1_scaled=risk,
+        mt1_unscaled=risk,
+        s8_scaled=risk,
+        s8_unscaled=risk,
+        mt1_delta_cer=0.0,
+        s8_delta_cer=0.0,
+        primary_difference_in_differences=0.0,
+        mt1_delta_interval=PercentileInterval(-0.1, 0.1),
+        primary_interval=PercentileInterval(-0.1, 0.1),
+        primary_lower_bound_positive=passed,
+        mt1_lower_bound_positive=passed,
+        mt1_drawdown_improved=passed,
+        mt1_expected_shortfall_improved=passed,
+        historical_statistical_conjuncts_pass=passed,
+    )
+
+
+def _preparation(conn: psycopg.Connection[tuple]) -> MT1InSamplePreparation:
+    mt1, s8 = build_declarations()
+    mt1_id = freeze_preregistration(conn, mt1)
+    s8_id = freeze_preregistration(conn, s8)
+    conn.commit()
+    authorities = (
+        MT1PreregistrationAuthority(mt1.strategy_id, mt1.strategy_version, mt1_id, mt1.sha256),
+        MT1PreregistrationAuthority(s8.strategy_id, s8.strategy_version, s8_id, s8.sha256),
+    )
+    prepared = MT1PreparedBundle(
+        cells=tuple(
+            MT1PreparedCell(cast(object, ambiguity), cast(object, quarantine), _book())  # type: ignore[arg-type]
+            for ambiguity, quarantine in _KEYS
+        ),
+        axis_dates=_AXIS,
+        opportunity_record=ResultUniverseRecord(
+            universe_rule_version="test-universe-v1",
+            evaluated_instrument_ids=frozenset({1, 2}),
+            validated_universe_ids=frozenset({1, 2}),
+        ),
+    )
+    return MT1InSamplePreparation(
+        authorities=authorities,
+        prepared=prepared,
+        mt1_strategy_version=mt1.strategy_version,
+        s8_control_strategy_version=s8.strategy_version,
+        mt1_source_strategy_version="mt1-source-v1",
+        s8_source_strategy_version="s8-source-v1",
+        corpus_version="corpus-v1",
+    )
+
+
+def _bundle(preparation: MT1InSamplePreparation) -> MT1HistoricalBundle:
+    return MT1HistoricalBundle(
+        cells=tuple(
+            MT1RobustnessCell(cell.ambiguity_arm, cell.quarantine_arm, cell.books, _result())
+            for cell in preparation.prepared.cells
+        ),
+        axis_dates=preparation.prepared.axis_dates,
+        opportunity_record=preparation.prepared.opportunity_record,
+    )
+
+
+def _refusal(preparation: MT1InSamplePreparation) -> MT1InSampleStructuralRefusal:
+    return MT1InSampleStructuralRefusal(
+        authorities=preparation.authorities,
+        axis_dates=preparation.prepared.axis_dates,
+        opportunity_record=preparation.prepared.opportunity_record,
+        detail="turnover exceeded the frozen ceiling",
+        mt1_strategy_version=preparation.mt1_strategy_version,
+        s8_control_strategy_version=preparation.s8_control_strategy_version,
+        mt1_source_strategy_version=preparation.mt1_source_strategy_version,
+        s8_source_strategy_version=preparation.s8_source_strategy_version,
+        corpus_version=preparation.corpus_version,
+    )
+
+
+def test_complete_structural_fan_commits_before_atomic_result_and_retries_read_back(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    preparation = _preparation(ebull_test_conn)
+    attempt_id = store.store_mt1_structural_preparation(ebull_test_conn, preparation)
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_mt1_structural_cells WHERE structural_attempt_id = %s", (attempt_id,)
+    ).fetchone() == (4,)
+
+    bundle = _bundle(preparation)
+    result_id = store.store_mt1_trial_bundle(ebull_test_conn, structural_attempt_id=attempt_id, bundle=bundle)
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_mt1_trial_result_cells WHERE mt1_trial_result_id = %s", (result_id,)
+    ).fetchone() == (4,)
+    assert store.store_mt1_structural_preparation(ebull_test_conn, preparation) == attempt_id
+    assert store.store_mt1_trial_bundle(ebull_test_conn, structural_attempt_id=attempt_id, bundle=bundle) == result_id
+
+
+def test_same_versions_cannot_be_rewritten_with_different_evidence(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    preparation = _preparation(ebull_test_conn)
+    store.store_mt1_structural_preparation(ebull_test_conn, preparation)
+    changed = MT1InSamplePreparation(
+        **{**preparation.__dict__, "corpus_version": "different-corpus"},
+    )
+    with pytest.raises(store.MT1EvidenceConflict, match="different structural evidence"):
+        store.store_mt1_structural_preparation(ebull_test_conn, changed)
+    ebull_test_conn.rollback()
+
+
+def test_structural_refusal_commits_no_cells_and_is_idempotent(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    refusal = _refusal(_preparation(ebull_test_conn))
+    attempt_id = store.store_mt1_structural_refusal(ebull_test_conn, refusal)
+    assert ebull_test_conn.execute(
+        """
+        SELECT passed, refusal_code,
+               (SELECT count(*) FROM strategy_mt1_structural_cells c
+                 WHERE c.structural_attempt_id = a.structural_attempt_id)
+          FROM strategy_mt1_structural_attempts a WHERE structural_attempt_id = %s
+        """,
+        (attempt_id,),
+    ).fetchone() == (False, "structural_gate_refused", 0)
+    assert store.store_mt1_structural_refusal(ebull_test_conn, refusal) == attempt_id
+
+
+def test_paved_runner_commits_structure_before_evaluating_any_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preparation = cast(
+        MT1InSamplePreparation,
+        SimpleNamespace(
+            prepared=object(),
+            authorities=(),
+            mt1_strategy_version="mt1-v1",
+            s8_control_strategy_version="s8-v1",
+            mt1_source_strategy_version="source-mt1-v1",
+            s8_source_strategy_version="source-s8-v1",
+            corpus_version="corpus-v1",
+        ),
+    )
+    bundle = cast(MT1HistoricalBundle, object())
+    events: list[str] = []
+    monkeypatch.setattr(store, "prepare_mt1_in_sample_evaluation", lambda *_args, **_kwargs: preparation)
+
+    def store_structure(*_args: object, **_kwargs: object) -> int:
+        events.append("structural_commit")
+        return 10
+
+    def evaluate(_prepared: object) -> MT1HistoricalBundle:
+        assert events == ["structural_commit"]
+        events.append("evaluate")
+        return bundle
+
+    def store_result(*_args: object, **_kwargs: object) -> int:
+        assert events == ["structural_commit", "evaluate"]
+        events.append("result_commit")
+        return 20
+
+    monkeypatch.setattr(store, "store_mt1_structural_preparation", store_structure)
+    monkeypatch.setattr(store, "evaluate_mt1_prepared_bundle", evaluate)
+    monkeypatch.setattr(store, "store_mt1_trial_bundle", store_result)
+    monkeypatch.setattr(store, "MT1InSampleEvaluation", lambda **_kwargs: cast(object, object()))
+
+    result = store.run_and_store_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]
+
+    assert events == ["structural_commit", "evaluate", "result_commit"]
+    assert isinstance(result, store.MT1StoredEvaluation)
+    assert (result.structural_attempt_id, result.trial_result_id) == (10, 20)
+
+
+def test_paved_runner_persists_structural_refusal_without_evaluating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    refusal = cast(MT1InSampleStructuralRefusal, SimpleNamespace(detail="refused"))
+    monkeypatch.setattr(
+        store,
+        "prepare_mt1_in_sample_evaluation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(MT1InSampleStructuralRefused(refusal)),
+    )
+    monkeypatch.setattr(store, "store_mt1_structural_refusal", lambda _conn, evidence: 42)
+    monkeypatch.setattr(
+        store,
+        "evaluate_mt1_prepared_bundle",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("outcomes must remain unevaluated")),
+    )
+    result = store.run_and_store_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]
+
+    assert isinstance(result, store.MT1StoredRefusal)
+    assert (result.structural_attempt_id, result.detail) == (42, "refused")

--- a/tests/test_strategy_mt1_store.py
+++ b/tests/test_strategy_mt1_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date
 from types import SimpleNamespace
 from typing import cast
@@ -23,6 +24,8 @@ from app.services.strategy_mt1_runner import (
     MT1PreparedCell,
     MT1PreregistrationAuthority,
     MT1RobustnessCell,
+    MT1RunnerRefused,
+    validate_mt1_preregistrations,
 )
 from app.services.strategy_mt1_trial import (
     ArmRiskReport,
@@ -178,6 +181,33 @@ def test_same_versions_cannot_be_rewritten_with_different_evidence(
     )
     with pytest.raises(store.MT1EvidenceConflict, match="different structural evidence"):
         store.store_mt1_structural_preparation(ebull_test_conn, changed)
+    ebull_test_conn.rollback()
+
+
+def test_database_frozen_declaration_term_mismatch_refuses_before_evaluation(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    mt1, s8 = build_declarations()
+    changed = replace(
+        mt1,
+        forward_shadow=replace(mt1.forward_shadow, min_calendar_weeks=mt1.forward_shadow.min_calendar_weeks + 1),
+    )
+    freeze_preregistration(ebull_test_conn, changed)
+    freeze_preregistration(ebull_test_conn, s8)
+    ebull_test_conn.commit()
+    with pytest.raises(MT1RunnerRefused, match="declaration_terms_changed=forward_shadow"):
+        validate_mt1_preregistrations(ebull_test_conn)
+
+
+def test_database_retry_refuses_a_metric_axis_derivation_drift(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    preparation = _preparation(ebull_test_conn)
+    store.store_mt1_structural_preparation(ebull_test_conn, preparation)
+    changed_axis = (*_COMMON_MONTHS, date(2019, 12, 15), *_DECISION_DATES)
+    drifted = replace(preparation, prepared=replace(preparation.prepared, axis_dates=changed_axis))
+    with pytest.raises(store.MT1EvidenceConflict, match="different structural evidence"):
+        store.store_mt1_structural_preparation(ebull_test_conn, drifted)
     ebull_test_conn.rollback()
 
 

--- a/tests/test_strategy_mt1_store.py
+++ b/tests/test_strategy_mt1_store.py
@@ -184,6 +184,24 @@ def test_same_versions_cannot_be_rewritten_with_different_evidence(
     ebull_test_conn.rollback()
 
 
+def test_idempotent_child_match_refuses_digest_strings_that_do_not_authenticate_json() -> None:
+    payload: dict[str, object] = {"canonical": "payload"}
+    digest = store._digest(payload)
+    expected = [("best_case", "admitted", digest, payload)]
+    assert store._stored_cells_match(
+        [("best_case", "admitted", digest, payload)],
+        expected,
+    )
+    assert not store._stored_cells_match(
+        [("best_case", "admitted", digest, {"canonical": "tampered"})],
+        expected,
+    )
+    assert not store._stored_cells_match(
+        [("best_case", "admitted", "0" * 64, payload)],
+        expected,
+    )
+
+
 def test_database_frozen_declaration_term_mismatch_refuses_before_evaluation(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_strategy_mt1_store.py
+++ b/tests/test_strategy_mt1_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import date
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import psycopg
 import pytest
@@ -42,6 +42,7 @@ _KEYS = (
     ("worst_case", "admitted"),
     ("worst_case", "masked"),
 )
+_RUNNER_HEAD = "a" * 40
 _COMMON_MONTHS = tuple(date(2010 + offset // 12, offset % 12 + 1, 1) for offset in range(120))
 _DECISION_DATES = (date(2020, 1, 2), date(2020, 2, 3))
 _AXIS = (*_COMMON_MONTHS, *_DECISION_DATES)
@@ -118,6 +119,7 @@ def _preparation(conn: psycopg.Connection[tuple]) -> MT1InSamplePreparation:
         mt1_source_strategy_version="mt1-source-v1",
         s8_source_strategy_version="s8-source-v1",
         corpus_version="corpus-v1",
+        runner_source_head=_RUNNER_HEAD,
     )
 
 
@@ -143,6 +145,7 @@ def _refusal(preparation: MT1InSamplePreparation) -> MT1InSampleStructuralRefusa
         mt1_source_strategy_version=preparation.mt1_source_strategy_version,
         s8_source_strategy_version=preparation.s8_source_strategy_version,
         corpus_version=preparation.corpus_version,
+        runner_source_head=preparation.runner_source_head,
     )
 
 
@@ -154,6 +157,11 @@ def test_complete_structural_fan_commits_before_atomic_result_and_retries_read_b
     assert ebull_test_conn.execute(
         "SELECT count(*) FROM strategy_mt1_structural_cells WHERE structural_attempt_id = %s", (attempt_id,)
     ).fetchone() == (4,)
+    assert ebull_test_conn.execute(
+        "SELECT runner_source_head,structural_evidence_json->>'runner_source_head' "
+        "FROM strategy_mt1_structural_attempts WHERE structural_attempt_id=%s",
+        (attempt_id,),
+    ).fetchone() == (_RUNNER_HEAD, _RUNNER_HEAD)
 
     bundle = _bundle(preparation)
     result_id = store.store_mt1_trial_bundle(ebull_test_conn, structural_attempt_id=attempt_id, bundle=bundle)
@@ -279,6 +287,7 @@ def test_paved_runner_commits_structure_before_evaluating_any_outcome(
             mt1_source_strategy_version="source-mt1-v1",
             s8_source_strategy_version="source-s8-v1",
             corpus_version="corpus-v1",
+            runner_source_head=_RUNNER_HEAD,
         ),
     )
     bundle = cast(MT1HistoricalBundle, object())
@@ -304,7 +313,9 @@ def test_paved_runner_commits_structure_before_evaluating_any_outcome(
     monkeypatch.setattr(store, "store_mt1_trial_bundle", store_result)
     monkeypatch.setattr(store, "MT1InSampleEvaluation", lambda **_kwargs: cast(object, object()))
 
-    result = store.run_and_store_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]
+    result = store.run_and_store_mt1_in_sample_evaluation(  # type: ignore[arg-type]
+        cast(Any, object()), runner_source_head=_RUNNER_HEAD
+    )
 
     assert events == ["structural_commit", "evaluate", "result_commit"]
     assert isinstance(result, store.MT1StoredEvaluation)
@@ -326,7 +337,9 @@ def test_paved_runner_persists_structural_refusal_without_evaluating(
         "evaluate_mt1_prepared_bundle",
         lambda *_args: (_ for _ in ()).throw(AssertionError("outcomes must remain unevaluated")),
     )
-    result = store.run_and_store_mt1_in_sample_evaluation(cast(object, object()))  # type: ignore[arg-type]
+    result = store.run_and_store_mt1_in_sample_evaluation(  # type: ignore[arg-type]
+        cast(Any, object()), runner_source_head=_RUNNER_HEAD
+    )
 
     assert isinstance(result, store.MT1StoredRefusal)
     assert (result.structural_attempt_id, result.detail) == (42, "refused")

--- a/tests/test_strategy_mt1_store.py
+++ b/tests/test_strategy_mt1_store.py
@@ -13,6 +13,7 @@ import app.services.strategy_mt1_store as store
 from app.services.result_ledger import freeze_preregistration
 from app.services.strategy_mt1_books import BOOK_RULE_VERSION, MT1FourArmBooks
 from app.services.strategy_mt1_preregistration import build_declarations
+from app.services.strategy_mt1_read_model import load_mt1_controlled_trial_state
 from app.services.strategy_mt1_runner import (
     MT1HistoricalBundle,
     MT1InSamplePreparation,
@@ -117,10 +118,10 @@ def _preparation(conn: psycopg.Connection[tuple]) -> MT1InSamplePreparation:
     )
 
 
-def _bundle(preparation: MT1InSamplePreparation) -> MT1HistoricalBundle:
+def _bundle(preparation: MT1InSamplePreparation, *, passed: bool = True) -> MT1HistoricalBundle:
     return MT1HistoricalBundle(
         cells=tuple(
-            MT1RobustnessCell(cell.ambiguity_arm, cell.quarantine_arm, cell.books, _result())
+            MT1RobustnessCell(cell.ambiguity_arm, cell.quarantine_arm, cell.books, _result(passed=passed))
             for cell in preparation.prepared.cells
         ),
         axis_dates=preparation.prepared.axis_dates,
@@ -158,6 +159,13 @@ def test_complete_structural_fan_commits_before_atomic_result_and_retries_read_b
     ).fetchone() == (4,)
     assert store.store_mt1_structural_preparation(ebull_test_conn, preparation) == attempt_id
     assert store.store_mt1_trial_bundle(ebull_test_conn, structural_attempt_id=attempt_id, bundle=bundle) == result_id
+    read_model = load_mt1_controlled_trial_state(ebull_test_conn)
+    assert read_model.state == "historical_conjuncts_passed"
+    assert len(read_model.result_cells) == 4
+    assert (read_model.holdout_evaluations, read_model.holdout_accesses) == (0, 0)
+    assert read_model.promotion_authority is False
+    assert read_model.paper_activation_reachable is False
+    assert read_model.live_activation_reachable is False
 
 
 def test_same_versions_cannot_be_rewritten_with_different_evidence(
@@ -188,6 +196,26 @@ def test_structural_refusal_commits_no_cells_and_is_idempotent(
         (attempt_id,),
     ).fetchone() == (False, "structural_gate_refused", 0)
     assert store.store_mt1_structural_refusal(ebull_test_conn, refusal) == attempt_id
+    read_model = load_mt1_controlled_trial_state(ebull_test_conn)
+    assert read_model.state == "structural_refused"
+    assert read_model.refusal_detail == refusal.detail
+    assert read_model.result_cells == ()
+
+
+def test_failed_all_cell_conjunction_is_terminal_and_operator_visible(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    preparation = _preparation(ebull_test_conn)
+    attempt_id = store.store_mt1_structural_preparation(ebull_test_conn, preparation)
+    store.store_mt1_trial_bundle(
+        ebull_test_conn,
+        structural_attempt_id=attempt_id,
+        bundle=_bundle(preparation, passed=False),
+    )
+    read_model = load_mt1_controlled_trial_state(ebull_test_conn)
+    assert read_model.state == "historical_conjuncts_failed"
+    assert read_model.historical_conjuncts_pass is False
+    assert all(cell.historical_conjuncts_pass is False for cell in read_model.result_cells)
 
 
 def test_paved_runner_commits_structure_before_evaluating_any_outcome(

--- a/tests/test_strategy_operator_promotion.py
+++ b/tests/test_strategy_operator_promotion.py
@@ -1,0 +1,657 @@
+"""Operator promotion selects complete evidence and cannot accept cherry-picked ids."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from threading import Barrier
+from types import SimpleNamespace
+from uuid import uuid4
+
+import psycopg
+import pytest
+from pydantic import ValidationError
+
+from app.api.strategies import (
+    StrategyInitialPaperSetupRequest,
+    StrategyPromotionRequest,
+    create_strategy_paper_setup,
+)
+from app.security.sessions import SessionRow
+from app.services.backtest_run import BACKTEST_UNIVERSE, corpus_version_for
+from app.services.cost_model import COST_MODEL_ID
+from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
+from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
+from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.result_ledger import freeze_preregistration, store_holdout_result
+from app.services.strategy_ambiguity_policy import AMBIGUITY_RULE_VERSION
+from app.services.strategy_control_plane import (
+    StrategyControlError,
+    configure_execution_policy,
+    configure_paper_pool,
+)
+from app.services.strategy_operator_promotion import (
+    _load_current_prospective_evidence,
+    advance_strategy_for_operator,
+    load_forward_floor_evidence,
+)
+from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+from app.services.strategy_result import (
+    METRIC_AXIS_RULE_VERSION,
+    STRUCTURAL_REFUSAL_POLICY_VERSION,
+    TOTAL_RETURN_BASIS,
+    metric_axis_sha256,
+)
+from app.services.strategy_statistics import periods_per_year
+from tests.fixtures.ebull_test_db import test_database_url
+from tests.test_result_ledger import build_metrics, build_result
+
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
+
+_STRATEGY_ID = "S-GOV"
+_VERSION = "operator-promotion-v1"
+
+
+def _store_matrix(conn: psycopg.Connection[tuple], *, omit_last: bool = False, duplicate_first: bool = False) -> None:
+    version = _VERSION
+    cells = [
+        (item.window.start, item.window.end, item.window_id, ambiguity, quarantine)
+        for item in RECENT_EVIDENCE_WINDOWS.values()
+        for ambiguity in ("best_case", "worst_case")
+        for quarantine in ("masked", "admitted")
+    ]
+    if omit_last:
+        cells.pop()
+    for index, (window_start, window_end, window_id, ambiguity, quarantine) in enumerate(cells):
+        axis = (window_start, window_end)
+        store_holdout_result(
+            conn,
+            build_result(
+                strategy_id=_STRATEGY_ID,
+                strategy_version=version,
+                result_scope="sleeve",
+                namespace="hold_out",
+                ambiguity_arm=ambiguity,
+                quarantine_arm=quarantine,
+                window_start=window_start,
+                window_end=window_end,
+                evidence_window_id=window_id,
+                metric_axis_rule_version=METRIC_AXIS_RULE_VERSION,
+                metric_axis_dates=axis,
+                metric_axis_start=axis[0],
+                metric_axis_end=axis[-1],
+                metric_axis_digest=metric_axis_sha256(axis),
+                opportunity_set_digest="0" * 64,
+                metrics=build_metrics(cagr_pct=-100, periods_per_year=periods_per_year(axis)),
+                corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
+                cost_model_id=COST_MODEL_ID,
+                sizing_rule=SIZING_RULE_ID,
+                benchmark_rule=BENCHMARK_RULE_ID,
+                return_basis=TOTAL_RETURN_BASIS,
+                ambiguity_rule_version=AMBIGUITY_RULE_VERSION,
+                position_rule_set_version=POSITION_RULE_SET_VERSION,
+                outcome_rule_set_version=OUTCOME_RULE_SET_VERSION,
+                input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+            ),
+            accessed_by="tests/test_strategy_operator_promotion.py",
+            purpose=f"authoritative matrix cell {index}",
+        )
+    if duplicate_first:
+        window_start, window_end, window_id, ambiguity, quarantine = cells[0]
+        axis = (window_start, window_start + timedelta(days=1), window_end)
+        store_holdout_result(
+            conn,
+            build_result(
+                strategy_id=_STRATEGY_ID,
+                strategy_version=version,
+                result_scope="sleeve",
+                namespace="hold_out",
+                ambiguity_arm=ambiguity,
+                quarantine_arm=quarantine,
+                window_start=window_start,
+                window_end=window_end,
+                evidence_window_id=window_id,
+                metric_axis_rule_version=METRIC_AXIS_RULE_VERSION,
+                metric_axis_dates=axis,
+                metric_axis_start=axis[0],
+                metric_axis_end=axis[-1],
+                metric_axis_digest=metric_axis_sha256(axis),
+                opportunity_set_digest="0" * 64,
+                metrics=build_metrics(cagr_pct=-100, periods_per_year=periods_per_year(axis)),
+                corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
+                cost_model_id=COST_MODEL_ID,
+                sizing_rule=SIZING_RULE_ID,
+                benchmark_rule=BENCHMARK_RULE_ID,
+                return_basis=TOTAL_RETURN_BASIS,
+                ambiguity_rule_version=AMBIGUITY_RULE_VERSION,
+                position_rule_set_version=POSITION_RULE_SET_VERSION,
+                outcome_rule_set_version=OUTCOME_RULE_SET_VERSION,
+                input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+            ),
+            accessed_by="tests/test_strategy_operator_promotion.py",
+            purpose="duplicate matrix cell under a distinct authenticated axis",
+        )
+
+
+def _register(conn: psycopg.Connection[tuple]) -> None:
+    advance_strategy_for_operator(
+        conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=_VERSION,
+        action="register_candidate",
+        promoted_by="operator",
+        reason="register preregistered candidate",
+    )
+
+
+def _session() -> SessionRow:
+    now = datetime.now(UTC)
+    return SessionRow("operator-promotion-session", uuid4(), "operator", now + timedelta(hours=1), now)
+
+
+def _seed_legacy_unlinked_paper_chain(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id,strategy_version,from_stage,to_stage,gate_version,
+            evidence_ref,promoted_by,reason
+        ) VALUES
+          (%s,%s,NULL,'research_candidate','test-v1',NULL,'test','registered'),
+          (%s,%s,'research_candidate','historical_validated','test-v1','hist','test','history'),
+          (%s,%s,'historical_validated','forward_observation','test-v1','forward','test','observe'),
+          (%s,%s,'forward_observation','paper_enabled','test-v1','paper','test','paper')
+        """,
+        (_STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION),
+    )
+
+
+def _seed_prospective_assessment(
+    conn: psycopg.Connection[tuple], *, forward_started_at: datetime, window_start: date
+) -> None:
+    checked_at = datetime(2026, 8, 15, 12, tzinfo=UTC)
+    conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id,strategy_version,from_stage,to_stage,gate_version,
+            evidence_ref,promoted_by,reason,promoted_at
+        ) VALUES
+          (%s,%s,NULL,'research_candidate','test-v1',NULL,'test','registered',%s-interval '2 days'),
+          (%s,%s,'research_candidate','historical_validated','test-v1','hist','test','history',%s-interval '1 day'),
+          (%s,%s,'historical_validated','forward_observation','test-v1','forward','test','observe',%s)
+        """,
+        (
+            _STRATEGY_ID,
+            _VERSION,
+            forward_started_at,
+            _STRATEGY_ID,
+            _VERSION,
+            forward_started_at,
+            _STRATEGY_ID,
+            _VERSION,
+            forward_started_at,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_calibrations (
+            calibration_id,model_version,holdout_start,holdout_end,sample_size,
+            brier_score,calibration_error,passed,evidence_ref
+        ) VALUES ('operator-cal','operator-model','2026-01-01','2026-06-30',100,0.18,0.04,true,'calibration:test')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_policies (
+            policy_id,effective_from,recent_window_days,minimum_resolved_forecasts,
+            adaptive_calibration_bins,max_normalized_brier_score,min_brier_skill_score,
+            max_classwise_calibration_error,max_ambiguous_rate,max_unresolved_rate,
+            max_pending_rate,max_assessment_age_days,evidence_ref
+        ) VALUES ('operator-policy','2026-01-01',30,30,5,0.5,0.01,0.2,0.1,0.1,0.1,7,'policy:test')
+        """
+    )
+    assessment_row = conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessments (
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,resolver_version,input_rule_set_version,
+            window_start,window_end,evidence_hash,total_forecasts,resolved_forecasts,
+            target_first_count,stop_first_count,timeout_count,ambiguous_count,unresolved_count,
+            pending_count,normalized_brier_score,baseline_normalized_brier_score,brier_skill_score,
+            max_classwise_calibration_error,ambiguous_rate,unresolved_rate,pending_rate,passed,reason_codes
+        ) VALUES (
+            'operator-policy',%s,%s,'forecast-v1','operator-model','operator-cal','setup-v1','exit-v1',
+            'resolver-v1','input-v1',%s,'2026-08-14','evidence-hash',30,30,30,0,0,0,0,0,
+            0.1,0.3,0.2,0.05,0,0,0,true,'[]'::jsonb
+        ) RETURNING assessment_id
+        """,
+        (_STRATEGY_ID, _VERSION, window_start),
+    ).fetchone()
+    assert assessment_row is not None
+    assessment_id = int(assessment_row[0])
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_current (
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,resolver_version,input_rule_set_version,
+            assessment_id,checked_at
+        ) VALUES ('operator-policy',%s,%s,'forecast-v1','operator-model','operator-cal','setup-v1',
+                  'exit-v1','resolver-v1','input-v1',%s,%s)
+        """,
+        (_STRATEGY_ID, _VERSION, assessment_id, checked_at),
+    )
+
+
+def _freeze_capital_declaration(conn: psycopg.Connection[tuple]) -> int:
+    return freeze_preregistration(
+        conn,
+        PreregDeclaration(
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_VERSION,
+            contract_version="operator-promotion-contract-v1",
+            prereg_purpose="capital_candidate",
+            structural_refusal_policy_version=STRUCTURAL_REFUSAL_POLICY_VERSION,
+            declared_universe_basis="survivorship_free",
+            declared_carry_unmodelled=False,
+            declared_fx_unmodelled=False,
+            expected_structural_refusals=(),
+            forward_shadow=ForwardShadowFloor(
+                min_independent_decision_dates=1,
+                min_calendar_weeks=1,
+                derivation="independently fixed one-date test floor",
+            ),
+            declared_by="operator",
+        ),
+    )
+
+
+def test_registration_is_ordered_and_idempotent(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    version = _VERSION
+    first = advance_strategy_for_operator(
+        ebull_test_conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=version,
+        action="register_candidate",
+        promoted_by="operator",
+        reason="register preregistered candidate",
+    )
+    retry = advance_strategy_for_operator(
+        ebull_test_conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=version,
+        action="register_candidate",
+        promoted_by="operator",
+        reason="browser retry",
+    )
+
+    assert first.created is True
+    assert retry.created is False
+    assert retry.promotion.promotion_id == first.promotion.promotion_id
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_promotions WHERE strategy_id=%s AND strategy_version=%s",
+        (_STRATEGY_ID, version),
+    ).fetchone() == (1,)
+
+
+def test_concurrent_registration_serializes_to_one_event(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.commit()
+    barrier = Barrier(2)
+
+    def register(reason: str) -> tuple[int, bool]:
+        with psycopg.connect(test_database_url()) as conn:
+            barrier.wait(timeout=5)
+            with conn.transaction():
+                result = advance_strategy_for_operator(
+                    conn,
+                    strategy_id=_STRATEGY_ID,
+                    strategy_version=_VERSION,
+                    action="register_candidate",
+                    promoted_by="operator",
+                    reason=reason,
+                )
+            return result.promotion.promotion_id, result.created
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(register, ("first submit", "concurrent retry")))
+
+    assert results[0][0] == results[1][0]
+    assert sorted(created for _promotion_id, created in results) == [False, True]
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_promotions WHERE strategy_id=%s AND strategy_version=%s",
+        (_STRATEGY_ID, _VERSION),
+    ).fetchone() == (1,)
+
+
+def test_historical_action_refuses_an_incomplete_denominator(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _register(ebull_test_conn)
+    _store_matrix(ebull_test_conn, omit_last=True)
+
+    with pytest.raises(StrategyControlError, match="expected=24, found=23"):
+        advance_strategy_for_operator(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_VERSION,
+            action="validate_historical",
+            promoted_by="operator",
+            reason="must bind every declared cell",
+        )
+
+
+def test_historical_action_refuses_duplicate_cell_even_when_every_label_exists(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _register(ebull_test_conn)
+    _store_matrix(ebull_test_conn, duplicate_first=True)
+
+    with pytest.raises(StrategyControlError, match="expected=24, found=25.*duplicate=1"):
+        advance_strategy_for_operator(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_VERSION,
+            action="validate_historical",
+            promoted_by="operator",
+            reason="duplicates are not completeness",
+        )
+
+
+def test_complete_matrix_is_replayed_and_bare_rows_still_cannot_promote(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _register(ebull_test_conn)
+    _store_matrix(ebull_test_conn)
+
+    with pytest.raises(StrategyControlError, match="fails promotion evidence"):
+        advance_strategy_for_operator(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_VERSION,
+            action="validate_historical",
+            promoted_by="operator",
+            reason="complete shape is necessary but not sufficient",
+        )
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_promotions WHERE strategy_id=%s AND to_stage='historical_validated'",
+        (_STRATEGY_ID,),
+    ).fetchone() == (0,)
+
+
+def test_prospective_assessment_cannot_reuse_pre_forward_observations(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_prospective_assessment(
+        ebull_test_conn,
+        forward_started_at=datetime(2026, 8, 1, 12, tzinfo=UTC),
+        window_start=date(2026, 8, 1),
+    )
+    with pytest.raises(StrategyControlError, match="includes pre-forward observations"):
+        _load_current_prospective_evidence(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_VERSION,
+            now=datetime(2026, 8, 15, 12, tzinfo=UTC),
+        )
+
+
+def test_prospective_assessment_accepts_only_a_wholly_post_forward_window(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_prospective_assessment(
+        ebull_test_conn,
+        forward_started_at=datetime(2026, 7, 1, 12, tzinfo=UTC),
+        window_start=date(2026, 7, 2),
+    )
+    evidence = _load_current_prospective_evidence(
+        ebull_test_conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=_VERSION,
+        now=datetime(2026, 8, 15, 12, tzinfo=UTC),
+    )
+
+    assert evidence.assessment_id > 0
+    assert evidence.evidence_ref.startswith("strategy-prospective-assessment:sha256:")
+
+
+def test_paper_forward_floor_reads_the_frozen_declaration_and_resolved_dates(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_prospective_assessment(
+        ebull_test_conn,
+        forward_started_at=datetime(2026, 7, 1, 12, tzinfo=UTC),
+        window_start=date(2026, 7, 2),
+    )
+    declaration_id = _freeze_capital_declaration(ebull_test_conn)
+    ebull_test_conn.execute("INSERT INTO exchanges (exchange_id,country,asset_class) VALUES ('2770','US','us_equity')")
+    ebull_test_conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,exchange,currency,is_tradable) "
+        "VALUES (2770001,'FWD','Forward floor fixture','2770','USD',true)"
+    )
+    signal_id = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id,strategy_version,instrument_id,signal_bar_date,signal_kind,
+            verdict,fill_bar_date,fill_price,universe,input_rule_set_versions,created_at
+        ) VALUES (%s,%s,2770001,'2026-07-02','entry','fired','2026-07-03',100,
+                  'survivor_only','{"indicator_series":"rules-v1"}'::jsonb,'2026-07-02 12:00+00')
+        RETURNING signal_id
+        """,
+        (_STRATEGY_ID, _VERSION),
+    ).fetchone()
+    assert signal_id is not None
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_outcomes (
+            signal_id,rule_set_version,input_rule_set_version,outcome,resolution_method,
+            exit_bar_date,exit_price,bars_held,gross_return_pct
+        ) VALUES (%s,%s,%s,'expired','daily_bar','2026-07-08',101,3,1)
+        """,
+        (signal_id[0], OUTCOME_RULE_SET_VERSION, QUARANTINE_RULE_SET_VERSION),
+    )
+
+    evidence = load_forward_floor_evidence(
+        ebull_test_conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=_VERSION,
+        now=datetime(2026, 8, 15, 12, tzinfo=UTC),
+    )
+
+    assert evidence.declaration_id == declaration_id
+    assert (evidence.resolved_signals, evidence.decision_dates) == (1, 1)
+    assert evidence.elapsed_days == 45
+
+
+def test_paper_forward_floor_refuses_zero_resolved_decision_dates(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_prospective_assessment(
+        ebull_test_conn,
+        forward_started_at=datetime(2026, 7, 1, 12, tzinfo=UTC),
+        window_start=date(2026, 7, 2),
+    )
+    _freeze_capital_declaration(ebull_test_conn)
+
+    with pytest.raises(StrategyControlError, match="decision-date floor"):
+        load_forward_floor_evidence(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_VERSION,
+            now=datetime(2026, 8, 15, 12, tzinfo=UTC),
+        )
+
+
+def test_request_vocabulary_has_no_live_or_arbitrary_stage() -> None:
+    with pytest.raises(ValidationError):
+        StrategyPromotionRequest(
+            strategy_version="v1",
+            action="live_enabled",  # type: ignore[arg-type]
+            reason="must be impossible",
+        )
+    with pytest.raises(ValidationError):
+        StrategyPromotionRequest(
+            strategy_version="v1",
+            action="paper_enabled",  # type: ignore[arg-type]
+            reason="destinations are not request actions",
+        )
+
+
+def test_execution_policy_rejects_non_finite_limits_before_database_access(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    with pytest.raises(StrategyControlError, match="must be finite"):
+        configure_execution_policy(
+            ebull_test_conn,
+            deployment_id=1,
+            ticket_sizing_mode="percent",
+            ticket_fraction=Decimal("0.1"),
+            fixed_ticket_amount=None,
+            max_ticket_amount=Decimal("10"),
+            stop_loss_pct=Decimal("5"),
+            take_profit_pct=Decimal("10"),
+            max_quote_age_seconds=30,
+            max_scan_age_seconds=300,
+            max_halt_feed_age_seconds=300,
+            max_cost_age_seconds=3600,
+            max_reconciliation_age_seconds=60,
+            max_instrument_exposure_pct=Decimal("20"),
+            max_portfolio_exposure_pct=Decimal("50"),
+            max_drawdown_pct=Decimal("10"),
+            min_net_expectancy_pct=Decimal("NaN"),
+            cost_stress_multiplier=Decimal("2"),
+            changed_by="operator",
+            reason="must reject NaN",
+        )
+
+
+def test_paper_retry_refuses_an_unresolvable_prospective_evidence_reference(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_legacy_unlinked_paper_chain(ebull_test_conn)
+    with pytest.raises(StrategyControlError, match="prospective evidence link is missing"):
+        advance_strategy_for_operator(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_VERSION,
+            action="approve_paper",
+            promoted_by="operator",
+            reason="a hash without its evidence row is not auditable",
+        )
+
+
+def test_promotion_assessment_link_has_restricting_foreign_keys(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    rows = ebull_test_conn.execute(
+        """
+        SELECT confrelid::regclass::text,confdeltype,pg_get_constraintdef(oid)
+        FROM pg_constraint
+        WHERE conrelid='strategy_promotion_forward_evidence'::regclass
+          AND contype='f'
+        ORDER BY confrelid::regclass::text
+        """
+    ).fetchall()
+    assert [(row[0], row[1]) for row in rows] == [
+        ("strategy_forecast_assessments", "r"),
+        ("strategy_preregistration_declarations", "r"),
+        ("strategy_promotions", "r"),
+    ]
+    definitions = "\n".join(str(row[2]) for row in rows)
+    assert "FOREIGN KEY (assessment_id, strategy_id, strategy_version)" in definitions
+    assert "FOREIGN KEY (declaration_id, strategy_id, strategy_version)" in definitions
+    assert "FOREIGN KEY (promotion_id, strategy_id, strategy_version, promotion_stage)" in definitions
+
+
+def test_promotion_sources_and_forward_evidence_are_immutable(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    trigger_tables = ebull_test_conn.execute(
+        """
+        SELECT event_object_table
+        FROM information_schema.triggers
+        WHERE trigger_name IN (
+            'trg_strategy_promotions_immutable',
+            'trg_strategy_forecast_assessments_immutable',
+            'trg_strategy_promotion_forward_evidence_immutable'
+        )
+        ORDER BY event_object_table
+        """
+    ).fetchall()
+    assert trigger_tables == [
+        ("strategy_forecast_assessments",),
+        ("strategy_forecast_assessments",),
+        ("strategy_promotion_forward_evidence",),
+        ("strategy_promotion_forward_evidence",),
+        ("strategy_promotions",),
+        ("strategy_promotions",),
+    ]
+
+
+def test_first_paper_setup_creates_disabled_deployment_and_explicit_policy_atomically(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_legacy_unlinked_paper_chain(ebull_test_conn)
+    configure_paper_pool(
+        ebull_test_conn,
+        enabled=False,
+        capital_limit=Decimal("1000"),
+        risk_profile="unconfigured",
+        changed_by="operator",
+        reason="bound the demo pool",
+    )
+    monkeypatch.setattr(
+        "app.api.strategies._current_versions",
+        lambda: {_STRATEGY_ID: _VERSION},
+    )
+    monkeypatch.setattr(
+        "app.api.strategies.get_strategy_overview",
+        lambda _conn: SimpleNamespace(
+            strategies=[
+                SimpleNamespace(
+                    strategy_id=_STRATEGY_ID,
+                    allocation=SimpleNamespace(policy_configured=False),
+                    allocation_refusals=["execution_policy_missing"],
+                )
+            ]
+        ),
+    )
+    response = create_strategy_paper_setup(
+        _STRATEGY_ID,
+        StrategyInitialPaperSetupRequest(
+            strategy_version=_VERSION,
+            capital_limit=Decimal("100"),
+            ticket_sizing_mode="percent",
+            ticket_value=Decimal("10"),
+            max_ticket_amount=Decimal("25"),
+            stop_loss_pct=Decimal("5"),
+            take_profit_pct=Decimal("10"),
+            max_quote_age_seconds=30,
+            max_scan_age_seconds=300,
+            max_halt_feed_age_seconds=300,
+            max_cost_age_seconds=3600,
+            max_reconciliation_age_seconds=60,
+            max_instrument_exposure_pct=Decimal("20"),
+            max_portfolio_exposure_pct=Decimal("50"),
+            max_drawdown_pct=Decimal("10"),
+            min_net_expectancy_pct=Decimal("0"),
+            cost_stress_multiplier=Decimal("2"),
+            reason="explicit first paper limits",
+        ),
+        _session(),
+        ebull_test_conn,
+    )
+
+    assert response.enabled is False
+    assert response.capital_limit == Decimal("100")
+    assert ebull_test_conn.execute(
+        "SELECT capital_limit,enabled FROM strategy_deployments WHERE deployment_id=%s",
+        (response.deployment_id,),
+    ).fetchone() == (Decimal("100"), False)
+    assert ebull_test_conn.execute(
+        "SELECT ticket_fraction,max_ticket_amount,cost_stress_multiplier "
+        "FROM strategy_execution_policies WHERE deployment_id=%s",
+        (response.deployment_id,),
+    ).fetchone() == (Decimal("0.1"), Decimal("25"), Decimal("2"))

--- a/tests/test_strategy_operator_promotion.py
+++ b/tests/test_strategy_operator_promotion.py
@@ -527,6 +527,34 @@ def test_execution_policy_rejects_non_finite_limits_before_database_access(
         )
 
 
+def test_execution_policy_rejects_negative_net_expectancy_floor_before_database_access(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    with pytest.raises(StrategyControlError, match="must be non-negative"):
+        configure_execution_policy(
+            ebull_test_conn,
+            deployment_id=1,
+            ticket_sizing_mode="percent",
+            ticket_fraction=Decimal("0.1"),
+            fixed_ticket_amount=None,
+            max_ticket_amount=Decimal("10"),
+            stop_loss_pct=Decimal("5"),
+            take_profit_pct=Decimal("10"),
+            max_quote_age_seconds=30,
+            max_scan_age_seconds=300,
+            max_halt_feed_age_seconds=300,
+            max_cost_age_seconds=3600,
+            max_reconciliation_age_seconds=60,
+            max_instrument_exposure_pct=Decimal("20"),
+            max_portfolio_exposure_pct=Decimal("50"),
+            max_drawdown_pct=Decimal("10"),
+            min_net_expectancy_pct=Decimal("-0.01"),
+            cost_stress_multiplier=Decimal("2"),
+            changed_by="operator",
+            reason="must reject negative expectancy authority",
+        )
+
+
 def test_paper_retry_refuses_an_unresolvable_prospective_evidence_reference(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_strategy_operator_promotion.py
+++ b/tests/test_strategy_operator_promotion.py
@@ -34,7 +34,9 @@ from app.services.strategy_control_plane import (
     configure_paper_pool,
 )
 from app.services.strategy_operator_promotion import (
+    _load_complete_result_bundle,
     _load_current_prospective_evidence,
+    _require_preserved_result_bundle,
     advance_strategy_for_operator,
     load_forward_floor_evidence,
 )
@@ -152,20 +154,45 @@ def _session() -> SessionRow:
     return SessionRow("operator-promotion-session", uuid4(), "operator", now + timedelta(hours=1), now)
 
 
-def _seed_legacy_unlinked_paper_chain(conn: psycopg.Connection[tuple]) -> None:
-    conn.execute(
+def _seed_legacy_unlinked_paper_chain(
+    conn: psycopg.Connection[tuple],
+    *,
+    result_ids: tuple[int, ...] = (),
+    result_evidence_ref: str = "hist",
+) -> None:
+    promotions = conn.execute(
         """
         INSERT INTO strategy_promotions (
             strategy_id,strategy_version,from_stage,to_stage,gate_version,
             evidence_ref,promoted_by,reason
         ) VALUES
           (%s,%s,NULL,'research_candidate','test-v1',NULL,'test','registered'),
-          (%s,%s,'research_candidate','historical_validated','test-v1','hist','test','history'),
-          (%s,%s,'historical_validated','forward_observation','test-v1','forward','test','observe'),
+          (%s,%s,'research_candidate','historical_validated','test-v1',%s,'test','history'),
+          (%s,%s,'historical_validated','forward_observation','test-v1',%s,'test','observe'),
           (%s,%s,'forward_observation','paper_enabled','test-v1','paper','test','paper')
+        RETURNING promotion_id,to_stage
         """,
-        (_STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION, _STRATEGY_ID, _VERSION),
-    )
+        (
+            _STRATEGY_ID,
+            _VERSION,
+            _STRATEGY_ID,
+            _VERSION,
+            result_evidence_ref,
+            _STRATEGY_ID,
+            _VERSION,
+            result_evidence_ref,
+            _STRATEGY_ID,
+            _VERSION,
+        ),
+    ).fetchall()
+    for promotion_id, stage in promotions:
+        if stage == "research_candidate":
+            continue
+        for result_id in result_ids:
+            conn.execute(
+                "INSERT INTO strategy_promotion_results (promotion_id,result_id) VALUES (%s,%s)",
+                (int(promotion_id), result_id),
+            )
 
 
 def _seed_prospective_assessment(
@@ -381,6 +408,79 @@ def test_complete_matrix_is_replayed_and_bare_rows_still_cannot_promote(
     ).fetchone() == (0,)
 
 
+def test_later_stage_refuses_an_incomplete_historical_pin(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _store_matrix(ebull_test_conn)
+    result_ids, evidence_ref = _load_complete_result_bundle(
+        ebull_test_conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=_VERSION,
+    )
+    promotion_id = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id,strategy_version,from_stage,to_stage,gate_version,
+            evidence_ref,promoted_by,reason
+        ) VALUES (%s,%s,'research_candidate','historical_validated','test-v1',%s,'test','history')
+        RETURNING promotion_id
+        """,
+        (_STRATEGY_ID, _VERSION, evidence_ref),
+    ).fetchone()
+    assert promotion_id is not None
+    for result_id in result_ids[:-1]:
+        ebull_test_conn.execute(
+            "INSERT INTO strategy_promotion_results (promotion_id,result_id) VALUES (%s,%s)",
+            (int(promotion_id[0]), result_id),
+        )
+
+    with pytest.raises(StrategyControlError, match="does not preserve the exact current historical evidence bundle"):
+        _require_preserved_result_bundle(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_VERSION,
+            stage="historical_validated",
+            result_ids=result_ids,
+            evidence_ref=evidence_ref,
+        )
+
+
+def test_later_stage_accepts_only_the_exact_historical_pin(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _store_matrix(ebull_test_conn)
+    result_ids, evidence_ref = _load_complete_result_bundle(
+        ebull_test_conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=_VERSION,
+    )
+    promotion_id = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id,strategy_version,from_stage,to_stage,gate_version,
+            evidence_ref,promoted_by,reason
+        ) VALUES (%s,%s,'research_candidate','historical_validated','test-v1',%s,'test','history')
+        RETURNING promotion_id
+        """,
+        (_STRATEGY_ID, _VERSION, evidence_ref),
+    ).fetchone()
+    assert promotion_id is not None
+    for result_id in result_ids:
+        ebull_test_conn.execute(
+            "INSERT INTO strategy_promotion_results (promotion_id,result_id) VALUES (%s,%s)",
+            (int(promotion_id[0]), result_id),
+        )
+
+    _require_preserved_result_bundle(
+        ebull_test_conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=_VERSION,
+        stage="historical_validated",
+        result_ids=result_ids,
+        evidence_ref=evidence_ref,
+    )
+
+
 def test_prospective_assessment_cannot_reuse_pre_forward_observations(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
@@ -558,7 +658,17 @@ def test_execution_policy_rejects_negative_net_expectancy_floor_before_database_
 def test_paper_retry_refuses_an_unresolvable_prospective_evidence_reference(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_legacy_unlinked_paper_chain(ebull_test_conn)
+    _store_matrix(ebull_test_conn)
+    result_ids, evidence_ref = _load_complete_result_bundle(
+        ebull_test_conn,
+        strategy_id=_STRATEGY_ID,
+        strategy_version=_VERSION,
+    )
+    _seed_legacy_unlinked_paper_chain(
+        ebull_test_conn,
+        result_ids=result_ids,
+        result_evidence_ref=evidence_ref,
+    )
     with pytest.raises(StrategyControlError, match="prospective evidence link is missing"):
         advance_strategy_for_operator(
             ebull_test_conn,

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -156,7 +156,6 @@ def _authorise_forecast_scope(
 def _seed(
     conn: psycopg.Connection[Any],
     *,
-    auto: bool = True,
     ticket_sizing_mode: str = "percent",
     include_forward_evidence: bool = True,
     assessment_passed: bool = True,
@@ -457,14 +456,13 @@ def _seed(
         """
         INSERT INTO runtime_config (
             id, enable_auto_trading, enable_live_trading, updated_by, reason
-        ) VALUES (true, %s, false, 'test', 'paper allocator fixture')
+        ) VALUES (true, false, false, 'test', 'paper allocator fixture')
         ON CONFLICT (id) DO UPDATE SET
             enable_auto_trading=EXCLUDED.enable_auto_trading,
             enable_live_trading=EXCLUDED.enable_live_trading,
             updated_by=EXCLUDED.updated_by, reason=EXCLUDED.reason,
             updated_at=now()
-        """,
-        (auto,),
+        """
     )
     conn.execute(
         """
@@ -1036,22 +1034,18 @@ def test_capital_modes_use_realised_owned_pnl_and_refuse_unknown_pnl(
     assert _effective_capital_bases(conn, intent) == "realised_pnl_incomplete"
 
 
-def test_disabled_global_switch_keeps_an_unfunded_shadow_arm(
+def test_legacy_automatic_switch_does_not_control_the_bounded_strategy_lane(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:
-    signal_id = _seed(ebull_test_conn, auto=False)
+    signal_id = _seed(ebull_test_conn)
     broker = _broker()
 
     result = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
 
-    assert result.verdict == "rejected"
-    assert result.reason_code == "auto_trading_disabled"
-    broker.get_account_risk_snapshot.assert_not_called()
-    broker.place_demo_strategy_order.assert_not_called()
-    assert ebull_test_conn.execute(
-        "SELECT verdict, reason_code FROM strategy_funding_decisions WHERE signal_id=%s",
-        (signal_id,),
-    ).fetchone() == ("rejected", "auto_trading_disabled")
+    assert result.verdict == "submitted"
+    assert result.reason_code == "broker_accepted"
+    broker.get_account_risk_snapshot.assert_called_once()
+    broker.place_demo_strategy_order.assert_called_once()
 
 
 def test_global_live_switch_refuses_paper_execution_before_broker_access(
@@ -1392,6 +1386,7 @@ def test_disabled_pool_reason_precedes_unconfigured_mandate_reason(
         ) VALUES (false,2000,'USD','fixed','legacy','disabled pre-mandate authority')
         """
     )
+    conn.execute("UPDATE runtime_config SET enable_auto_trading=true WHERE id=true")
     conn.commit()
     broker = _broker()
 

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -8,6 +8,7 @@ from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from threading import Barrier, Event
 from time import sleep
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 from uuid import UUID
@@ -15,6 +16,7 @@ from uuid import UUID
 import psycopg
 import pytest
 
+from app.api import strategies as strategies_api
 from app.providers.broker import (
     BrokerAccountRiskSnapshot,
     BrokerCostComponent,
@@ -33,6 +35,7 @@ from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
 from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
 from app.services.result_ledger import freeze_preregistration, store_holdout_result, store_in_sample_result
 from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
+from app.services.strategy_ambiguity_policy import AMBIGUITY_RULE_VERSION
 from app.services.strategy_control_plane import (
     configure_deployment,
     configure_execution_policy,
@@ -59,6 +62,7 @@ from app.services.strategy_paper_executor import (
     _effective_capital_bases,
     execute_fired_paper_signal,
 )
+from app.services.strategy_promotion_evidence_store import store_promotion_evidence
 from app.services.strategy_result import METRIC_AXIS_RULE_VERSION, STRUCTURAL_REFUSAL_POLICY_VERSION, metric_axis_sha256
 from app.services.strategy_result_universe import (
     ResultUniverseRecord,
@@ -75,6 +79,7 @@ from tests.test_result_ledger import (
     build_metrics,
     build_result,
 )
+from tests.test_strategy_control_plane import _arm_ambiguity_record, _passing_promotion_evidence
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
@@ -161,6 +166,7 @@ def _seed(
     include_forward_evidence: bool = True,
     assessment_passed: bool = True,
     assessment_window_start: date | None = None,
+    promotion_evidence_valid_through: date | None = None,
 ) -> int:
     if conn.execute("SELECT 1 FROM strategy_paper_pool_events LIMIT 1").fetchone() is None:
         configure_paper_pool(
@@ -188,6 +194,7 @@ def _seed(
             **BOOTSTRAP_BLOCK,
             "expectancy_ci_low_pct": 5.0,
             "expectancy_ci_high_pct": 6.0,
+            "profit_factor": 1.5,
         }
     )
     deflated = build_deflated(
@@ -200,6 +207,7 @@ def _seed(
         "universe_basis": "survivorship_free",
         "carry_unmodelled": False,
         "fx_unmodelled": False,
+        "ambiguity_rule_version": AMBIGUITY_RULE_VERSION,
         "evaluated_instrument_count": 3,
         "deflated": deflated,
         "trial_count": deflated.declared_trials,
@@ -253,6 +261,7 @@ def _seed(
             ),
         )
         store_result_universe(conn, result_id=support_id, record=universe_record)
+        _arm_ambiguity_record(conn, support_id, threshold=0.5)
     holdout_axis = (date(2022, 1, 1), date(2024, 9, 27))
     result_ids: list[int] = []
     for quarantine_arm in ("masked", "admitted"):
@@ -272,6 +281,15 @@ def _seed(
         )
         result_ids.append(result_id)
         store_result_universe(conn, result_id=result_id, record=universe_record)
+        _arm_ambiguity_record(conn, result_id, threshold=None)
+        promotion_evidence = _passing_promotion_evidence()
+        if promotion_evidence_valid_through is not None:
+            promotion_evidence = replace(
+                promotion_evidence,
+                cost_observed_on=promotion_evidence_valid_through,
+                cost_valid_through=promotion_evidence_valid_through,
+            )
+        store_promotion_evidence(conn, result_id=result_id, evidence=promotion_evidence)
     declaration_id = freeze_preregistration(
         conn,
         PreregDeclaration(
@@ -831,6 +849,38 @@ def test_current_result_policy_supersession_refuses_before_broker_access(
     broker.check_instrument_eligibility.assert_not_called()
     broker.get_what_if_costs.assert_not_called()
     broker.place_demo_strategy_order.assert_not_called()
+
+
+def test_expired_promotion_cost_evidence_blocks_runtime_and_operator_readiness(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(
+        conn,
+        promotion_evidence_valid_through=date.today() - timedelta(days=1),
+    )
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "pinned_promotion_evidence_invalid"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.check_instrument_eligibility.assert_not_called()
+    broker.get_what_if_costs.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+    versions = strategies_api._current_versions()
+    versions["S-ALLOC"] = "v1"
+    manifest = dict(strategies_api.STRATEGY_MANIFEST)
+    manifest["S-ALLOC"] = cast(Any, SimpleNamespace(purpose="capital_candidate", exit_levels=object()))
+    monkeypatch.setattr(strategies_api, "_current_versions", lambda: versions)
+    monkeypatch.setattr(strategies_api, "STRATEGY_MANIFEST", manifest)
+    overview = strategies_api.get_strategy_overview(conn)
+    strategy = next(item for item in overview.strategies if item.strategy_id == "S-ALLOC")
+    assert "pinned_promotion_evidence_invalid" in strategy.allocation_refusals
+    assert not strategy.allocation_ready
 
 
 def test_missing_opportunity_forecast_refuses_before_broker_access(

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -29,8 +29,9 @@ from app.providers.broker import (
     BrokerWhatIfCostResponse,
 )
 from app.services.cost_model import COST_MODEL_ID
+from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
 from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
-from app.services.result_ledger import store_holdout_result, store_in_sample_result
+from app.services.result_ledger import freeze_preregistration, store_holdout_result, store_in_sample_result
 from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
 from app.services.strategy_control_plane import (
     configure_deployment,
@@ -58,7 +59,7 @@ from app.services.strategy_paper_executor import (
     _effective_capital_bases,
     execute_fired_paper_signal,
 )
-from app.services.strategy_result import METRIC_AXIS_RULE_VERSION, metric_axis_sha256
+from app.services.strategy_result import METRIC_AXIS_RULE_VERSION, STRUCTURAL_REFUSAL_POLICY_VERSION, metric_axis_sha256
 from app.services.strategy_result_universe import (
     ResultUniverseRecord,
     record_sha256,
@@ -81,8 +82,13 @@ _REQUEST_ID = UUID("1c94300c-90aa-4303-9d00-dec376d74efb")
 
 
 def _authorise_forecast_scope(
-    conn: psycopg.Connection[Any], *, setup_version: str, checked_at: datetime = _NOW
-) -> None:
+    conn: psycopg.Connection[Any],
+    *,
+    setup_version: str,
+    checked_at: datetime = _NOW,
+    passed: bool = True,
+    window_start: date | None = None,
+) -> int:
     """Explicit synthetic prospective authority for executor plumbing tests."""
     conn.execute(
         """
@@ -109,7 +115,7 @@ def _authorise_forecast_scope(
             ambiguous_rate,unresolved_rate,pending_rate,passed,reason_codes
         ) VALUES (
             'test-assessment-policy-v1','S-ALLOC','v1',%s,'test-model-v1','test-calibration-v1',%s,'test-exit-v1',%s,%s,
-            %s::date-89,%s::date,'synthetic-' || %s,30,30,10,10,10,0,0,0,0,0.33333333,1,0,0,0,0,true,'[]'::jsonb
+            %s::date,%s::date,'synthetic-' || %s,30,30,10,10,10,0,0,0,0,0.33333333,1,0,0,0,0,%s,'[]'::jsonb
         ) RETURNING assessment_id
         """,
         (
@@ -117,9 +123,10 @@ def _authorise_forecast_scope(
             setup_version,
             FORECAST_OUTCOME_RESOLVER_VERSION,
             QUARANTINE_RULE_SET_VERSION,
-            checked_at,
+            window_start or checked_at.date() - timedelta(days=89),
             checked_at,
             setup_version,
+            passed,
         ),
     ).fetchone()
     assert assessment is not None
@@ -143,6 +150,7 @@ def _authorise_forecast_scope(
             checked_at,
         ),
     )
+    return int(assessment[0])
 
 
 def _seed(
@@ -150,6 +158,9 @@ def _seed(
     *,
     auto: bool = True,
     ticket_sizing_mode: str = "percent",
+    include_forward_evidence: bool = True,
+    assessment_passed: bool = True,
+    assessment_window_start: date | None = None,
 ) -> int:
     if conn.execute("SELECT 1 FROM strategy_paper_pool_events LIMIT 1").fetchone() is None:
         configure_paper_pool(
@@ -252,20 +263,46 @@ def _seed(
         purpose="paper allocation evidence fixture",
     )
     store_result_universe(conn, result_id=result_id, record=universe_record)
+    declaration_id = freeze_preregistration(
+        conn,
+        PreregDeclaration(
+            strategy_id="S-ALLOC",
+            strategy_version="v1",
+            contract_version="synthetic-executor-contract-v1",
+            prereg_purpose="capital_candidate",
+            structural_refusal_policy_version=STRUCTURAL_REFUSAL_POLICY_VERSION,
+            declared_universe_basis="survivorship_free",
+            declared_carry_unmodelled=False,
+            declared_fx_unmodelled=False,
+            expected_structural_refusals=(),
+            forward_shadow=ForwardShadowFloor(
+                min_independent_decision_dates=1,
+                min_calendar_weeks=1,
+                derivation="synthetic executor fixture floor",
+            ),
+            declared_by="test",
+        ),
+    )
     promotion_rows = conn.execute(
         """
         INSERT INTO strategy_promotions (
             strategy_id, strategy_version, from_stage, to_stage, gate_version,
-            evidence_ref, promoted_by, reason
+            evidence_ref, promoted_by, reason, promoted_at
         ) VALUES
-          ('S-ALLOC', 'v1', NULL, 'research_candidate', 'test-v1', NULL, 'test', 'registered'),
-          ('S-ALLOC', 'v1', 'research_candidate', 'historical_validated', 'test-v1', 'e:h', 'test', 'historical'),
-          ('S-ALLOC', 'v1', 'historical_validated', 'forward_observation', 'test-v1', 'e:f', 'test', 'forward'),
-          ('S-ALLOC', 'v1', 'forward_observation', 'paper_enabled', 'test-v1', 'e:p', 'test', 'paper')
+          ('S-ALLOC', 'v1', NULL, 'research_candidate', 'test-v1', NULL,
+           'test', 'registered', %s - interval '102 days'),
+          ('S-ALLOC', 'v1', 'research_candidate', 'historical_validated', 'test-v1', 'e:h',
+           'test', 'historical', %s - interval '101 days'),
+          ('S-ALLOC', 'v1', 'historical_validated', 'forward_observation', 'test-v1', 'e:f',
+           'test', 'forward', %s - interval '100 days'),
+          ('S-ALLOC', 'v1', 'forward_observation', 'paper_enabled', 'test-v1', 'e:p',
+           'test', 'paper', %s - interval '1 day')
         RETURNING promotion_id, to_stage
-        """
+        """,
+        (_NOW, _NOW, _NOW, _NOW),
     ).fetchall()
     historical_id = next(int(row[0]) for row in promotion_rows if row[1] == "historical_validated")
+    paper_id = next(int(row[0]) for row in promotion_rows if row[1] == "paper_enabled")
     conn.execute(
         "INSERT INTO strategy_promotion_results (promotion_id, result_id) VALUES (%s, %s)",
         (historical_id, result_id),
@@ -356,7 +393,22 @@ def _seed(
             cost_model_id=COST_MODEL_ID,
         ),
     )
-    _authorise_forecast_scope(conn, setup_version="test-setup-v1")
+    assessment_id = _authorise_forecast_scope(
+        conn,
+        setup_version="test-setup-v1",
+        passed=assessment_passed,
+        window_start=assessment_window_start,
+    )
+    if include_forward_evidence:
+        conn.execute(
+            """
+            INSERT INTO strategy_promotion_forward_evidence (
+                promotion_id,strategy_id,strategy_version,declaration_id,assessment_id,
+                forward_resolved_signals,forward_decision_dates,forward_elapsed_days,assessed_at
+            ) VALUES (%s,'S-ALLOC','v1',%s,%s,1,1,99,%s)
+            """,
+            (paper_id, declaration_id, assessment_id, _NOW - timedelta(days=1)),
+        )
     persist_ranking_batch(
         conn,
         opportunities=[
@@ -736,6 +788,44 @@ def test_missing_opportunity_forecast_refuses_before_broker_access(
     ).fetchone() == (None, HALT_IDENTITY_RULE_VERSION)
 
 
+def test_missing_paper_forward_evidence_refuses_before_broker_access(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn, include_forward_evidence=False)
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.reason_code == "paper_forward_evidence_missing"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+
+def test_paused_strategy_refuses_even_if_deployment_was_left_enabled(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id,strategy_version,from_stage,to_stage,gate_version,
+            evidence_ref,promoted_by,reason,promoted_at
+        ) VALUES ('S-ALLOC','v1','paper_enabled','paused','test-v1',NULL,'test','pause test',%s)
+        """,
+        (_NOW,),
+    )
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.reason_code == "paper_stage_required"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+
 def test_unbatched_opportunity_refuses_before_broker_access(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:
@@ -794,6 +884,7 @@ def test_invalid_opportunity_evidence_refuses_before_broker_access(
         ("calibration_scope", "opportunity_assessment_missing"),
         ("failed", "opportunity_assessment_not_passed"),
         ("stale", "opportunity_assessment_stale"),
+        ("pre_forward", "opportunity_assessment_pre_forward"),
     ],
 )
 def test_prospective_assessment_refuses_before_broker_access(
@@ -802,7 +893,11 @@ def test_prospective_assessment_refuses_before_broker_access(
     reason_code: str,
 ) -> None:
     conn = ebull_test_conn
-    signal_id = _seed(conn)
+    signal_id = _seed(
+        conn,
+        assessment_passed=invalidity != "failed",
+        assessment_window_start=_NOW.date() - timedelta(days=101) if invalidity == "pre_forward" else None,
+    )
     if invalidity == "policy":
         conn.execute("UPDATE strategy_forecast_assessment_policies SET effective_from=%s + interval '1 day'", (_NOW,))
     elif invalidity == "missing":
@@ -819,9 +914,7 @@ def test_prospective_assessment_refuses_before_broker_access(
             """
         )
         conn.execute("UPDATE strategy_forecast_assessment_current SET calibration_id='other-calibration'")
-    elif invalidity == "failed":
-        conn.execute("UPDATE strategy_forecast_assessments SET passed=false")
-    else:
+    elif invalidity == "stale":
         conn.execute("UPDATE strategy_forecast_assessment_current SET checked_at=%s - interval '3 days'", (_NOW,))
     conn.commit()
     broker = _broker()

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -457,7 +457,7 @@ def _seed(
         """
         INSERT INTO runtime_config (
             id, enable_auto_trading, enable_live_trading, updated_by, reason
-        ) VALUES (true, %s, true, 'test', 'paper allocator fixture')
+        ) VALUES (true, %s, false, 'test', 'paper allocator fixture')
         ON CONFLICT (id) DO UPDATE SET
             enable_auto_trading=EXCLUDED.enable_auto_trading,
             enable_live_trading=EXCLUDED.enable_live_trading,
@@ -1052,6 +1052,27 @@ def test_disabled_global_switch_keeps_an_unfunded_shadow_arm(
         "SELECT verdict, reason_code FROM strategy_funding_decisions WHERE signal_id=%s",
         (signal_id,),
     ).fetchone() == ("rejected", "auto_trading_disabled")
+
+
+def test_global_live_switch_refuses_paper_execution_before_broker_access(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    conn.execute("UPDATE runtime_config SET enable_live_trading=true WHERE id=true")
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "live_trading_enabled"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+    assert conn.execute(
+        "SELECT verdict, reason_code FROM strategy_funding_decisions WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == ("rejected", "live_trading_enabled")
 
 
 def test_shared_paper_pool_is_a_master_switch_and_hard_cap(

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -66,6 +66,7 @@ from app.services.strategy_result_universe import (
     store_result_universe,
 )
 from app.services.strategy_statistics import periods_per_year
+from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
 from tests.fixtures.ebull_test_db import test_database_url
 from tests.test_result_ledger import (
     BOOTSTRAP_BLOCK,
@@ -189,7 +190,10 @@ def _seed(
             "expectancy_ci_high_pct": 6.0,
         }
     )
-    deflated = build_deflated()
+    deflated = build_deflated(
+        declared_trials=TRIAL_REGISTER.declared_count,
+        trial_register_version=TRIAL_REGISTER_VERSION,
+    )
     shared_result = {
         "strategy_id": "S-ALLOC",
         "strategy_version": "v1",
@@ -229,39 +233,45 @@ def _seed(
     # The random-entry cohort is an in-sample falsification.  The withheld row
     # must remain control-free; production derives this exact support rather
     # than spending 1,000 additional looks at holdout outcomes (#2737).
-    support_id = store_in_sample_result(
-        conn,
-        build_result(
-            **shared_result,
-            **support_fields,
-            namespace="in_sample",
-            purpose="harness_validation",
-            synthetic_control=build_control(
-                support_metrics,
-                mean_return_pct=0.0,
-                mean_return_ci_low_pct=-1.0,
-                mean_return_ci_high_pct=1.0,
-                cohort_sharpe_threshold=-4.0,
-                cohort_return_threshold_pct=-101.0,
+    for quarantine_arm in ("masked", "admitted"):
+        support_id = store_in_sample_result(
+            conn,
+            build_result(
+                **shared_result,
+                **support_fields,
+                namespace="in_sample",
+                quarantine_arm=quarantine_arm,
+                purpose="harness_validation",
+                synthetic_control=build_control(
+                    support_metrics,
+                    mean_return_pct=0.0,
+                    mean_return_ci_low_pct=-1.0,
+                    mean_return_ci_high_pct=1.0,
+                    cohort_sharpe_threshold=-4.0,
+                    cohort_return_threshold_pct=-101.0,
+                ),
             ),
-        ),
-    )
-    store_result_universe(conn, result_id=support_id, record=universe_record)
+        )
+        store_result_universe(conn, result_id=support_id, record=universe_record)
     holdout_axis = (date(2022, 1, 1), date(2024, 9, 27))
-    result_id = store_holdout_result(
-        conn,
-        build_result(
-            **shared_result,
-            **current_result_fields(holdout_axis, evidence_window_id="primary-2022-plus"),
-            namespace="hold_out",
-            window_start=date(2022, 1, 1),
-            window_end=date(2024, 9, 27),
-            synthetic_control=None,
-        ),
-        accessed_by="tests/test_strategy_paper_executor.py",
-        purpose="paper allocation evidence fixture",
-    )
-    store_result_universe(conn, result_id=result_id, record=universe_record)
+    result_ids: list[int] = []
+    for quarantine_arm in ("masked", "admitted"):
+        result_id = store_holdout_result(
+            conn,
+            build_result(
+                **shared_result,
+                **current_result_fields(holdout_axis, evidence_window_id="primary-2022-plus"),
+                namespace="hold_out",
+                quarantine_arm=quarantine_arm,
+                window_start=date(2022, 1, 1),
+                window_end=date(2024, 9, 27),
+                synthetic_control=None,
+            ),
+            accessed_by="tests/test_strategy_paper_executor.py",
+            purpose="paper allocation evidence fixture",
+        )
+        result_ids.append(result_id)
+        store_result_universe(conn, result_id=result_id, record=universe_record)
     declaration_id = freeze_preregistration(
         conn,
         PreregDeclaration(
@@ -302,10 +312,15 @@ def _seed(
     ).fetchall()
     historical_id = next(int(row[0]) for row in promotion_rows if row[1] == "historical_validated")
     paper_id = next(int(row[0]) for row in promotion_rows if row[1] == "paper_enabled")
-    conn.execute(
-        "INSERT INTO strategy_promotion_results (promotion_id, result_id) VALUES (%s, %s)",
-        (historical_id, result_id),
-    )
+    for result_id in result_ids:
+        conn.execute(
+            "INSERT INTO strategy_promotion_results (promotion_id, result_id) VALUES (%s, %s)",
+            (historical_id, result_id),
+        )
+        conn.execute(
+            "INSERT INTO strategy_promotion_results (promotion_id, result_id) VALUES (%s, %s)",
+            (paper_id, result_id),
+        )
     deployment = configure_deployment(
         conn,
         strategy_id="S-ALLOC",
@@ -717,7 +732,7 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
 
     result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
 
-    assert result.verdict == "submitted"
+    assert result.verdict == "submitted", result
     assert result.amount == Decimal("50.00")  # 30% equity cap - $250 manual/existing exposure
     submitted = broker.place_demo_strategy_order.call_args
     assert submitted.kwargs["request_id"] == _REQUEST_ID
@@ -797,6 +812,25 @@ def test_zero_net_expectancy_refuses_before_demo_submission(
         Decimal("0E-8"),
         COST_BASIS_BROKER_PREFLIGHT_VALUE,
     )
+
+
+def test_current_result_policy_supersession_refuses_before_broker_access(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    broker = _broker()
+    monkeypatch.setattr("app.services.strategy_result.TRIAL_REGISTER_VERSION", "superseded-after-paper-approval")
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "pinned_promotion_evidence_invalid"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.check_instrument_eligibility.assert_not_called()
+    broker.get_what_if_costs.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
 
 
 def test_missing_opportunity_forecast_refuses_before_broker_access(

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -764,6 +764,41 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
     broker.place_demo_strategy_order.assert_called_once()
 
 
+def test_zero_net_expectancy_refuses_before_demo_submission(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    broker = _broker()
+    # $1.25 on the $50 risk-bounded ticket, stressed 2x, is exactly 5%;
+    # the frozen conservative gross lower bound is 5%, so net expectancy is zero.
+    broker.get_what_if_costs.return_value = replace(
+        broker.get_what_if_costs.return_value,
+        costs=(
+            replace(
+                broker.get_what_if_costs.return_value.costs[0],
+                value=Decimal("1.25"),
+            ),
+        ),
+    )
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "net_expectancy_not_positive"
+    broker.place_demo_strategy_order.assert_not_called()
+    assert conn.execute(
+        "SELECT verdict,stressed_cost_amount,net_expectancy_pct,cost_basis "
+        "FROM strategy_entry_preflights WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == (
+        "rejected",
+        Decimal("2.500000"),
+        Decimal("0E-8"),
+        COST_BASIS_BROKER_PREFLIGHT_VALUE,
+    )
+
+
 def test_missing_opportunity_forecast_refuses_before_broker_access(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -1588,6 +1588,30 @@ def test_transport_uncertainty_retries_only_the_committed_uuid(
     ).fetchall() == [(_REQUEST_ID,)]
 
 
+def test_live_switch_does_not_resubmit_an_uncertain_demo_order(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    broker = _broker()
+    broker.place_demo_strategy_order.side_effect = BrokerOrderSubmissionUncertain("timeout")
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+
+    first = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+    assert first.verdict == "submission_uncertain"
+    conn.execute("UPDATE runtime_config SET enable_live_trading=true WHERE id=true")
+    conn.commit()
+    broker.reset_mock()
+
+    second = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert second == first
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.lookup_order.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+
 def test_uncertain_harness_submission_is_looked_up_without_resubmission(
     ebull_test_conn: psycopg.Connection[Any],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_strategy_paper_runtime.py
+++ b/tests/test_strategy_paper_runtime.py
@@ -10,6 +10,8 @@ import psycopg
 import pytest
 from psycopg.pq import TransactionStatus
 
+from app.api.strategies import get_fired_signals, get_strategy_owned_positions
+from app.providers.broker import BrokerPortfolio
 from app.services.cost_model import COST_MODEL_ID
 from app.services.strategy_live_gate import assess_live_gate
 from app.services.strategy_opportunity_forecast import OpportunityForecast, record_opportunity_forecast
@@ -21,7 +23,13 @@ from app.services.strategy_paper_runtime import (
     run_strategy_paper_cycle,
 )
 from tests.test_strategy_paper_executor import _NOW, _REQUEST_ID, _authorise_forecast_scope, _broker, _seed
-from tests.test_strategy_position_manager import _opened_trade
+from tests.test_strategy_position_manager import (
+    _MANUAL_POSITION_ID,
+    _POSITION_ID,
+    _opened_trade,
+    _order_detail,
+    _position,
+)
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
@@ -111,6 +119,153 @@ def test_cycle_refreshes_health_then_executes_one_current_paper_candidate(
         ("quote_freshness", False),
         ("scan_freshness", False),
     ]
+
+
+def test_generated_demo_trade_is_auditable_through_reconciliation_and_operator_reads(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Execution-plumbing acceptance only; ``S-ALLOC`` is a synthetic test candidate."""
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    broker = _broker()
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+
+    submitted = run_strategy_paper_cycle(conn, broker=broker, now=_NOW, strategy_versions=["v1"])
+
+    assert submitted.evaluated_signals == 1
+    broker.place_demo_strategy_order.assert_called_once()
+    order_row = conn.execute(
+        """
+        SELECT t.strategy_trade_id,o.order_id,o.strategy_request_id,o.broker_order_ref,
+               pf.forecast_id,pf.ranking_member_id,pf.verdict,fd.amount
+        FROM strategy_funding_decisions fd
+        JOIN strategy_entry_preflights pf ON pf.signal_id=fd.signal_id
+        JOIN strategy_trades t ON t.funding_decision_id=fd.funding_decision_id
+        JOIN strategy_trade_orders sto ON sto.strategy_trade_id=t.strategy_trade_id
+        JOIN orders o ON o.order_id=sto.order_id
+        WHERE fd.signal_id=%s
+        """,
+        (signal_id,),
+    ).fetchone()
+    assert order_row is not None
+    trade_id, order_id, request_id, broker_order_ref, forecast_id, ranking_member_id, verdict, amount = order_row
+    assert request_id == _REQUEST_ID
+    assert broker_order_ref == "13902598"
+    assert forecast_id is not None and ranking_member_id is not None
+    assert verdict == "allocated"
+    assert amount == Decimal("50.000000")
+    conn.commit()
+
+    # The next bounded cycle observes the broker fill, claims only its exact
+    # execution and manages it. A same-instrument manual position is visible to
+    # the broker but must never be claimed by strategy ownership.
+    broker.lookup_order.return_value = _order_detail()
+    manual = _position(_MANUAL_POSITION_ID, stop=None, take=None)
+    broker.get_portfolio.return_value = BrokerPortfolio(
+        positions=(
+            _position(_POSITION_ID, stop=Decimal("95"), take=Decimal("110")),
+            manual,
+        ),
+        available_cash=Decimal("500"),
+        raw_payload={},
+    )
+    reconciled = run_strategy_paper_cycle(
+        conn,
+        broker=broker,
+        now=_NOW + timedelta(minutes=5),
+        strategy_versions=["v1"],
+    )
+
+    assert reconciled.reconciled_orders == 1
+    assert reconciled.managed_positions == 1
+    assert reconciled.evaluated_signals == 0
+    broker.place_demo_strategy_order.assert_called_once()
+    assert conn.execute(
+        """
+        SELECT ownership.broker_position_id,t.status,reconciliation.state,
+               reconciliation.broker_status
+        FROM strategy_position_ownership ownership
+        JOIN strategy_trades t ON t.strategy_trade_id=ownership.strategy_trade_id
+        JOIN strategy_trade_orders sto ON sto.strategy_trade_id=t.strategy_trade_id
+        JOIN strategy_order_reconciliation_state reconciliation ON reconciliation.order_id=sto.order_id
+        WHERE ownership.strategy_trade_id=%s
+        """,
+        (trade_id,),
+    ).fetchall() == [(_POSITION_ID, "open", "resolved", "Filled")]
+    assert conn.execute(
+        "SELECT count(*) FROM strategy_position_ownership WHERE broker_position_id=%s",
+        (_MANUAL_POSITION_ID,),
+    ).fetchone() == (0,)
+
+    # The production endpoint intentionally filters to current manifest
+    # versions. Admit only this synthetic fixture version at that boundary;
+    # this is plumbing proof, never production strategy registration.
+    monkeypatch.setattr("app.api.strategies._current_versions", lambda: {"S-ALLOC": "v1"})
+    signals = get_fired_signals(cursor=None, limit=50, strategy_id="S-ALLOC", conn=conn)
+    visible = next(item for item in signals.items if item.signal_id == signal_id)
+    assert visible.funding_status == "funded"
+    assert visible.funded_amount == amount
+    assert visible.strategy_trade_id == trade_id
+    assert visible.trade_lifecycle is not None
+    assert visible.trade_lifecycle.trade_status == "open"
+    assert visible.trade_lifecycle.ownership_count == 1
+    assert visible.trade_lifecycle.broker_position_id == _POSITION_ID
+    assert visible.trade_lifecycle.latest_reconciliation_state == "resolved"
+
+    conn.execute(
+        """
+        UPDATE strategy_order_reconciliation_state
+        SET state='ambiguous',reconciled_at=NULL,last_error_code='multiple_position_executions'
+        WHERE order_id=%s
+        """,
+        (order_id,),
+    )
+    ambiguous_signals = get_fired_signals(cursor=None, limit=50, strategy_id="S-ALLOC", conn=conn)
+    ambiguous = next(item for item in ambiguous_signals.items if item.signal_id == signal_id)
+    assert ambiguous.trade_lifecycle is not None
+    assert ambiguous.trade_lifecycle.incomplete_reasons == ["entry_order_reconciliation_ambiguous"]
+    conn.execute(
+        """
+        UPDATE strategy_order_reconciliation_state
+        SET state='resolved',reconciled_at=now(),last_error_code=NULL
+        WHERE order_id=%s
+        """,
+        (order_id,),
+    )
+
+    positions = get_strategy_owned_positions(conn)
+    owned = next(item for item in positions.positions if item.strategy_trade_id == trade_id)
+    assert owned.broker_position_id == _POSITION_ID
+    assert owned.strategy_id == "S-ALLOC"
+    assert owned.trade_status == "open"
+    # The operator can see the owned identity immediately; valuation stays
+    # explicitly unavailable until the independent portfolio sync persists it.
+    assert not owned.valuation_available
+    assert positions.live_quote_instrument_ids == [2449001]
+    conn.commit()
+
+    # A third replay is read-only for this signal/order and remains one owned
+    # lifecycle. It may manage the already-open position again, but cannot mint
+    # another funding decision, trade, order or broker submission.
+    replay = run_strategy_paper_cycle(
+        conn,
+        broker=broker,
+        now=_NOW + timedelta(minutes=10),
+        strategy_versions=["v1"],
+    )
+    assert replay.reconciled_orders == 0
+    assert replay.evaluated_signals == 0
+    broker.place_demo_strategy_order.assert_called_once()
+    assert conn.execute(
+        """
+        SELECT
+          (SELECT count(*) FROM strategy_funding_decisions WHERE signal_id=%s),
+          (SELECT count(*) FROM strategy_trades WHERE strategy_trade_id=%s),
+          (SELECT count(*) FROM strategy_trade_orders WHERE order_id=%s),
+          (SELECT count(*) FROM strategy_position_ownership WHERE strategy_trade_id=%s)
+        """,
+        (signal_id, trade_id, order_id, trade_id),
+    ).fetchone() == (1, 1, 1, 1)
 
 
 def test_runtime_ranks_the_complete_set_before_applying_its_execution_limit(


### PR DESCRIPTION
Refs #2766
Refs #2767
Refs #2768
Refs #2769
Refs #2770

## Stack dependency

This is a stacked draft on #2757. It must not merge before the metric-axis branch is accepted and merged. After that, this branch must be rebased onto the resulting main head and all final-sha gates rerun.

Detailed handover: `docs/proposals/ta/2026-08-16-paper-trading-milestone-handover.md`.

## Outcome

Recovers and integrates the stopped MT-1 and operator-paper branches into one reviewable path: preregistered two-phase in-sample evaluation, evidence-bound promotion, explicit disabled-first policy setup, bounded paper allocation, demo broker preflight/execution, reconciliation, monitoring, and a Strategies workspace that exposes the lifecycle end to end.

## Safety boundaries

- All current catalogue strategies remain harness_validation; no strategy is automatically relabelled as a capital candidate.
- MT-1 trial output is historical falsification evidence only and carries no promotion authority.
- Paper activation requires a separately reviewed capital-candidate version, complete promotion replay, forward evidence, explicit operator limits, a configured shared risk mandate, demo credentials, current broker/cost/quote/reconciliation evidence, and live-off state.
- Strategy paper automation has its own master switch and cannot enable the unrelated legacy auto-order pipeline.
- The generic promotion path refuses live_enabled. The live endpoint records an assessment only; it does not activate a strategy or submit real-money orders.

## Integrated capabilities

- reserves one paper lifecycle worker slot without increasing the PostgreSQL connection budget
- prepares and commits a complete outcome-free MT-1 structural fan before evaluation
- seals MT-1 strategy and regime reads at the registered in-sample boundary
- stores the controlled-trial result fan atomically with invocation and derivation auditors
- provides authenticated, evidence-pinned research-to-paper transitions
- requires explicit first paper limits and creates the initial deployment disabled
- replays the complete pinned evidence bundle before operator readiness and again before broker access
- enforces shared and per-strategy capital, sizing, freshness, cost, expectancy, exposure, drawdown, daily-loss, concurrency, long-only, and no-leverage controls
- executes only against the demo broker contract and preserves ambiguous/reconciliation-required states
- shows generated signals, funding decisions, exact strategy trades, broker requests/orders, reconciliation, owned positions, close history, fees and P&L on /strategies

## Verification on exact head

- head: `56775c1ffac4b9df73d314963a86c4c9ea6c6822`
- full repository pre-push gate green: Ruff, formatting, Pyright, shellcheck, mirrored static invariants, fast tests, app boot smoke tests, frontend integrity checks, and 289 branch-local probe anchors
- focused backend integration surface green across MT-1, promotion, allocation, paper executor/runtime, monitoring and Strategies API
- frontend typecheck and production build green
- all 137 frontend files / 1,537 tests green
- real-Postgres lifecycle acceptance covers rank, fund, broker-priced preflight, one demo submission, reconciliation, exact position ownership, close lifecycle visibility, replay idempotence, and exclusion of a same-instrument manual position
- broad backend run completed with nine parallel global-state, connection-pressure, or source-lock failures; all nine passed on clean serial rerun, including the two source-lock exclusivity tests while the development lane was free
- handover now pins #2773 at `510cd60bc7aac491edba5e30b4521c672177f2b3` and records its completed durable exact synthetic-control match gate
- PR review state at this head: no review, comment, bot response, or hosted check queued on this stacked non-main base

## Programme gates still outstanding

1. Continue #2772 on stacked #2773 with a bounded, outcome-free time/memory/read-cost parallel canary: spawned-worker startup, collector/input transfer, worker RSS, observed scaling, and current PostgreSQL decode cost.
2. Use that fixed evidence to document the current read path inside budget or land a digest-bound reusable representation with deterministic and stratified `load_arms` equivalence; complete the outcome-blind stratified real-corpus differential.
3. Review and merge #2773 onto #2757, then run only its exact three-member production pilot over the sealed corpus; stop on any correctness, time, or memory refusal.
4. Only after that pilot admits the projection, run #2757 legacy structural evidence and the exact-head full-population A/B, obtain substantive review, and merge it.
5. Rebase this branch onto accepted main and rerun final-sha verification, including the two source-lock tests with the development worker clear.
6. Supersede the stale MT-1/S-8 declarations in the audited order.
7. Run the corrected preregistered MT-1 in-sample trial and its structural/invocation/derivation audits.
8. Only if the full conjunctive evidence warrants it, register a distinct reviewed capital-candidate version and proceed through holdout and prospective observation.
9. Exercise the resulting evidence-qualified strategy with bounded demo capital and audit its actual generated trade lifecycle.

This PR proves plumbing and fail-closed authority boundaries. It makes no profitability, promotion-readiness, or live-trading claim.
