### PR TITLE
fix(#2775): report the memory projection's two terms so a refusal is actionable

### DIFF
--- a/app/services/synthetic_control_run.py
+++ b/app/services/synthetic_control_run.py
@@ -282,11 +282,31 @@ class LaunchPilotReport:
     max_memory_bytes: int
     time_admitted: bool
     memory_admitted: bool
+    #: ⚠ The projection's two terms, reported separately so a refusal says WHICH
+    #: it is and what would change it. ``projected_unique_memory_bytes`` is
+    #: ``parent_peak_bytes + max_workers * per_worker_unique_bytes``, and
+    #: ``max_workers`` changes execution only — spawned members are byte-for-byte
+    #: the serial ones — so a memory refusal at one worker count can be re-asked
+    #: at another from these two numbers alone, without re-running a corpus pass.
+    parent_peak_bytes: int = 0
+    per_worker_unique_bytes: int = 0
+    projection_max_workers: int = 0
     stopped_before_full_cohort: bool = True
 
     @property
     def admitted(self) -> bool:
         return self.time_admitted and self.memory_admitted
+
+    def admissible_workers(self, *, max_memory_bytes: int | None = None) -> int:
+        """The largest worker count whose projection fits the memory ceiling.
+
+        ⚠ Zero means the PARENT alone already exceeds it, which no worker count
+        can fix — that is a corpus-representation problem, not a fan-out one.
+        """
+        ceiling = self.max_memory_bytes if max_memory_bytes is None else max_memory_bytes
+        if self.per_worker_unique_bytes <= 0:
+            return 0
+        return max((ceiling - self.parent_peak_bytes) // self.per_worker_unique_bytes, 0)
 
 
 @dataclass
@@ -1055,11 +1075,12 @@ def run_launch_pilot(
     )
     # ⚠ The pilot projects a fan-out it will never start, so it measures the
     # child and the post-shared parent peak exactly as the real launch does.
-    projected_memory, _per_worker_unique_bytes = _project_unique_memory_bytes(
+    projected_memory, per_worker_unique_bytes = _project_unique_memory_bytes(
         inputs,
         max_workers=max_workers,
         measure_child=True,
     )
+    parent_peak_bytes = projected_memory - max_workers * per_worker_unique_bytes
     return LaunchPilotReport(
         member_indices=indices,
         placement_series=len(collector.placements),
@@ -1073,6 +1094,9 @@ def run_launch_pilot(
         max_memory_bytes=max_memory_bytes,
         time_admitted=projected_s <= max_cohort_s,
         memory_admitted=projected_memory <= max_memory_bytes,
+        parent_peak_bytes=parent_peak_bytes,
+        per_worker_unique_bytes=per_worker_unique_bytes,
+        projection_max_workers=max_workers,
     )
 
 

--- a/app/services/synthetic_control_run.py
+++ b/app/services/synthetic_control_run.py
@@ -290,6 +290,9 @@ class LaunchPilotReport:
     #: at another from these two numbers alone, without re-running a corpus pass.
     parent_peak_bytes: int = 0
     per_worker_unique_bytes: int = 0
+    #: ⚠ ``False`` means ``per_worker_unique_bytes`` is the FLOOR, not a
+    #: measurement, and nothing may be extrapolated from it.
+    per_worker_measured: bool = False
     projection_max_workers: int = 0
     stopped_before_full_cohort: bool = True
 
@@ -297,15 +300,19 @@ class LaunchPilotReport:
     def admitted(self) -> bool:
         return self.time_admitted and self.memory_admitted
 
-    def admissible_workers(self, *, max_memory_bytes: int | None = None) -> int:
+    def admissible_workers(self, *, max_memory_bytes: int | None = None) -> int | None:
         """The largest worker count whose projection fits the memory ceiling.
 
-        ⚠ Zero means the PARENT alone already exceeds it, which no worker count
-        can fix — that is a corpus-representation problem, not a fan-out one.
+        ⚠ ``None`` means the per-worker figure was never measured, so there is
+        nothing to divide by — dividing a ceiling by the FLOOR would over-state
+        how wide a fan-out fits, which is the one direction this must not err in.
+        ⚠ Zero is a different answer: the PARENT alone already exceeds the
+        ceiling, which no worker count can fix. That is a corpus-representation
+        problem rather than a fan-out one, and the two want different next moves.
         """
+        if not self.per_worker_measured or self.per_worker_unique_bytes <= 0:
+            return None
         ceiling = self.max_memory_bytes if max_memory_bytes is None else max_memory_bytes
-        if self.per_worker_unique_bytes <= 0:
-            return 0
         return max((ceiling - self.parent_peak_bytes) // self.per_worker_unique_bytes, 0)
 
 
@@ -949,7 +956,7 @@ def _project_unique_memory_bytes(
     *,
     max_workers: int,
     measure_child: bool,
-) -> tuple[int, int]:
+) -> tuple[int, int, bool]:
     """Projected unique memory for the fan-out, and the per-worker figure in it.
 
     ⚠⚠ ONE COPY OF THIS RULE, DELIBERATELY (#2775). It was written twice — once
@@ -969,16 +976,24 @@ def _project_unique_memory_bytes(
     those blocks measures the real cost instead of modelling it, so there is no
     coefficient to get wrong.
 
+    ⚠ WHETHER TO MEASURE IS THE CALLER'S CALL, not a function of the worker
+    count. It used to be gated on ``max_workers > 1`` here, which quietly
+    returned the FLOOR for a one-worker projection — harmless while the figure
+    was only summed, and unsafe as soon as it was reported, because dividing a
+    ceiling by a floor over-states how wide a fan-out would fit. The third
+    return value says whether the figure was measured, so no caller can mistake
+    the floor for a measurement.
+
     ⚠ The child's own peak includes the shared pages it mapped, so they are
     subtracted before multiplying: counting them once per worker would over-state
     unique memory eightfold. This is the same accounting the worker canary uses.
     """
     per_worker_unique_bytes = SYNTHETIC_CONTROL_WORKER_BASE_RSS_BYTES
-    if measure_child and max_workers > 1:
+    if measure_child:
         child_peak_bytes, shared_block_bytes = _measure_child_member_peak(inputs, index=0)
         per_worker_unique_bytes = max(child_peak_bytes - shared_block_bytes, SYNTHETIC_CONTROL_WORKER_BASE_RSS_BYTES)
     parent_peak_bytes = _peak_rss_bytes()
-    return parent_peak_bytes + max_workers * per_worker_unique_bytes, per_worker_unique_bytes
+    return parent_peak_bytes + max_workers * per_worker_unique_bytes, per_worker_unique_bytes, measure_child
 
 
 def _measure_canary_member_in_worker(index: int) -> _WorkerCanarySample:
@@ -1075,7 +1090,7 @@ def run_launch_pilot(
     )
     # ⚠ The pilot projects a fan-out it will never start, so it measures the
     # child and the post-shared parent peak exactly as the real launch does.
-    projected_memory, per_worker_unique_bytes = _project_unique_memory_bytes(
+    projected_memory, per_worker_unique_bytes, per_worker_measured = _project_unique_memory_bytes(
         inputs,
         max_workers=max_workers,
         measure_child=True,
@@ -1096,6 +1111,7 @@ def run_launch_pilot(
         memory_admitted=projected_memory <= max_memory_bytes,
         parent_peak_bytes=parent_peak_bytes,
         per_worker_unique_bytes=per_worker_unique_bytes,
+        per_worker_measured=per_worker_measured,
         projection_max_workers=max_workers,
     )
 
@@ -1272,10 +1288,12 @@ def _run_members(
         projected_s = pilot_elapsed + (
             pilot_elapsed / pilot_size * remaining / max_workers * SYNTHETIC_CONTROL_PROJECTION_SAFETY_FACTOR
         )
-        projected_memory_bytes, per_worker_unique_bytes = _project_unique_memory_bytes(
+        projected_memory_bytes, per_worker_unique_bytes, _measured = _project_unique_memory_bytes(
             inputs,
             max_workers=max_workers,
-            measure_child=pilot_size < cohort_size,
+            # No pool is spawned in the serial path, so there is no child to
+            # measure and nothing to extrapolate from.
+            measure_child=max_workers > 1 and pilot_size < cohort_size,
         )
         scale_budget.reserve(
             label=label,

--- a/docs/proposals/ta/2026-08-16-backtest-scale-readiness.md
+++ b/docs/proposals/ta/2026-08-16-backtest-scale-readiness.md
@@ -205,15 +205,42 @@ after exact members `0..2`.
 | Python reference | 10,492 | 4,227,215 | 28.398s | 5,393.858s (89.9m) | 4,647,837,480 bytes |
 | compiled shared-mark | 10,492 | 4,227,215 | 5.183s | 984.505s (16.4m) | 4,393,377,576 bytes |
 
-⚠ **The two projected-memory figures above are SUPERSEDED and are both
-under-statements** (#2775, 2026-08-19). They were produced by a projection that
-inferred per-worker memory from a difference of two `ru_maxrss` readings — a
-process lifetime mark, so the difference is zero once the process has already
-been that large — and that added the shared-input cost once where the parent
-pays it about twice. Both are fixed; the time figures are unaffected, because
-`time.monotonic()` differences are intervals. **The launch pilot must be re-run
-before the first bounded invocation so the 8 GiB ceiling is checked against a
-corrected projection**, which will be larger than 4.39 GB.
+⚠⚠ **The two projected-memory figures above are SUPERSEDED, were both
+under-statements, and the corrected projection REFUSES this cohort** (#2775,
+2026-08-19). The old projection inferred per-worker memory from a difference of
+two `ru_maxrss` readings — a process lifetime mark, so the difference is zero
+once the process has already been that large — and added the shared-input cost
+once where the parent pays it about twice. The time figures are unaffected,
+because `time.monotonic()` differences are intervals.
+
+Re-measured on the full S-1 survivorship-free corpus with the corrected
+projection, zero database writes and zero outcome fields:
+
+| term | value |
+| --- | ---: |
+| parent peak | 4.54 GiB |
+| per worker unique | 0.49 GiB |
+| workers | 8 |
+| **projected unique memory** | **8.49 GiB** against the 8 GiB ceiling — refused |
+| projected cohort time | 14.7 min against the 20 min ceiling — admitted |
+
+⚠ **The first bounded S-1 invocation is therefore refused before fan-out, which
+is the gate working.** Time has headroom while memory binds, and the two trade
+against each other through `max_workers`; the report now carries the
+projection's two terms so that question is arithmetic rather than another
+corpus pass.
+
+⚠ **Do not tune the worker count to the edge on one pilot.** Two identical
+full-corpus runs on the same commit projected 12.20 GiB and 8.49 GiB (seconds
+per member 3.12 and 4.64), so the parent term varies by roughly 40% run to run
+and any "N workers would fit" conclusion sits inside that spread. Both refuse at
+eight. The gate is unaffected — each invocation measures itself — but a worker
+count picked from one pilot is not evidence.
+
+⚠ The parent alone is over half the ceiling, so even a single worker projects
+about 5 GiB and no pool size buys much. The lever is the remaining performance
+boundary below — the per-strategy `research_price_daily` fetch and Decimal
+reconstruction — not the fan-out width.
 
 The compiled result is an 81.7% reduction in projected cohort time. It admits
 under the calibrated 20-minute cohort and 8 GiB memory ceilings while preserving

--- a/scripts/probe_2601_synthetic_control.py
+++ b/scripts/probe_2601_synthetic_control.py
@@ -179,7 +179,7 @@ PROBES: list[tuple[str, Path, str, list[tuple[str, str]], str]] = [
         [
             (
                 "    per_worker_unique_bytes = SYNTHETIC_CONTROL_WORKER_BASE_RSS_BYTES\n"
-                "    if measure_child and max_workers > 1:\n"
+                "    if measure_child:\n"
                 "        child_peak_bytes, shared_block_bytes = _measure_child_member_peak(inputs, index=0)\n"
                 "        per_worker_unique_bytes = max("
                 "child_peak_bytes - shared_block_bytes, SYNTHETIC_CONTROL_WORKER_BASE_RSS_BYTES)",

--- a/tests/test_synthetic_control_run.py
+++ b/tests/test_synthetic_control_run.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import inspect
 import re
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
@@ -924,9 +924,10 @@ class TestScaleGate:
             benchmark=None,
             expected_trade_count=collector.matchable_trade_count,
         )
-        projected, per_worker = synthetic_control_run._project_unique_memory_bytes(
+        projected, per_worker, measured = synthetic_control_run._project_unique_memory_bytes(
             inputs, max_workers=2, measure_child=True
         )
+        assert measured is True
 
         assert events == ["child", "peak"], "the parent mark must be read after the shared blocks have existed"
         assert per_worker >= synthetic_control_run.SYNTHETIC_CONTROL_WORKER_BASE_RSS_BYTES
@@ -949,6 +950,7 @@ class TestScaleGate:
             memory_admitted=parent + 8 * per_worker <= ceiling,
             parent_peak_bytes=parent,
             per_worker_unique_bytes=per_worker,
+            per_worker_measured=True,
             projection_max_workers=8,
         )
 
@@ -970,7 +972,16 @@ class TestScaleGate:
         """
         report = self._report(parent=9_000, per_worker=1_000, ceiling=8_000)
         assert report.admissible_workers() == 0
-        assert self._report(parent=1_000, per_worker=0, ceiling=8_000).admissible_workers() == 0
+
+    def test_an_UNMEASURED_per_worker_figure_refuses_to_answer_at_all(self) -> None:
+        """⚠⚠ The floor is not a measurement, and dividing a ceiling by it
+        over-states how wide a fan-out fits — the one direction this must not
+        err in. ``None`` and ``0`` are deliberately different answers: nothing
+        to divide by, versus a parent no pool size can rescue.
+        """
+        unmeasured = replace(self._report(parent=4_000, per_worker=1_000, ceiling=8_000), per_worker_measured=False)
+        assert unmeasured.admissible_workers() is None
+        assert replace(self._report(parent=1_000, per_worker=0, ceiling=8_000)).admissible_workers() is None
 
     def test_the_memory_budget_refuses_before_reserving_any_run_time(self) -> None:
         budget = SyntheticControlScaleBudget(max_cohort_s=100.0, max_run_s=100.0, max_memory_bytes=999)

--- a/tests/test_synthetic_control_run.py
+++ b/tests/test_synthetic_control_run.py
@@ -56,6 +56,7 @@ from app.services.synthetic_control_run import (
     CONTROL_NAMESPACE,
     PLACEMENT_SPACE_ID,
     CohortCollector,
+    LaunchPilotReport,
     ScaleBudgetExceeded,
     SyntheticControlScaleBudget,
     WorkerCanaryBudgetExceeded,
@@ -930,6 +931,46 @@ class TestScaleGate:
         assert events == ["child", "peak"], "the parent mark must be read after the shared blocks have existed"
         assert per_worker >= synthetic_control_run.SYNTHETIC_CONTROL_WORKER_BASE_RSS_BYTES
         assert projected > 2 * per_worker, "the parent's own footprint is missing from the projection"
+
+    @staticmethod
+    def _report(*, parent: int, per_worker: int, ceiling: int) -> LaunchPilotReport:
+        return LaunchPilotReport(
+            member_indices=(0, 1, 2),
+            placement_series=1,
+            trades_per_member=1,
+            shared_input_bytes=0,
+            pilot_wall_s=1.0,
+            seconds_per_member=1.0,
+            projected_cohort_s=1.0,
+            projected_unique_memory_bytes=parent + 8 * per_worker,
+            max_cohort_s=1200.0,
+            max_memory_bytes=ceiling,
+            time_admitted=True,
+            memory_admitted=parent + 8 * per_worker <= ceiling,
+            parent_peak_bytes=parent,
+            per_worker_unique_bytes=per_worker,
+            projection_max_workers=8,
+        )
+
+    def test_a_memory_refusal_says_which_worker_counts_would_still_fit(self) -> None:
+        """⚠ ``max_workers`` changes execution only — spawned members are
+        byte-for-byte the serial ones — so a memory refusal at one worker count
+        is a question about the fan-out, not about the estimator. Reporting the
+        projection's two terms answers it without a second corpus pass.
+        """
+        report = self._report(parent=4_000, per_worker=1_000, ceiling=8_000)
+        assert not report.memory_admitted
+        assert report.admissible_workers() == 4
+        assert report.admissible_workers(max_memory_bytes=20_000) == 8 + 8
+
+    def test_a_parent_that_alone_exceeds_the_ceiling_admits_NO_worker_count(self) -> None:
+        """⚠ Zero is a different diagnosis, and the distinction is the point: no
+        fan-out size fixes a parent that does not fit, so the next move is the
+        corpus representation rather than a smaller pool.
+        """
+        report = self._report(parent=9_000, per_worker=1_000, ceiling=8_000)
+        assert report.admissible_workers() == 0
+        assert self._report(parent=1_000, per_worker=0, ceiling=8_000).admissible_workers() == 0
 
     def test_the_memory_budget_refuses_before_reserving_any_run_time(self) -> None:
         budget = SyntheticControlScaleBudget(max_cohort_s=100.0, max_run_s=100.0, max_memory_bytes=999)


### PR DESCRIPTION
Refs #2775
Refs #2772

Stacked on `fix/2697-metric-axis-integrity` (#2757), which is where this merges. Hosted CI and the review bot do not run on a non-main base — every workflow in `.github/workflows/` gates on `branches: [main]`, which matches the PR's base — so review here is the local gate plus a Codex pass, and the hosted gates arrive at #2757.

## Why

#2775 corrected the scale gate's memory projection, and the corrected projection **refuses** the S-1 cohort. The refusal said only "too big". That is expensive and ambiguous:

- expensive, because re-asking the question at another worker count meant another ~15-minute full-corpus pass;
- ambiguous, because "too big" conflates a fan-out that is too wide with a **parent that does not fit at any pool size**. Those have different next moves — shrink the pool, versus change the corpus representation.

## What changed

`LaunchPilotReport` now carries `parent_peak_bytes`, `per_worker_unique_bytes` and `projection_max_workers`, so the projection is reported as its two terms rather than only its sum. `admissible_workers()` answers the worker-count question from those terms.

`max_workers` changes execution only — `test_spawned_workers_are_byte_for_byte_equivalent_to_serial_members` pins that spawned members equal the serial ones — so re-asking the memory question at another worker count is arithmetic, not another corpus pass. `admissible_workers()` returning **0** is the second diagnosis and reports it as such: no fan-out size fixes a parent that alone exceeds the ceiling.

No estimator, seed, placement rule, cost, axis or result identity is touched. No refusal bound is changed. This adds reporting to a measurement, and one derived property over it.

## Measured

Full S-1 survivorship-free corpus, zero database writes, zero outcome fields emitted:

| term | value |
| --- | ---: |
| placement series | 10,492 |
| trades per member | 4,227,215 |
| parent peak | 4.54 GiB |
| per worker unique | 0.49 GiB |
| workers | 8 |
| **projected unique memory** | **8.49 GiB** against an 8 GiB ceiling — `memory_admitted: false` |
| projected cohort time | 14.7 min against a 20 min ceiling — `time_admitted: true` |

⚠ **The worker-count arithmetic is reported, not recommended.** Two identical full-corpus pilot runs on the same commit projected **12.20 GiB** and **8.49 GiB** (seconds per member 3.12 and 4.64), so the parent term varies by roughly 40% run to run and any "N workers would fit" conclusion sits inside that spread. Both runs refuse at eight workers. The gate itself is unaffected — every invocation measures itself and refuses on its own reading — but a worker count picked from one pilot is not evidence.

⚠ The parent alone is over half the ceiling, so even a single worker projects about 5 GiB. The lever is therefore the readiness doc's remaining performance boundary — the per-strategy `research_price_daily` fetch and Decimal reconstruction — rather than the fan-out width.

## Verification

- full local pre-push gate green: Ruff, formatting, Pyright, fast tier, app/DB boot smoke
- mutation probes: statistics/equity 40/40, #2601 orchestration 9/9, #2697 metric axis 7/7; restored suites green
- new pure tests pin both diagnoses: a memory refusal that names the worker counts that would still fit, and a parent-too-large case that admits none
- the measurements above come from `uv run python -m scripts.verify_2772_production_worker_canary --full-launch-pilot`, which stops at the `run_cohort` boundary and writes nothing

No strategy performance or profitability claim is made.
