### PR TITLE
fix(#2778): a scale-gate refusal costs one arm's control, not the whole run

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -192,6 +192,7 @@ from app.services.synthetic_control_run import (
     HOLDOUT_CONTROL_REASON,
     CohortCollector,
     CohortResult,
+    ScaleBudgetExceeded,
     SyntheticControlScaleBudget,
     run_cohort,
 )
@@ -532,6 +533,18 @@ class NamespaceMeasurement:
         return self.axis_dates[-1]
 
 
+def _arm_label(strategy_id: str, ambiguity_arm: AmbiguityArm | None, quarantine_arm: QuarantineArm) -> str:
+    """The one spelling of an arm's name, shared by the gate and the report.
+
+    ⚠ ONE FUNCTION AND NOT AN f-STRING AT EACH SITE. This label is what a scale
+    refusal is keyed by in ``BacktestRunReport.control_refusals``, so the string
+    the gate refuses under and the string an operator looks the refusal up by
+    have to be the same string by construction rather than by two format
+    expressions agreeing.
+    """
+    return f"{strategy_id}/{ambiguity_arm or 'shared'}/{quarantine_arm}"
+
+
 @dataclass(frozen=True)
 class ArmMeasurement:
     """Everything one ``(strategy, quarantine arm)`` corpus pass produced."""
@@ -553,7 +566,25 @@ class ArmMeasurement:
     #: invocation asked for one. ⚠ ``None`` is the DEFAULT and means the run did
     #: not compute it — never that a computed control was lost: ``run_cohort``
     #: raises rather than returning a partial one.
+    #:
+    #: ⚠ SINCE #2778 ``None`` HAS A SECOND CAUSE, and the invariant above still
+    #: holds. The scale gate can refuse this cohort, and ``ScaleBudgetExceeded``
+    #: is raised by ``SyntheticControlScaleBudget.reserve`` *before* the member
+    #: pool fans out — so a refused cohort has produced no member outcome and
+    #: there is still nothing lost to report. ``cohort_refusal`` says which of
+    #: the two ``None`` means; anything raised from INSIDE the fan-out is still
+    #: fatal, because that one WOULD be discarding computed work.
     cohort: CohortResult | None = None
+    #: Why ``cohort`` is ``None`` when the invocation asked for one, verbatim
+    #: from the gate. ⚠ ``None`` here means the control was never requested for
+    #: this arm — an operator reading ``synthetic_control_not_run`` on the stored
+    #: row cannot otherwise tell "this run did not ask for a control" from "the
+    #: gate refused to run one", and those want different next moves.
+    cohort_refusal: str | None = None
+
+    @property
+    def label(self) -> str:
+        return _arm_label(self.strategy_id, self.ambiguity_arm, self.quarantine_arm)
 
 
 @dataclass(frozen=True)
@@ -595,6 +626,18 @@ class BacktestRunReport:
     @property
     def rows_written(self) -> int:
         return len(self.rows)
+
+    @property
+    def control_refusals(self) -> Mapping[str, str]:
+        """Why §9's control is absent, per arm the scale gate refused (#2778).
+
+        ⚠ DERIVED FROM ``arms`` RATHER THAN CARRIED AS A FIELD, unlike
+        ``deflation_refusals``. A deflation group is not an arm and has nowhere
+        else to live; a control refusal belongs to exactly one arm, which is
+        already in this report — so a second copy could only ever disagree with
+        the first.
+        """
+        return {arm.label: arm.cohort_refusal for arm in self.arms if arm.cohort_refusal is not None}
 
 
 # ---------------------------------------------------------------------------
@@ -1946,6 +1989,22 @@ def evaluate_arm(
         )
         if outcome is not None:
             measured[name] = outcome
+    # ⚠ PINNED BEFORE THE COHORT RUNS. ``elapsed_s`` is the ARM's evaluation
+    # time and the cohort reports its own ``elapsed_s`` separately; folding §9's
+    # thousand members into the arm figure would silently redefine it.
+    elapsed_s = time.monotonic() - started
+    cohort, cohort_refusal = _run_cohort_for(
+        collector,
+        measured=measured,
+        corpus=corpus,
+        cohort_size=cohort_size,
+        label=_arm_label(entry.strategy_id, ambiguity_arm, quarantine_arm),
+        progress=progress,
+        strategy_id=entry.strategy_id,
+        quarantine_arm=quarantine_arm,
+        ambiguity_arm=ambiguity_arm,
+        scale_budget=scale_budget,
+    )
     return ArmMeasurement(
         strategy_id=entry.strategy_id,
         strategy_version=identity.version,
@@ -1955,19 +2014,9 @@ def evaluate_arm(
         holdout_positions_discarded=discarded.get("hold_out", 0),
         close_sources=dict(close_sources),
         series_evaluated=evaluated,
-        elapsed_s=time.monotonic() - started,
-        cohort=_run_cohort_for(
-            collector,
-            measured=measured,
-            corpus=corpus,
-            cohort_size=cohort_size,
-            label=f"{entry.strategy_id}/{ambiguity_arm or 'shared'}/{quarantine_arm}",
-            progress=progress,
-            strategy_id=entry.strategy_id,
-            quarantine_arm=quarantine_arm,
-            ambiguity_arm=ambiguity_arm,
-            scale_budget=scale_budget,
-        ),
+        elapsed_s=elapsed_s,
+        cohort=cohort,
+        cohort_refusal=cohort_refusal,
     )
 
 
@@ -2002,7 +2051,7 @@ def _run_cohort_for(
     ambiguity_arm: AmbiguityArm | None = None,
     progress: ProgressCallback | None = None,
     scale_budget: SyntheticControlScaleBudget | None = None,
-) -> CohortResult | None:
+) -> tuple[CohortResult | None, str | None]:
     """§9's control for this arm, once the sleeve it is compared against exists.
 
     ⚠ THE STRATEGY-SIDE FIGURES COME FROM THE MEASUREMENT THIS RUN JUST MADE,
@@ -2010,9 +2059,26 @@ def _run_cohort_for(
     much as to the result — a Sharpe compared with a cohort built for a
     different arm is two measurements joined on nothing — and the measurement is
     already in hand here.
+
+    Returns ``(control, refusal)``: at most one is ever populated.
+
+    ⚠⚠ A SCALE REFUSAL COSTS THIS ARM'S CONTROL AND NOTHING ELSE (#2778). It
+    used to abort the whole invocation: on 2026-08-19 one cohort's *estimate*
+    came in 45 seconds over a threshold and discarded a completed 1,000-member
+    cohort plus about ninety minutes of compute, persisting nothing — and the
+    work it refused subsequently ran in less than half the threshold. The
+    projection is a 3-member extrapolation and swings by more than 2x in BOTH
+    directions, so a gate that aborts on it aborts at random.
+
+    ⚠ ONLY ``ScaleBudgetExceeded`` IS CAUGHT, AND THE NARROWNESS IS THE POINT.
+    ``reserve`` runs before the member pool fans out, so a refused cohort has
+    produced no member outcome and the arm's own measurement — already complete
+    by the time this is called — is intact. Anything raised from inside the
+    fan-out means members WERE computed, and swallowing that would report a
+    partial cohort's absence as a plain "not run"; it stays fatal.
     """
     if collector is None or cohort_size is None:
-        return None
+        return None, None
     outcome = measured.get(CONTROL_NAMESPACE)
     if outcome is None:
         raise RuntimeError(
@@ -2020,7 +2086,7 @@ def _run_cohort_for(
             "a cohort with no strategy Sharpe beside it is a null distribution nobody can read"
         )
     if outcome.metrics.trade_count == 0:
-        return None
+        return None, None
 
     def report_member(member_seen: int, member_total: int) -> None:
         _emit_progress(
@@ -2035,16 +2101,25 @@ def _run_cohort_for(
             ),
         )
 
-    result = run_cohort(
-        collector,
-        axis=outcome.axis_dates,
-        strategy_metrics=outcome.metrics,
-        benchmark=None,
-        cohort_size=cohort_size,
-        progress=report_member if progress is not None else None,
-        scale_budget=scale_budget,
-        label=label,
-    )
+    try:
+        result = run_cohort(
+            collector,
+            axis=outcome.axis_dates,
+            strategy_metrics=outcome.metrics,
+            benchmark=None,
+            cohort_size=cohort_size,
+            progress=report_member if progress is not None else None,
+            scale_budget=scale_budget,
+            label=label,
+        )
+    except ScaleBudgetExceeded as exc:
+        logger.warning(
+            "strategy_backtest_run: %s synthetic control REFUSED by the scale gate — %s; this arm's rows will "
+            "carry synthetic_control_not_run and the run continues",
+            label,
+            exc,
+        )
+        return None, str(exc)
     logger.info(
         "strategy_backtest_run: %s synthetic control completed — %d members over %d series in %.1fs "
         "(%.3fs/member); outcomes withheld pending structural completion audit",
@@ -2054,7 +2129,7 @@ def _run_cohort_for(
         result.elapsed_s,
         result.seconds_per_member,
     )
-    return result
+    return result, None
 
 
 def evaluate_level_arms(
@@ -2308,6 +2383,18 @@ def evaluate_level_arms(
             )
             if outcome is not None:
                 measured[name] = outcome
+        cohort, cohort_refusal = _run_cohort_for(
+            collectors[ambiguity],
+            measured=measured,
+            corpus=corpus,
+            cohort_size=cohort_size,
+            label=_arm_label(entry.strategy_id, ambiguity, quarantine_arm),
+            progress=progress,
+            strategy_id=entry.strategy_id,
+            quarantine_arm=quarantine_arm,
+            ambiguity_arm=ambiguity,
+            scale_budget=scale_budget,
+        )
         measurements.append(
             ArmMeasurement(
                 strategy_id=entry.strategy_id,
@@ -2319,18 +2406,8 @@ def evaluate_level_arms(
                 close_sources=dict(close_sources[ambiguity]),
                 series_evaluated=evaluated,
                 elapsed_s=elapsed,
-                cohort=_run_cohort_for(
-                    collectors[ambiguity],
-                    measured=measured,
-                    corpus=corpus,
-                    cohort_size=cohort_size,
-                    label=f"{entry.strategy_id}/{ambiguity}/{quarantine_arm}",
-                    progress=progress,
-                    strategy_id=entry.strategy_id,
-                    quarantine_arm=quarantine_arm,
-                    ambiguity_arm=ambiguity,
-                    scale_budget=scale_budget,
-                ),
+                cohort=cohort,
+                cohort_refusal=cohort_refusal,
             )
         )
     return tuple(measurements)
@@ -4107,6 +4184,11 @@ def log_report(report: BacktestRunReport) -> None:
                 cohort.elapsed_s,
                 cohort.seconds_per_member,
             )
+        elif measurement.cohort_refusal is not None:
+            # ⚠ WARNING AND NOT INFO. The arm's rows are complete and stored; what
+            # is missing is §9's evidence, so this is the line that stops a
+            # refused control looking like a control that was never asked for.
+            logger.warning("    synthetic control REFUSED: %s", measurement.cohort_refusal)
     for row in report.rows:
         logger.info(
             "    stored %s %s/%s/%s %s instruments=%d folds=%d; outcomes withheld",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5722,6 +5722,18 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
                     release_read_locks=True,
                 )
                 tracker.row_count = report.rows_written
+                if report.control_refusals:
+                    # ⚠ ON THE JOB ROW AND NOT ONLY IN THE LOG (#2778). The
+                    # `refresh_recent` refusal above exists so an operator who
+                    # asked for a control never silently gets rows saying
+                    # `synthetic_control_not_run`; a scale refusal is discovered
+                    # mid-run rather than up front, so it cannot be refused
+                    # up front — but it must not be silent either.
+                    refused = ", ".join(sorted(report.control_refusals))
+                    tracker.note = (
+                        f"the synthetic-control scale gate refused {len(report.control_refusals)} arm(s) "
+                        f"({refused}); their rows carry synthetic_control_not_run and the rest of the run stands"
+                    )
                 if progress_writer is not None:
                     progress_writer.record_window_commit(rows_written=report.rows_written, completed=1)
             finally:

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -3194,6 +3194,22 @@ Two things S-4 adds to the prevention above:
 - Enforced in: this prevention log; `scripts/ab_2140_def14a_parser.py`
   (`traced_parse_table` and `patched` both take `**kwargs`, with the measured
   `67,828 -> 0` in the why-comment).
+- ⚠ **The RETURN shape rots the same way, and `**kwargs` does not cover it
+  (#2778, 2026-08-21).** `_run_cohort_for` returned `CohortResult | None`;
+  #2778 widened it to `(control, refusal)` so a scale refusal stops aborting the
+  invocation. Three shadows of that contract had to move in the same commit, and
+  none of them would have failed at import: `scripts/verify_2697_metric_axis_ab.py`
+  (a monkeypatch whose own why-comment already records this exact rot happening
+  once before, when #2772 added `scale_budget`), plus three
+  `SimpleNamespace(rows_written=N)` report stubs in
+  `tests/test_strategy_recent_evidence.py` that stood in for `BacktestRunReport`
+  and lacked the new attribute the scheduler now reads.
+- Prevention, generalised: **when a function's signature OR return shape moves,
+  grep for its name across `scripts/` AND `tests/` in the same commit** —
+  `grep -rn "_run_cohort_for" scripts tests`. A `SimpleNamespace` standing in for
+  a real dataclass is a monkeypatch by another name and rots on exactly the same
+  trigger; the fast tier catches the test stubs, and nothing at all catches the
+  script until someone runs it.
 
 ### Cite a migration by its SLUG — a renumber re-aims every bare "sql/NNN" at someone else's SQL (#2304, 2026-08-07)
 

--- a/scripts/verify_2697_metric_axis_ab.py
+++ b/scripts/verify_2697_metric_axis_ab.py
@@ -465,9 +465,14 @@ def main() -> None:
             # got an unexpected keyword argument 'scale_budget'` ever since,
             # discoverable only by running it. Forwarded rather than swallowed
             # so the A/B honours the same launch gates production does.
+            #
+            # ⚠ Same rot, second instance: #2778 changed the RETURN to
+            # ``(control, refusal)`` so a refused cohort no longer aborts the
+            # invocation. Forward both halves — dropping the refusal here would
+            # make the A/B abort where production carries on.
             scale_budget: SyntheticControlScaleBudget | None = None,
-        ) -> CohortResult | None:
-            current_result = original_run_cohort_for(
+        ) -> tuple[CohortResult | None, str | None]:
+            current_result, cohort_refusal = original_run_cohort_for(
                 collector,
                 measured=measured,
                 scale_budget=scale_budget,
@@ -490,7 +495,7 @@ def main() -> None:
                     label=label,
                 )
             cohort_pairs.append((legacy_control, None if current_result is None else current_result.control))
-            return current_result
+            return current_result, cohort_refusal
 
         backtest_run._measure_namespace = capture  # type: ignore[assignment]
         backtest_run._run_cohort_for = capture_cohort  # type: ignore[assignment]

--- a/tests/test_2778_scale_refusal_non_fatal.py
+++ b/tests/test_2778_scale_refusal_non_fatal.py
@@ -144,3 +144,17 @@ def test_arm_label_is_the_string_the_gate_refuses_under() -> None:
 
     assert arm.label == "s1-time-series-momentum/worst_case/admitted"
     assert arm.label in _REFUSAL
+
+
+@pytest.mark.parametrize("ambiguity_arm", ["worst_case", "best_case", None])
+def test_arm_label_reproduces_the_f_string_it_replaced(ambiguity_arm: str | None) -> None:
+    """Both replaced sites, including the ``None`` branch neither test path hits.
+
+    ``evaluate_arm`` spelled this ``f"{sid}/{ambiguity_arm or 'shared'}/{q}"`` and
+    ``evaluate_level_arms`` spelled it ``f"{sid}/{ambiguity}/{q}"`` over a
+    never-``None`` loop variable. Pinned against the literal the gate's refusal
+    messages already contain, so the helper cannot drift from either.
+    """
+    expected = f"s1-time-series-momentum/{ambiguity_arm or 'shared'}/admitted"
+
+    assert _arm_label("s1-time-series-momentum", ambiguity_arm, "admitted") == expected  # type: ignore[arg-type]

--- a/tests/test_2778_scale_refusal_non_fatal.py
+++ b/tests/test_2778_scale_refusal_non_fatal.py
@@ -1,0 +1,146 @@
+"""#2778 — a scale-gate refusal costs one arm's control, not the whole run.
+
+The gate's own projection is a 3-member extrapolation that swings by more than
+2x in BOTH directions (#2778's measurements), so a refusal is partly noise. What
+makes that expensive is not the estimate, it is the blast radius: on 2026-08-19
+one cohort's estimate came in 45 seconds over the threshold, `ScaleBudgetExceeded`
+propagated out of the arm constructor, and a full-set invocation lost a completed
+1,000-member cohort and ~90 minutes of compute while persisting nothing.
+
+These tests pin the two halves of the fix that must not drift apart:
+
+* the pre-fan-out refusal is absorbed and named, and
+* anything raised from INSIDE the fan-out is still fatal.
+
+Pure — no DB, no fixtures. Deliberately a separate module from
+``test_backtest_run.py``, which is fully ``db``-marked and therefore off the
+pre-push gate.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.services import backtest_run
+from app.services.backtest_run import ArmMeasurement, BacktestRunReport, _arm_label, _run_cohort_for
+from app.services.strategy_result import synthetic_control_promotion_refusals
+from app.services.synthetic_control_run import CONTROL_NAMESPACE, ScaleBudgetExceeded
+
+_REFUSAL = (
+    "synthetic-control scale gate refused s1-time-series-momentum/worst_case/admitted: "
+    "projected cohort wall time 1245.1s exceeds 1200.0s budget"
+)
+
+
+def _measured(trade_count: int = 5) -> dict[str, Any]:
+    """The minimum ``_run_cohort_for`` reads off a namespace measurement."""
+    return {CONTROL_NAMESPACE: SimpleNamespace(axis_dates=(), metrics=SimpleNamespace(trade_count=trade_count))}
+
+
+def _call(monkeypatch: pytest.MonkeyPatch, raises: BaseException) -> tuple[Any, str | None]:
+    seen: list[str] = []
+
+    def _stub(_collector: Any, **kwargs: Any) -> Any:
+        seen.append(kwargs["label"])
+        raise raises
+
+    monkeypatch.setattr(backtest_run, "run_cohort", _stub)
+    result = _run_cohort_for(
+        SimpleNamespace(),  # type: ignore[arg-type]
+        measured=_measured(),  # type: ignore[arg-type]
+        corpus=SimpleNamespace(),  # type: ignore[arg-type]
+        cohort_size=1000,
+        label=_arm_label("s1-time-series-momentum", "worst_case", "admitted"),
+        strategy_id="s1-time-series-momentum",
+        quarantine_arm="admitted",
+        ambiguity_arm="worst_case",
+    )
+    assert seen == ["s1-time-series-momentum/worst_case/admitted"]
+    return result
+
+
+def test_scale_refusal_is_absorbed_and_named(monkeypatch: pytest.MonkeyPatch) -> None:
+    control, refusal = _call(monkeypatch, ScaleBudgetExceeded(_REFUSAL))
+
+    assert control is None
+    assert refusal == _REFUSAL
+
+
+def test_a_refused_arm_carries_the_declared_not_run_code() -> None:
+    """The absorbed refusal lands on an EXISTING refusal code, not a new one.
+
+    ``synthetic_control_not_run`` is documented as *"no cohort exists for this
+    result. The WRITER has not run §9's control"* — which is exactly true of a
+    cohort the gate refused before fan-out, so nothing had to be invented.
+    """
+    assert synthetic_control_promotion_refusals(None) == ("synthetic_control_not_run",)
+
+
+def test_a_failure_inside_the_fan_out_is_still_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The narrowness of the ``except`` is the safety property.
+
+    ``reserve`` refuses before any member runs, so absorbing it discards nothing.
+    A ``RuntimeError`` from the member pool means members WERE computed, and
+    reporting that arm as a plain "control not run" would hide a partial cohort.
+    """
+    with pytest.raises(RuntimeError, match="cohort member set is incomplete"):
+        _call(monkeypatch, RuntimeError("cohort member set is incomplete: missing=[7]"))
+
+
+def test_no_cohort_requested_is_not_a_refusal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``(None, None)`` and ``(None, message)`` are different states."""
+    monkeypatch.setattr(backtest_run, "run_cohort", lambda *a, **k: pytest.fail("must not run"))
+
+    assert _run_cohort_for(
+        None,
+        measured=_measured(),  # type: ignore[arg-type]
+        corpus=SimpleNamespace(),  # type: ignore[arg-type]
+        cohort_size=None,
+        label="unused",
+        strategy_id="s1-time-series-momentum",
+        quarantine_arm="admitted",
+    ) == (None, None)
+
+
+def _arm(*, ambiguity_arm: str | None, refusal: str | None) -> ArmMeasurement:
+    return ArmMeasurement(
+        strategy_id="s1-time-series-momentum",
+        strategy_version="strategy-registry-v1+deadbeef",
+        quarantine_arm="admitted",
+        namespaces={},
+        holdout_positions_discarded=0,
+        close_sources={},
+        series_evaluated=1,
+        elapsed_s=1.0,
+        ambiguity_arm=ambiguity_arm,  # type: ignore[arg-type]
+        cohort_refusal=refusal,
+    )
+
+
+def test_report_lists_only_refused_arms_keyed_by_the_gate_s_own_label() -> None:
+    report = BacktestRunReport(
+        runnable=("s1-time-series-momentum",),
+        excluded=(),
+        holdout_requested=False,
+        arms=(
+            _arm(ambiguity_arm="worst_case", refusal=_REFUSAL),
+            _arm(ambiguity_arm="best_case", refusal=None),
+            _arm(ambiguity_arm=None, refusal="refused/shared"),
+        ),
+    )
+
+    assert report.control_refusals == {
+        "s1-time-series-momentum/worst_case/admitted": _REFUSAL,
+        "s1-time-series-momentum/shared/admitted": "refused/shared",
+    }
+
+
+def test_arm_label_is_the_string_the_gate_refuses_under() -> None:
+    """One spelling, so a refusal can be looked up by the key it was filed under."""
+    arm = _arm(ambiguity_arm="worst_case", refusal=_REFUSAL)
+
+    assert arm.label == "s1-time-series-momentum/worst_case/admitted"
+    assert arm.label in _REFUSAL

--- a/tests/test_strategy_recent_evidence.py
+++ b/tests/test_strategy_recent_evidence.py
@@ -101,7 +101,7 @@ def test_refresh_recent_skips_complete_windows_and_commits_each_missing_window(
 
     def run_backtest(_conn: object, **kwargs: object) -> SimpleNamespace:
         calls.append(kwargs["evidence_window_id"])
-        return SimpleNamespace(rows_written=12)
+        return SimpleNamespace(rows_written=12, control_refusals={})
 
     monkeypatch.setattr(scheduler, "_tracked_job", tracked)
     monkeypatch.setattr(scheduler, "connect_job", connected)
@@ -186,7 +186,7 @@ def test_refresh_progress_is_transient_until_evidence_commit(
         progress = kwargs["progress"]
         assert callable(progress)
         progress(BacktestProgressEvent(phase="evaluation", series_seen=25, series_total=100))
-        return SimpleNamespace(rows_written=16)
+        return SimpleNamespace(rows_written=16, control_refusals={})
 
     monkeypatch.setattr(scheduler, "_tracked_job", tracked)
     monkeypatch.setattr(scheduler, "connect_job", connected)
@@ -250,7 +250,7 @@ def test_single_run_reports_progress_and_only_checkpoints_after_return(
         assert callable(progress)
         progress(BacktestProgressEvent(phase="synthetic_control", series_seen=17, series_total=1000))
         events.append("evidence_returned")
-        return SimpleNamespace(rows_written=40)
+        return SimpleNamespace(rows_written=40, control_refusals={})
 
     writer = Writer()
     monkeypatch.setattr(scheduler, "_tracked_job", tracked)
@@ -268,6 +268,48 @@ def test_single_run_reports_progress_and_only_checkpoints_after_return(
         "closed",
     ]
     assert tracker.row_count == 40
+    assert tracker.note is None
+
+
+def test_a_scale_refused_control_lands_on_the_job_row_not_only_in_the_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2778 — the run survives a refused cohort, and says so where an operator looks.
+
+    ``refresh_recent + synthetic_control`` is refused outright so an operator who
+    asked for a control never silently receives rows saying
+    ``synthetic_control_not_run``. A scale refusal is discovered mid-run and so
+    cannot be refused up front — but the same principle binds it, which is why
+    it reaches ``job_runs.error_msg`` through ``tracker.note`` rather than
+    living only in a log line.
+    """
+    tracker = SimpleNamespace(row_count=None, run_id=9, progress=None, note=None)
+    refusal = "synthetic-control scale gate refused s1/worst_case/admitted: projected cohort wall time ..."
+
+    @contextmanager
+    def tracked(_job_name: str) -> Iterator[SimpleNamespace]:
+        yield tracker
+
+    @contextmanager
+    def connected() -> Iterator[MagicMock]:
+        yield MagicMock()
+
+    def run_backtest(_conn: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(rows_written=40, control_refusals={"s1/worst_case/admitted": refusal})
+
+    monkeypatch.setattr(scheduler, "_tracked_job", tracked)
+    monkeypatch.setattr(scheduler, "connect_job", connected)
+    monkeypatch.setattr(scheduler, "_open_backtest_progress_writer", lambda **_kwargs: None)
+    monkeypatch.setattr("app.services.backtest_run.run_backtest", run_backtest)
+
+    scheduler.strategy_backtest_run({"synthetic_control": True})
+
+    # The rows still landed: the refusal cost one arm's control, not the run.
+    assert tracker.row_count == 40
+    assert tracker.note is not None
+    assert "refused 1 arm(s)" in tracker.note
+    assert "s1/worst_case/admitted" in tracker.note
+    assert "synthetic_control_not_run" in tracker.note
 
 
 def test_refresh_failure_before_commit_never_publishes_a_window_checkpoint(


### PR DESCRIPTION
## Problem

`SyntheticControlScaleBudget.reserve` raises `ScaleBudgetExceeded`, and that exception propagated out of the `ArmMeasurement` constructor in `evaluate_arm` / `evaluate_level_arms` — so it aborted the **entire backtest invocation**.

Measured on 2026-08-19 (#2778): one cohort's *estimate* came in 45 seconds over a 1,200s threshold. The refusal discarded a completed 1,000-member cohort and roughly ninety minutes of compute, persisting nothing. The same arm re-projected at 611.3s on the next invocation and actually completed in **528.8s** — the projection that destroyed the run over-stated the work by 2.35x.

The projection is a 3-member serial pilot extrapolated across 8 workers, so it is noise in both directions. But the blast radius is the larger defect and is independent of the threshold, which the ticket says explicitly: *"A refusal that skipped the arm, or that persisted completed work first, would have made the bad estimate survivable."*

Real, current, and on the critical path: backtest run `111610` is the walk-forward evidence run for the S-1..S-10 set, and runs `111447` / `108436` both died mid-flight — `108436` on exactly this gate.

## Change

`_run_cohort_for` returns `(control, refusal)` and absorbs `ScaleBudgetExceeded`. The arm's own measurement is complete before the cohort is attempted, so the arm survives, the run continues, and that arm's rows carry `synthetic_control_not_run`.

**No new vocabulary was invented.** `synthetic_control_not_run` is documented in `app/services/strategy_result.py:289` as *"no cohort exists for this result. The WRITER has not run §9's control"* — which is exactly true of a cohort refused before fan-out.

## Why catching only `ScaleBudgetExceeded` is the safety property

`ArmMeasurement.cohort`'s docstring already states that `None` *"never [means] that a computed control was lost"*. That invariant survives, and the reason is positional: `reserve()` is called at `synthetic_control_run.py:1354`, strictly **before** the `ProcessPoolExecutor` fans out at line 1376. A refused cohort has produced no member outcome, so there is nothing to lose.

Anything raised from inside the fan-out means members **were** computed; reporting that arm as a plain "control not run" would hide a partial cohort, so it stays fatal. `tests/test_2778_scale_refusal_non_fatal.py::test_a_failure_inside_the_fan_out_is_still_fatal` pins this.

## Not silent

The scheduler already refuses `refresh_recent + synthetic_control` outright (`scheduler.py:5601`) on the stated principle that an operator who asked for a control must never silently receive rows saying `synthetic_control_not_run`. A scale refusal is discovered mid-run and so cannot be refused up front, but the same principle binds it. Three surfaces:

- `job_runs.error_msg`, via `tracker.note` — the operator-visible success-path channel.
- `BacktestRunReport.control_refusals` — a derived property keyed by `_arm_label`, mirroring the existing `deflation_refusals` shape ("a refusal an operator can act on"). Derived from `arms` rather than carried as a second field, since a control refusal belongs to exactly one arm that is already in the report.
- `logger.warning` in `_run_cohort_for` and `log_report`.

`_arm_label` is new and exists so the string the gate refuses under and the key an operator looks the refusal up by are the same string by construction, not by two f-strings agreeing. It replaces two hand-written copies.

## Scope left out, and why

**The estimator itself is unchanged.** #2778's first acceptance clause — *"projection error measured across at least one full strategy set, reported as a distribution"* — requires a full-strategy-set run on an idle box. Backtest run `111610` has been running on this host since 02:07 UTC; a projection measured under that contention would measure the contention, and the ticket's own closing line warns against re-fitting constants to a single observation. **Unblock condition: re-measure once `111610` reaches a terminal status, then decide between widening the pilot, spawning the pilot pool, or dropping the per-cohort estimate in favour of the cumulative budget.** The third acceptance clause (a probe for "whatever replaces the current estimate") is unreachable until that choice is made.

Worth noting the threshold half of the ticket has already been fixed on `main`: `SYNTHETIC_CONTROL_MAX_PROJECTED_COHORT_S` is now derived as ⅓ of the 4h invocation budget (4,800s), so the specific 1,245.1s refusal that killed run `108436` can no longer fire. This PR removes the failure *mode*, not just that instance.

## Prevention

`docs/review-prevention-log.md` — extended the #2175 entry ("a monkeypatched entry point must forward the FULL signature"). That entry covers the **signature** axis and `**kwargs`; it does not cover the **return shape**, which rots identically. This change moved a return type and three shadows of the contract had to follow, none of which would fail at import:

- `scripts/verify_2697_metric_axis_ab.py` — whose own why-comment already records this exact rot happening once before, when #2772 added `scale_budget`.
- three `SimpleNamespace(rows_written=N)` stubs in `tests/test_strategy_recent_evidence.py` standing in for `BacktestRunReport`.

Generalised rule added: when a signature **or return shape** moves, grep the name across `scripts/` **and** `tests/` in the same commit.

## Security

No security surface. No auth, no user input, no SQL, no broker path. The change strictly narrows what aborts a read-mostly research job.

## Verification

| check | result |
| --- | --- |
| `uv run ruff check .` / `ruff format --check .` | pass |
| `uv run pyright` | 0 errors, 0 warnings |
| `uv run pytest -m "not db"` (fast tier) | pass — includes the 6 new pure tests, which collect under `not db` |
| `uv run pytest -m db tests/test_backtest_run.py tests/test_synthetic_control_run.py tests/test_strategy_holdout_namespace.py` | exit 0 |
| `uv run pytest tests/smoke -n 0` | exit 0 |
| `codex exec review --base origin/main` (checkpoint 2) | no actionable regression |

Not a corpus/parser/schema change — no migration, no backfill, no stored-data semantics move — so Definition-of-Done clauses 8-12 do not apply. `ScaleBudgetExceeded` was previously unreachable in any stored row; the only behavioural delta is which rows get written at all, and it is strictly more.

Closes #2778
