### PR TITLE
test(#2811): assert the card says never-asked instead of rendering a zero

### DIFF
--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -1186,6 +1186,30 @@ describe("StrategiesPage", () => {
     expect(screen.getByText(/Result version criterion7-v1/)).toBeInTheDocument();
   });
 
+  it("says a periodic strategy was never asked rather than showing it declined", async () => {
+    // #2811. S-2 and S-10 rebalance monthly and are `not_fired` on every bar that
+    // is not a rebalance date, so a version the scan has never carried to one has a
+    // denominator in the thousands and a numerator of zero. Rendering that as
+    // "0.00%" is a confident measured zero standing for a non-measurement — the
+    // live shape on 2026-08-21, where S-2 showed 0/3,277.
+    const uncovered = structuredClone(OVERVIEW);
+    const strategy = uncovered.strategies[0]!;
+    strategy.purpose = "harness_validation";
+    strategy.fire_rate.decision_days = 0;
+    strategy.fire_rate.fired_entry_signals = 0;
+    strategy.fire_rate.evaluable_entry_decisions = 0;
+    strategy.fire_rate.fired_share_of_evaluable = null;
+    strategy.fire_rate.share_unavailable_reason = "no_decision_date_scanned";
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(uncovered);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+
+    expect(await screen.findByText("No decision date scanned")).toBeInTheDocument();
+    // ⚠ The whole point: the misleading zero must be GONE, not merely accompanied.
+    expect(screen.queryByText("0.00%")).not.toBeInTheDocument();
+  });
+
   it("distinguishes a result version that never measured the hold from one that closed no trades", async () => {
     // The other branch of the same blank. `sql/347` permits a null median under
     // `criterion7-v2` ONLY when trade_count is 0, so under the current version an


### PR DESCRIPTION
Follow-up to #2812 (merged `c31841ca`). One test, one file.

## Why

#2811's operator-visible half is a *label*: S-2 and S-10 must read "No decision date
scanned" rather than `0.00%`. That was covered by the endpoint contract and by
`SHARE_UNAVAILABLE_LABELS` being a `Record<>` keyed on the union (so a missing label fails
typecheck) — but nothing asserted the **rendering**.

The FE-QA visual pass could not run this iteration: the Playwright browser launch timed out
at 180s under the load of backtest run 111610, which is still live. Rather than claim a
visual check I did not do, this covers the same ground with a test.

## What it asserts

The card renders "No decision date scanned", **and** that `0.00%` is *gone* — not merely
accompanied by a reason. The second half is the one that matters: the defect was never an
absent explanation, it was a confident zero standing in for a non-measurement.

## Evidence

Revert-probed. Restoring the pre-fix shape in the fixture (`fired_share_of_evaluable:
"0.0000"`, `share_unavailable_reason: null`) fails it:

```
TestingLibraryElementError: Unable to find an element with the text: No decision date scanned
Tests  1 failed | 40 skipped (41)
```

Restored → 41 passed. Frontend typecheck green.

⚠ This file is an **integration** test that `pnpm test:unit` excludes and CI's full `test`
script runs — which is exactly how the flake on #2812 surfaced. Run
`pnpm --dir frontend exec vitest run src/pages/StrategiesPage.test.tsx` when touching it.

## Security

Test-only diff. No runtime code, no new surface.

Refs #2811
