### PR TITLE
fix(#2797): reconcile the S-2 panel figures to one population, fix a broken node id

### DIFF
--- a/app/services/strategies/s10_relative_strength_leader.py
+++ b/app/services/strategies/s10_relative_strength_leader.py
@@ -170,9 +170,9 @@ def s10_rebalance_dates(calendar: Iterable[date]) -> frozenset[date]:
     weekend`` on ``s2_cross_sectional_momentum.py`` returned nothing — so the
     only record of S-2's exposure was this sentence, in the module that did not
     have it. S-2 then fired zero signals for two weeks (#2797). Both modules now
-    carry the cut, duplicated rather than shared so that neither identity moves
-    for the other's sake, and bound against drift by
-    ``tests/test_2797_s2_weekday_rebalance.py::test_s2_and_s10_agree_on_the_rebalance_calendar``.
+    carry the cut, duplicated rather than shared so that the check for drift can
+    be behavioural rather than a tautology over one shared import, and bound by
+    ``tests/test_2797_s2_weekday_rebalance.py::TestNoDriftAgainstS10``.
 
     ⚠ A corpus-hole WEEKDAY (243 of ~3,500 names on 2023-12-01) still takes
     its month and is then refused by ``MIN_CROSS_SECTION`` — that month

--- a/app/services/strategies/s2_cross_sectional_momentum.py
+++ b/app/services/strategies/s2_cross_sectional_momentum.py
@@ -200,13 +200,23 @@ def rebalance_dates(calendar: Iterable[date]) -> frozenset[date]:
     Measured on the validated universe at 2026-08-20 (6,774 instruments,
     3,673,648 bars): **3,669 weekend bars** across 389 instruments and 329
     distinct weekend dates — 0.0998% of the corpus, controlling **13 of 73**
-    rebalance dates (17.8%). On those dates the panel ran 4–117 names against
-    3,629–5,747 on every real one. The most recent, Sat 2026-08-01, had 9
-    eligible names — below ``MIN_CROSS_SECTION`` — and Mon 2026-08-03 had 5,380,
-    which is the whole of S-2's zero fired signals in production. Reproduce::
+    rebalance dates (17.8%). Reproduce::
 
         select count(*), count(distinct instrument_id), count(distinct price_date)
         from price_daily where extract(isodow from price_date) >= 6;
+
+    ⚠ TWO POPULATIONS ANSWER "HOW BIG WAS THE PANEL", AND ONLY ONE OF THEM
+    DECIDES ANYTHING. The query above counts raw ``price_daily`` rows; the
+    number this rule is judged on is the DECISION population — masked bars, past
+    the 273-bar warm-up, above the $1 floor — which is what
+    ``scripts/ab_2797_s2_weekday_rebalance.py`` reports and what
+    ``MIN_CROSS_SECTION`` is compared against. On that population the 13 weekend
+    dates ranked **0–11** names and yielded **7** entry signals across five
+    years; the 13 weekday dates that replace them rank up to **3,346** and yield
+    **2,419**. Sat 2026-08-01 ranked **0** and Mon 2026-08-03 ranks **3,204**,
+    which is the whole of S-2's zero fired signals in production. Quoting the raw
+    row count here instead would state a larger, truer-sounding number that no
+    gate reads.
 
     ⚠ The failure this removes was SILENT: the junk instruments are not
     frontier-eligible, so the scan wrote no row of any kind for 2026-08-01 — not
@@ -222,7 +232,12 @@ def rebalance_dates(calendar: Iterable[date]) -> frozenset[date]:
     .s10_rebalance_dates`` — identical rule, two modules, and that is a choice
     rather than an oversight. Both identities move in #2797 regardless (a
     docstring edit moves ``_source_hash``), so co-location was not ruled out on
-    cost. It is ruled out because the binding that catches drift has to be
+    cost. What is duplicated is the four-line rule AND this rationale prose; the
+    thresholds are NOT — S-2 cuts at ``MIN_CROSS_SECTION`` 10 and 273 warm-up
+    bars, S-10 at 1000 with no warm-up constant, deliberately (its own comment
+    says "much larger than S-2's 10 on purpose"). So there is no lockstep
+    requirement on the constants, and the test below covers the rule but not the
+    prose. Co-location is ruled out because the binding that catches drift has to be
     behavioural: two independent implementations checked against each other is
     evidence, whereas a test over one shared import is the tautology this repo
     has already shipped once (prevention log, *"a reference that IMPORTS the

--- a/scripts/ab_2797_s2_weekday_rebalance.py
+++ b/scripts/ab_2797_s2_weekday_rebalance.py
@@ -106,11 +106,21 @@ def main() -> int:
         print(f"[ab] scoring the panel on {len(wanted)} distinct dates", flush=True)
         scores = _scores_at(conn, instrument_ids, wanted)
 
-    def selected(when: date) -> tuple[int, int]:
+    def selected(when: date) -> tuple[int, int | None]:
+        """Panel size and names selected, or ``None`` where the runner refuses.
+
+        ``None`` rather than a sentinel int: "refused" is a different kind of
+        answer from "selected zero", and a magic -1 that later gets summed or
+        formatted alongside real counts is how the two get conflated.
+        """
         panel = scores[when]
         if len(panel) < MIN_CROSS_SECTION:
-            return len(panel), -1  # thin_cross_section — the runner refuses it
+            return len(panel), None  # thin_cross_section — the runner refuses it
         return len(panel), len(s2_select(when, panel))
+
+    def _row(when: date, panel: int, picked: int | None) -> str:
+        verdict = "refused" if picked is None else str(picked)
+        return f"{when!s:<12} {when.strftime('%a'):<4} {panel:>7} {verdict:>9}"
 
     moved_out = sorted(set(control) - set(treatment))
     moved_in = sorted(set(treatment) - set(control))
@@ -121,16 +131,16 @@ def main() -> int:
     control_only_fired = 0
     for when in moved_out:
         panel, picked = selected(when)
-        control_only_fired += max(picked, 0)
-        print(f"{when!s:<12} {when.strftime('%a'):<4} {panel:>7} {('refused' if picked < 0 else picked):>9}")
+        control_only_fired += picked or 0
+        print(_row(when, panel, picked))
 
     print("\n[ab] TREATMENT-only dates (what the fix gains)")
     print(f"{'date':<12} {'day':<4} {'panel':>7} {'selected':>9}")
     treatment_only_fired = 0
     for when in moved_in:
         panel, picked = selected(when)
-        treatment_only_fired += max(picked, 0)
-        print(f"{when!s:<12} {when.strftime('%a'):<4} {panel:>7} {('refused' if picked < 0 else picked):>9}")
+        treatment_only_fired += picked or 0
+        print(_row(when, panel, picked))
 
     print(f"\n[ab] entry signals on control-only dates:   {control_only_fired}")
     print(f"[ab] entry signals on treatment-only dates: {treatment_only_fired}")

--- a/tests/test_2797_s2_weekday_rebalance.py
+++ b/tests/test_2797_s2_weekday_rebalance.py
@@ -4,12 +4,16 @@ The bug these pin: ``price_daily`` carries weekend rows (3,669 across 389
 instruments on 329 distinct dates, measured 2026-08-20 on the validated
 universe), and because S-2's rule takes the FIRST bar of a new month over the
 panel's *union* calendar, one weekend artefact consumed the whole month. The
-real first trading day then never rebalanced, and the cross-section on the
-weekend date was 4-117 names against 3,629-5,747 on every real one.
+real first trading day then never rebalanced.
 
-The most recent instance, Sat 2026-08-01, had 9 eligible names — below S-2's
-``MIN_CROSS_SECTION`` of 10 — and is the entire reason S-2 had fired zero
-signals in production under every version.
+On the DECISION population — masked bars past the 273-bar warm-up and above the
+$1 floor, which is the one ``MIN_CROSS_SECTION`` is compared against — the 13
+weekend dates ranked 0-11 names and yielded 7 entry signals across five years,
+against up to 3,346 names and 2,419 signals on the weekday dates that replace
+them (``scripts/ab_2797_s2_weekday_rebalance.py``).
+
+The most recent instance, Sat 2026-08-01, ranked 0 — and is the entire reason
+S-2 had fired zero signals in production under every version.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Refs #2797. Follow-up to #2799 (merged as `71a2ce5a`).

## Why this is a separate PR

#2799 merged at `cbdebba1` while its Codex checkpoint-3 pass was still running. That pass raised
nothing that blocked the merge — *"Nothing I found should block merge"* — but it did find two
real defects in the prose and one in the measurement script, and the commit carrying those fixes
landed after the merge. This is that commit, rebased onto the squashed `main`. Nothing here
changes the shipped behaviour.

## What it fixes

**1. Three panel-size ranges were stated as if they measured one population.**

The merged diff quoted `0–11`, `4–117` and `~11` for "the panel on a weekend rebalance date".
They are different measurements:

| figure | what it actually counts |
| --- | --- |
| `4–117` | raw `price_daily` rows with `close >= 1.0` — no masking, no warm-up, no eligibility |
| `0–11` | the **decision** population: masked bars, past the 273-bar warm-up, above the $1 floor |
| `~11` | S-10's own pre-existing figure, for its own panel |

Only the middle one governs anything — it is what `MIN_CROSS_SECTION` is compared against and
what `scripts/ab_2797_s2_weekday_rebalance.py` reports. Worse, `5,747` appeared in the S-2
docstring as though measured there; it was carried across from S-10's docstring and was never
measured on this population at all.

The docstring and the test header now state the A/B's decision-population numbers (13 weekend
dates ranking 0–11 names for 7 entry signals across five years, against up to 3,346 and 2,419 on
the weekday dates that replace them) and say explicitly why the raw row count is the wrong number
to quote there.

This is the repo's own *"never hardcode a derived statistic whose subject the reader has to
infer"* rule, broken while writing a prevention entry about an adjacent failure. The
prevention-log entry itself already quoted the decision-population figure and is unchanged.

**2. The S-10 docstring's pytest node id did not resolve.**

It named `tests/test_2797_s2_weekday_rebalance.py::test_s2_and_s10_agree_on_the_rebalance_calendar`,
omitting the class, so the selector matched nothing. Now
`tests/test_2797_s2_weekday_rebalance.py::TestNoDriftAgainstS10`.

**3. `selected()` carried a `-1` sentinel in the same `int` as real counts.**

Raised as a formatting nitpick on #2799; the formatting was the symptom. `-1` ("the runner
refuses this date") and a genuine `0` ("ranked a panel, selected nobody") were both `int` and
were summed through `max(picked, 0)`. It now returns `int | None` and one `_row()` helper does
the formatting, so the two cannot be conflated.

**4. An over-broad claim in the S-2 docstring.**

It said the function body was the *only* thing duplicated between S-2 and S-10. The rationale
prose is duplicated too, and `TestNoDriftAgainstS10` covers the rule but not the prose. The
docstring now says that. The thresholds remain **not** duplicated and that half of the original
nitpick is still refuted: S-2 cuts at `MIN_CROSS_SECTION = DECILE` (10) with
`ELIGIBILITY_BARS = 273`, S-10 at 1000 with no warm-up constant, deliberately.

## Identity impact

S-2 and S-10 move again — `_source_hash` hashes the module file, so a docstring edit moves it.
Still free: both remain at 0 fired signals, 0 promotions, 0 preregistration declarations and 0
live-gate assessments, and S-2's next possible rebalance is 2026-09-01.

## Security

None. Two docstrings, one test header, and a return type in a read-only measurement script.

## Verification

| gate | result |
| --- | --- |
| `ruff check .` / `ruff format --check .` | clean |
| `uv run pyright` | 0 errors |
| targeted tests (S-2, S-10, #2797) | exit 0 |
| pre-push hook on the rebased branch | green |
| full-population A/B after the `selected()` refactor | **byte-identical** to the pre-refactor run (`diff` reports no change), `[ab] OK`, exit 0 |

`git diff --stat origin/main...HEAD` is the four files above and nothing else.
