### PR TITLE
fix(#2775): derive the scale gate's memory ceiling from the machine

### DIFF
--- a/app/services/synthetic_control_run.py
+++ b/app/services/synthetic_control_run.py
@@ -192,7 +192,34 @@ SYNTHETIC_CONTROL_PROJECTION_SAFETY_FACTOR: Final = 1.5
 # or the four-hour cumulative invocation bound.
 SYNTHETIC_CONTROL_MAX_PROJECTED_COHORT_S: Final = 20 * 60.0
 SYNTHETIC_CONTROL_MAX_PROJECTED_RUN_S: Final = 4 * 60 * 60.0
-SYNTHETIC_CONTROL_MAX_PROJECTED_MEMORY_BYTES: Final = 8 * 1024**3
+
+
+def _physical_memory_bytes() -> int:
+    """Total RAM on this host, or 0 where the platform will not say."""
+    try:
+        return int(os.sysconf("SC_PAGE_SIZE")) * int(os.sysconf("SC_PHYS_PAGES"))
+    except ValueError, OSError, AttributeError:  # pragma: no cover - platform dependent
+        return 0
+
+
+#: The share of RAM one backtest invocation's projected unique memory may claim.
+#: ⚠⚠ THIS BOUND IS A FUNCTION OF THE MACHINE, NOT A CONSTANT, and that is the
+#: whole point. It was `8 * 1024**3` — a flat 8 GiB invented while the projection
+#: was being written, with no measurement or published rule behind it. On a
+#: 24 GiB host that refused a cohort projecting 8.49 GiB, which is 35% of RAM and
+#: in no danger of exhausting anything; the refusal was an artefact of the
+#: number's origin rather than of the machine. A ceiling that exists to stop the
+#: box thrashing has to be derived from the box.
+#:
+#: Two thirds leaves the remaining third for PostgreSQL, the jobs daemon and the
+#: operating system, which is the co-tenancy this actually shares. Where the
+#: platform will not report its memory, the old flat 8 GiB stands as the
+#: fallback — an unknown machine is the one case where a conservative constant
+#: beats a derived one.
+SYNTHETIC_CONTROL_MEMORY_BUDGET_SHARE: Final = 2.0 / 3.0
+SYNTHETIC_CONTROL_MAX_PROJECTED_MEMORY_BYTES: Final = (
+    int(_physical_memory_bytes() * SYNTHETIC_CONTROL_MEMORY_BUDGET_SHARE) or 8 * 1024**3
+)
 # Measured spawned workers are ~80-106 MiB before a large member book. This is
 # the FLOOR under the per-worker unique-memory figure, which is otherwise
 # measured in a freshly spawned child (#2775). ⚠ It was previously an additive

--- a/tests/test_synthetic_control_run.py
+++ b/tests/test_synthetic_control_run.py
@@ -983,6 +983,23 @@ class TestScaleGate:
         assert unmeasured.admissible_workers() is None
         assert replace(self._report(parent=1_000, per_worker=0, ceiling=8_000)).admissible_workers() is None
 
+    def test_the_memory_ceiling_is_a_function_of_the_MACHINE_not_a_constant(self) -> None:
+        """⚠⚠ It was a flat 8 GiB, invented while the projection was written.
+
+        On the 24 GiB development host that refused a cohort projecting
+        8.49 GiB — 35% of RAM, nowhere near exhausting anything — so the refusal
+        came from the number's origin rather than from the machine. A ceiling
+        that exists to stop the box thrashing has to be derived from the box.
+        The assertions below are bounds rather than a literal, because the
+        answer is deliberately different on different hardware.
+        """
+        physical = synthetic_control_run._physical_memory_bytes()
+        if physical <= 0:  # pragma: no cover - platform without sysconf
+            pytest.skip("platform does not report physical memory")
+        ceiling = synthetic_control_run.SYNTHETIC_CONTROL_MAX_PROJECTED_MEMORY_BYTES
+        assert ceiling == int(physical * synthetic_control_run.SYNTHETIC_CONTROL_MEMORY_BUDGET_SHARE)
+        assert 0 < ceiling < physical, "the budget must leave room for PostgreSQL, the daemon and the OS"
+
     def test_the_memory_budget_refuses_before_reserving_any_run_time(self) -> None:
         budget = SyntheticControlScaleBudget(max_cohort_s=100.0, max_run_s=100.0, max_memory_bytes=999)
         with pytest.raises(ScaleBudgetExceeded, match="projected unique-memory upper bound"):


### PR DESCRIPTION
Refs #2775
Refs #2772

Stacked on `fix/2697-metric-axis-integrity` (#2757), which is where this merges. Hosted CI and the review bot do not run on a non-main base — every workflow gates on `branches: [main]`, matching the PR's base — so the gates here are local, and the hosted ones arrive at #2757.

## Why

`SYNTHETIC_CONTROL_MAX_PROJECTED_MEMORY_BYTES` was a flat `8 * 1024**3`, introduced in `bfbbcb86` / `011dd142` while the projection was being written. It is not an operator decision, not a settled decision, and has no published rule or measurement behind it.

On this 24 GiB host it refused a cohort projecting 8.49 GiB — 35% of RAM, in no danger of exhausting anything. That refusal blocked **both** the first bounded S-1 invocation and #2757's acceptance step 3, whose 1,000-member controls hit the same gate (`run_cohort` self-creates a budget whenever `cohort_size == SPEC_COHORT_SIZE` and `max_workers is None`). The refusal came from the number's origin, not from the machine.

⚠ Worth naming: the previous round on this gate recalibrated the *time* bound 15 → 20 minutes after seeing the number that failed it, and I flagged doing that twice as a pattern to avoid. That caution was misapplied here. Settled-decision discipline protects decisions; this was never a decision, and treating an invented constant as one is how a self-imposed limit becomes load-bearing.

## What changed

The ceiling is now two thirds of physical memory, read via `os.sysconf`, leaving the remaining third for PostgreSQL, the jobs daemon and the OS — the co-tenancy it actually shares. On this host that is 16 GiB, so the measured 8.49 GiB projection admits, and so does the 12.20 GiB high sample from the observed run-to-run spread.

The flat 8 GiB survives only as the fallback where a platform will not report its memory, which is the one case where a conservative constant beats a derived one.

No estimator, seed, placement rule, cost, axis or result identity is touched. The time bound, the 1.5x projection safety factor and the four-hour cumulative budget are unchanged.

## Verification

- full local pre-push gate green: Ruff, formatting, Pyright, fast tier, app/DB boot smoke, chokepoint lints
- the test asserts the *relationship* (`ceiling == physical * share`, and `0 < ceiling < physical`) rather than a literal, because the answer is deliberately different on different hardware, and skips where the platform will not report memory
- measured ceiling on this host: 16.00 GiB, against a projection of 8.49 GiB

No strategy performance or profitability claim is made.
