### PR TITLE
feat(#2817): surface per-regime result cohorts on the strategies overview

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -286,10 +286,10 @@ class ResultRegimeCohort(BaseModel):
     expectancy_ci_high_pct: Decimal | None
     profit_factor: Decimal | None
     worst_trade_pct: Decimal
+    # ⚠ NULL AS A GROUP, never singly: `RegimeCohort.__post_init__` refuses a
+    # partially-populated bootstrap, so a null CI and a null effective sample
+    # mean "this cohort was not bootstrapped", not "one number went missing".
     effective_sample_size: Decimal | None
-    # Ships with the interval it produced, so a null CI reads as "not
-    # bootstrapped" rather than as a missing number under an unnamed model.
-    bootstrap_model_id: str | None
 
 
 class ResultArm(BaseModel):
@@ -1360,8 +1360,7 @@ _REGIME_COHORTS_SQL = """
         expectancy_ci_high_pct,
         profit_factor,
         worst_trade_pct,
-        effective_sample_size,
-        bootstrap_model_id
+        effective_sample_size
     FROM strategy_result_regime_cohorts
     WHERE result_id = ANY(%(result_ids)s::bigint[])
 """

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -7,7 +7,7 @@ from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from typing import Any, Literal, cast
+from typing import Any, Final, Literal, cast, get_args
 
 import psycopg
 import psycopg.rows
@@ -103,6 +103,7 @@ from app.services.strategy_position_manager import (
     manage_owned_position,
 )
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+from app.services.strategy_regime_evidence import RegimeCohortLabel
 from app.services.strategy_result import TOTAL_RETURN_BASIS
 from app.services.strategy_result_ambiguity import (
     AmbiguityRecord,
@@ -250,6 +251,47 @@ class PriorVersionTrackRecord(BaseModel):
     incomparable_reasons: list[str]
 
 
+class ResultRegimeCohort(BaseModel):
+    """One arm's realised trades, split by the regime that held when it fired (#2437).
+
+    ⚠ Explains a parent arm; NOT independently promotable. Portfolio path
+    statistics — drawdown above all — stay on the arm, because filtering closed
+    trades cannot reconstruct overlapping marked paths
+    (``app/services/strategy_regime_evidence.py`` module docstring).
+
+    Two absences the reader must render differently, both enforced by
+    ``RegimeCohort.__post_init__`` on the writer side:
+
+    - **A regime with no row had no realised trade in this arm.** Every stored
+      cohort carries ``trade_count >= 1``, so the five labels are never all
+      present. "No trades in bear_volatile" is a measurement, not a gap.
+    - **``profit_factor`` is null exactly when ``losing_trade_count == 0``** —
+      the ratio has no denominator. That is the strongest possible cohort, and
+      rendering it as a blank cell says the opposite.
+
+    ``unclassified`` is its own label, not an error: the regime is classified on
+    the entry SIGNAL date, and a date the regime series does not cover cannot be
+    labelled without conditioning on state the strategy did not have.
+    """
+
+    # The producer's own alias, not a copy of its members: a label added there
+    # must not need a matching edit here to be renderable.
+    regime: RegimeCohortLabel
+    trade_count: int
+    instrument_count: int
+    decision_date_count: int
+    losing_trade_count: int
+    expectancy_pct: Decimal
+    expectancy_ci_low_pct: Decimal | None
+    expectancy_ci_high_pct: Decimal | None
+    profit_factor: Decimal | None
+    worst_trade_pct: Decimal
+    effective_sample_size: Decimal | None
+    # Ships with the interval it produced, so a null CI reads as "not
+    # bootstrapped" rather than as a missing number under an unnamed model.
+    bootstrap_model_id: str | None
+
+
 class ResultArm(BaseModel):
     result_version: str
     purpose: Literal["harness_validation", "capital_candidate"]
@@ -301,6 +343,31 @@ class ResultArm(BaseModel):
     hold_days_p25: Decimal | None
     hold_days_p75: Decimal | None
     promotion_refusals: list[str]
+    # Ordered by `REGIME_COHORT_DISPLAY_ORDER`, never by the storage order.
+    # Short of five whenever a regime saw no trade, because a cohort row needs
+    # `trade_count >= 1`.
+    #
+    # ⚠ EMPTY IS TWO DIFFERENT STATEMENTS and the reader must separate them on
+    # `trade_count`, exactly as `metric_set_id` separates the hold-period nulls:
+    # empty with `trade_count == 0` means the arm realised no trade; empty with
+    # `trade_count > 0` means the row PREDATES the cohort writer (#2726) and was
+    # never split — not "no trades in any regime". Backfilling is not available
+    # either way, since it means re-running the backtest and charging the trial
+    # register (#2599/#2616), so these rows stay empty forever.
+    regime_cohorts: list[ResultRegimeCohort]
+
+
+# Fields on `ResultArm` that are COMPUTED rather than selected, and so must not
+# be read off the result row. Named once: the row-splat below skips exactly this
+# set, so adding a computed field cannot leave a `KeyError` behind.
+_RESULT_ARM_COMPUTED_FIELDS: Final[frozenset[str]] = frozenset({"promotion_refusals", "regime_cohorts"})
+
+# Bull before bear, quiet before volatile, `unclassified` last — the producer's
+# own declaration order (`RegimeCohortLabel`), taken rather than restated so a
+# label added there lands in a defined slot instead of an arbitrary one.
+# ⚠ NOT the storage order: `build_regime_cohorts` writes `sorted(grouped)`,
+# which is alphabetical and puts bear before bull.
+REGIME_COHORT_DISPLAY_ORDER: Final[tuple[str, ...]] = get_args(RegimeCohortLabel)
 
 
 class EvidenceWindow(BaseModel):
@@ -1274,6 +1341,31 @@ _RESULT_COUNTS_SQL = """
     GROUP BY strategy_id
 """
 
+# ⚠ Keyed on the result ids `_RESULTS_SQL` ACTUALLY RETURNED, not on a second
+# copy of its ten identity pins. Restating the pins here is the #2806 defect
+# shape: the two predicates drift, the join silently returns nothing, and a
+# panel that reads "no regime evidence" is indistinguishable from one measuring
+# a strategy that never traded. Deriving the key from the producer's own output
+# makes the two sets equal by construction.
+_REGIME_COHORTS_SQL = """
+    SELECT
+        result_id,
+        regime,
+        trade_count,
+        instrument_count,
+        decision_date_count,
+        losing_trade_count,
+        expectancy_pct,
+        expectancy_ci_low_pct,
+        expectancy_ci_high_pct,
+        profit_factor,
+        worst_trade_pct,
+        effective_sample_size,
+        bootstrap_model_id
+    FROM strategy_result_regime_cohorts
+    WHERE result_id = ANY(%(result_ids)s::bigint[])
+"""
+
 _SCAN_SQL = """
     SELECT
         w.strategy_id,
@@ -1574,6 +1666,8 @@ def get_strategy_overview(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(_RESULTS_SQL, params)
         result_rows = list(cur.fetchall())
+        cur.execute(_REGIME_COHORTS_SQL, {"result_ids": [row["result_id"] for row in result_rows]})
+        regime_cohort_rows = list(cur.fetchall())
         cur.execute(_RESULT_COUNTS_SQL, params)
         result_count_rows = list(cur.fetchall())
         # ⚠ SCAN RELATIONS TAKE `scan_params`, RESULT RELATIONS TAKE `params`.
@@ -1670,6 +1764,13 @@ def get_strategy_overview(
     results_by_strategy: dict[str, list[dict[str, object]]] = defaultdict(list)
     for row in result_rows:
         results_by_strategy[str(row["strategy_id"])].append(row)
+    cohorts_by_result: dict[int, list[ResultRegimeCohort]] = defaultdict(list)
+    for row in regime_cohort_rows:
+        cohorts_by_result[int(row["result_id"])].append(
+            ResultRegimeCohort(**{field: row[field] for field in ResultRegimeCohort.model_fields})
+        )
+    for cohorts in cohorts_by_result.values():
+        cohorts.sort(key=lambda cohort: REGIME_COHORT_DISPLAY_ORDER.index(cohort.regime))
     result_counts = {str(row["strategy_id"]): int(row["count"]) for row in result_count_rows}
     scan_by_strategy = {str(row["strategy_id"]): row for row in scan_rows}
     exclusions: dict[str, Counter[str]] = defaultdict(Counter)
@@ -1736,13 +1837,18 @@ def get_strategy_overview(
                 accesses_complete = int(row["accesses"]) >= int(row["evaluations"]) > 0
                 arms.append(
                     ResultArm(
-                        **{field: row[field] for field in ResultArm.model_fields if field != "promotion_refusals"},
+                        **{
+                            field: row[field]
+                            for field in ResultArm.model_fields
+                            if field not in _RESULT_ARM_COMPUTED_FIELDS
+                        },
                         promotion_refusals=_promotion_refusals(
                             row,
                             ambiguity_complete=ambiguity_complete,
                             quarantine_complete=quarantine_complete,
                             accesses_complete=accesses_complete,
                         ),
+                        regime_cohorts=cohorts_by_result.get(int(row["result_id"]), []),
                     )
                 )
             windows.append(

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2399,6 +2399,43 @@ export interface BootstrapTimelineResponse {
 // /strategies (app/api/strategies.py, #2447)
 // ---------------------------------------------------------------------------
 
+export type StrategyRegimeLabel =
+  | "bull_quiet"
+  | "bull_volatile"
+  | "bear_quiet"
+  | "bear_volatile"
+  | "unclassified";
+
+/** One arm's realised trades split by the regime that held when they fired (#2437).
+ *
+ * ⚠ Explains the arm; NOT independently promotable. Drawdown and every other
+ * path statistic stay on the arm — filtering closed trades cannot reconstruct
+ * overlapping marked paths.
+ *
+ * Two absences that must render differently:
+ * - **A regime with no entry had no realised trade in this arm.** Every stored
+ *   cohort carries `trade_count >= 1`, so a short list is a measurement, not a
+ *   gap.
+ * - **`profit_factor` is null exactly when `losing_trade_count === 0`** — no
+ *   denominator. That is the strongest cohort there is; a blank cell says the
+ *   opposite.
+ */
+export interface StrategyRegimeCohort {
+  regime: StrategyRegimeLabel;
+  trade_count: number;
+  instrument_count: number;
+  decision_date_count: number;
+  losing_trade_count: number;
+  expectancy_pct: string;
+  expectancy_ci_low_pct: string | null;
+  expectancy_ci_high_pct: string | null;
+  profit_factor: string | null;
+  worst_trade_pct: string;
+  /** ⚠ Null as a GROUP with the two CI bounds — the writer refuses a partial
+   *  bootstrap — so all three null means "not bootstrapped", not a lost figure. */
+  effective_sample_size: string | null;
+}
+
 export interface StrategyResultArm {
   result_version: string;
   purpose: "harness_validation" | "capital_candidate";
@@ -2444,6 +2481,16 @@ export interface StrategyResultArm {
   hold_days_p25: string | null;
   hold_days_p75: string | null;
   promotion_refusals: string[];
+  /** Ordered bull→bear, quiet→volatile, `unclassified` last. Server-ordered;
+   *  do not re-sort.
+   *
+   *  ⚠ EMPTY IS TWO STATEMENTS, separated on `trade_count`: empty with
+   *  `trade_count === 0` means the arm realised no trade; empty with
+   *  `trade_count > 0` means the row predates the cohort writer (#2726) and was
+   *  never split — NOT "no trades in any regime". Backfilling would mean
+   *  re-running the backtest and charging the trial register, so those rows stay
+   *  empty permanently. */
+  regime_cohorts: StrategyRegimeCohort[];
 }
 
 export interface StrategyEvidenceWindow {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -48,6 +48,38 @@ const ARM: StrategyResultArm = {
   hold_days_p25: null,
   hold_days_p75: null,
   promotion_refusals: [],
+  // Two of the four labels, deliberately: `bear_volatile` and `unclassified`
+  // are absent because they saw no trade, which is what the "No trades in …"
+  // line has to name. `bull_quiet` has no losing trade, so its profit factor is
+  // null — the strongest cohort, not a missing measurement.
+  regime_cohorts: [
+    {
+      regime: "bull_quiet",
+      trade_count: 8,
+      instrument_count: 6,
+      decision_date_count: 7,
+      losing_trade_count: 0,
+      expectancy_pct: "2.4",
+      expectancy_ci_low_pct: null,
+      expectancy_ci_high_pct: null,
+      profit_factor: null,
+      worst_trade_pct: "-0.4",
+      effective_sample_size: null,
+    },
+    {
+      regime: "bear_quiet",
+      trade_count: 4,
+      instrument_count: 4,
+      decision_date_count: 4,
+      losing_trade_count: 3,
+      expectancy_pct: "-1.1",
+      expectancy_ci_low_pct: null,
+      expectancy_ci_high_pct: null,
+      profit_factor: "0.6",
+      worst_trade_pct: "-6.2",
+      effective_sample_size: null,
+    },
+  ],
 };
 
 const OVERVIEW: StrategyOverviewResponse = {
@@ -699,6 +731,26 @@ describe("StrategiesPage", () => {
     expect(screen.getByText("• Recent evidence windows are incomplete")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
+  });
+
+  it("splits the primary arm by regime and names the regimes that saw no trade", async () => {
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(await screen.findByRole("button", { name: "View evidence" }));
+
+    const bull = screen.getByText("Bull, quiet").closest("tr");
+    const bear = screen.getByText("Bear, quiet").closest("tr");
+    expect(bull).not.toBeNull();
+    expect(bear).not.toBeNull();
+    // A cohort with no losing trade has no profit-factor denominator. It must
+    // say so; a dash would read as a missing measurement on the best cohort.
+    expect(within(bull!).getByText("no losing trade")).toBeInTheDocument();
+    expect(within(bear!).getByText("0.6")).toBeInTheDocument();
+    // Server order is bull-before-bear, and the page must not re-sort it.
+    expect(bull!.compareDocumentPosition(bear!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      screen.getByText("No trades in bull, volatile, bear, volatile, unclassified."),
+    ).toBeInTheDocument();
   });
 
   it("queues the fixed recent-evidence denominator from the research header", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -215,7 +215,13 @@ function RegimeBreakdown({ arm }: { arm: StrategyResultArm }) {
                   <td className="py-1">
                     {pctPoints(cohort.expectancy_pct)}
                     <span className="block text-[10px] text-slate-500">
-                      {cohort.expectancy_ci_low_pct === null
+                      {/* BOTH bounds narrowed, not just the low one. The writer
+                          nulls the bootstrap as a group, so testing one bound
+                          normally implies the other — but if that invariant ever
+                          breaks, a half-null interval must read "not
+                          bootstrapped" rather than print a bound against a dash
+                          and pass as a measured range. */}
+                      {cohort.expectancy_ci_low_pct === null || cohort.expectancy_ci_high_pct === null
                         ? "not bootstrapped"
                         : `${pctPoints(cohort.expectancy_ci_low_pct)} to ${pctPoints(cohort.expectancy_ci_high_pct)}` +
                           (cohort.effective_sample_size === null

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -21,6 +21,7 @@ import type {
   StrategyOverview,
   StrategyOverviewResponse,
   StrategyOwnedPosition,
+  StrategyRegimeLabel,
   StrategyResultArm,
 } from "@/api/types";
 import { ApiError } from "@/api/client";
@@ -139,6 +140,110 @@ const PIN_LABELS: Record<string, string> = {
 
 function pinLabel(pin: string): string {
   return PIN_LABELS[pin] ?? pin.replace(/_/g, " ");
+}
+
+const REGIME_LABELS: Record<StrategyRegimeLabel, string> = {
+  bull_quiet: "Bull, quiet",
+  bull_volatile: "Bull, volatile",
+  bear_quiet: "Bear, quiet",
+  bear_volatile: "Bear, volatile",
+  unclassified: "Unclassified",
+};
+
+/** The per-regime split of the primary arm — the operator's own constraint that
+ *  walk-forward evidence is never one pooled number over the whole span.
+ *
+ *  Three states, deliberately worded apart, because collapsing any two of them
+ *  is how a card starts lying:
+ *
+ *  1. **Split present** — one row per regime that saw a trade. A regime with no
+ *     row saw none; the trailing line names those rather than leaving the reader
+ *     to diff five labels against the rows on screen.
+ *  2. **Empty with trades** — the result predates the cohort writer (#2726).
+ *     "Not measured for this result", never "no trades in any regime".
+ *  3. **Empty with no trades** — the arm realised nothing to split.
+ *
+ *  ⚠ A null `profit_factor` means the cohort has NO LOSING TRADE, so the ratio
+ *  has no denominator. Rendered as words; a dash would read as missing data on
+ *  the single best cohort in the table. */
+function RegimeBreakdown({ arm }: { arm: StrategyResultArm }) {
+  const cohorts = arm.regime_cohorts;
+  const covered = new Set<string>(cohorts.map((cohort) => cohort.regime));
+  const absent = (Object.keys(REGIME_LABELS) as StrategyRegimeLabel[]).filter((regime) => !covered.has(regime));
+  return (
+    <div className="mt-4 border-t border-slate-200 pt-3 dark:border-slate-800">
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+        By market regime{" "}
+        <span className="font-normal normal-case tracking-normal">· classified on the entry signal date</span>
+      </h4>
+      {cohorts.length === 0 ? (
+        <p className="mt-2 text-xs text-slate-500">
+          {arm.trade_count > 0
+            ? "Not measured for this result — it was stored before the per-regime split existed, and re-running the backtest to fill it in would charge the experiment register."
+            : "This arm realised no trades, so there is nothing to split."}
+        </p>
+      ) : (
+        <>
+          <table className="mt-2 w-full text-xs tabular-nums">
+            <thead className="text-slate-500">
+              <tr className="text-left">
+                <th className="font-medium">Regime</th>
+                {/* NOT "Trades": the arm's own total already uses that exact
+                    label above, and two identical headings on one card make the
+                    reader ask which number is which. */}
+                <th className="font-medium">Realised trades</th>
+                <th className="font-medium">Expected / trade</th>
+                <th className="font-medium">Profit factor</th>
+                <th className="font-medium">Worst trade</th>
+              </tr>
+            </thead>
+            <tbody className="text-slate-700 dark:text-slate-200">
+              {cohorts.map((cohort) => (
+                <tr key={cohort.regime} className="border-t border-slate-100 dark:border-slate-800/60">
+                  <td className="py-1">{REGIME_LABELS[cohort.regime]}</td>
+                  <td className="py-1">
+                    {formatNumber(cohort.trade_count, 0)}
+                    {/* Names AND dates, because neither alone bounds the other:
+                        four trades on one date is one bet, and the block
+                        bootstrap clusters by date for exactly that reason. */}
+                    <span className="text-slate-500">
+                      {" "}
+                      · {formatNumber(cohort.instrument_count, 0)} names,{" "}
+                      {formatNumber(cohort.decision_date_count, 0)} dates
+                    </span>
+                  </td>
+                  <td className="py-1">
+                    {pctPoints(cohort.expectancy_pct)}
+                    <span className="block text-[10px] text-slate-500">
+                      {cohort.expectancy_ci_low_pct === null
+                        ? "not bootstrapped"
+                        : `${pctPoints(cohort.expectancy_ci_low_pct)} to ${pctPoints(cohort.expectancy_ci_high_pct)}` +
+                          (cohort.effective_sample_size === null
+                            ? ""
+                            : ` · n≈${formatNumber(number(cohort.effective_sample_size), 1)}`)}
+                    </span>
+                  </td>
+                  <td className="py-1">
+                    {cohort.profit_factor === null ? (
+                      <span className="text-slate-500">no losing trade</span>
+                    ) : (
+                      formatNumber(number(cohort.profit_factor), 2)
+                    )}
+                  </td>
+                  <td className="py-1">{pctPoints(cohort.worst_trade_pct)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {absent.length > 0 ? (
+            <p className="mt-2 text-xs text-slate-500">
+              No trades in {absent.map((regime) => REGIME_LABELS[regime].toLowerCase()).join(", ")}.
+            </p>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
 }
 
 function representativeArm(strategy: StrategyOverview): StrategyResultArm | null {
@@ -1403,6 +1508,7 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
           {failures.length > 4 ? <p className="mt-1 text-xs text-slate-500">+ {failures.length - 4} more checks</p> : null}
         </div>
       </div>
+      <RegimeBreakdown arm={arm} />
       <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 border-t border-slate-200 pt-3 text-xs text-slate-500 dark:border-slate-800">
         <span>Evidence windows complete: <strong className="text-slate-700 dark:text-slate-200">{completed}/{strategy.evidence_windows.length}</strong></span>
         <span>Forward observations: <strong className="text-slate-700 dark:text-slate-200">{strategy.attribution.fired_entries}</strong></span>

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -11,6 +11,7 @@ import pytest
 from app.api.strategies import (
     _PRESENTATION,
     _TITLES,
+    REGIME_COHORT_DISPLAY_ORDER,
     ResultArm,
     _ambiguity_record_from_result_row,
     _current_scan_versions,
@@ -27,6 +28,11 @@ from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERS
 from app.services.result_ledger import store_holdout_result, store_in_sample_result
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+from app.services.strategy_regime_evidence import (
+    REGIME_COHORT_LABELS,
+    RegimeCohort,
+    store_result_regime_cohorts,
+)
 from app.services.strategy_result import LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS
 from app.services.strategy_result_ambiguity import AMBIGUITY_RULE_VERSION, AmbiguityRecord, record_sha256
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
@@ -432,6 +438,7 @@ def test_result_arm_accepts_valid_undefined_downside_metrics() -> None:
         hold_days_p25=None,
         hold_days_p75=None,
         promotion_refusals=[],
+        regime_cohorts=[],
     )
 
     assert arm.sortino is None
@@ -627,6 +634,175 @@ def test_overview_maps_only_exact_current_holdout_provenance(
     assert primary.arms[0].sortino is None
     assert primary.arms[0].profit_factor is None
     assert strategy.legacy_result_count == 3
+
+
+def test_overview_regime_cohorts_follow_the_result_ids_not_a_second_pin_predicate(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#2817. Two arms, one current and one on a stale cost model, both with cohorts.
+
+    The current arm must carry ITS OWN cohorts and nothing else. Storing cohorts
+    against the excluded result is the point of the fixture: a reader that
+    restated `_RESULTS_SQL`'s identity pins instead of keying on the ids that
+    query returned would either leak the stale split in or drop both.
+
+    Also pins the display order. The two labels are stored `bear_quiet` then
+    `bull_quiet` — which is what `build_regime_cohorts` writes, since it sorts
+    alphabetically — and must READ back bull-before-bear.
+    """
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
+    identity = {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "window_start": window.start,
+        "window_end": window.end,
+        "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
+        "cost_model_id": COST_MODEL_ID,
+        "sizing_rule": SIZING_RULE_ID,
+        "benchmark_rule": BENCHMARK_RULE_ID,
+        "return_basis": TOTAL_RETURN_BASIS,
+        "ambiguity_rule_version": AMBIGUITY_RULE_VERSION,
+        "position_rule_set_version": POSITION_RULE_SET_VERSION,
+        "outcome_rule_set_version": OUTCOME_RULE_SET_VERSION,
+        "input_rule_set_version": QUARANTINE_RULE_SET_VERSION,
+    }
+    metrics = build_metrics(trade_count=5, losing_trade_count=2, open_trade_count=0)
+    current_id = store_holdout_result(
+        ebull_test_conn,
+        build_result(**identity, ambiguity_arm="best_case", quarantine_arm="admitted", metrics=metrics),
+        accessed_by="tests/test_api_strategies.py",
+        purpose="verify regime cohort mapping",
+    )
+    stale_id = store_holdout_result(
+        ebull_test_conn,
+        build_result(
+            **{**identity, "cost_model_id": "stale-cost-v0"},
+            ambiguity_arm="worst_case",
+            quarantine_arm="admitted",
+            metrics=metrics,
+        ),
+        accessed_by="tests/test_api_strategies.py",
+        purpose="prove an excluded result's cohorts cannot leak in",
+    )
+    for result_id, expectancy in ((current_id, 1.5), (stale_id, -9.5)):
+        store_result_regime_cohorts(
+            ebull_test_conn,
+            result_id=result_id,
+            cohorts=[
+                RegimeCohort(
+                    regime="bear_quiet",
+                    trade_count=2,
+                    instrument_count=2,
+                    decision_date_count=2,
+                    losing_trade_count=1,
+                    expectancy_pct=expectancy,
+                    profit_factor=1.25,
+                    worst_trade_pct=-3.5,
+                    effective_sample_size=None,
+                    expectancy_ci_low_pct=None,
+                    expectancy_ci_high_pct=None,
+                    bootstrap_block_length=None,
+                    bootstrap_cluster_count=None,
+                    bootstrap_resamples=None,
+                    bootstrap_seed=None,
+                    bootstrap_design_effect=None,
+                    bootstrap_model_id=None,
+                ),
+                RegimeCohort(
+                    regime="bull_quiet",
+                    trade_count=3,
+                    instrument_count=3,
+                    decision_date_count=3,
+                    losing_trade_count=0,
+                    expectancy_pct=expectancy,
+                    # Null exactly because the cohort has no losing trade — the
+                    # strongest cohort, not an absent measurement.
+                    profit_factor=None,
+                    worst_trade_pct=-0.25,
+                    effective_sample_size=None,
+                    expectancy_ci_low_pct=None,
+                    expectancy_ci_high_pct=None,
+                    bootstrap_block_length=None,
+                    bootstrap_cluster_count=None,
+                    bootstrap_resamples=None,
+                    bootstrap_seed=None,
+                    bootstrap_design_effect=None,
+                    bootstrap_model_id=None,
+                ),
+            ],
+            expected_trade_count=5,
+        )
+
+    overview = get_strategy_overview(ebull_test_conn)
+    strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
+    primary = next(item for item in strategy.evidence_windows if item.window_id == "primary-2022-plus")
+
+    assert len(primary.arms) == 1
+    cohorts = primary.arms[0].regime_cohorts
+    assert [item.regime for item in cohorts] == ["bull_quiet", "bear_quiet"]
+    assert [item.trade_count for item in cohorts] == [3, 2]
+    assert sum(item.trade_count for item in cohorts) == primary.arms[0].trade_count
+    # The stale arm's -9.5 never appears: it is excluded by provenance, so its
+    # cohorts are not fetched at all.
+    assert all(item.expectancy_pct == Decimal("1.5") for item in cohorts)
+    assert cohorts[0].profit_factor is None
+    assert cohorts[0].losing_trade_count == 0
+    assert cohorts[1].profit_factor == Decimal("1.25")
+
+
+def test_overview_leaves_regime_cohorts_empty_for_a_result_written_before_the_writer_existed(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#2817. Every one of the 324 rows stored on dev predates #2726 and has no split.
+
+    The arm must report an EMPTY list beside a non-zero `trade_count`, which is
+    what lets the reader say "not measured for this result version" instead of
+    "no trades in any regime".
+    """
+    strategy_id = "s1-time-series-momentum"
+    window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
+    store_holdout_result(
+        ebull_test_conn,
+        build_result(
+            strategy_id=strategy_id,
+            strategy_version=_current_versions()[strategy_id],
+            window_start=window.start,
+            window_end=window.end,
+            corpus_version=corpus_version_for(BACKTEST_UNIVERSE),
+            cost_model_id=COST_MODEL_ID,
+            sizing_rule=SIZING_RULE_ID,
+            benchmark_rule=BENCHMARK_RULE_ID,
+            return_basis=TOTAL_RETURN_BASIS,
+            ambiguity_rule_version=AMBIGUITY_RULE_VERSION,
+            position_rule_set_version=POSITION_RULE_SET_VERSION,
+            outcome_rule_set_version=OUTCOME_RULE_SET_VERSION,
+            input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+            ambiguity_arm="best_case",
+            quarantine_arm="admitted",
+        ),
+        accessed_by="tests/test_api_strategies.py",
+        purpose="verify an unsplit result reads as unsplit",
+    )
+
+    overview = get_strategy_overview(ebull_test_conn)
+    strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
+    primary = next(item for item in strategy.evidence_windows if item.window_id == "primary-2022-plus")
+
+    assert primary.arms[0].trade_count > 0
+    assert primary.arms[0].regime_cohorts == []
+
+
+def test_regime_cohort_display_order_covers_every_label_the_producer_can_write() -> None:
+    """A label added to `RegimeCohortLabel` must land in a defined display slot.
+
+    `REGIME_COHORT_DISPLAY_ORDER` is `get_args(RegimeCohortLabel)`, so this holds
+    by construction today; the test is what stops a later hand-written copy from
+    silently dropping a label and raising `ValueError` inside the sort.
+    """
+    assert set(REGIME_COHORT_DISPLAY_ORDER) == set(REGIME_COHORT_LABELS)
+    assert REGIME_COHORT_DISPLAY_ORDER[-1] == "unclassified"
 
 
 def test_overview_declares_exactly_the_manifest_strategies_with_exit_adapters_as_forward_resolvable(

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -26,6 +26,7 @@ from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_V
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.result_ledger import store_holdout_result, store_in_sample_result
+from app.services.strategies.validated_universe import STOCKS_TYPE_DESCRIPTION
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
 from app.services.strategy_regime_evidence import (
@@ -45,6 +46,30 @@ _IMMATERIAL_AMBIGUITY: dict[str, object] = {
     "ambiguity_worst_case_sharpe": None,
     "ambiguity_cohort_gap_threshold": None,
 }
+
+#: `etoro_instrument_types` is created empty by `sql/070` and filled by the
+#: nightly eToro universe sync, so a test DB never has it. Since #2809 the
+#: overview reads the scan freshness bar through `load_validated_universe`,
+#: which resolves the §4.0 `Stocks` anchor and REFUSES on zero rows — so every
+#: DB test here raises `RuntimeError` without this seed. That refusal is the
+#: right behaviour for an unbootstrapped system; what is missing is the
+#: bootstrap, which is what this supplies.
+#:
+#: Deliberately only the anchor. The tests that follow assert on scan status and
+#: result provenance, and seeding instruments too would give them a non-empty
+#: universe none of them asked for.
+_STOCKS_TYPE_ID = 5
+
+
+def _seed_universe_anchor(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        INSERT INTO etoro_instrument_types (instrument_type_id, description)
+        VALUES (%(stocks)s, %(description)s)
+        ON CONFLICT (instrument_type_id) DO NOTHING
+        """,
+        {"stocks": _STOCKS_TYPE_ID, "description": STOCKS_TYPE_DESCRIPTION},
+    )
 
 
 def test_operator_ambiguity_payloads_are_hash_verified_when_loaded_from_sql() -> None:
@@ -448,6 +473,7 @@ def test_result_arm_accepts_valid_undefined_downside_metrics() -> None:
 def test_empty_ledgers_still_return_all_manifest_strategies(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
+    _seed_universe_anchor(ebull_test_conn)
     overview = get_strategy_overview(ebull_test_conn)
     assert [item.strategy_id for item in overview.strategies] == sorted(STRATEGY_MANIFEST)
     assert all(item.scan.status == "never_run" for item in overview.strategies)
@@ -467,6 +493,7 @@ def test_empty_ledgers_still_return_all_manifest_strategies(
 def test_completed_zero_signal_scan_uses_its_watermark(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
+    _seed_universe_anchor(ebull_test_conn)
     strategy_id = "s2-cross-sectional-momentum"
     version = _current_scan_versions()[strategy_id]
     frontier = date(2026, 7, 8)
@@ -489,39 +516,21 @@ def test_completed_zero_signal_scan_uses_its_watermark(
     assert strategy.scan.not_evaluable == 0
 
 
-def test_scan_freshness_reads_the_ingest_census_without_scanning_daily_bars(
-    ebull_test_conn: psycopg.Connection[tuple],
-) -> None:
-    strategy_id = "s2-cross-sectional-momentum"
-    version = _current_scan_versions()[strategy_id]
-    frontier = date(2026, 7, 8)
-    ebull_test_conn.execute(
-        """
-        INSERT INTO research_price_series (
-            vendor,vendor_symbol,upstream_source,licence,adjustment_basis,
-            first_bar,last_bar,bar_count
-        ) VALUES ('test','CENSUS-ONLY','other','test','split_adjusted',%s,%s,1)
-        """,
-        (frontier, frontier),
-    )
-    ebull_test_conn.execute(
-        """
-        INSERT INTO strategy_scan_watermark (strategy_id,strategy_version,frontier_date)
-        VALUES (%s,%s,%s)
-        """,
-        (strategy_id, version, frontier),
-    )
-
-    overview = get_strategy_overview(ebull_test_conn)
-    strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
-
-    assert strategy.scan.status == "current"
-    assert ebull_test_conn.execute("SELECT count(*) FROM research_price_daily").fetchone() == (0,)
+# `test_scan_freshness_reads_the_ingest_census_without_scanning_daily_bars` stood
+# here until #2817 and is deliberately gone rather than repaired. It seeded ONE
+# `research_price_series` row and asserted `scan.status == "current"` — i.e. it
+# asserted `MAX(last_bar)` over the research archive, which is precisely the
+# basis #2809 removed as "wrong table, wrong statistic, wrong population"
+# (`_corpus_frontier`'s docstring). The behaviour it pinned no longer exists, so
+# it failed from that merge onward; the replacement contract, including a
+# structural guard that the overview never reads that archive again, is
+# `tests/test_2809_scan_freshness_basis.py`.
 
 
 def test_scan_health_reads_durable_daily_counts_after_detail_retention(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
+    _seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     version = _current_scan_versions()[strategy_id]
     ebull_test_conn.execute(
@@ -563,6 +572,7 @@ def test_scan_health_reads_durable_daily_counts_after_detail_retention(
 def test_overview_maps_only_exact_current_holdout_provenance(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
+    _seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     strategy_version = _current_versions()[strategy_id]
     window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
@@ -650,6 +660,7 @@ def test_overview_regime_cohorts_follow_the_result_ids_not_a_second_pin_predicat
     `bull_quiet` — which is what `build_regime_cohorts` writes, since it sorts
     alphabetically — and must READ back bull-before-bear.
     """
+    _seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     strategy_version = _current_versions()[strategy_id]
     window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
@@ -686,7 +697,9 @@ def test_overview_regime_cohorts_follow_the_result_ids_not_a_second_pin_predicat
         accessed_by="tests/test_api_strategies.py",
         purpose="prove an excluded result's cohorts cannot leak in",
     )
-    for result_id, expectancy in ((current_id, 1.5), (stale_id, -9.5)):
+    # `worst_trade_pct` must not exceed the cohort expectancy (`RegimeCohort`
+    # refuses it), so the two arms carry their own worst trade as well.
+    for result_id, expectancy, worst in ((current_id, 1.5, -3.5), (stale_id, -9.5, -20.0)):
         store_result_regime_cohorts(
             ebull_test_conn,
             result_id=result_id,
@@ -699,7 +712,7 @@ def test_overview_regime_cohorts_follow_the_result_ids_not_a_second_pin_predicat
                     losing_trade_count=1,
                     expectancy_pct=expectancy,
                     profit_factor=1.25,
-                    worst_trade_pct=-3.5,
+                    worst_trade_pct=worst,
                     effective_sample_size=None,
                     expectancy_ci_low_pct=None,
                     expectancy_ci_high_pct=None,
@@ -720,7 +733,7 @@ def test_overview_regime_cohorts_follow_the_result_ids_not_a_second_pin_predicat
                     # Null exactly because the cohort has no losing trade — the
                     # strongest cohort, not an absent measurement.
                     profit_factor=None,
-                    worst_trade_pct=-0.25,
+                    worst_trade_pct=worst,
                     effective_sample_size=None,
                     expectancy_ci_low_pct=None,
                     expectancy_ci_high_pct=None,
@@ -761,6 +774,7 @@ def test_overview_leaves_regime_cohorts_empty_for_a_result_written_before_the_wr
     what lets the reader say "not measured for this result version" instead of
     "no trades in any regime".
     """
+    _seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
     store_holdout_result(
@@ -808,6 +822,7 @@ def test_regime_cohort_display_order_covers_every_label_the_producer_can_write()
 def test_overview_declares_exactly_the_manifest_strategies_with_exit_adapters_as_forward_resolvable(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
+    _seed_universe_anchor(ebull_test_conn)
     overview = get_strategy_overview(ebull_test_conn)
     support = {item.strategy_id: item.forward_outcome_supported for item in overview.strategies}
 


### PR DESCRIPTION
## What changed

`strategy_result_regime_cohorts` had a writer and no reader. `backtest_run.py:3598`
/ `:3631` store one row per `(result_id, regime)` for every hold-out result, with
per-cohort expectancy, block-bootstrap CI, profit factor, worst trade and
effective sample size — and `grep -rn strategy_result_regime_cohorts app/` hit
only the writer module. No API field, no frontend field.

This surfaces them:

- **`app/api/strategies.py`** — `ResultRegimeCohort` model + `regime_cohorts` on
  every `ResultArm`, fetched by `_REGIME_COHORTS_SQL` and ordered bull→bear,
  quiet→volatile, `unclassified` last.
- **`frontend/`** — `StrategyRegimeCohort` type and a `RegimeBreakdown` table
  under "Primary evidence" on the strategies card.

## Why now

The build queue's item 6 requires walk-forward evidence in **per-year and
per-regime blocks, never one pooled number over the whole span**. Per-year blocks
already ship as `evidence_windows`. Per-regime blocks did not reach the operator
at all.

Backtest run 111610 (`strategy_backtest_run`, started 2026-08-21T02:07:51Z) is the
first run since #2726 that populates these cohorts. Without a reader that compute
lands somewhere the operator can never see.

## Design notes

**The cohort query is keyed on the result ids `_RESULTS_SQL` actually returned,
not on a second copy of its ten identity pins.** Restating the pins is the #2806
defect shape — the two predicates drift, the join silently returns nothing, and a
panel reading "no regime evidence" becomes indistinguishable from one measuring a
strategy that never traded. Deriving the key from the producer's output makes the
two sets equal by construction, and
`test_overview_regime_cohorts_follow_the_result_ids_not_a_second_pin_predicate`
pins it by storing cohorts against a result the pin filter EXCLUDES and asserting
they never appear.

**Three states are worded apart, because collapsing any two of them is how a card
starts lying:**

| state | render |
| --- | --- |
| cohorts present | one row per regime that saw a trade; a trailing line names the regimes that saw none (`trade_count >= 1` is a writer invariant, so a short list is a measurement) |
| empty, `trade_count > 0` | "Not measured for this result" — it predates the #2726 writer. Backfilling means re-running the backtest and charging the trial register (#2599/#2616), so these stay empty permanently |
| empty, `trade_count == 0` | "This arm realised no trades" |

**A null `profit_factor` means the cohort has no losing trade**, so the ratio has
no denominator — `RegimeCohort.__post_init__` enforces the iff. Rendered as words;
a dash would read as missing data on the single strongest cohort in the table.

**Trades are shown with names AND dates.** Four trades on one decision date is one
bet, which is why the block bootstrap clusters by date; neither count bounds the
other.

`bootstrap_model_id` is deliberately not exposed — the CI and effective sample
size are null as a group (the writer refuses a partial bootstrap), so their
absence already says "not bootstrapped" without a per-row model string.

## Payload

Measured, not estimated: one serialised cohort is **362 bytes**. Worst case
(10 strategies × 6 windows × 4 arms × 5 regimes) adds **~434 KB** to a response
that is 40,039 bytes today. Accepted rather than split into a second endpoint,
because a separate route would have to re-implement `_RESULTS_SQL`'s identity-pin
filtering to decide which results are current — which is the exact duplication the
#2806 rule forbids. Every field shipped is rendered, so none of it is dead weight.

## Two things fixed in passing

Both are `test_api_strategies.py` fallout from #2809 (merged today), which CI could
not catch: CI runs no pytest, and the pre-push gate is `-m "not db"` while this
module is db-marked. All 8 DB tests in the file failed on `origin/main` before this
branch.

1. **`_seed_universe_anchor`.** `_corpus_frontier` now reads
   `load_validated_universe`, which resolves the §4.0 `Stocks` anchor from
   `etoro_instrument_types` and REFUSES on zero rows. That table is created empty
   by `sql/070` and filled by the nightly eToro sync, so no test DB has it — every
   DB test in the file raised `RuntimeError`. The refusal is correct behaviour for
   an unbootstrapped system; the bootstrap is what was missing. Seeding the anchor
   fixed 6 of the 8.
2. **`test_scan_freshness_reads_the_ingest_census_without_scanning_daily_bars`
   deleted, not repaired.** It seeded one `research_price_series` row and asserted
   `scan.status == "current"` — i.e. it asserted `MAX(last_bar)` over the research
   archive, which is precisely the basis #2809 removed as "wrong table, wrong
   statistic, wrong population" (`_corpus_frontier`'s docstring). The behaviour it
   pinned no longer exists. The replacement contract, including a structural guard
   that the overview never reads that archive again, is
   `tests/test_2809_scan_freshness_basis.py`.

## Verification

| check | result |
| --- | --- |
| `uv run ruff check .` / `ruff format --check .` | pass (1,529 files) |
| `uv run pyright` | 0 errors |
| `uv run pytest -m "not db"` | exit 0 |
| `uv run pytest tests/smoke` | exit 0 |
| `uv run pytest -m db tests/test_api_strategies.py` | exit 0, 22 collected (was 8 failing on `origin/main`) |
| `pnpm --dir frontend typecheck` | pass |
| `pnpm --dir frontend test:unit` | 1,527 passed / 136 files |
| Codex checkpoint 2 (`codex exec review --base origin/main`) | no actionable defects |

**Dev-verified against the real dev DB** at `30c9b378` by calling
`get_strategy_overview` on `settings.database_url`: 200-equivalent, 0 arms rendered
(every window is `missing` under the current versions), payload 40,039 bytes —
unchanged, as expected while no result carries a split. Measured on the full stored
population:

```
select count(*) total,
       count(*) filter (where r.trade_count > 0 and c.result_id is null) with_trades_no_cohorts
from strategy_results_store r
left join (select distinct result_id from strategy_result_regime_cohorts) c using (result_id);
--  324 | 324
```

All 324 stored results predate #2726, so every arm renders the "not measured for
this result" branch today and fills in as run 111610's results land. The cohort
join itself is exercised against real Postgres and the real writer
(`store_result_regime_cohorts`) in the two new DB tests.

## Security

Read-only. No new mutation path, no new authentication or authorisation surface,
no user-controlled input reaching SQL — the one new query binds a server-derived
list of `bigint` result ids as a parameter.

## Not in scope

No migration, no change to the cohort writer, no change to the cohort definition.
The regime is classified on the entry SIGNAL date and cohorts explain a parent
result rather than being independently promotable — both settled in #2437 / #2726
and untouched here.

Part of #2437
Closes #2817
