### PR TITLE
fix(#2807): pool a strategy's owned P&L across the versions it holds positions under

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -95,6 +95,7 @@ from app.services.strategy_monitoring import (
     load_entry_block_state,
     load_fire_rate,
     load_owned_pnl,
+    pool_owned_pnl_by_strategy,
     realised_pnl_for_keys,
 )
 from app.services.strategy_position_manager import (
@@ -1637,15 +1638,15 @@ def get_strategy_overview(
     # Current versions only: a strategy_version is a rule set, so pooling two
     # would average two arithmetics into one rate (#2670's lesson).
     fire_rate_by_strategy = load_fire_rate(conn, versions=scan_version_values)
-    # ⚠⚠ THE DEPLOYMENT VERSIONS STAY IN THE FILTER — they are NOT dead weight
-    # behind the single-key card lookup below. `realised_pnl_for_keys` reads this
-    # same dict at `paper_deployment_keys` for the capital base, and its own
-    # docstring is why: *"Old strategy versions remain part of the shared pot
-    # after they are retired; limiting this calculation to the current manifest
-    # would make realised gains or losses disappear from the capital base."*
-    # Dropping them would not raise — a missing key defaults to `StrategyPnl()`,
-    # whose `reconciled_realised_pnl` is 0 with no incomplete reason, so a
-    # deployed strategy's realised P&L would read as a confident zero.
+    # ⚠⚠ THE DEPLOYMENT VERSIONS STAY IN THE FILTER — `realised_pnl_for_keys`
+    # reads this same dict at `paper_deployment_keys` for the capital base, and
+    # its own docstring is why: *"Old strategy versions remain part of the shared
+    # pot after they are retired; limiting this calculation to the current
+    # manifest would make realised gains or losses disappear from the capital
+    # base."* Dropping them would not raise — a missing key defaults to
+    # `StrategyPnl()`, whose `reconciled_realised_pnl` is 0 with no incomplete
+    # reason, so a deployed strategy's realised P&L would read as a confident
+    # zero.
     #
     # ⚠ That the lookup succeeds at all also fixes the basis question here: the
     # rows are keyed by `strategy_signals.strategy_version`, so a deployment key
@@ -1653,6 +1654,11 @@ def get_strategy_overview(
     # carry — the scan basis. Untestable today at 0 deployment rows.
     scan_pnl_versions = sorted({*scan_version_values, *(version for _strategy_id, version in paper_deployment_keys)})
     pnl_by_strategy = load_owned_pnl(conn, versions=scan_pnl_versions)
+    # #2807: pooled per strategy, so a deployment held at a PRIOR scan version
+    # keeps its P&L on the card instead of only in the capital base. The pool is
+    # exactly `scan_pnl_versions` — current scan ∪ paper deployments — so the
+    # card's contribution and the capital base's are drawn from one set of rows.
+    pooled_pnl_by_strategy = pool_owned_pnl_by_strategy(pnl_by_strategy)
     control_by_strategy = load_control_state(conn, versions=version_values)
     entry_block = load_entry_block_state(conn)
     paper_pool = load_paper_pool(conn)
@@ -1806,11 +1812,11 @@ def get_strategy_overview(
         # A key absent from the census has never been scanned, which the default
         # `rate_unavailable_reason` states rather than reading as a zero rate.
         fire_rate = fire_rate_by_strategy.get(scan_key, StrategyFireRate())
-        # ⚠ ONE key, so a deployment held at a PRIOR scan version shows no P&L on
-        # the card even though `scan_pnl_versions` loaded it and the capital base
-        # counts it. Pre-existing and unchanged here — summing `StrategyPnl`
-        # across versions is a definitional change, tracked separately.
-        pnl = pnl_by_strategy.get(scan_key, StrategyPnl())
+        # ⚠ NOT keyed by version (#2807) — unlike `fire_rate` and `attribution`
+        # above, which stay single-version because a rate pools two arithmetics.
+        # Cash does not: a position opened before a rotation is still owned, so
+        # its dollars belong on the card as well as in the capital base.
+        pnl = pooled_pnl_by_strategy.get(strategy_id, StrategyPnl())
         control = control_by_strategy.get(key, StrategyControlState())
         allocation_refusals: list[str] = []
         if entry.purpose == "harness_validation":

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -807,6 +807,70 @@ def load_owned_pnl(conn: psycopg.Connection[Any], *, versions: Sequence[str]) ->
     return result
 
 
+def _pooled_cash(values: Sequence[Decimal | None]) -> Decimal | None:
+    """Sum cash across versions, propagating a single unknown to the whole pool.
+
+    ``None`` on a ``StrategyPnl`` cash field means *unreconcilable*, never zero —
+    each one is set exactly when a named ``incomplete_reason`` makes that figure
+    unknown. Treating it as zero would report a confident total built on a hole,
+    so one unknown part makes the pooled figure unknown.
+    """
+    if any(value is None for value in values):
+        return None
+    return sum((value for value in values if value is not None), Decimal("0"))
+
+
+def pool_owned_pnl_by_strategy(
+    pnl_by_strategy: dict[tuple[str, str], StrategyPnl],
+) -> dict[str, StrategyPnl]:
+    """Pool each strategy's owned P&L across every version it holds positions under.
+
+    A paper deployment stays at the ``strategy_version`` it was deployed on while
+    the live scan rotates to a new one, so reading the per-version dict at the
+    CURRENT scan key alone drops that deployment's P&L off its card even though
+    ``load_paper_realised_pnl`` still counts it in the capital base — the
+    asymmetry #2807 records. Dollars pool across rule sets in a way rates do not
+    (#2670: pooling two rates averages two arithmetics), so the counts and cash
+    sums add; ``complete`` and ``incomplete_reasons`` combine FAIL-CLOSED, as
+    ``all()`` and a set union, because a hole in any version is a hole in the
+    pooled figure.
+
+    Only versions the caller loaded can appear here: the pool is exactly the set
+    ``load_owned_pnl`` was asked for, not every version that ever existed.
+    """
+    grouped: dict[str, list[StrategyPnl]] = defaultdict(list)
+    for (strategy_id, _version), pnl in pnl_by_strategy.items():
+        grouped[strategy_id].append(pnl)
+
+    pooled: dict[str, StrategyPnl] = {}
+    for strategy_id, parts in grouped.items():
+        realised = _pooled_cash([part.realised_pnl for part in parts])
+        unrealised = _pooled_cash([part.unrealised_pnl for part in parts])
+        reasons: set[str] = set()
+        for part in parts:
+            reasons.update(part.incomplete_reasons)
+        pooled[strategy_id] = StrategyPnl(
+            strategy_trade_count=sum(part.strategy_trade_count for part in parts),
+            owned_position_count=sum(part.owned_position_count for part in parts),
+            active_position_count=sum(part.active_position_count for part in parts),
+            close_event_count=sum(part.close_event_count for part in parts),
+            invested_capital=_pooled_cash([part.invested_capital for part in parts]),
+            realised_pnl=realised,
+            unrealised_pnl=unrealised,
+            # Recomputed rather than summed, so the pooled row keeps the same
+            # total == realised + unrealised invariant each part was built with.
+            total_pnl=(realised + unrealised if realised is not None and unrealised is not None else None),
+            observed_fees=_pooled_cash([part.observed_fees for part in parts]),
+            complete=all(part.complete for part in parts),
+            incomplete_reasons=tuple(sorted(reasons)),
+            reconciled_realised_pnl=sum(
+                (part.reconciled_realised_pnl for part in parts),
+                Decimal("0"),
+            ),
+        )
+    return pooled
+
+
 def realised_pnl_for_keys(
     pnl_by_strategy: dict[tuple[str, str], StrategyPnl],
     keys: Sequence[tuple[str, str]],
@@ -986,4 +1050,5 @@ __all__ = [
     "load_entry_block_state",
     "load_fire_rate",
     "load_owned_pnl",
+    "pool_owned_pnl_by_strategy",
 ]

--- a/tests/test_2803_scan_card_version_basis.py
+++ b/tests/test_2803_scan_card_version_basis.py
@@ -16,6 +16,7 @@ import ast
 import inspect
 import re
 import textwrap
+from typing import get_type_hints
 
 from app.api import strategies as strategies_api
 from app.api.strategies import (
@@ -290,11 +291,57 @@ def test_every_loader_over_a_scan_relation_is_called_on_the_scan_basis() -> None
             )
 
 
+def _assert_read_through_a_version_collapsing_pool(
+    source: str,
+    holder: str,
+    scan_derived: frozenset[str],
+    result_derived: frozenset[str],
+) -> None:
+    """The second safe read shape: the version dimension is ERASED, not chosen (#2807).
+
+    ``load_owned_pnl``'s rows are no longer read one version at a time. A paper
+    deployment stays at the version it was deployed on while the live scan
+    rotates, so the card pools every version the strategy holds positions under —
+    there is then no version key to get wrong, which is a stronger property than
+    picking the right one.
+
+    That is only true while the pooling function really collapses the version, so
+    this asserts its RETURN TYPE rather than trusting its name: a bare ``str`` key
+    is a ``strategy_id``, and a tuple key would put the #2806 defect straight back
+    with a guard that no longer looks for it.
+    """
+    pooled = re.findall(rf"(\w+)\s*=\s*(\w+)\(\s*{holder}\s*\)", source)
+    assert pooled, (
+        f"{holder} is never read back — neither at a scan key nor through a pooling call that "
+        "takes it whole (#2806/#2807)"
+    )
+    for pooled_name, pooler_name in pooled:
+        pooler = getattr(strategy_monitoring, pooler_name, None)
+        assert pooler is not None, f"{pooler_name} is not a strategy_monitoring function"
+        returns = get_type_hints(pooler)["return"]
+        assert returns == dict[str, strategy_monitoring.StrategyPnl], (
+            f"{pooler_name} returns {returns!r}, so it does not collapse the version dimension — "
+            "a pooled read is only basis-safe while the key is a bare strategy_id (#2807)"
+        )
+        lookups = re.findall(rf"\b{pooled_name}\.get\(\s*(\w+)", source)
+        assert lookups, f"{pooled_name} is never read back"
+        for lookup_key in lookups:
+            assert lookup_key not in scan_derived and lookup_key not in result_derived, (
+                f"{pooled_name} holds one row per strategy but is read at {lookup_key!r}, which "
+                "carries a version basis — the pooled dict has no version key (#2807)"
+            )
+
+
 def test_the_scan_basis_loaders_are_read_back_at_the_scan_key() -> None:
     """Rebinding the query is only half the fix, and the halves fail identically.
 
     Both a result-basis filter and a result-basis dict lookup produce an empty
     card, so fixing one and not the other looks exactly like fixing neither.
+
+    Two read shapes are safe, and a loader must use one of them: per-version at a
+    scan-derived key, or pooled through a call that erases the version entirely
+    (#2807). Neither branch is an exemption — the pooled one carries its own
+    assertions in the helper above.
     """
     source = inspect.getsource(get_strategy_overview)
     scan_derived, result_derived = _the_two_bases_as_named_in(source)
@@ -303,7 +350,9 @@ def test_the_scan_basis_loaders_are_read_back_at_the_scan_key() -> None:
         assert assigned, f"{name} result is not bound to a name in get_strategy_overview"
         for holder in assigned:
             lookups = re.findall(rf"\b{holder}\.get\(\s*(\w+)", source)
-            assert lookups, f"{holder} is never read back"
+            if not lookups:
+                _assert_read_through_a_version_collapsing_pool(source, holder, scan_derived, result_derived)
+                continue
             for lookup_key in lookups:
                 assert lookup_key in scan_derived and lookup_key not in result_derived, (
                     f"{holder} holds rows keyed by the scan basis but is read at {lookup_key!r}, "

--- a/tests/test_2807_pooled_owned_pnl.py
+++ b/tests/test_2807_pooled_owned_pnl.py
@@ -88,10 +88,12 @@ def test_cash_and_counts_add_across_two_versions() -> None:
         }
     )["s5-support-bounce"]
 
-    assert pooled.realised_pnl == Decimal("30")
-    assert pooled.unrealised_pnl == Decimal("7.50")
+    realised, unrealised = pooled.realised_pnl, pooled.unrealised_pnl
+    assert realised is not None and unrealised is not None
+    assert realised == Decimal("30")
+    assert unrealised == Decimal("7.50")
     assert pooled.total_pnl == Decimal("37.50")
-    assert pooled.total_pnl == pooled.realised_pnl + pooled.unrealised_pnl
+    assert pooled.total_pnl == realised + unrealised
     assert pooled.invested_capital == Decimal("400")
     assert pooled.observed_fees == Decimal("2.00")
     assert pooled.strategy_trade_count == 4

--- a/tests/test_2807_pooled_owned_pnl.py
+++ b/tests/test_2807_pooled_owned_pnl.py
@@ -1,0 +1,181 @@
+"""#2807 — a strategy's owned P&L pools across the versions it holds positions under.
+
+Pure-logic tests over `pool_owned_pnl_by_strategy`. The defect is latent on dev
+(0 `strategy_deployments` rows, 0 allocated `strategy_funding_decisions`), so a
+full-population A/B of the endpoint is a 0 → 0 no-op and seeded inputs are the
+only evidence available. See the module docstring on
+`pool_owned_pnl_by_strategy` for the combination rule these pin.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.services.strategy_monitoring import (
+    StrategyPnl,
+    pool_owned_pnl_by_strategy,
+    realised_pnl_for_keys,
+)
+
+
+def _pnl(
+    *,
+    realised: Decimal | None = Decimal("0"),
+    unrealised: Decimal | None = Decimal("0"),
+    invested: Decimal | None = Decimal("0"),
+    fees: Decimal | None = Decimal("0"),
+    trades: int = 0,
+    owned: int = 0,
+    active: int = 0,
+    closes: int = 0,
+    reasons: tuple[str, ...] = (),
+    reconciled: Decimal = Decimal("0"),
+) -> StrategyPnl:
+    total = realised + unrealised if realised is not None and unrealised is not None else None
+    return StrategyPnl(
+        strategy_trade_count=trades,
+        owned_position_count=owned,
+        active_position_count=active,
+        close_event_count=closes,
+        invested_capital=invested,
+        realised_pnl=realised,
+        unrealised_pnl=unrealised,
+        total_pnl=total,
+        observed_fees=fees,
+        complete=not reasons,
+        incomplete_reasons=reasons,
+        reconciled_realised_pnl=reconciled,
+    )
+
+
+def test_no_owned_rows_pools_to_no_key_at_all() -> None:
+    """An absent key is what the card reads as never-owned; do not mint a zero row."""
+    assert pool_owned_pnl_by_strategy({}) == {}
+
+
+def test_a_single_version_pools_to_itself_unchanged() -> None:
+    """The common case must not drift: one version in, byte-identical value out."""
+    only = _pnl(realised=Decimal("12.50"), unrealised=Decimal("-3"), invested=Decimal("100"), trades=2, owned=2)
+    assert pool_owned_pnl_by_strategy({("s5-support-bounce", "v1"): only}) == {"s5-support-bounce": only}
+
+
+def test_cash_and_counts_add_across_two_versions() -> None:
+    """The deployment's dollars and the current scan's are one pot (#2807)."""
+    pooled = pool_owned_pnl_by_strategy(
+        {
+            ("s5-support-bounce", "deployed-v1"): _pnl(
+                realised=Decimal("40"),
+                unrealised=Decimal("5"),
+                invested=Decimal("300"),
+                fees=Decimal("1.25"),
+                trades=3,
+                owned=3,
+                active=1,
+                closes=2,
+                reconciled=Decimal("40"),
+            ),
+            ("s5-support-bounce", "current-v2"): _pnl(
+                realised=Decimal("-10"),
+                unrealised=Decimal("2.50"),
+                invested=Decimal("100"),
+                fees=Decimal("0.75"),
+                trades=1,
+                owned=1,
+                active=1,
+                closes=1,
+                reconciled=Decimal("-10"),
+            ),
+        }
+    )["s5-support-bounce"]
+
+    assert pooled.realised_pnl == Decimal("30")
+    assert pooled.unrealised_pnl == Decimal("7.50")
+    assert pooled.total_pnl == Decimal("37.50")
+    assert pooled.total_pnl == pooled.realised_pnl + pooled.unrealised_pnl
+    assert pooled.invested_capital == Decimal("400")
+    assert pooled.observed_fees == Decimal("2.00")
+    assert pooled.strategy_trade_count == 4
+    assert pooled.owned_position_count == 4
+    assert pooled.active_position_count == 2
+    assert pooled.close_event_count == 3
+    assert pooled.reconciled_realised_pnl == Decimal("30")
+    assert pooled.complete is True
+    assert pooled.incomplete_reasons == ()
+
+
+def test_one_unknown_version_makes_only_that_figure_unknown() -> None:
+    """`None` is unreconcilable, never zero — it poisons its own pooled sum and no other."""
+    pooled = pool_owned_pnl_by_strategy(
+        {
+            ("s6-resistance-breakout", "deployed-v1"): _pnl(
+                realised=None,
+                invested=Decimal("300"),
+                reasons=("realised_pnl_missing_from_history",),
+            ),
+            ("s6-resistance-breakout", "current-v2"): _pnl(realised=Decimal("25"), invested=Decimal("100")),
+        }
+    )["s6-resistance-breakout"]
+
+    assert pooled.realised_pnl is None
+    assert pooled.total_pnl is None
+    # The unrelated figures stay known: both parts reconciled their capital.
+    assert pooled.invested_capital == Decimal("400")
+    assert pooled.unrealised_pnl == Decimal("0")
+
+
+def test_completeness_fails_closed_and_reasons_union() -> None:
+    """One hole in one version is a hole in the pooled card, with every reason named."""
+    pooled = pool_owned_pnl_by_strategy(
+        {
+            ("s7-trend-pullback", "deployed-v1"): _pnl(
+                unrealised=None,
+                reasons=("active_position_mark_unavailable", "trade_not_reconciled_to_position"),
+            ),
+            ("s7-trend-pullback", "current-v2"): _pnl(
+                unrealised=None,
+                reasons=("active_position_mark_unavailable",),
+            ),
+        }
+    )["s7-trend-pullback"]
+
+    assert pooled.complete is False
+    assert pooled.incomplete_reasons == (
+        "active_position_mark_unavailable",
+        "trade_not_reconciled_to_position",
+    )
+
+
+def test_versions_of_different_strategies_never_pool_together() -> None:
+    pooled = pool_owned_pnl_by_strategy(
+        {
+            ("s5-support-bounce", "v1"): _pnl(realised=Decimal("10"), reconciled=Decimal("10")),
+            ("s6-resistance-breakout", "v1"): _pnl(realised=Decimal("99"), reconciled=Decimal("99")),
+        }
+    )
+    assert pooled["s5-support-bounce"].realised_pnl == Decimal("10")
+    assert pooled["s6-resistance-breakout"].realised_pnl == Decimal("99")
+
+
+def test_card_matches_the_capital_base_after_a_rotation() -> None:
+    """The ticket's acceptance: one dict, two consumers, one figure.
+
+    Before the fix the card read a single key — the CURRENT scan version — and so
+    reported `StrategyPnl()` for a deployment left behind at a prior version,
+    while `realised_pnl_for_keys` still counted that same deployment in the
+    capital base.
+    """
+    deployment_key = ("s5-support-bounce", "deployed-v1")
+    current_key = ("s5-support-bounce", "current-v2")
+    pnl_by_strategy = {
+        deployment_key: _pnl(realised=Decimal("40"), trades=1, owned=1, closes=1, reconciled=Decimal("40")),
+        current_key: _pnl(realised=Decimal("0"), reconciled=Decimal("0")),
+    }
+
+    capital_base = realised_pnl_for_keys(pnl_by_strategy, [deployment_key])
+    assert capital_base is not None
+
+    card = pool_owned_pnl_by_strategy(pnl_by_strategy)["s5-support-bounce"]
+    assert card.reconciled_realised_pnl == sum(capital_base.values())
+    assert card.realised_pnl == Decimal("40")
+    # And the pre-fix read is what it replaced: the current key alone is blind.
+    assert pnl_by_strategy[current_key].realised_pnl == Decimal("0")


### PR DESCRIPTION
## What changed

A paper deployment's owned P&L vanished from its `/strategies/overview` card the moment the scan version rotated, while the same P&L stayed counted in the capital base. `load_owned_pnl` returns rows keyed by `strategy_signals.strategy_version` and was read at a **single** key — `scan_key`, the current scan version — so a position opened before a rotation was orphaned from its own card.

- `app/services/strategy_monitoring.py::pool_owned_pnl_by_strategy` — pools a strategy's `StrategyPnl` across every version the caller loaded.
- `app/api/strategies.py` — the card reads the pooled dict at `strategy_id`. `realised_pnl_for_keys` still reads the per-version dict at `paper_deployment_keys` for the capital base, unchanged.

## The combination rule (the actual design decision)

The ticket left this open; it is fixed here as:

| field | rule | why |
| --- | --- | --- |
| counts (`strategy_trade_count`, `owned_position_count`, `active_position_count`, `close_event_count`) | sum | disjoint per version |
| cash (`invested_capital`, `realised_pnl`, `unrealised_pnl`, `observed_fees`) | sum, but **`None` if any part is `None`** | `None` means *unreconcilable*, never zero — one unknown makes the pooled figure unknown, and poisons only its own sum |
| `total_pnl` | recomputed from the pooled realised + unrealised | keeps the `total == realised + unrealised` invariant each part was built with |
| `complete` | `all()` | fail-closed |
| `incomplete_reasons` | sorted set union | every reason survives, de-duplicated |
| `reconciled_realised_pnl` | sum | always a `Decimal` |

Dollars pool across rule sets in a way rates do not, so #2670's *"pooling two would average two arithmetics into one rate"* does not bar this — and `load_fire_rate` and `load_attribution` deliberately stay single-version for exactly that reason.

Scope note: `strategy_live_gate.py` also calls `load_owned_pnl`, at `versions=[strategy_version]` for the one version being promoted. That is per-version evidence for that version's own paper record and is correctly single-key; unchanged.

## Evidence

Measured on dev before the change:

| quantity | value |
| --- | --- |
| `strategy_deployments` rows | **0** |
| `strategy_funding_decisions` where `verdict='allocated'` | **0** |
| `strategy_scan_watermark` rows / distinct strategies / distinct versions | **28 / 10 / 28** |
| rotations on the busiest strategies | **4** each for s2, s4, s5, s6 |

So the defect is **latent, not live**, and a full-population A/B is a 0 → 0 no-op: with no allocated funding decision, `_OWNED_LIFECYCLE_SQL` returns no rows on either read. Exercised against the real dev DB at `1130dc9b` — `load_owned_pnl` 0 keys → `pool_owned_pnl_by_strategy` 0 keys, so the live card is byte-identical today. The 28-versions-over-10-strategies figure is why it will bite: any position opened before a rotation is orphaned the moment one happens.

Seeded inputs are therefore the only available evidence, in `tests/test_2807_pooled_owned_pnl.py` (7 pure tests, fast tier): single-version identity, two-version pooling, unknown-poisons-only-its-own-sum, fail-closed completeness with reason union, cross-strategy isolation, and the ticket's acceptance — the pooled card equals what `realised_pnl_for_keys` contributes to the capital base for the same dict.

## The #2806 guard was retargeted, not weakened

`test_the_scan_basis_loaders_are_read_back_at_the_scan_key` requires every scan-relation loader's holder to be read at a scan-derived key, and it caught this change. It now admits a second read shape — the holder consumed whole by a call that **erases** the version dimension — and proves the erasure from the pooling function's return type rather than its name: `dict[str, StrategyPnl]` has a bare `strategy_id` key and is structurally incapable of carrying the wrong version.

Both branches revert-probed at `1130dc9b`:

- read the pooled dict at `scan_key` → `AssertionError: pooled_pnl_by_strategy holds one row per strategy but is read at 'scan_key', which carries a version basis`
- change the pooler's return to `dict[tuple[str, str], StrategyPnl]` → `AssertionError: ... does not collapse the version dimension`

## No version bump

Per the #2670 prevention entry, a version stamp answers "under which rules was this object judged". Nothing here is stamped or stored: `StrategyPnl` is a read model assembled per request, no promotion gate or persisted row changes, and `StrategyIdentity` is untouched. Deliberately so — a running backtest (`job_runs` 111610) is producing results at the current versions.

## Security

No new input surface, no auth or authorisation change, no SQL modified — `_OWNED_LIFECYCLE_SQL` is unchanged and still parameterised. The endpoint's existing session dependency is untouched.

## Local gates

`ruff check` · `ruff format --check` · `pyright` · `pytest -m "not db"` · `pytest tests/smoke` — all pass. Codex checkpoint 2 (`review --base origin/main`): no findings.

Incidental, not fixed here and not ticketed per the loop's standing order: the `db` tier of `tests/test_strategy_monitoring.py` fails in this environment with `etoro_instrument_types.description = 'Stocks' resolved to 0 rows` — the test Postgres has no validated-universe anchor. Confirmed **pre-existing** by running the same test in a detached worktree at `origin/main`, where it fails identically.

Closes #2807
Refs #2806
