### PR TITLE
fix(#2274): defer a jobs-daemon reload past a job that is provably alive

### DIFF
--- a/app/jobs/dev_reload.py
+++ b/app/jobs/dev_reload.py
@@ -32,10 +32,53 @@ is fully reaped — releasing the lock — BEFORE the replacement is
 spawned. Never spawn-then-kill. After a SIGKILL escalation we also
 settle for ``_POST_KILL_SETTLE_S`` so Postgres notices the dead session
 and drops the lock, mirroring ``stack-restart.sh``'s ``kill_jobs_process``.
+
+Deferring a reload past a live job (#2274)
+------------------------------------------
+An automatic reload used to preempt the child unconditionally. A job
+that cannot drain inside ``_DRAIN_TIMEOUT_S`` — which a multi-hour
+corpus run or backtest never can — was therefore SIGKILLed, and the
+next boot's reaper wrote it off as ``orphaned: reaped at boot``. On
+2026-08-21 that destroyed three consecutive ``strategy_backtest_run``
+attempts inside one hour; the last died 8 seconds after its own
+heartbeat, i.e. while healthy and 12,625 of 17,290 targets through.
+The trigger each time was an ordinary merge re-detaching the checkout
+at ``origin/main``, which is exactly how a merged change is *meant* to
+reach this daemon — so the loop's own merge cadence made a long run
+unfinishable.
+
+So a reload now WAITS for a job that is provably alive instead of
+killing it. "Provably alive" is a claim the job volunteers, not one we
+infer: a ``job_runs`` row in ``status='running'`` whose
+``last_progress_at`` is inside that job's own staleness threshold, as
+already defined for the admin console by
+``app/services/processes/stale_thresholds.py``. Deliberately NOT an age
+cut — age is a proxy for liveness and would protect a wedged job
+forever. A job that stops heartbeating goes stale and stops blocking
+reloads on its own, which is why this needs no watchdog and cannot
+false-fire on a legitimately-long run (#2274's own constraint).
+
+This is a correctness fix as much as an availability one. Had a drain
+mid-run actually succeeded, the surviving rows would carry a
+``strategy_version`` derived from code that changed underneath the run.
+
+Three properties are load-bearing:
+
+* **Fail open.** Any probe failure — Postgres down, slow, schema drift —
+  reloads as before. A supervisor must never be blockable by its own
+  liveness check, or a DB blip freezes the daemon on stale code.
+* **Ownership is free.** The singleton fence means there is exactly one
+  jobs process, so a freshly-heartbeating ``running`` row is necessarily
+  the current child's. No PID plumbing.
+* **Only AUTOMATIC reloads defer.** An explicit stop (SIGTERM to the
+  supervisor, operator stopping the task) still drains-then-kills
+  immediately. Deferral is about not letting a file-watcher preempt
+  hours of work; it is not a veto on the operator.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import signal
@@ -48,6 +91,11 @@ from pathlib import Path
 from typing import Final
 
 from app.config import DEV_LIKE_ENVS, settings
+from app.services.processes.stale_thresholds import (
+    DEFAULT_THRESHOLD_S,
+    get_threshold,
+    overridden_process_ids,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +133,114 @@ _POST_KILL_SETTLE_S: Final[float] = 1.0
 _WATCH_TICK_MS: Final[int] = 1000
 
 _CHILD_ARGV: Final[list[str]] = [sys.executable, "-m", "app.jobs"]
+
+# How recent a job's heartbeat must be for it to count as alive and so
+# block an automatic reload (#2274).
+#
+# NOT a fresh choice, and NOT a local constant: the repo already owns
+# this rule in `app/services/processes/stale_thresholds.py`, which the
+# admin console's mid_flight_stuck detection reads. Default 300s with
+# per-job overrides to 1800s for slow-tick producers (SEC bulk seeds,
+# the insider backfill) whose natural inter-tick gap exceeds five
+# minutes. Hard-coding the 300s default here would have made those eight
+# jobs "healthy" to the console and "stale" to the supervisor at the
+# same moment — i.e. still SIGKILL-able while nothing reported them at
+# risk (Codex checkpoint 2).
+#
+# The registry travels INTO the query as a jsonb map so the per-job cut
+# is applied by Postgres, before any row limit. Filtering in Python
+# after a `LIMIT` is unsafe in the direction that matters: 50 fresh
+# rows that are stale by their own 300s cut would mask an older but
+# still-live 1800s job and return "nothing to defer" — preempting
+# exactly the run this change protects (Codex checkpoint 2, round 3).
+_THRESHOLD_OVERRIDES_JSON: Final[str] = json.dumps(
+    {process_id: get_threshold(process_id) for process_id in sorted(overridden_process_ids())}
+)
+
+# How often to re-probe while a reload sits deferred. The watcher ticks
+# at _WATCH_TICK_MS (1s); probing on every tick would open a connection
+# per second for the hours a corpus run lasts.
+_LIVE_JOB_PROBE_PERIOD_S: Final[float] = 15.0
+
+# How often to restate a deferral. Same reasoning as _DRAIN_PROGRESS_S:
+# a reload deferred for hours must not be silent, or an observer polling
+# PIDs concludes the watcher is dead rather than waiting on purpose.
+_DEFER_PROGRESS_S: Final[float] = 60.0
+
+# Bound on the probe's own connection. The probe is advisory — a slow
+# DB must degrade to "reload anyway", never stall the supervisor.
+_LIVE_JOB_CONNECT_TIMEOUT_S: Final[int] = 5
+
+# ``connect_timeout`` bounds only the CONNECT. Once connected, a query
+# can wait indefinitely on a lock or a stalled server, and because the
+# supervisor probes on its own thread that would stop it servicing
+# watcher ticks entirely — a wedge, wearing fail-open's clothes (Codex
+# checkpoint 2). Bounded with a libpq STARTUP option for the reason
+# `app/jobs/job_connection.py` documents: `options=` is applied outside
+# any transaction, so it cannot be undone by a ROLLBACK and opens no
+# implicit transaction. The cancel surfaces as an exception, which the
+# probe's own guard turns into "no live job".
+_LIVE_JOB_STATEMENT_TIMEOUT_MS: Final[int] = 3_000
+
+# Every row this returns is already live by its OWN threshold, so LIMIT 1
+# is safe: it picks a blocker to name, it does not decide whether one
+# exists. Freshest heartbeat first — the row that ticked most recently is
+# the most likely to still be alive and the most useful to name.
+_LIVE_JOB_SQL: Final[str] = """
+    SELECT run_id,
+           job_name,
+           processed_count,
+           target_count,
+           EXTRACT(EPOCH FROM (now() - last_progress_at)) AS heartbeat_age_s
+      FROM job_runs
+     WHERE status = 'running'
+       AND last_progress_at IS NOT NULL
+       AND last_progress_at > now() - make_interval(
+               secs => COALESCE((%(overrides)s::jsonb ->> job_name)::int, %(default_s)s)
+           )
+     ORDER BY last_progress_at DESC
+     LIMIT 1
+"""
+
+
+def live_job() -> str | None:
+    """Describe the in-flight job that should defer a reload, else ``None``.
+
+    Returns a human-readable one-liner (job name, run id, progress,
+    heartbeat age) so the deferral log names what it is waiting for —
+    "reload deferred" with no subject is the kind of message an operator
+    learns to ignore.
+
+    ⚠ Never raises. Every failure path returns ``None``, which reloads
+    as the pre-#2274 code did. The probe is an optimisation on top of
+    correct-but-destructive behaviour, so a broken probe must degrade to
+    the old behaviour rather than wedge the supervisor on stale code.
+    Deliberately not ``app.jobs.job_connection.connect_job``: that helper
+    exists to apply the per-job ``statement_timeout`` ContextVar set by
+    ``_tracked_job``, and the supervisor is not a job body.
+    """
+    try:
+        import psycopg
+
+        with psycopg.connect(
+            settings.database_url,
+            connect_timeout=_LIVE_JOB_CONNECT_TIMEOUT_S,
+            options=f"-c statement_timeout={_LIVE_JOB_STATEMENT_TIMEOUT_MS}",
+            autocommit=True,
+        ) as conn:
+            row = conn.execute(
+                _LIVE_JOB_SQL,
+                {"overrides": _THRESHOLD_OVERRIDES_JSON, "default_s": DEFAULT_THRESHOLD_S},
+            ).fetchone()
+    except Exception:
+        # Intentionally broad: a probe is not worth an exception class.
+        logger.debug("jobs dev-reload: live-job probe failed; treating as no live job", exc_info=True)
+        return None
+    if row is None:
+        return None
+    run_id, job_name, processed, target, heartbeat_age_s = row
+    progress = f"{processed}/{target}" if target is not None else str(processed)
+    return f"{job_name} run {run_id} ({progress} done, heartbeat {float(heartbeat_age_s):.0f}s ago)"
 
 
 def changes_are_stale(paths: Iterable[str], spawn_time: float) -> bool:
@@ -248,6 +404,15 @@ def _supervise() -> int:
     child, spawn_time = _spawn_child()
     crash_reported = False
 
+    # Changes seen but not yet applied, because a live job is holding the
+    # reload off (#2274). A dict keeps insertion order for the "e.g."
+    # message while de-duplicating: a deferral lasting hours would
+    # otherwise re-accumulate the same paths on every save.
+    pending: dict[str, None] = {}
+    deferred_since: float | None = None
+    last_probe = 0.0
+    last_defer_log = 0.0
+
     try:
         for changes in watch(
             _APP_DIR,
@@ -260,7 +425,13 @@ def _supervise() -> int:
             if stop_event.is_set():
                 break
 
-            if not changes:
+            if changes:
+                paths = [path for _change, path in changes]
+                if changes_are_stale(paths, spawn_time):
+                    logger.debug("jobs dev-reload: ignoring %d change(s) older than the running child", len(paths))
+                    continue
+                pending.update(dict.fromkeys(paths))
+            else:
                 # Idle tick — the only place we notice the child dying on
                 # its own. A clean exit means somebody stopped the daemon
                 # deliberately, so we stop too. A crash (bad import after a
@@ -268,32 +439,85 @@ def _supervise() -> int:
                 # so the next edit can bring it back without the operator
                 # re-running the task.
                 code = child.poll()
-                if code is None:
+                if code is not None:
+                    if code == 0:
+                        logger.info("jobs dev-reload: child exited 0; supervisor exiting")
+                        return 0
+                    if not crash_reported:
+                        # Once per crash, not once per tick.
+                        crash_reported = True
+                        logger.error(
+                            "jobs dev-reload: child exited %d — staying up; next *.py change will respawn",
+                            code,
+                        )
+                    if pending:
+                        # The child died holding changes it never read, so
+                        # the deferral's reason died with it — respawn now
+                        # rather than wait for an unrelated edit. Observed
+                        # for real: the jobs child took a bare SIGKILL
+                        # (`child exited -9`) mid-backtest on 2026-08-21,
+                        # which is exactly this path.
+                        #
+                        # Deliberately NOT probing live_job() first. A dead
+                        # child's own `running` rows stay inside the
+                        # staleness window for _LIVE_JOB_STALENESS_S, so a
+                        # probe here would make a crash wait out a heartbeat
+                        # that can never advance again.
+                        logger.info(
+                            "jobs dev-reload: child died with %d change(s) held — respawning on them",
+                            len(pending),
+                        )
+                        child, spawn_time = _spawn_child()
+                        crash_reported = False
+                        pending.clear()
+                        deferred_since = None
                     continue
-                if code == 0:
-                    logger.info("jobs dev-reload: child exited 0; supervisor exiting")
-                    return 0
-                if not crash_reported:
-                    # Once per crash, not once per tick.
-                    crash_reported = True
-                    logger.error(
-                        "jobs dev-reload: child exited %d — staying up; next *.py change will respawn",
-                        code,
+                if not pending:
+                    continue
+
+            # Changes are waiting. Reload only if no job is provably alive.
+            now = time.monotonic()
+            if deferred_since is not None and now - last_probe < _LIVE_JOB_PROBE_PERIOD_S:
+                continue
+            last_probe = now
+            blocker = live_job()
+            if blocker is not None:
+                if deferred_since is None:
+                    deferred_since = now
+                    last_defer_log = now
+                    logger.info(
+                        "jobs dev-reload: %d change(s) pending, e.g. %s — DEFERRING reload, live job: %s",
+                        len(pending),
+                        next(iter(pending)),
+                        blocker,
+                    )
+                elif now - last_defer_log >= _DEFER_PROGRESS_S:
+                    last_defer_log = now
+                    logger.info(
+                        "jobs dev-reload: reload still deferred after %.0fs, %d change(s) pending, live job: %s",
+                        now - deferred_since,
+                        len(pending),
+                        blocker,
                     )
                 continue
 
-            paths = [path for _change, path in changes]
-            if changes_are_stale(paths, spawn_time):
-                logger.debug("jobs dev-reload: ignoring %d change(s) older than the running child", len(paths))
-                continue
-
-            logger.info("jobs dev-reload: %d change(s), e.g. %s — reloading", len(paths), paths[0])
+            if deferred_since is not None:
+                logger.info(
+                    "jobs dev-reload: no live job after %.0fs deferred — applying held reload",
+                    now - deferred_since,
+                )
+            logger.info("jobs dev-reload: %d change(s), e.g. %s — reloading", len(pending), next(iter(pending)))
             _stop_child(child)
             if stop_event.is_set():
                 return 0
             child, spawn_time = _spawn_child()
             crash_reported = False
+            pending.clear()
+            deferred_since = None
     finally:
+        # An explicit stop drains and kills regardless of any live job:
+        # deferral withholds an AUTOMATIC reload, it does not veto the
+        # operator stopping the stack.
         _stop_child(child)
 
     return 0

--- a/app/jobs/dev_reload.py
+++ b/app/jobs/dev_reload.py
@@ -122,6 +122,13 @@ _KILL_REAP_TIMEOUT_S: Final[float] = 10.0
 # itself from "never started".
 _DRAIN_PROGRESS_S: Final[float] = 15.0
 
+# How much longer to wait when the drain budget expires but a job is
+# still provably alive (#2274, Codex checkpoint 2 round 4). Also the
+# re-probe cadence in that state, since each extension ends in another
+# probe. Bounded by liveness rather than wall-clock: the extension stops
+# the moment the heartbeat goes stale.
+_DRAIN_EXTENSION_S: Final[float] = 60.0
+
 # After a SIGKILL the fence connection is closed by the OS, not by the
 # daemon, so Postgres only drops the advisory lock once it notices the
 # dead session. Same one-second settle stack-restart.sh uses.
@@ -153,6 +160,19 @@ _CHILD_ARGV: Final[list[str]] = [sys.executable, "-m", "app.jobs"]
 # rows that are stale by their own 300s cut would mask an older but
 # still-live 1800s job and return "nothing to defer" — preempting
 # exactly the run this change protects (Codex checkpoint 2, round 3).
+#
+# ⚠ The registry is keyed by admin `process_id` and this query matches on
+# `job_runs.job_name`, which is NOT a bug: `process_id` is the
+# `ScheduledJob.name` verbatim for everything that owns a job_runs row.
+# The three keys that do not match (`bootstrap`, `sec_13f_sweep`,
+# `nport_sweep`) are exactly the three that are not scheduled jobs and so
+# can never produce one — the registry's own docstring says sweeps "have
+# no own active_run". Translating them to `sec_13f_quarterly_sweep` /
+# `sec_n_port_ingest` (Codex checkpoint 2, round 6) would add keys that
+# match nothing either. Reproduce with:
+#   python -c "from app.workers.scheduler import SCHEDULED_JOBS; \
+#   from app.services.processes.stale_thresholds import overridden_process_ids; \
+#   n={j.name for j in SCHEDULED_JOBS}; print({k: k in n for k in overridden_process_ids()})"
 _THRESHOLD_OVERRIDES_JSON: Final[str] = json.dumps(
     {process_id: get_threshold(process_id) for process_id in sorted(overridden_process_ids())}
 )
@@ -327,11 +347,43 @@ def _spawn_child() -> tuple[subprocess.Popen[bytes], float]:
     return subprocess.Popen(_CHILD_ARGV, cwd=_REPO_ROOT), spawn_time
 
 
-def _stop_child(proc: subprocess.Popen[bytes]) -> None:
+def _stop_child(
+    proc: subprocess.Popen[bytes],
+    *,
+    extend_while_live: bool = False,
+    stop_event: threading.Event | None = None,
+) -> None:
     """SIGTERM the child and WAIT for it to die, escalating if it hangs.
 
     Returns only once the process has been reaped, so the caller is safe
     to spawn a replacement (see the singleton-fence note above).
+
+    ``extend_while_live`` closes the gap between the supervisor's liveness
+    probe and this SIGTERM (Codex checkpoint 2, round 4). The scheduler can
+    start a long job in that window, and it would then be SIGKILLed at the
+    drain budget — the very loss this change exists to prevent. With the
+    flag set, expiry of the budget re-probes instead of escalating, and
+    extends by ``_DRAIN_EXTENSION_S`` for as long as a job is provably
+    alive. Bounded by liveness, not by wall-clock: a job that stops
+    heartbeating goes stale and the escalation proceeds.
+
+    It also fixes the original bug from the other side. A fixed 180s cap is
+    what turns a graceful shutdown into data loss, because the drain a
+    long job needs is longer than any constant that is safe to wait on
+    blindly — the heartbeat is what makes waiting safe.
+
+    Left OFF for the supervisor's own shutdown: an explicit stop drains
+    and kills on the budget, because deferral must not become a veto on
+    the operator stopping the stack.
+
+    ⚠ That is not enough on its own, which is why ``stop_event`` is also
+    threaded in (Codex checkpoint 2, round 5). A shutdown signal can
+    arrive while an AUTOMATIC reload is already inside this function, and
+    the handler that sets the event runs on the watcher's frame, not
+    this one — so without the event here the extension loop keeps
+    extending and the operator cannot stop the stack for as long as the
+    job keeps heartbeating. Once the event is set, extensions stop and
+    the escalation proceeds on the current budget.
     """
     if proc.poll() is not None:
         return
@@ -345,12 +397,31 @@ def _stop_child(proc: subprocess.Popen[bytes]) -> None:
     # Wait in _DRAIN_PROGRESS_S slices rather than one long block, so a slow
     # drain reports itself (#2666).  The deadline is computed once: slicing must
     # not extend the total budget, which is what a naive per-slice timeout would
-    # do.
+    # do.  The ONLY thing that may move it is a proven-live job, below.
     deadline = started + _DRAIN_TIMEOUT_S
     drained = False
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
+            shutting_down = stop_event is not None and stop_event.is_set()
+            if extend_while_live and shutting_down:
+                logger.info(
+                    "jobs dev-reload: shutdown requested mid-drain — no longer extending pid %d",
+                    proc.pid,
+                )
+            if extend_while_live and not shutting_down:
+                blocker = live_job()
+                if blocker is not None:
+                    logger.info(
+                        "jobs dev-reload: pid %d past its %.0fs drain budget but %s is live — "
+                        "extending %.0fs rather than escalating",
+                        proc.pid,
+                        _DRAIN_TIMEOUT_S,
+                        blocker,
+                        _DRAIN_EXTENSION_S,
+                    )
+                    deadline = time.monotonic() + _DRAIN_EXTENSION_S
+                    continue
             break
         try:
             proc.wait(timeout=min(_DRAIN_PROGRESS_S, remaining))
@@ -369,7 +440,7 @@ def _stop_child(proc: subprocess.Popen[bytes]) -> None:
     logger.warning(
         "jobs dev-reload: pid %d still draining after %.0fs — escalating to SIGKILL",
         proc.pid,
-        _DRAIN_TIMEOUT_S,
+        time.monotonic() - started,
     )
     proc.kill()
     try:
@@ -507,7 +578,10 @@ def _supervise() -> int:
                     now - deferred_since,
                 )
             logger.info("jobs dev-reload: %d change(s), e.g. %s — reloading", len(pending), next(iter(pending)))
-            _stop_child(child)
+            # extend_while_live closes the probe->SIGTERM race: the scheduler
+            # can start a long job in that window, and it must not be killed
+            # at the drain budget just for starting a moment too late.
+            _stop_child(child, extend_while_live=True, stop_event=stop_event)
             if stop_event.is_set():
                 return 0
             child, spawn_time = _spawn_child()

--- a/app/jobs/dev_reload.py
+++ b/app/jobs/dev_reload.py
@@ -531,7 +531,7 @@ def _supervise() -> int:
                         #
                         # Deliberately NOT probing live_job() first. A dead
                         # child's own `running` rows stay inside the
-                        # staleness window for _LIVE_JOB_STALENESS_S, so a
+                        # staleness window for its own threshold, so a
                         # probe here would make a crash wait out a heartbeat
                         # that can never advance again.
                         logger.info(

--- a/tests/jobs/test_dev_reload.py
+++ b/tests/jobs/test_dev_reload.py
@@ -1,4 +1,7 @@
-"""#2144 / #2666 — dev jobs-daemon auto-reload: stale-batch suppression and drain visibility.
+"""#2144 / #2666 / #2274 — dev jobs-daemon auto-reload.
+
+Stale-batch suppression, drain visibility, and (#2274) deferring a
+reload past a job that is provably alive.
 
 Pure-logic only (no DB, no subprocess). The one non-obvious decision in
 the supervisor is whether a change batch delivered *after* a restart
@@ -6,6 +9,13 @@ should trigger another restart: the rust watcher keeps buffering while
 we block on a drain, so the batch that lands right after a reload
 usually replays the very edits that caused it, and acting on it costs a
 second full drain for nothing.
+
+⚠ Keep this module DB-free. ``tests/conftest.py::pytest_collection_modifyitems``
+auto-applies the ``db`` marker per MODULE (``_module_source_touches_db``),
+so one DB-backed test here would deselect every pure test in this file
+from the ``-m "not db"`` pre-push gate — silently, since the file still
+passes when run directly. ``live_job``'s SQL is exercised in
+``tests/jobs/test_dev_reload_live_job_sql.py`` for exactly that reason.
 """
 
 from __future__ import annotations
@@ -146,3 +156,254 @@ def test_running_commit_ignores_an_inherited_git_dir(monkeypatch: pytest.MonkeyP
 def test_running_commit_degrades_rather_than_raising(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(dev_reload, "_REPO_ROOT", tmp_path)  # not a git repo
     assert dev_reload.running_commit() == "unknown"
+
+
+# --- #2274: a live job defers the reload instead of being SIGKILLed ------------
+
+
+class _FakeCursorConn:
+    """Minimal stand-in for the connection `live_job` opens."""
+
+    def __init__(self, row: tuple[Any, ...] | None) -> None:
+        self._row = row
+
+    def __enter__(self) -> _FakeCursorConn:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, _sql: str, _params: object = None) -> _FakeCursorConn:
+        return self
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._row
+
+
+def test_live_job_fails_open_when_the_database_is_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The probe is an optimisation on top of correct-but-destructive
+    behaviour. If it cannot answer, the reload must proceed exactly as it
+    did before #2274 — a DB blip must never freeze the daemon on stale code."""
+    import psycopg
+
+    def _boom(*_a: object, **_kw: object) -> object:
+        raise psycopg.OperationalError("connection refused")
+
+    monkeypatch.setattr(psycopg, "connect", _boom)
+    assert dev_reload.live_job() is None
+
+
+def test_live_job_names_the_blocking_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """'reload deferred' with no subject is a message an operator learns to
+    ignore, so the blocker identifies itself."""
+    import psycopg
+
+    monkeypatch.setattr(
+        psycopg,
+        "connect",
+        lambda *_a, **_kw: _FakeCursorConn((111447, "strategy_backtest_run", 12625, 17290, 8.0)),
+    )
+    described = dev_reload.live_job()
+    assert described is not None
+    assert "strategy_backtest_run" in described
+    assert "111447" in described
+    assert "12625/17290" in described
+
+
+def test_live_job_handles_an_unbounded_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`target_count` is NULL for unbounded sweeps (sql/140), so the
+    description must not render 'None' at the operator."""
+    import psycopg
+
+    monkeypatch.setattr(
+        psycopg,
+        "connect",
+        lambda *_a, **_kw: _FakeCursorConn((99, "sec_manifest_worker", 312, None, 2.0)),
+    )
+    described = dev_reload.live_job()
+    assert described is not None
+    assert "312 done" in described
+    assert "None" not in described
+
+
+def test_the_threshold_registry_travels_into_the_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-job cut is applied by Postgres, so the only thing provable here
+    is that the registry is actually what gets sent. Whether the SQL honours it
+    is a property of the statement, tested in `test_dev_reload_live_job_sql.py`.
+    """
+    import json
+
+    from app.services.processes.stale_thresholds import get_threshold, overridden_process_ids
+
+    sent = json.loads(dev_reload._THRESHOLD_OVERRIDES_JSON)
+    assert sent, "no overrides reached the query — every job would fall back to the default"
+    assert set(sent) == set(overridden_process_ids()), "the query and the registry disagree on which jobs are slow-tick"
+    for process_id, seconds in sent.items():
+        assert seconds == get_threshold(process_id)
+
+
+class _LiveProc:
+    """A child that never exits on its own."""
+
+    def __init__(self) -> None:
+        self.pid = 4242
+
+    def poll(self) -> int | None:
+        return None
+
+
+class _DyingProc:
+    """A child that reports itself crashed from the Nth poll onwards."""
+
+    def __init__(self, alive_polls: int) -> None:
+        self.pid = 4243
+        self._alive_polls = alive_polls
+
+    def poll(self) -> int | None:
+        if self._alive_polls > 0:
+            self._alive_polls -= 1
+            return None
+        return -9
+
+
+def _drive_supervisor(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    batches: list[list[tuple[int, str]]],
+    live_job_results: list[str | None],
+    procs: list[Any] | None = None,
+) -> tuple[list[str], int]:
+    """Run `_supervise` against a scripted watcher, returning
+    (stop_child call reasons, spawn count).
+
+    `watchfiles` is imported inside `_supervise`, so a stub module in
+    `sys.modules` is enough to script the change batches without any real
+    filesystem watching or subprocess.
+    """
+    import sys
+    import types
+
+    stub = types.ModuleType("watchfiles")
+    stub.PythonFilter = object  # type: ignore[attr-defined]
+    stub.watch = lambda *_a, **_kw: iter(batches)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "watchfiles", stub)
+
+    spawns = 0
+
+    def _fake_spawn() -> tuple[Any, float]:
+        nonlocal spawns
+        proc = procs[spawns] if procs is not None and spawns < len(procs) else _LiveProc()
+        spawns += 1
+        # spawn_time 0.0 so any real file counts as newer (not stale).
+        return cast(Any, proc), 0.0
+
+    stops: list[str] = []
+    monkeypatch.setattr(dev_reload, "_spawn_child", _fake_spawn)
+    monkeypatch.setattr(dev_reload, "_stop_child", lambda proc: stops.append(str(proc.pid)))
+    monkeypatch.setattr(dev_reload, "_LIVE_JOB_PROBE_PERIOD_S", 0.0)
+
+    results = iter(live_job_results)
+    monkeypatch.setattr(dev_reload, "live_job", lambda: next(results, live_job_results[-1]))
+
+    dev_reload._supervise()
+    return stops, spawns
+
+
+def test_a_live_job_defers_the_reload_rather_than_killing_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """#2274's regression. Three `strategy_backtest_run` attempts died inside
+    one hour because an ordinary merge changed an `app/**` mtime; the last was
+    12,625/17,290 through and had heartbeat 8s earlier. The reload must wait."""
+    changed = _touch(tmp_path / "svc.py", time.time())
+    with caplog.at_level(logging.INFO, logger=dev_reload.__name__):
+        stops, spawns = _drive_supervisor(
+            monkeypatch,
+            batches=[[(1, changed)], [], [], []],
+            live_job_results=["strategy_backtest_run run 111447 (12625/17290 done, heartbeat 8s ago)"],
+        )
+    # One spawn (the initial child) and one stop (the `finally` on exit) — the
+    # change never triggered a reload.
+    assert spawns == 1, "a live job must not be preempted by a file change"
+    assert stops == ["4242"], "the only _stop_child is the supervisor's own shutdown"
+    assert any("DEFERRING reload" in r.message for r in caplog.records)
+
+
+def test_a_deferred_reload_is_applied_once_the_job_finishes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Deferral must not be a silent drop: the held change has to land as soon
+    as the job stops being live, without waiting for another edit."""
+    changed = _touch(tmp_path / "svc.py", time.time())
+    stops, spawns = _drive_supervisor(
+        monkeypatch,
+        batches=[[(1, changed)], [], [], []],
+        live_job_results=["strategy_backtest_run run 111447 (1/2 done, heartbeat 1s ago)", None],
+    )
+    assert spawns == 2, "the held reload never landed"
+    assert len(stops) == 2, "expected the deferred reload's stop plus the shutdown stop"
+
+
+def test_a_child_that_dies_holding_changes_respawns_on_them(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Codex checkpoint 2, P1. If the child crashes while a reload is deferred,
+    the held edits were never loaded by anything — clearing them would leave the
+    daemon dead until some unrelated file happened to change.
+
+    Not hypothetical: the jobs child took a bare SIGKILL (`child exited -9`,
+    no preceding SIGTERM) mid-backtest on 2026-08-21.
+
+    The respawn must also NOT consult `live_job` first — the dead child's own
+    `running` rows stay inside the staleness window, so probing would make a
+    crash wait out a heartbeat that can never advance again.
+    """
+    changed = _touch(tmp_path / "svc.py", time.time())
+    probes = 0
+
+    def _counting_live_job() -> str | None:
+        nonlocal probes
+        probes += 1
+        return "strategy_backtest_run run 111447 (1/2 done, heartbeat 1s ago)"
+
+    import sys
+    import types
+
+    stub = types.ModuleType("watchfiles")
+    stub.PythonFilter = object  # type: ignore[attr-defined]
+    # Change arrives, deferred behind a live job, then the child crashes.
+    batches: list[list[tuple[int, str]]] = [[(1, changed)], [], []]
+    stub.watch = lambda *_a, **_kw: iter(batches)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "watchfiles", stub)
+
+    spawns = 0
+    procs: list[Any] = [_DyingProc(alive_polls=0), _LiveProc()]
+
+    def _fake_spawn() -> tuple[Any, float]:
+        nonlocal spawns
+        proc = procs[spawns] if spawns < len(procs) else _LiveProc()
+        spawns += 1
+        return cast(Any, proc), 0.0
+
+    monkeypatch.setattr(dev_reload, "_spawn_child", _fake_spawn)
+    monkeypatch.setattr(dev_reload, "_stop_child", lambda _proc: None)
+    monkeypatch.setattr(dev_reload, "_LIVE_JOB_PROBE_PERIOD_S", 0.0)
+    monkeypatch.setattr(dev_reload, "live_job", _counting_live_job)
+
+    with caplog.at_level(logging.INFO, logger=dev_reload.__name__):
+        dev_reload._supervise()
+
+    assert spawns == 2, "a crash holding pending changes must respawn on them"
+    assert any("died with" in r.message for r in caplog.records)
+    # Exactly one probe: the initial deferral. The crash path must not add one.
+    assert probes == 1, f"the crash path probed live_job {probes} times; it must not probe at all"
+
+
+def test_no_live_job_reloads_immediately(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The pre-#2274 path is unchanged for the 111,401 of 111,409 `job_runs`
+    rows that never heartbeat: nothing to defer behind, so reload at once."""
+    changed = _touch(tmp_path / "svc.py", time.time())
+    _stops, spawns = _drive_supervisor(
+        monkeypatch,
+        batches=[[(1, changed)], []],
+        live_job_results=[None],
+    )
+    assert spawns == 2

--- a/tests/jobs/test_dev_reload.py
+++ b/tests/jobs/test_dev_reload.py
@@ -145,6 +145,76 @@ def test_slicing_the_wait_does_not_extend_the_drain_budget(monkeypatch: pytest.M
     assert elapsed < 5.0, f"drain budget was not bounded: {elapsed:.2f}s"
 
 
+def test_a_job_that_goes_live_during_the_drain_is_not_escalated(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Codex checkpoint 2, round 4 — the probe->SIGTERM race.
+
+    `live_job()` can return None and the scheduler start a long job before
+    SIGTERM lands. That job would then be SIGKILLed at the drain budget, which
+    is the exact loss this change exists to prevent. Expiry re-probes instead
+    of escalating, for as long as something is provably alive.
+    """
+    monkeypatch.setattr(dev_reload, "_DRAIN_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(dev_reload, "_DRAIN_PROGRESS_S", 0.01)
+    monkeypatch.setattr(dev_reload, "_DRAIN_EXTENSION_S", 0.05)
+    monkeypatch.setattr(dev_reload, "_POST_KILL_SETTLE_S", 0.0)
+    # Live for the first two budget expiries, then stale.
+    results = iter(["strategy_backtest_run run 1 (1/2 done, heartbeat 1s ago)"] * 2)
+    monkeypatch.setattr(dev_reload, "live_job", lambda: next(results, None))
+
+    proc = _FakeProc(hangs_for=10_000)  # never drains on its own
+    with caplog.at_level(logging.INFO, logger=dev_reload.__name__):
+        dev_reload._stop_child(cast(Any, proc), extend_while_live=True)
+
+    extensions = [r for r in caplog.records if "extending" in r.message]
+    assert len(extensions) == 2, f"expected 2 liveness extensions, got {len(extensions)}"
+    assert proc.killed, "escalation must still happen once the heartbeat goes stale"
+
+
+def test_a_shutdown_signal_mid_drain_stops_the_extensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Codex checkpoint 2, round 5. The shutdown handler runs on the watcher's
+    frame, so without the event threaded in here an operator Ctrl-C arriving
+    during an automatic reload would be ignored for as long as the job kept
+    heartbeating — the stack would become unstoppable."""
+    import threading
+
+    monkeypatch.setattr(dev_reload, "_DRAIN_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(dev_reload, "_DRAIN_PROGRESS_S", 0.01)
+    monkeypatch.setattr(dev_reload, "_DRAIN_EXTENSION_S", 0.05)
+    monkeypatch.setattr(dev_reload, "_POST_KILL_SETTLE_S", 0.0)
+    # Always live: only the stop event can end this drain.
+    monkeypatch.setattr(dev_reload, "live_job", lambda: "strategy_backtest_run run 1 (1/2, heartbeat 1s ago)")
+
+    stop_event = threading.Event()
+    stop_event.set()
+    proc = _FakeProc(hangs_for=10_000)
+    dev_reload._stop_child(cast(Any, proc), extend_while_live=True, stop_event=stop_event)
+    assert proc.killed, "a set stop_event must end the drain even while a job is live"
+
+
+def test_the_shutdown_path_still_kills_on_the_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deferral withholds an AUTOMATIC reload; it is not a veto on the operator
+    stopping the stack. So the default (shutdown) path must not consult
+    `live_job` at all."""
+    monkeypatch.setattr(dev_reload, "_DRAIN_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(dev_reload, "_DRAIN_PROGRESS_S", 0.01)
+    monkeypatch.setattr(dev_reload, "_POST_KILL_SETTLE_S", 0.0)
+
+    probes = 0
+
+    def _counting_live_job() -> str | None:
+        nonlocal probes
+        probes += 1
+        return "strategy_backtest_run run 1 (1/2 done, heartbeat 1s ago)"
+
+    monkeypatch.setattr(dev_reload, "live_job", _counting_live_job)
+    proc = _FakeProc(hangs_for=10_000)
+    dev_reload._stop_child(cast(Any, proc))
+    assert proc.killed, "an explicit stop must still escalate on the budget"
+    assert probes == 0, "the shutdown path must not consult live_job"
+
+
 def test_running_commit_ignores_an_inherited_git_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     """A git hook exports GIT_DIR into everything it runs, so an unscrubbed call
     would resolve against the hook's repo rather than ours (#2658's trap)."""
@@ -299,7 +369,7 @@ def _drive_supervisor(
 
     stops: list[str] = []
     monkeypatch.setattr(dev_reload, "_spawn_child", _fake_spawn)
-    monkeypatch.setattr(dev_reload, "_stop_child", lambda proc: stops.append(str(proc.pid)))
+    monkeypatch.setattr(dev_reload, "_stop_child", lambda proc, **_kw: stops.append(str(proc.pid)))
     monkeypatch.setattr(dev_reload, "_LIVE_JOB_PROBE_PERIOD_S", 0.0)
 
     results = iter(live_job_results)
@@ -384,7 +454,7 @@ def test_a_child_that_dies_holding_changes_respawns_on_them(
         return cast(Any, proc), 0.0
 
     monkeypatch.setattr(dev_reload, "_spawn_child", _fake_spawn)
-    monkeypatch.setattr(dev_reload, "_stop_child", lambda _proc: None)
+    monkeypatch.setattr(dev_reload, "_stop_child", lambda _proc, **_kw: None)
     monkeypatch.setattr(dev_reload, "_LIVE_JOB_PROBE_PERIOD_S", 0.0)
     monkeypatch.setattr(dev_reload, "live_job", _counting_live_job)
 

--- a/tests/jobs/test_dev_reload_live_job_sql.py
+++ b/tests/jobs/test_dev_reload_live_job_sql.py
@@ -1,0 +1,152 @@
+"""#2274 — `dev_reload.live_job`'s statement, run against a real `job_runs`.
+
+Split out of `test_dev_reload.py` on purpose. `live_job` swallows every
+exception by design (it must fail OPEN, so a DB blip reloads as before
+rather than freezing the daemon on stale code). The cost of that contract
+is that a typo in its SQL degrades the probe to a permanent `None`: the
+deferral silently stops working and every pure-logic test still passes.
+Executing the real statement is the only thing that catches it.
+
+It lives in its own module because `tests/conftest.py::pytest_collection_modifyitems`
+applies the `db` marker per MODULE — keeping this here leaves the pure
+supervisor tests on the fast `-m "not db"` pre-push gate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.jobs import dev_reload
+from app.services.processes.stale_thresholds import (
+    DEFAULT_THRESHOLD_S,
+    get_threshold,
+    overridden_process_ids,
+)
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test Postgres not reachable",
+)
+
+_FIXTURE_JOB = "dev_reload_probe_fixture"
+
+# Real registry entries, so the per-job branch is exercised with the
+# names the supervisor will actually see. `sec_insider_transactions_backfill`
+# is a 1800s slow-tick producer; `strategy_backtest_run` takes the 300s
+# default and is the job #2274 was opened over.
+_SLOW_TICK_JOB = "sec_insider_transactions_backfill"
+_DEFAULT_TICK_JOB = "strategy_backtest_run"
+
+_CLEANUP = "DELETE FROM job_runs WHERE job_name = ANY(%s)"
+_ALL_FIXTURE_JOBS = [_FIXTURE_JOB, _SLOW_TICK_JOB, _DEFAULT_TICK_JOB]
+
+_SEED = """
+    INSERT INTO job_runs (job_name, status, started_at, last_progress_at, processed_count, target_count)
+    VALUES (%s, 'running', now(), now() - make_interval(secs => %s), 7, 9)
+"""
+
+
+@pytest.fixture
+def conn(monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
+    """A test-DB connection, with `settings.database_url` redirected.
+
+    `live_job` opens its OWN connection from `settings.database_url`, so
+    without the redirect it would probe the operator's dev DB — and the
+    seeded row would have to be committed there to be visible.
+    """
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "database_url", _test_database_url())
+    c: psycopg.Connection[Any] = psycopg.connect(_test_database_url(), autocommit=True)
+    c.execute(_CLEANUP, (_ALL_FIXTURE_JOBS,))
+    try:
+        yield c
+    finally:
+        try:
+            c.execute(_CLEANUP, (_ALL_FIXTURE_JOBS,))
+        finally:
+            c.close()
+
+
+def test_a_fresh_heartbeat_blocks_a_reload(conn: Any) -> None:
+    conn.execute(_SEED, (_FIXTURE_JOB, 0))
+    described = dev_reload.live_job()
+    assert described is not None, "a running job heartbeating now must block a reload"
+    assert _FIXTURE_JOB in described
+    assert "7/9 done" in described
+
+
+def test_a_stale_heartbeat_stops_blocking_on_its_own(conn: Any) -> None:
+    """Why this needs no watchdog: a wedged job ages out of protection.
+
+    Deferral is unbounded in wall-clock but bounded by liveness, so a job
+    that dies without a terminal status cannot hold the daemon on stale
+    code forever.
+
+    Aged past the WIDEST threshold in the registry, so this stays true
+    whatever `stale_thresholds.py` says about this job name.
+    """
+    widest = max([DEFAULT_THRESHOLD_S, *(get_threshold(p) for p in overridden_process_ids())])
+    conn.execute(_SEED, (_FIXTURE_JOB, widest + 60))
+    assert dev_reload.live_job() is None
+
+
+def test_a_slow_tick_job_is_live_past_the_default_threshold(conn: Any) -> None:
+    """Codex checkpoint 2, round 2. Eight producers in `stale_thresholds.py`
+    are given 1800s because their natural inter-tick gap exceeds five minutes.
+    On the 300s default they would be 'healthy' to the admin console and
+    'stale' to the supervisor at the same instant — still SIGKILL-able, with
+    nothing reporting them at risk."""
+    assert get_threshold(_SLOW_TICK_JOB) == 1800, "registry changed; revisit this test"
+    conn.execute(_SEED, (_SLOW_TICK_JOB, 900))  # quiet 15 min, live under its 1800s cut
+    described = dev_reload.live_job()
+    assert described is not None
+    assert _SLOW_TICK_JOB in described
+
+
+def test_a_default_threshold_job_goes_stale_at_the_default(conn: Any) -> None:
+    """The other half: honouring the overrides must not silently promote every
+    job to the widest one, or a wedged run blocks reloads for half an hour."""
+    assert get_threshold(_DEFAULT_TICK_JOB) == 300, "registry changed; revisit this test"
+    conn.execute(_SEED, (_DEFAULT_TICK_JOB, 900))  # same 15 min, stale at its 300s cut
+    assert dev_reload.live_job() is None
+
+
+def test_a_stale_fast_tick_row_cannot_mask_a_live_slow_tick_one(conn: Any) -> None:
+    """Codex checkpoint 2, round 3. The staleness cut must be applied BEFORE
+    any row limit. Filtering in Python after `LIMIT` let a fresher-but-stale
+    default-threshold row hide an older-but-live override row, returning
+    'nothing to defer' and preempting the run this change exists to protect.
+
+    The stale row is seeded with the FRESHER heartbeat, so a query that ordered
+    and limited before applying the per-job cut would return it and miss the
+    live one.
+    """
+    conn.execute(_SEED, (_DEFAULT_TICK_JOB, 400))  # fresher, but past its 300s cut
+    conn.execute(_SEED, (_SLOW_TICK_JOB, 1200))  # older, but inside its 1800s cut
+    described = dev_reload.live_job()
+    assert described is not None, "a live slow-tick job was masked by a stale fast-tick one"
+    assert _SLOW_TICK_JOB in described
+
+
+def test_a_running_row_that_never_heartbeats_does_not_block(conn: Any) -> None:
+    """8 of 111,409 `job_runs` rows carry `last_progress_at` at all, so the
+    NULL case is the overwhelmingly common one and must behave as pre-#2274."""
+    conn.execute(
+        """
+        INSERT INTO job_runs (job_name, status, started_at, last_progress_at)
+        VALUES (%s, 'running', now(), NULL)
+        """,
+        (_FIXTURE_JOB,),
+    )
+    assert dev_reload.live_job() is None


### PR DESCRIPTION
Refs #2274

Scoped to item 2 of that ticket (`dev_reload` reaping long jobs). Item 1 (wall-clock ceiling / no-progress watchdog) stays open, so this uses `Refs`, not `Closes`.

## Why now

This is the live blocker on the strategy build queue's item 6. The first in-sample backtest at current strategy versions died three times inside one hour.

| UTC | event |
| --- | --- |
| 00:17:05 | `dev_reload` respawns the child |
| 00:17:41 | `strategy_backtest_run` **111447** starts (17,290 targets) |
| 00:57:25 | `app/api/strategies.py` mtime changes — merge `1ab1704c` re-detaching `~/Dev/eBull` at `origin/main` — SIGTERM |
| 01:00:25 | child cannot drain in 180s (43 min into a ~17h run) → **SIGKILL** |
| 01:00:28 | boot reaper marks 111447 `failure: orphaned` at 12,625/17,290 |

Log timestamps are BST and `job_runs` is UTC; the offset is applied above. Those two clocks living in different stores is a large part of why three consecutive reaps read as mysterious worker deaths rather than as one repeating cause.

**The run was healthy when it was killed.** 111447's `last_progress_at` is `01:00:20` — 8 seconds before the SIGKILL. Not a wedged job being cleaned up; a working one being preempted.

The trigger each time was an ordinary merge, which is exactly how a merged change is *meant* to reach this daemon. So the loop's own merge cadence made a long run unfinishable, and 7 of 10 strategies stay unmeasured until it is fixed.

## What changed

An automatic reload now **waits** for a job that is provably alive instead of killing it.

"Provably alive" is a claim the job volunteers, not one the supervisor infers: a `job_runs` row in `status='running'` whose `last_progress_at` is inside that job's own staleness threshold. Deliberately **not** an age cut — age is a proxy for liveness and would protect a wedged job forever. A job that stops heartbeating goes stale and stops blocking reloads on its own, which is why this needs no watchdog and cannot false-fire on a legitimately-long run — #2274's own stated constraint.

Also a **correctness** fix, not only an availability one: had a drain mid-run actually succeeded, the surviving rows would carry a `strategy_version` derived from code that changed underneath the run.

Load-bearing properties:

- **Fails open.** Any probe failure — DB down, slow, schema drift — reloads exactly as before. Bounded by both `connect_timeout` *and* a libpq startup `statement_timeout`, because the former bounds only the connect and a hung query on the supervisor's own thread is a wedge wearing fail-open's clothes.
- **Thresholds are not invented and not local.** They come from `app/services/processes/stale_thresholds.py`, the registry the admin console's `mid_flight_stuck` detection already reads (default 300s, 1800s for eight slow-tick producers). They travel into the query as a jsonb map so Postgres applies the per-job cut **before** any row limit.
- **Ownership is free.** The singleton advisory-lock fence means exactly one jobs process, so a freshly-heartbeating `running` row is necessarily the current child's. No PID plumbing.
- **Only automatic reloads defer.** An explicit stop still drains and kills on the budget.
- **A child that dies holding pending changes respawns on them**, and does not probe first — a dead child's own `running` rows stay inside the staleness window and would otherwise make a crash wait out a heartbeat that can never advance again.

## Answering the ticket's own open question

> worth checking whether the progress heartbeat is actually reaching `job_runs` for this job

Measured on the full table:

```sql
select count(*) from job_runs where last_progress_at is not null;  -- 8
select count(*) from job_runs;                                     -- 111409
```

8 of 111,409, four of them `strategy_backtest_run`. The heartbeat does **not** reach `job_runs` for the routine jobs, but it works reliably for the backtest — which is precisely the job that needed protecting. The other 111,401 rows behave exactly as they did pre-change.

⚠ My first attempt at this measurement was wrong and self-consistently so: `count(processed_count)` on a `NOT NULL DEFAULT 0` column returns the row count whatever the data says, so it read as "the heartbeat is universal".

## Why not the option the ticket called cheapest

#2274 lists "accept that multi-hour sweeps must run outside a dev session and write it in the runbook" as cheapest and possibly correct. It is no longer correct, and the evidence is the table above: the autonomy loop merges continuously, the backtest needs ~17h, three runs died in one hour. Under that option there is no window in which item 6 can ever complete — it would convert a fixable ops defect into a permanent block on measuring 7 of 10 strategies.

## Codex checkpoint 2 — six rounds

Every finding was real except the last. Recording them because several are non-obvious:

1. **P1 — a crash while deferred discarded the held changes**, leaving the daemon dead until an unrelated edit landed. Not hypothetical: the jobs child took a bare SIGKILL (`child exited -9`, no preceding SIGTERM) mid-backtest on the same night. Now respawns on the pending batch.
2. **P2 — `connect_timeout` bounds only the connect.** A hung query would block the supervisor's thread entirely. Added a libpq startup `statement_timeout`, verified empirically: `SHOW statement_timeout` → `3s`, and `SELECT pg_sleep(10)` → `QueryCanceled` (which the probe's guard turns into "no live job", so it still fails open).
3. **P1 — hard-coding the 300s default** would have made the eight slow-tick producers "healthy" to the admin console and "stale" to the supervisor at the same instant. Rewired to the existing registry.
4. **P1 — filtering per-job thresholds in Python after a `LIMIT`** let stale fast-tick rows mask a live slow-tick one, returning "nothing to defer". Pushed the per-job cut into SQL so `LIMIT 1` only ever picks *which* blocker to name, never *whether* one exists.
5. **P2 — the probe→SIGTERM race.** A job starting in that window would still be killed at the budget. Expiry now re-probes and extends while something is alive. This fixes the original bug from the other side as well: a fixed 180s cap is what turns a graceful shutdown into data loss, because the drain a long job needs is longer than any constant it is safe to wait on blindly.
6. **P1 — an operator stop must stay bounded.** The shutdown handler runs on the watcher's frame, so a Ctrl-C arriving while an automatic reload was already inside `_stop_child` was invisible to the extension loop and the stack became unstoppable. `stop_event` is threaded in.
7. **P1 — REBUTTED.** Codex read the registry's admin `process_id` keys against `job_runs.job_name` and called the mismatch a defect. It is not: `process_id` **is** the `ScheduledJob.name` verbatim for everything that owns a job_runs row. The three keys that do not match (`bootstrap`, `sec_13f_sweep`, `nport_sweep`) are exactly the three that are not scheduled jobs and can never produce one — the registry's own docstring says sweeps "have no own active_run". Measured against both `SCHEDULED_JOBS` and the distinct `job_name` values in `job_runs`: all five keys that can appear do match. The proposed translations `sec_13f_quarterly_sweep` / `sec_n_port_ingest` appear in neither, so adopting them would add dead keys implying coverage that does not exist. A reproduce command is recorded in the constant's comment.

## Tests

19 pure-logic tests on the fast gate; 6 DB-backed tests in a separate module.

The split is deliberate and was itself a caught regression: `tests/conftest.py::pytest_collection_modifyitems` applies the `db` marker **per module**, so adding one DB test to the pure file silently deselected all 9 pre-existing tests from the `-m "not db"` pre-push gate. It surfaced as `EXIT=5` ("no tests collected"), which greps for `FAILED` cannot distinguish from success. The pure module carries a `⚠ Keep this module DB-free` note so it does not recur.

The DB module exists because `live_job` swallows every exception by design — a typo in its SQL would degrade the probe to a permanent `None`, silently disabling the feature while every pure test still passed.

## Verification

- `ruff check` / `ruff format --check` / `pyright` (0 errors) / `pytest -m "not db"` / `tests/smoke` — all green at `12404364`.
- New SQL executed unguarded against the dev DB (outside `live_job`'s exception guard) to prove it parses and runs.
- jsonb per-job lookup verified read-only on dev: override → `1800`, default-threshold job → `300`, unknown job → `300`.
- `statement_timeout` verified enforced, not merely set (see round 2 above).
- DB-backed tests exercise real `job_runs` rows, including the stale-masks-live regression with the stale row seeded as the *fresher* heartbeat.

⚠ **Not yet verified live, and deliberately so.** The end-to-end acceptance is: restart the daemon on this commit, dispatch the backtest, touch an `app/**` file, and confirm the log says `DEFERRING reload` rather than `SIGTERM`. That cannot be done before this merges, because the daemon runs from `~/Dev/eBull` at `origin/main` — and dispatching a 17h backtest under the *current* code would just feed another run to the bug. Sequencing is: merge → re-detach → restart daemon → dispatch → verify. I will run it and report on the issue.

## Security

No security surface. The change adds one read-only `SELECT` against `job_runs` from a dev-only supervisor that is a documented pass-through outside `DEV_LIKE_ENVS`. Parameterised throughout — the threshold registry is passed as a jsonb parameter, never interpolated. No new credentials, endpoints, or external calls.

## Risk

The failure mode of this change is "the daemon runs slightly older code for a while", against a current failure mode of "hours of corpus work destroyed". Deferral is unbounded in wall-clock but bounded by liveness at both decision points, so nothing can hold the daemon on stale code indefinitely without also heartbeating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
