### PR TITLE
fix(#2809): measure scan freshness against the frontier a scan would choose

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -37,7 +37,7 @@ from app.services.cost_model import COST_MODEL_ID
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
-from app.services.price_masked_bars import load_recent_last_bar_counts
+from app.services.price_masked_bars import load_bar_spans, load_recent_last_bar_counts
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.runtime_config import (
     RuntimeConfigCorrupt,
@@ -110,7 +110,12 @@ from app.services.strategy_result_ambiguity import (
     composed_holdout_ambiguity_refusals,
     record_sha256,
 )
-from app.services.strategy_signal_scan import SCAN_UNIVERSE, modal_bar_date
+from app.services.strategy_signal_scan import (
+    SCAN_UNIVERSE,
+    choose_frontier,
+    modal_bar_date,
+    window_decides_the_mode,
+)
 from app.services.strategy_wealth import load_strategy_wealth_history
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
@@ -1069,13 +1074,22 @@ def _corpus_frontier(conn: psycopg.Connection[Any], *, as_of: date) -> date | No
     The old comment justified the choice as an optimisation — *"avoids a full
     scan of the multi-million-row bar corpus on every Strategies page load"* —
     and the cost was real: the honest statistic unbounded is 0.60s on a 30-66ms
-    endpoint. ``_CORPUS_FRESHNESS_WINDOW`` is what buys it back, at 0.036s for
-    the identical answer.
+    endpoint. The windowed read buys it back at 0.036s, and
+    ``window_decides_the_mode`` is what keeps it from buying a different answer.
     """
     universe = load_validated_universe(conn)
     counts = load_recent_last_bar_counts(conn, universe, since=as_of - _CORPUS_FRESHNESS_WINDOW)
     modal = modal_bar_date(counts)
-    return None if modal is None else modal[0]
+    if modal is not None and window_decides_the_mode(
+        modal_count=modal[1], seen=sum(counts.values()), universe_size=len(universe)
+    ):
+        return modal[0]
+    # The window cannot settle it, so pay for the whole distribution rather than
+    # answer from the part of the corpus that happened to refresh recently.
+    frontier = choose_frontier(
+        {instrument_id: span.last_bar for instrument_id, span in load_bar_spans(conn, universe).items()}
+    )
+    return None if frontier is None else frontier.bar_date
 
 
 def _ambiguity_record_from_result_row(

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -7,7 +7,7 @@ from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import psycopg
 import psycopg.rows
@@ -37,6 +37,7 @@ from app.services.cost_model import COST_MODEL_ID
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
+from app.services.price_masked_bars import load_recent_last_bar_counts
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.runtime_config import (
     RuntimeConfigCorrupt,
@@ -44,6 +45,7 @@ from app.services.runtime_config import (
     get_runtime_config,
     update_runtime_config,
 )
+from app.services.strategies.validated_universe import load_validated_universe
 from app.services.strategy_ambiguity_policy import AMBIGUITY_RULE_VERSION
 from app.services.strategy_base_currency import (
     DEPLOYMENT_CURRENCY_UNSUPPORTED,
@@ -108,7 +110,7 @@ from app.services.strategy_result_ambiguity import (
     composed_holdout_ambiguity_refusals,
     record_sha256,
 )
-from app.services.strategy_signal_scan import SCAN_UNIVERSE
+from app.services.strategy_signal_scan import SCAN_UNIVERSE, modal_bar_date
 from app.services.strategy_wealth import load_strategy_wealth_history
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
@@ -1038,6 +1040,44 @@ def _current_scan_versions() -> dict[str, str]:
     }
 
 
+def _corpus_frontier(conn: psycopg.Connection[Any], *, as_of: date) -> date | None:
+    """The bar date a scan run RIGHT NOW would choose, i.e. what ``current`` means.
+
+    The scan card's freshness bar. Reads the same population the scanner reads
+    (the validated universe, through the quarantine-masked predicate) and applies
+    the scanner's own tie-break, ``modal_bar_date`` — so ``frontier >=
+    _corpus_frontier()`` says "the stored scan sits on the frontier a new run
+    would pick", which is the only claim the card can honestly make.
+
+    ⚠⚠ THIS REPLACED ``MAX(last_bar) FROM research_price_series`` (#2809), which
+    was wrong three ways at once and reported all 10 strategies ``stale`` while
+    every one of them sat exactly on the frontier:
+
+    1. **Wrong table.** ``research_price_series`` is the backtest archive; the
+       scan reads ``price_daily``. Its ``MAX`` was ONE row — CBOE VIX, refreshed
+       on its own path — against a corpus whose next-newest series ended six
+       weeks earlier.
+    2. **Wrong statistic.** ``strategy_signal_scan``'s module docstring item 2 is
+       explicit: *"The frontier is the MODAL last bar, never ``max(price_date)``"*,
+       because a max is set by whichever handful of series refreshed first. On
+       ``price_daily`` at the time of the fix that max was 2026-08-20, held by
+       1,563 rows of an in-flight ``daily_candle_refresh`` against ~11,000 on
+       each completed day.
+    3. **Wrong population.** The whole archive rather than the validated
+       universe the scan is scored on.
+
+    The old comment justified the choice as an optimisation — *"avoids a full
+    scan of the multi-million-row bar corpus on every Strategies page load"* —
+    and the cost was real: the honest statistic unbounded is 0.60s on a 30-66ms
+    endpoint. ``_CORPUS_FRESHNESS_WINDOW`` is what buys it back, at 0.036s for
+    the identical answer.
+    """
+    universe = load_validated_universe(conn)
+    counts = load_recent_last_bar_counts(conn, universe, since=as_of - _CORPUS_FRESHNESS_WINDOW)
+    modal = modal_bar_date(counts)
+    return None if modal is None else modal[0]
+
+
 def _ambiguity_record_from_result_row(
     row: dict[str, object],
     *,
@@ -1289,10 +1329,17 @@ _EXCLUSIONS_SQL = """
     GROUP BY strategy_id, strategy_version, reason_code
 """
 
-# The ingest transaction maintains this census on every series. Reading its
-# ~one-row-per-symbol metadata avoids a full scan of the multi-million-row bar
-# corpus on every Strategies page load.
-_LATEST_CORPUS_SQL = "SELECT MAX(last_bar) FROM research_price_series"
+#: How far back ``_corpus_frontier`` looks for the corpus's modal last bar.
+#:
+#: BY CONSTRUCTION, no published rule: the window has to outlast the longest
+#: exchange closure, or a real holiday week empties it and the card reports a
+#: stale corpus that is merely shut. The longest modern NYSE closures are four
+#: sessions (9/11) and two (Sandy); with the weekends either side that is ~9
+#: calendar days, so 10 clears it with a session to spare while staying far
+#: short of the ~30 days at which a genuinely dead refresh would still look
+#: alive. Widening it costs latency (0.036s at 10d, 0.072s at 30d, measured on
+#: the 6,773-instrument corpus); narrowing it risks the holiday case.
+_CORPUS_FRESHNESS_WINDOW = timedelta(days=10)
 
 _LATEST_EVIDENCE_REFRESH_SQL = """
     SELECT p.request_id, p.status AS request_status, p.requested_at, p.error_msg AS request_error,
@@ -1530,9 +1577,11 @@ def get_strategy_overview(
         prior_result_rows = list(cur.fetchall())
         cur.execute(_PRIOR_VERSION_SCANS_SQL, prior_scan_params)
         prior_scan_rows = list(cur.fetchall())
-        cur.execute(_LATEST_CORPUS_SQL)
-        latest_row = cur.fetchone()
-        latest_corpus_date = None if latest_row is None else latest_row["max"]
+        # ⚠ The freshness bar is the frontier a scan run NOW would choose, not a
+        # MAX over a different corpus (#2809). `None` means no universe member
+        # carried a bar inside the window at all, which the status below reads as
+        # `stale` — a corpus nothing has refreshed in ten days IS stale.
+        latest_corpus_date = _corpus_frontier(conn, as_of=as_of.date())
         cur.execute(_LATEST_EVIDENCE_REFRESH_SQL, {"job_name": _STRATEGY_BACKTEST_JOB})
         refresh_row = cur.fetchone()
         cur.execute(

--- a/app/services/price_masked_bars.py
+++ b/app/services/price_masked_bars.py
@@ -101,6 +101,33 @@ _LAST_BAR_SQL = """
     GROUP BY d.instrument_id
 """
 
+#: ``_LAST_BAR_SQL`` aggregated one step further and bounded to a recent window:
+#: how many instruments' last bar falls on each date. Same coverage predicate, for
+#: the same fail-closed reason.
+#:
+#: ⚠ The ``since`` bound is why this is a SEPARATE query rather than a caller-side
+#: `Counter` over ``load_bar_spans`` — which returns the identical distribution
+#: and costs 0.60s against this one's 0.036s on the live corpus (6,773
+#: instruments, 3.6M bars), on an endpoint that answers in 30-66ms. The bound is
+#: sound HERE and would be wrong in ``load_bar_spans``: an instrument with no bar
+#: inside the window cannot be the freshest date the corpus reached, but it is
+#: still a universe member the scan must account for.
+_RECENT_LAST_BAR_COUNTS_SQL = """
+    SELECT spans.last_bar, count(*)
+    FROM (
+        SELECT d.instrument_id, max(d.price_date) AS last_bar
+        FROM price_daily d
+        JOIN price_quarantine_coverage cov
+          ON cov.instrument_id = d.instrument_id
+         AND cov.rule_set_version = %(quarantine_version)s
+         AND d.price_date BETWEEN cov.first_bar AND cov.last_bar
+        WHERE d.instrument_id = ANY(%(instrument_ids)s)
+          AND d.price_date >= %(since)s
+        GROUP BY d.instrument_id
+    ) spans
+    GROUP BY spans.last_bar
+"""
+
 _UNION_CALENDAR_SQL = """
     SELECT DISTINCT d.price_date
     FROM price_daily d
@@ -231,6 +258,34 @@ def load_bar_spans(
         int(instrument_id): InstrumentBarSpan(last_bar=last_bar, bars=int(bars))
         for instrument_id, last_bar, bars in rows
     }
+
+
+def load_recent_last_bar_counts(
+    conn: psycopg.Connection[Any],
+    instrument_ids: Sequence[int],
+    *,
+    since: date,
+) -> dict[date, int]:
+    """How many instruments' last bar falls on each date at or after ``since``.
+
+    The distribution ``choose_frontier`` picks the mode of, through the same
+    masked predicate, for a reader that needs the corpus's frontier WITHOUT
+    paying for the whole per-instrument span. See ``_RECENT_LAST_BAR_COUNTS_SQL``
+    for the measured reason the bound exists and why it is sound only here.
+
+    ⚠ Empty result is a MEASUREMENT, not a gap: no universe member has a bar in
+    the window, so the corpus has not been refreshed inside it. Callers must not
+    default that to "fresh".
+    """
+    rows = conn.execute(
+        _RECENT_LAST_BAR_COUNTS_SQL,
+        {
+            "instrument_ids": list(instrument_ids),
+            "quarantine_version": QUARANTINE_RULE_SET_VERSION,
+            "since": since,
+        },
+    ).fetchall()
+    return {last_bar: int(members) for last_bar, members in rows}
 
 
 def load_union_calendar(conn: psycopg.Connection[Any], instrument_ids: Sequence[int]) -> tuple[date, ...]:

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -249,6 +249,35 @@ def modal_bar_date(counts: Mapping[date, int]) -> tuple[date, int] | None:
     return bar_date, modal_count
 
 
+def window_decides_the_mode(*, modal_count: int, seen: int, universe_size: int) -> bool:
+    """Can a reader that only looked at a RECENT window trust its mode?
+
+    A caller that bounds the last-bar query to a window — ``/strategies/overview``
+    does, because the unbounded distribution costs 0.60s on a 30-66ms endpoint —
+    is not computing the same statistic. The bound cannot corrupt an instrument's
+    last bar (a ``max`` over the tail of a series still equals the true max
+    whenever that max is inside the window), but it DROPS every instrument whose
+    last bar predates the window, and dropped instruments do not vote.
+
+    So the windowed mode differs from the true one exactly when the dropped set
+    could outvote it. ``universe_size - seen`` is an upper bound on that set, and
+    if it is no larger than ``modal_count`` then no date outside the window can
+    beat the mode even if every dropped instrument shares one. The comparison is
+    ``<=`` and not ``<`` because an exact tie breaks on the LATER date, which is
+    the in-window one — the same rule ``modal_bar_date`` applies.
+
+    ⚠ Caught by Codex at checkpoint 2 on #2809, not by any test: with most of the
+    universe stale and a minority freshly refreshed, the windowed mode is the
+    minority's date while a scan run now would choose the stale majority's — so
+    the card would call a scan sitting exactly on the frontier ``stale``, which
+    is the very defect #2809 fixed, reintroduced by its own optimisation.
+
+    False here is not an error. It says the cheap read is not decisive, so the
+    caller must pay for the full distribution.
+    """
+    return universe_size - seen <= modal_count
+
+
 def write_window_indices(dates: Sequence[date], *, watermark: date | None, frontier: date) -> range:
     """The bar indices this run may write for one instrument.
 
@@ -1047,5 +1076,6 @@ __all__ = [
     "modal_bar_date",
     "read_watermarks",
     "run_signal_scan",
+    "window_decides_the_mode",
     "write_window_indices",
 ]

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -221,9 +221,32 @@ def choose_frontier(last_bars: Mapping[int, date]) -> Frontier | None:
     """
     if not last_bars:
         return None
-    counts = Counter(last_bars.values())
-    bar_date, modal_count = max(counts.items(), key=lambda item: (item[1], item[0]))
+    modal = modal_bar_date(Counter(last_bars.values()))
+    if modal is None:
+        return None
+    bar_date, modal_count = modal
     return Frontier(bar_date=bar_date, modal_count=modal_count, loadable=len(last_bars))
+
+
+def modal_bar_date(counts: Mapping[date, int]) -> tuple[date, int] | None:
+    """``(modal last bar, how many instruments sit on it)`` — the rule, alone.
+
+    Split out of ``choose_frontier`` so a reader that already holds the
+    distribution — the ``/strategies/overview`` freshness bar, which reads it
+    from ``load_recent_last_bar_counts`` rather than paying for every
+    instrument's span — applies the SAME tie-break instead of a second copy.
+
+    ⚠ That second copy is what #2809 was: the card compared this frontier against
+    ``MAX(research_price_series.last_bar)`` — a different table, a different
+    statistic and a different population — and reported all 10 strategies
+    ``stale`` while every one of them sat exactly on the frontier. A ``max`` is
+    forbidden HERE (module docstring item 2) and re-importing it through a
+    reader's own SQL is the same error at one remove.
+    """
+    if not counts:
+        return None
+    bar_date, modal_count = max(counts.items(), key=lambda item: (item[1], item[0]))
+    return bar_date, modal_count
 
 
 def write_window_indices(dates: Sequence[date], *, watermark: date | None, frontier: date) -> range:
@@ -1021,6 +1044,7 @@ __all__ = [
     "assert_census_complete",
     "choose_frontier",
     "log_report",
+    "modal_bar_date",
     "read_watermarks",
     "run_signal_scan",
     "write_window_indices",

--- a/tests/test_2809_scan_freshness_basis.py
+++ b/tests/test_2809_scan_freshness_basis.py
@@ -1,0 +1,148 @@
+"""The scan card's freshness bar is the frontier a scan would choose (#2809).
+
+Pure (no Postgres). The defect: ``scan.status`` compared the stored scan frontier
+against ``MAX(last_bar) FROM research_price_series`` — a different table, a
+different statistic and a different population — and reported all 10 strategies
+``stale`` while every one of them sat exactly on the frontier.
+
+Measured on dev at the fix: the frontier a scan would choose was 2026-08-19
+(modal 5,819 of 6,584 loadable); ``MAX(research_price_series.last_bar)`` was
+2026-08-20, held by ONE row — CBOE VIX, series_id 7728 — while the next-newest
+series in that archive ended 2026-07-08. ``max(price_daily.price_date)`` was also
+2026-08-20, held by 1,563 rows of an in-flight ``daily_candle_refresh`` against
+~11,000 on each completed day: the refresh-in-flight case the modal rule exists
+to survive.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from collections import Counter
+from datetime import date, timedelta
+
+from app.api.strategies import _CORPUS_FRESHNESS_WINDOW, _corpus_frontier, get_strategy_overview
+from app.services.price_masked_bars import _LAST_BAR_SQL, _RECENT_LAST_BAR_COUNTS_SQL
+from app.services.strategy_signal_scan import choose_frontier, modal_bar_date
+
+
+def _calls_in(func: object) -> set[str]:
+    """Every plain function name called in ``func``'s body."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))  # type: ignore[arg-type]
+    return {
+        node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+
+
+class TestOneTieBreakRule:
+    """``modal_bar_date`` is the rule; ``choose_frontier`` is one of its callers."""
+
+    def test_the_card_and_the_scanner_break_ties_identically(self) -> None:
+        """The whole point of extracting it: two copies is how #2809 happened.
+
+        A tie must resolve to the LATER date on both sides, or a corpus split
+        evenly between two sessions makes the card disagree with the scan that
+        wrote the row it is describing.
+        """
+        last_bars = {1: date(2026, 8, 18), 2: date(2026, 8, 19)}
+        frontier = choose_frontier(last_bars)
+        assert frontier is not None
+        assert modal_bar_date(Counter(last_bars.values())) == (frontier.bar_date, frontier.modal_count)
+        assert frontier.bar_date == date(2026, 8, 19)
+
+    def test_modal_not_max_on_the_distribution_the_card_reads(self) -> None:
+        """The refresh-in-flight shape, as counts rather than per-instrument.
+
+        The live numbers at the fix: 5,819 instruments last traded 2026-08-19 and
+        1,563 carried a partial 2026-08-20 written by a refresh that was still
+        running. A ``max`` calls the corpus fresh at 08-20 and every scan stale;
+        the mode calls it 08-19, which is what a scan run then would evaluate.
+        """
+        assert modal_bar_date({date(2026, 8, 19): 5819, date(2026, 8, 20): 1563}) == (date(2026, 8, 19), 5819)
+
+    def test_empty_distribution_is_none_not_an_exception(self) -> None:
+        assert modal_bar_date({}) is None
+
+
+class TestTheFreshnessBarIsTheScannersOwnStatistic:
+    """Structural: both sides of the comparison must route through one rule."""
+
+    def test_the_card_reads_the_scan_population_through_the_scan_rule(self) -> None:
+        """``_corpus_frontier`` must use the scanner's universe AND its tie-break.
+
+        Asserted structurally rather than by value because the failure is silent:
+        a freshness bar computed off a different population still returns a
+        plausible date, and the card renders it without complaint. That is
+        exactly how ``MAX(last_bar) FROM research_price_series`` survived — it
+        answered, and the answer was about a corpus nothing on this card reads.
+        """
+        calls = _calls_in(_corpus_frontier)
+        assert "load_validated_universe" in calls, (
+            "the freshness bar must be measured over the population the scan is scored on"
+        )
+        assert "load_recent_last_bar_counts" in calls, (
+            "the freshness bar must read price_daily through the masked predicate, not another corpus"
+        )
+        assert "modal_bar_date" in calls, (
+            "the freshness bar must break ties the way the scanner does — a second copy is #2809"
+        )
+
+    def test_the_overview_no_longer_reads_a_max_over_the_research_archive(self) -> None:
+        """Retarget this guard rather than deleting it if the source moves."""
+        source = inspect.getsource(get_strategy_overview)
+        assert "research_price_series" not in source, (
+            "the scan card's freshness bar must not come from the backtest archive (#2809)"
+        )
+        assert "_corpus_frontier(" in source, "get_strategy_overview no longer computes a freshness bar"
+
+
+class TestTheBoundedQueryKeepsTheMaskedPopulation:
+    """The bound may shorten the window; it must not widen the population.
+
+    ``price_masked_bars``' own docstring makes the mirror the discipline —
+    *"the SQL is mirrored field for field rather than shared — and the mirror is
+    checkable"*. Checking it is what stops the cheap query from quietly counting
+    bars the fail-closed loader never returns, which would be defect (3) of #2809
+    (wrong population) reintroduced by the fix for defects (1) and (2).
+    """
+
+    def test_it_carries_the_same_coverage_predicate_as_the_span_query(self) -> None:
+        for clause in (
+            "JOIN price_quarantine_coverage cov",
+            "cov.instrument_id = d.instrument_id",
+            "cov.rule_set_version = %(quarantine_version)s",
+            "d.price_date BETWEEN cov.first_bar AND cov.last_bar",
+            "d.instrument_id = ANY(%(instrument_ids)s)",
+        ):
+            assert clause in _LAST_BAR_SQL, f"{clause!r} left the span query — retarget this mirror"
+            assert clause in _RECENT_LAST_BAR_COUNTS_SQL, (
+                f"{clause!r} is missing from the freshness query, which would count bars the "
+                "masked loader never returns (#2809)"
+            )
+
+    def test_only_the_freshness_query_is_bounded(self) -> None:
+        """The bound is sound for a freshness bar and wrong for the scan's own
+        eligibility: an instrument with no bar in the window cannot be the
+        freshest date the corpus reached, but it is still a universe member the
+        scan must account for."""
+        assert "%(since)s" in _RECENT_LAST_BAR_COUNTS_SQL
+        assert "%(since)s" not in _LAST_BAR_SQL
+
+
+class TestTheWindowIsWideEnoughForAClosedMarket:
+    """The bound is by construction, so its construction is the assertion."""
+
+    def test_the_window_outlasts_the_longest_exchange_closure(self) -> None:
+        """Four sessions (9/11) plus the weekends either side is ~9 days.
+
+        A window that a holiday week can empty turns a shut market into a stale
+        corpus, which is the false-alarm direction — and a card that cries wolf
+        is how the real #2803 staleness signal would be dismissed.
+        """
+        longest_closure = timedelta(days=4 + 2 + 2 + 1)
+        assert _CORPUS_FRESHNESS_WINDOW >= longest_closure
+
+    def test_the_window_is_short_enough_that_a_dead_refresh_still_reads_stale(self) -> None:
+        """The other side of the same choice: a month of silence must not pass."""
+        assert _CORPUS_FRESHNESS_WINDOW < timedelta(days=30)

--- a/tests/test_2809_scan_freshness_basis.py
+++ b/tests/test_2809_scan_freshness_basis.py
@@ -24,15 +24,13 @@ from datetime import date, timedelta
 
 from app.api.strategies import _CORPUS_FRESHNESS_WINDOW, _corpus_frontier, get_strategy_overview
 from app.services.price_masked_bars import _LAST_BAR_SQL, _RECENT_LAST_BAR_COUNTS_SQL
-from app.services.strategy_signal_scan import choose_frontier, modal_bar_date
+from app.services.strategy_signal_scan import choose_frontier, modal_bar_date, window_decides_the_mode
 
 
 def _calls_in(func: object) -> set[str]:
     """Every plain function name called in ``func``'s body."""
     tree = ast.parse(textwrap.dedent(inspect.getsource(func)))  # type: ignore[arg-type]
-    return {
-        node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-    }
+    return {node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)}
 
 
 class TestOneTieBreakRule:
@@ -95,6 +93,53 @@ class TestTheFreshnessBarIsTheScannersOwnStatistic:
             "the scan card's freshness bar must not come from the backtest archive (#2809)"
         )
         assert "_corpus_frontier(" in source, "get_strategy_overview no longer computes a freshness bar"
+
+
+class TestTheWindowedReadKnowsWhenItCannotAnswer:
+    """Codex checkpoint 2 on #2809: the optimisation can change the answer.
+
+    Bounding the last-bar query drops every instrument whose last bar predates
+    the window, and dropped instruments do not vote. With most of the universe
+    stale and a minority freshly refreshed, the windowed mode is the minority's
+    date while a scan run now would choose the stale majority's — the card would
+    then call a scan sitting exactly on the frontier ``stale``, which is #2809
+    reintroduced by its own fix.
+    """
+
+    def test_the_live_shape_is_decisive(self) -> None:
+        """6,773 in the universe, 5,819 on the mode: the dropped set cannot win."""
+        assert window_decides_the_mode(modal_count=5819, seen=6584, universe_size=6773)
+
+    def test_a_fresh_minority_over_a_stale_majority_is_not_decisive(self) -> None:
+        """The case Codex named, and the one the old code answered wrongly."""
+        assert not window_decides_the_mode(modal_count=800, seen=1000, universe_size=6773)
+
+    def test_the_boundary_is_a_tie_and_a_tie_goes_to_the_later_date(self) -> None:
+        """``<=`` not ``<``.
+
+        With the dropped set exactly the size of the mode, the worst case is a
+        tie — and ``modal_bar_date`` breaks ties on the later date, which is the
+        in-window one. So the windowed answer still stands.
+        """
+        assert window_decides_the_mode(modal_count=100, seen=900, universe_size=1000)
+        assert not window_decides_the_mode(modal_count=100, seen=899, universe_size=1000)
+        assert modal_bar_date({date(2026, 8, 19): 100, date(2026, 8, 18): 100}) == (date(2026, 8, 19), 100)
+
+    def test_seeing_nothing_is_never_decisive(self) -> None:
+        assert not window_decides_the_mode(modal_count=0, seen=0, universe_size=6773)
+
+    def test_the_endpoint_falls_back_rather_than_answering_from_the_window(self) -> None:
+        """Structural: an undecisive window must reach the full distribution.
+
+        The failure is silent — a windowed mode is a plausible date whether or
+        not it is the right one — so the fallback is asserted rather than
+        reasoned about.
+        """
+        calls = _calls_in(_corpus_frontier)
+        assert "window_decides_the_mode" in calls, "the windowed read must check that it is decisive"
+        assert {"load_bar_spans", "choose_frontier"} <= calls, (
+            "an undecisive window must fall back to the scanner's own unbounded distribution"
+        )
 
 
 class TestTheBoundedQueryKeepsTheMaskedPopulation:


### PR DESCRIPTION
`/strategies/overview` reported `scan.status = "stale"` for all 10 strategies while every one of them sat **exactly** on the frontier a scan run at that moment would choose. The freshness bar was measured against a different corpus with a statistic the scanner explicitly forbids.

Closes #2809. Follows #2803 and #2806, which were the same family — a verdict keyed on a basis the producer never writes — on the version identity rather than the corpus date.

## The defect

`app/api/strategies.py` compared the stored scan frontier against:

```python
_LATEST_CORPUS_SQL = "SELECT MAX(last_bar) FROM research_price_series"
```

Wrong three ways at once:

| | what the scan does | what the card did |
| --- | --- | --- |
| table | `price_daily`, through the quarantine-masked predicate | `research_price_series`, the backtest archive |
| statistic | **modal** last bar (`choose_frontier`) | **max** |
| population | the validated universe | the whole archive |

The statistic is not a preference. `app/services/strategy_signal_scan.py`'s module docstring, item 2:

> **The frontier is the MODAL last bar, never `max(price_date)`.** On the day of measurement 7 instruments carried a bar the other 5,783 did not; keying on the maximum manufactures thousands of terminal refusals out of a refresh still in flight.

The card re-imported that forbidden max through the back door, from a second corpus.

## Measured on dev, 2026-08-21

```
frontier a scan would choose now  : 2026-08-19  (modal 5,819 of 6,584 loadable, universe 6,773)
strategy_scan_watermark, all 10   : 2026-08-19  (written 00:38Z that day)
MAX(research_price_series.last_bar): 2026-08-20  — ONE row: series_id 7728, vendor 'cboe', symbol 'VIX'
```

`select last_bar, count(*) from research_price_series group by 1 order by 1 desc limit 3` → `(2026-08-20, 1), (2026-07-08, 1018), (2026-07-07, 3191)`. A single VIX row on its own refresh path set the freshness bar for every strategy card.

The `price_daily` side shows the same shape from the other direction:

```
price_date  rows
2026-08-18  11,014
2026-08-19  11,004
2026-08-20   1,563   <- daily_candle_refresh run 111693 still RUNNING
```

`max(price_daily.price_date)` was also 2026-08-20 — held by a **partial, in-flight refresh**, which is precisely the case the modal rule exists to survive.

## The fix

`_corpus_frontier` reads the scan's own population (`load_validated_universe`, masked predicate) and applies the scanner's own tie-break. That tie-break is now `modal_bar_date`, extracted from `choose_frontier` so there is **one rule with two callers** rather than two copies — two copies being how this happened. `current` now means "the stored scan sits on the frontier a new run would pick".

### The cost, and what it forced

The old comment justified the archive read as an optimisation — *"avoids a full scan of the multi-million-row bar corpus on every Strategies page load"* — and that cost is real. Measured here:

| variant | latency | answer |
| --- | --- | --- |
| `load_bar_spans` + `choose_frontier` (full) | 0.60s | 2026-08-19 |
| the same as one SQL, unbounded | 0.53s | 2026-08-19 |
| bounded to `price_date >= today - 10d` | **0.036s** | 2026-08-19 |

The endpoint answers in 30-66ms, so the unbounded form is a 10-20x regression. `_CORPUS_FRESHNESS_WINDOW` is 10 days, fixed **by construction** and stated as such (no published rule exists): it must outlast the longest exchange closure — four sessions (9/11) plus the weekends either side is ~9 calendar days — while staying far short of the ~30 days at which a genuinely dead refresh would still look alive.

### Codex checkpoint 2 found the optimisation could change the answer

[P1] The bound drops every instrument whose last bar predates the window, and dropped instruments do not vote. With most of the universe stale and a minority freshly refreshed, the windowed mode is the minority's date while a scan run now would choose the stale majority's — the card would then call a scan sitting exactly on the frontier `stale`, i.e. this very defect reintroduced by its own fix.

Resolved with a certificate rather than by dropping the optimisation. The bound cannot *corrupt* an instrument's last bar (a `max` over the tail of a series still equals the true max whenever that max is inside the window), so divergence needs the dropped set to outvote the surviving mode. `universe_size - seen` bounds the dropped set, so:

```python
def window_decides_the_mode(*, modal_count, seen, universe_size) -> bool:
    return universe_size - seen <= modal_count
```

When true, no date outside the window can beat the mode even if every dropped instrument shares one, and the windowed answer is *provably* the unbounded one. `<=` and not `<` because an exact tie breaks on the later date, which is the in-window one — the same rule `modal_bar_date` applies. When false, `_corpus_frontier` falls back to `load_bar_spans` + `choose_frontier` and pays the 0.60s.

Live: universe 6,773, seen 5,830, modal 5,819 → decisive, and the windowed answer equals the unbounded one, at 47-66ms.

Codex re-review after the change: *"consistently uses the scanner's validated, quarantine-masked population and modal frontier rule, with a sound fallback when the bounded query is inconclusive. No actionable correctness defects were identified."*

## Behaviour change

`scan.status` flips from `stale` to `current` for all 10 strategies on the current dev corpus. `never_run` / `rotated` are untouched — they are decided before the freshness bar is consulted. The `latest_corpus_date is None` path (nothing in the window and the fallback also finds nothing) still reads `stale`, unchanged.

## Tests

`tests/test_2809_scan_freshness_basis.py`, pure (no Postgres). Every guard revert-probed:

| probe | result |
| --- | --- |
| `_corpus_frontier` reverted to `MAX(...) FROM research_price_series` | fails: *"the freshness bar must be measured over the population the scan is scored on"* |
| `since` bound dropped from the freshness query | fails on the bound assertion |
| quarantine-coverage predicate dropped from the freshness query | fails: *"would count bars the masked loader never returns"* |
| window narrowed to 5 days | fails the closure-length assertion |

Plus the tie-break equality between `modal_bar_date` and `choose_frontier`, the certificate's boundary (tie decisive, one fewer not), and a mirror check that the new SQL carries the same coverage predicate as `_LAST_BAR_SQL` — the "wrong population" leg of the defect, which the fix for the other two legs could otherwise have reintroduced.

## Security

No security surface. Read-only endpoint change; no new input reaches SQL (`instrument_ids` and `since` are parameterised, `since` is server-derived from `datetime.now(tz=UTC)`), no authorisation boundary touched.

## Verification

| clause | evidence |
| --- | --- |
| local gates at `6379842a` | ruff / ruff format / pyright / `pytest -m "not db"` / `tests/smoke` all green |
| Codex ckpt-2 | one P1 found and fixed; re-review clean |
| dev-verify (live endpoint) | pending — recorded in a follow-up comment, since the API serves `~/Dev/eBull` and this branch must be checked out there |
