### PR TITLE
fix(#2803): read the scan card on the scan identity basis, not the result one

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -108,6 +108,7 @@ from app.services.strategy_result_ambiguity import (
     composed_holdout_ambiguity_refusals,
     record_sha256,
 )
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
 from app.services.strategy_wealth import load_strategy_wealth_history
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
@@ -1001,8 +1002,38 @@ def _live_gate_view(report: LiveGateReport) -> LiveGateResponse:
 
 
 def _current_versions() -> dict[str, str]:
+    """The identities STORED RESULTS carry — the backtest measurement basis.
+
+    ⚠ NOT the identities the live scan writes. See ``_current_scan_versions``.
+    """
     return {
         strategy_id: entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        for strategy_id, entry in STRATEGY_MANIFEST.items()
+    }
+
+
+def _current_scan_versions() -> dict[str, str]:
+    """The identities the LIVE SCAN writes — the scan basis (#2803).
+
+    ⚠⚠ ``universe`` IS PART OF ``StrategyIdentity``, and the two bases are
+    different universes: results are measured on ``BACKTEST_UNIVERSE``
+    (``survivorship_free``) while ``strategy_signal_scan`` stamps
+    ``SCAN_UNIVERSE`` (``survivor_only``, ``strategy_signal_scan.py:484``). So
+    the two version sets are DISJOINT — measured, not assumed: the intersection
+    over the full manifest is 0, and of the 28 rows in
+    ``strategy_scan_watermark``, 0 match the backtest basis and 10 match the
+    scan basis.
+
+    ⚠ Filtering a scan relation by ``_current_versions()`` therefore does not
+    merely risk a miss, it can never match. That is the #2803 defect: every
+    strategy read ``scan.status = "rotated"`` with zero counts immediately after
+    a scan that wrote 81,485 rows, because the panel and the scanner disagreed
+    about which identity "current" means. Route ``strategy_scan_watermark`` and
+    ``strategy_signal_daily_counts`` through THIS function; keep
+    ``strategy_results*`` on ``_current_versions``.
+    """
+    return {
+        strategy_id: entry.identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID).version
         for strategy_id, entry in STRATEGY_MANIFEST.items()
     }
 
@@ -1454,6 +1485,11 @@ def get_strategy_overview(
     as_of = datetime.now(tz=UTC)
     versions = _current_versions()
     version_values = list(versions.values())
+    # ⚠ A SECOND, DISJOINT VERSION SET — not a convenience alias (#2803). The
+    # scan relations are keyed by the scan basis and share no identity with the
+    # result basis, so binding `version_values` to them matches nothing at all.
+    scan_versions = _current_scan_versions()
+    scan_params = {"versions": list(scan_versions.values())}
     params = {
         "versions": version_values,
         "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
@@ -1471,9 +1507,10 @@ def get_strategy_overview(
         result_rows = list(cur.fetchall())
         cur.execute(_RESULT_COUNTS_SQL, params)
         result_count_rows = list(cur.fetchall())
-        cur.execute(_SCAN_SQL, params)
+        # ⚠ SCAN RELATIONS TAKE `scan_params`, RESULT RELATIONS TAKE `params`.
+        cur.execute(_SCAN_SQL, scan_params)
         scan_rows = list(cur.fetchall())
-        cur.execute(_EXCLUSIONS_SQL, params)
+        cur.execute(_EXCLUSIONS_SQL, scan_params)
         exclusion_rows = list(cur.fetchall())
         # Two parallel arrays `unnest`ed into current `(id, version)` pairs. Built
         # from one `items()` pass so the pairing cannot drift on a later edit.
@@ -1481,9 +1518,16 @@ def get_strategy_overview(
             "strategy_ids": [strategy_id for strategy_id, _ in versions.items()],
             "versions": [version for _, version in versions.items()],
         }
+        # The "everything that is NOT current" predicate has to exclude the
+        # CURRENT SCAN identity, or the live version is itself reported as a
+        # prior one — which is what manufactured #2803's bogus `rotation` block.
+        prior_scan_params = {
+            "strategy_ids": [strategy_id for strategy_id, _ in scan_versions.items()],
+            "versions": [version for _, version in scan_versions.items()],
+        }
         cur.execute(_PRIOR_VERSION_RESULTS_SQL, prior_params)
         prior_result_rows = list(cur.fetchall())
-        cur.execute(_PRIOR_VERSION_SCANS_SQL, prior_params)
+        cur.execute(_PRIOR_VERSION_SCANS_SQL, prior_scan_params)
         prior_scan_rows = list(cur.fetchall())
         cur.execute(_LATEST_CORPUS_SQL)
         latest_row = cur.fetchone()

--- a/tests/test_2803_scan_card_version_basis.py
+++ b/tests/test_2803_scan_card_version_basis.py
@@ -1,0 +1,78 @@
+"""The scan card reads the SCAN identity basis, not the result basis (#2803).
+
+Pure (no Postgres). The defect was a params binding, not logic: three queries over
+live-scan relations were handed ``_current_versions()``, which is built on
+``BACKTEST_UNIVERSE``. ``universe`` is part of ``StrategyIdentity``, so those
+predicates matched nothing and every strategy reported ``scan.status = "rotated"``
+with zero counts immediately after a scan that wrote 81,485 rows.
+
+Measured on dev at the fix: ``_SCAN_SQL`` returned 0 rows on the result basis and
+10 on the scan basis.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from app.api.strategies import (
+    _EXCLUSIONS_SQL,
+    _PRIOR_VERSION_SCANS_SQL,
+    _SCAN_SQL,
+    _current_scan_versions,
+    _current_versions,
+    get_strategy_overview,
+)
+from app.services.backtest_run import BACKTEST_UNIVERSE
+from app.services.cost_model import COST_MODEL_ID
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
+
+#: Every relation the live scan writes. A query naming one of these MUST be
+#: filtered on the scan basis.
+_SCAN_RELATIONS = ("strategy_scan_watermark", "strategy_signal_daily_counts")
+
+
+def test_the_scan_basis_is_the_universe_the_scanner_actually_stamps() -> None:
+    expected = {
+        strategy_id: entry.identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        for strategy_id, entry in STRATEGY_MANIFEST.items()
+    }
+    assert _current_scan_versions() == expected
+
+
+def test_the_two_bases_are_disjoint_so_one_cannot_stand_in_for_the_other() -> None:
+    """The whole defect in one assertion.
+
+    If these sets ever overlapped, binding the wrong one would degrade to a
+    partial miss. They do not overlap, so the wrong one matches NOTHING — which
+    is why the bug presented as a permanently empty card rather than a flaky one.
+    """
+    assert SCAN_UNIVERSE != BACKTEST_UNIVERSE
+    assert not set(_current_versions().values()) & set(_current_scan_versions().values())
+
+
+def test_every_scan_relation_query_is_executed_on_the_scan_basis() -> None:
+    """Guard the BINDING, not just the helper.
+
+    ``_current_scan_versions`` existing changes nothing if the overview keeps
+    passing ``params``; that pairing is the thing that regressed, and no type or
+    comment catches it because both dicts have the same shape and key name.
+    """
+    source = inspect.getsource(get_strategy_overview)
+    scan_sql = {
+        "_SCAN_SQL": _SCAN_SQL,
+        "_EXCLUSIONS_SQL": _EXCLUSIONS_SQL,
+        "_PRIOR_VERSION_SCANS_SQL": _PRIOR_VERSION_SCANS_SQL,
+    }
+    for name, sql in scan_sql.items():
+        assert any(relation in sql for relation in _SCAN_RELATIONS), (
+            f"{name} no longer reads a scan relation — retarget this guard rather than deleting it"
+        )
+        executed = re.findall(rf"cur\.execute\(\s*{name}\s*,\s*(\w+)\s*\)", source)
+        assert executed, f"{name} is not executed by get_strategy_overview"
+        for params_name in executed:
+            assert "scan" in params_name, (
+                f"{name} reads {_SCAN_RELATIONS} but is executed with {params_name!r}; "
+                "live-scan relations are keyed by the scan identity basis (#2803)"
+            )

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -13,6 +13,7 @@ from app.api.strategies import (
     _TITLES,
     ResultArm,
     _ambiguity_record_from_result_row,
+    _current_scan_versions,
     _current_versions,
     _promotion_refusals,
     get_strategy_overview,
@@ -460,7 +461,7 @@ def test_completed_zero_signal_scan_uses_its_watermark(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     strategy_id = "s2-cross-sectional-momentum"
-    version = _current_versions()[strategy_id]
+    version = _current_scan_versions()[strategy_id]
     frontier = date(2026, 7, 8)
     ebull_test_conn.execute(
         """
@@ -485,7 +486,7 @@ def test_scan_freshness_reads_the_ingest_census_without_scanning_daily_bars(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     strategy_id = "s2-cross-sectional-momentum"
-    version = _current_versions()[strategy_id]
+    version = _current_scan_versions()[strategy_id]
     frontier = date(2026, 7, 8)
     ebull_test_conn.execute(
         """
@@ -515,7 +516,7 @@ def test_scan_health_reads_durable_daily_counts_after_detail_retention(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     strategy_id = "s1-time-series-momentum"
-    version = _current_versions()[strategy_id]
+    version = _current_scan_versions()[strategy_id]
     ebull_test_conn.execute(
         """
         INSERT INTO strategy_scan_watermark (strategy_id, strategy_version, frontier_date)


### PR DESCRIPTION
Closes #2803

## What was wrong

`/strategies/overview` reported every one of the 10 strategies as
`scan.status: "rotated"`, `frontier_date: null`, `fired_entries: 0` — i.e. "this strategy has
never scanned" — immediately after a `strategy_signal_scan` run that wrote **81,485** rows
(run `111454`, 2026-08-21). The operator's Strategies page showed a dead product while the
scanner was working perfectly.

## Why

`app/api/strategies.py::_current_versions()` builds identities on the **result** basis:

```python
entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)   # survivorship_free
```

That single set was bound as `%(versions)s` for the result queries — correct, stored results
*are* on that basis — **and** for three queries over **live-scan** relations:

| query | reads | filter |
| --- | --- | --- |
| `_SCAN_SQL` | `strategy_scan_watermark`, `strategy_signal_daily_counts` | `w.strategy_version = ANY(%(versions)s)` |
| `_EXCLUSIONS_SQL` | `strategy_signal_daily_counts` | `strategy_version = ANY(%(versions)s)` |
| `_PRIOR_VERSION_SCANS_SQL` | `strategy_scan_watermark` | `NOT EXISTS (… cur.version = w.strategy_version)` |

But the scanner stamps `SCAN_UNIVERSE = "survivor_only"`
(`app/services/strategy_signal_scan.py:88`, used at `:484`), and `universe` is part of
`StrategyIdentity`.

The two bases are **disjoint**, so those predicates could not merely miss — they could never
match, for any strategy, at any time. `_PRIOR_VERSION_SCANS_SQL` then classified the genuinely
current scan version as "prior", which is what synthesised the misleading `rotation` block
pointing at a version that was in fact live.

## Full-population verification

Not a sample — the intersection is empty by construction:

```
SCAN_UNIVERSE = survivor_only | BACKTEST_UNIVERSE = survivorship_free
overlap between backtest-basis and scan-basis version sets:        0
watermark rows matching backtest-basis versions (panel queries):   0
watermark rows matching scan-basis versions (scan writes):        10
total strategy_scan_watermark rows:                               28
```

## A/B of `_SCAN_SQL` on the dev DB

| basis | rows |
| --- | --- |
| backtest (before) | **0** |
| scan (after) | **10** |

| strategy | frontier | entries | exits | not_fired |
| --- | --- | ---: | ---: | ---: |
| s1-time-series-momentum | 2026-08-19 | 8,821 | 6,822 | 18,033 |
| s4-volatility-compression-breakout | 2026-08-19 | 748 | 0 | 26,567 |
| s5-support-bounce | 2026-08-19 | 244 | 0 | 5,345 |
| s7-trend-pullback | 2026-08-19 | 167 | 6,800 | 26,609 |
| s6-resistance-breakout | 2026-08-19 | 25 | 0 | 3,990 |
| s3-mean-reversion-in-trend | 2026-08-19 | 25 | 9,971 | 23,580 |
| s8-range-mean-reversion | 2026-08-19 | 24 | 0 | 27,838 |
| s9-squeeze-expansion | 2026-08-19 | 8 | 0 | 27,914 |
| s2-cross-sectional-momentum | 2026-08-19 | 0 | 0 | 3,277 |
| s10-relative-strength-leader | 2026-08-19 | 0 | 0 | 11,378 |

s2 and s10 legitimately show 0 entries: both rebalance monthly and next fire 2026-09-01 (#2797).

## The fix

Add `_current_scan_versions()` on `SCAN_UNIVERSE`; bind it to the three scan-relation queries.
`_RESULTS_SQL` / `_PRIOR_VERSION_RESULTS_SQL` stay on the result basis, unchanged.

`build_prior_versions` is unaffected: it iterates result-bearing versions and uses the scan rows
only as an optional enrichment lookup.

## Why the tests did not catch it

Three DB tests in `tests/test_api_strategies.py` seeded `strategy_scan_watermark` using
`_current_versions()` — **the same wrong constant the reader used**. Being self-consistent, they
were structurally incapable of detecting the defect. They now seed on the scan basis.

`tests/test_2803_scan_card_version_basis.py` guards the **binding**, not just the helper: adding
`_current_scan_versions()` changes nothing if the overview keeps passing `params`, and both dicts
have the same shape and key name, so neither the typechecker nor a comment catches the drift.
Confirmed by revert-probe — restoring the old binding fails the guard and names the query.

## Not a settled decision

`docs/settled-decisions.md` and `docs/review-prevention-log.md` carry no entry for the scan card,
`SCAN_UNIVERSE`, or the watermark basis. #2624 introduced `rotated` to distinguish "current
version has no watermark" from "never ran"; it did not choose the basis this query filters on.

## Checks

- `ruff check` / `ruff format --check` / `pyright` — clean
- `pytest -m "not db"` — green; `pytest tests/smoke` — green
- `pytest -m db tests/test_api_strategies.py tests/test_strategy_monitoring.py` — green
- Codex checkpoint 2 (`review --base origin/main`) — "No actionable regressions were identified."

## Security

No change. Read-only endpoint behind the same auth dependency; no new user-controlled input
reaches SQL — the bound values are derived from the in-process `STRATEGY_MANIFEST`.
