### PR TITLE
feat(#2823): surface criterion 5's purged K-fold split on /strategies

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -118,6 +118,10 @@ from app.services.strategy_signal_scan import (
     modal_bar_date,
     window_decides_the_mode,
 )
+from app.services.strategy_walk_forward_evidence import (
+    SplitUnavailableReason,
+    derive_walk_forward_split,
+)
 from app.services.strategy_wealth import load_strategy_wealth_history
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
@@ -379,6 +383,77 @@ class EvidenceWindow(BaseModel):
     arms: list[ResultArm]
 
 
+class WalkForwardFold(BaseModel):
+    """One block of criterion 5's split (#2823).
+
+    ⚠ ``first_date`` / ``last_date`` bound the **test** block, not a training
+    interval — ``app/services/walk_forward.py``: *"One contiguous block of the
+    panel axis, held out for testing."*
+
+    ⚠ The four counts are ONE population re-classified by this fold, and
+    ``FoldCensus.total`` asserts exactly that. Summing any of them across folds
+    counts the same observations ``fold_count`` times, so no total is exposed
+    here and none may be rendered.
+
+    ⚠ NO PER-FOLD PERFORMANCE FIELD EXISTS AND NONE MAY BE ADDED. §5.3: the
+    split is a validity GATE, not a training loop, and a per-fold number *"would
+    invite exactly the 'which fold did best' search criterion 6 exists to
+    bound"*.
+
+    Two legitimate zeroes (``sql/269``): ``test_count`` may be 0 on a fold that
+    spans real dates when no observation STARTS inside a thin era, and
+    ``embargo_bars`` 0 means *"nothing to measure on this fold's training
+    side"* — never that the embargo was skipped.
+    """
+
+    fold_index: int
+    first_date: date
+    last_date: date
+    bar_count: int
+    #: MEASURED, on the PANEL-date axis — not instrument bars, not calendar days
+    #: and not a declared holding period. It is the maximum panel-axis label span
+    #: over this fold's own post-purge training set, so it varies per fold and
+    #: needs no constant from any strategy.
+    embargo_bars: int
+    test_count: int
+    train_count: int
+    #: Training observations whose LABEL WINDOW overlaps the test block.
+    purged_count: int
+    #: Training observations that START in the window immediately FOLLOWING the
+    #: test block. A separate verdict from ``purged_count`` and not a second
+    #: symmetric purge — collapsing the two would make §5.3's finding about
+    #: their relative size unreportable.
+    embargoed_count: int
+
+
+class WalkForwardSplit(BaseModel):
+    """The strategy's stored split, or the named reason it has none (#2823).
+
+    Grain is the STRATEGY CARD, not the arm and not the evidence window: the
+    geometry is identical across all four stored arms (measured — see
+    ``strategy_walk_forward_evidence``), and the folds sit inside the in-sample
+    prefix, so they belong to no hold-out window.
+
+    ⚠ The construction is **purged K-fold over contiguous blocks**, NOT an
+    anchored or rolling walk-forward, whatever the table's name suggests. Both
+    sides of a test block carry training data; that is what leaves room for the
+    embargo at all.
+    """
+
+    folds: list[WalkForwardFold]
+    #: The STORED id, never today's constant — a split cut under a superseded
+    #: construction stays readable as that construction.
+    walk_forward_model_id: str | None
+    fold_count: int | None
+    #: Which arm's census the counts are. The geometry is arm-invariant; the
+    #: census is not, because masking changes the universe.
+    quarantine_arm: str | None
+    window_start: date | None
+    window_end: date | None
+    #: Non-null exactly when ``folds`` is empty.
+    unavailable_reason: SplitUnavailableReason | None
+
+
 class StrategyOverview(BaseModel):
     strategy_id: str
     strategy_version: str
@@ -391,6 +466,10 @@ class StrategyOverview(BaseModel):
     exclusion_reason: str | None
     scan: ScanHealth
     evidence_windows: list[EvidenceWindow]
+    #: Criterion 5's split for this version, per strategy rather than per window
+    #: — the folds partition the in-sample prefix and belong to no hold-out
+    #: window (#2823).
+    walk_forward_split: WalkForwardSplit
     prior_versions: list[PriorVersionTrackRecord]
     # ⚠ NOT a prior-version summary, despite the name: `_RESULT_COUNTS_SQL`
     # filters on the CURRENT versions, so this counts rows under the current
@@ -1365,6 +1444,59 @@ _REGIME_COHORTS_SQL = """
     WHERE result_id = ANY(%(result_ids)s::bigint[])
 """
 
+# Criterion 5's stored split (#2823). ⚠ THE ONE PREDICATE THAT DIFFERS FROM
+# `_RESULTS_SQL` IS `namespace`, AND IT HAS TO: folds hang off `in_sample`
+# results while the card's arms are `hold_out` ones. Keying this on the result
+# ids `_RESULTS_SQL` returned — #2817's pattern, and the right one there — would
+# match nothing at all, forever, and read as "no strategy has a split".
+# `strategy_result_control_support` does not bridge the two either: it holds 0
+# rows on dev, and its `control_result_id` is the control ARM, not the in-sample
+# companion. So the link is the identity pins.
+#
+# ⚠ Restating those pins is the #2806 shape — two copies drift, the join
+# silently empties, and a panel reading "no walk-forward evidence" becomes
+# indistinguishable from a split that was never cut. They are not restated: this
+# statement binds THE SAME `params` dict as `_RESULTS_SQL`, with the same
+# placeholder names, so the two pin sets are equal by construction and a new pin
+# added to one is a `ProgrammingError` on the other rather than a silent drift.
+#
+# ⚠ LEFT JOIN, not INNER. An in-sample result carrying no folds must still
+# arrive, or `no_split_stored` collapses into `no_in_sample_result` and the two
+# states stop being distinguishable — which is the whole point of naming them.
+_WALK_FORWARD_SPLIT_SQL = """
+    SELECT
+        r.strategy_id,
+        r.result_id,
+        r.quarantine_arm,
+        r.window_start,
+        r.window_end,
+        f.fold_index,
+        f.walk_forward_model_id,
+        f.fold_count,
+        f.first_date,
+        f.last_date,
+        f.bar_count,
+        f.embargo_bars,
+        f.test_count,
+        f.train_count,
+        f.purged_count,
+        f.embargoed_count
+    FROM strategy_results_store r
+    LEFT JOIN strategy_result_folds f ON f.result_id = r.result_id
+    WHERE r.strategy_version = ANY(%(versions)s)
+      AND r.namespace = 'in_sample'
+      AND r.corpus_version = %(corpus_version)s
+      AND r.cost_model_id = %(cost_model_id)s
+      AND r.sizing_rule = %(sizing_rule)s
+      AND r.benchmark_rule = %(benchmark_rule)s
+      AND r.return_basis = %(return_basis)s
+      AND r.ambiguity_rule_version = %(ambiguity_rule_version)s
+      AND r.position_rule_set_version = %(position_version)s
+      AND r.outcome_rule_set_version = %(outcome_version)s
+      AND r.input_rule_set_version = %(input_version)s
+    ORDER BY r.strategy_id, r.result_id, f.fold_index
+"""
+
 _SCAN_SQL = """
     SELECT
         w.strategy_id,
@@ -1667,6 +1799,10 @@ def get_strategy_overview(
         result_rows = list(cur.fetchall())
         cur.execute(_REGIME_COHORTS_SQL, {"result_ids": [row["result_id"] for row in result_rows]})
         regime_cohort_rows = list(cur.fetchall())
+        # ⚠ `params`, deliberately — the SAME pin dict `_RESULTS_SQL` binds. See
+        # the statement's own header for why it is not a second copy.
+        cur.execute(_WALK_FORWARD_SPLIT_SQL, params)
+        walk_forward_rows = list(cur.fetchall())
         cur.execute(_RESULT_COUNTS_SQL, params)
         result_count_rows = list(cur.fetchall())
         # ⚠ SCAN RELATIONS TAKE `scan_params`, RESULT RELATIONS TAKE `params`.
@@ -1770,6 +1906,9 @@ def get_strategy_overview(
         )
     for cohorts in cohorts_by_result.values():
         cohorts.sort(key=lambda cohort: REGIME_COHORT_DISPLAY_ORDER.index(cohort.regime))
+    walk_forward_by_strategy: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    for row in walk_forward_rows:
+        walk_forward_by_strategy[str(row["strategy_id"])].append(row)
     result_counts = {str(row["strategy_id"]): int(row["count"]) for row in result_count_rows}
     scan_by_strategy = {str(row["strategy_id"]): row for row in scan_rows}
     exclusions: dict[str, Counter[str]] = defaultdict(Counter)
@@ -1980,6 +2119,7 @@ def get_strategy_overview(
                 ):
                     allocation_refusals.append("prospective_assessment_stale")
         remaining = max(control.capital_limit - control.reserved_capital, Decimal("0"))
+        split = derive_walk_forward_split(walk_forward_by_strategy.get(strategy_id, []))
         strategies.append(
             StrategyOverview(
                 strategy_id=strategy_id,
@@ -1993,6 +2133,12 @@ def get_strategy_overview(
                 exclusion_reason=excluded_by_id.get(strategy_id),
                 scan=scan,
                 evidence_windows=windows,
+                walk_forward_split=WalkForwardSplit(
+                    **{
+                        **split.__dict__,
+                        "folds": [WalkForwardFold(**fold.__dict__) for fold in split.folds],
+                    }
+                ),
                 prior_versions=prior_versions_by_strategy.get(strategy_id, []),
                 legacy_result_count=result_counts.get(strategy_id, 0) - sum(len(rows) for rows in exact.values()),
                 all_recent_evidence_complete=all_complete,

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -120,6 +120,7 @@ from app.services.strategy_signal_scan import (
 )
 from app.services.strategy_walk_forward_evidence import (
     SplitUnavailableReason,
+    StrategyWalkForwardSplit,
     derive_walk_forward_split,
 )
 from app.services.strategy_wealth import load_strategy_wealth_history
@@ -1673,6 +1674,42 @@ def _evidence_window_counts(strategies: list[StrategyOverview]) -> tuple[int, in
     return completed, partial
 
 
+def _walk_forward_split_view(split: StrategyWalkForwardSplit) -> WalkForwardSplit:
+    """The derivation's dataclass as the response model, field by field.
+
+    ⚠ EXPLICIT RATHER THAN ``**split.__dict__``, which is the house pattern two
+    lines below on ``StrategyAttributionView``. The splat is fine where the two
+    shapes are flat and parallel; this one also has to rebuild ``folds`` into a
+    different type on the way through, so the splat hid a nested conversion
+    inside a dict literal and would have reported a later field rename at
+    request time instead of at review time. ``tests/test_strategy_walk_forward
+    _evidence.py`` pins the two field sets equal so drift fails at the fast tier
+    rather than here.
+    """
+    return WalkForwardSplit(
+        folds=[
+            WalkForwardFold(
+                fold_index=fold.fold_index,
+                first_date=fold.first_date,
+                last_date=fold.last_date,
+                bar_count=fold.bar_count,
+                embargo_bars=fold.embargo_bars,
+                test_count=fold.test_count,
+                train_count=fold.train_count,
+                purged_count=fold.purged_count,
+                embargoed_count=fold.embargoed_count,
+            )
+            for fold in split.folds
+        ],
+        walk_forward_model_id=split.walk_forward_model_id,
+        fold_count=split.fold_count,
+        quarantine_arm=split.quarantine_arm,
+        window_start=split.window_start,
+        window_end=split.window_end,
+        unavailable_reason=split.unavailable_reason,
+    )
+
+
 def _current_identity_pins() -> dict[str, str]:
     """The pins a stored row must match to sit on today's measurement basis.
 
@@ -2133,12 +2170,7 @@ def get_strategy_overview(
                 exclusion_reason=excluded_by_id.get(strategy_id),
                 scan=scan,
                 evidence_windows=windows,
-                walk_forward_split=WalkForwardSplit(
-                    **{
-                        **split.__dict__,
-                        "folds": [WalkForwardFold(**fold.__dict__) for fold in split.folds],
-                    }
-                ),
+                walk_forward_split=_walk_forward_split_view(split),
                 prior_versions=prior_versions_by_strategy.get(strategy_id, []),
                 legacy_result_count=result_counts.get(strategy_id, 0) - sum(len(rows) for rows in exact.values()),
                 all_recent_evidence_complete=all_complete,

--- a/app/services/strategy_walk_forward_evidence.py
+++ b/app/services/strategy_walk_forward_evidence.py
@@ -1,0 +1,249 @@
+"""Criterion 5's stored split, shaped for the operator card (#2823).
+
+``sql/269_strategy_result_folds.sql`` calls the consumer it was written for
+*"the phase-6 read"*. It was never built: ``store_walk_forward_folds`` has
+written folds since #2240 and the only callers of ``read_walk_forward_folds``
+are tests and one-off scripts, so the evidence that criterion 5's split was
+actually purged and embargoed has never reached ``/strategies``. #2817 closed
+the same gap one table over, on the per-regime cohorts.
+
+WHAT THIS MODULE IS FOR, AND WHY IT IS PURE
+-------------------------------------------
+Choosing WHICH stored split represents a strategy, and deciding what to say when
+there is none, are the two decisions on this path that can be wrong. Both are
+functions of rows alone, so they are table-testable with no database — the
+``strategy_monitoring.derive_fire_rate`` shape, for the same reason.
+
+⚠⚠ THE SPLIT IS PER STRATEGY, NOT PER ARM — AND THAT IS MEASURED, NOT ASSUMED.
+A strategy version stores FOUR in-sample results, the 2x2 of ``ambiguity_arm``
+(``best_case`` / ``worst_case``) x ``quarantine_arm`` (``masked`` / ``admitted``),
+and each carries its own four fold rows. Measured on dev 2026-08-21 for
+``s1-time-series-momentum`` at ``strategy-registry-v1+2307ee566d7b`` (result ids
+117-120), fold 0 of each:
+
+    arm                       first_date  last_date   bar_count  embargo_bars   train
+    best_case  / masked       1962-01-02  1999-09-02  4,375,006           615   1,694,103
+    best_case  / admitted     1962-01-02  1999-09-02  4,375,006           615   1,694,643
+    worst_case / masked       1962-01-02  1999-09-02  4,375,006           615   1,694,103
+    worst_case / admitted     1962-01-02  1999-09-02  4,375,006           615   1,694,643
+
+So the GEOMETRY — dates, bars, embargo — is identical across all four, which is
+``bar_weighted_folds`` reading only the panel AXIS (``backtest_run.py``: *"reads
+only the axis, so every result…"*). The CENSUS moves with ``quarantine_arm``
+alone, because masking changes which instruments are in the universe and
+therefore which observations exist. ``ambiguity_arm`` is a fill-price
+assumption and cannot move a population, which the table confirms: 117 == 119
+and 118 == 120, exactly.
+
+Rendering four near-identical splits would therefore be four copies of one
+measurement plus a 0.03% census difference. One split is rendered, and the arm
+whose census it is, is NAMED in the payload rather than left implicit.
+
+WHAT A FOLD IS — the four words below are all easy to get backwards, and the
+card's copy depends on every one of them (``app/services/walk_forward.py``):
+
+- The design is **purged K-fold over contiguous blocks**, NOT an anchored or
+  rolling walk-forward. Both sides of a test block carry training data; an
+  anchored design has none after it, which would delete the embargo — *"half of
+  what criterion 5 asks for"*.
+- ``first_date`` / ``last_date`` bound the **test** block. They are not a
+  training interval.
+- ``purged`` counts training observations whose LABEL WINDOW overlaps that test
+  block. ``embargoed`` counts training observations that START in the window
+  immediately FOLLOWING it. They are separate verdicts and not one "dropped"
+  bucket, because §5.3's finding is about their relative size.
+- ``train`` is what survives both, on BOTH sides of the block.
+
+⚠ THE FOUR COUNTS ARE ONE POPULATION RE-CLASSIFIED PER FOLD.
+``FoldCensus.total`` is ``test + train + purged + embargoed`` and asserts that
+every observation lands in exactly one bucket — per fold. So a cross-fold sum of
+any of them counts the same population ``fold_count`` times over. No total is
+derived here and none may be rendered.
+
+⚠ NO PER-FOLD PERFORMANCE EXISTS, BY DESIGN. ``FoldRecord``: *"these strategies
+fit no parameters, so the split is a validity GATE and not a training loop. A
+per-fold Sharpe would invite exactly the 'which fold did best' search criterion 6
+exists to bound."* Nothing here may be described as a return or a score.
+
+⚠ Two zeroes that are measurements rather than gaps, both stated by ``sql/269``:
+a fold spanning real dates may carry ``test_count == 0`` (no observation STARTS
+inside a thin era), and ``embargo_bars == 0`` means *"nothing to measure on this
+fold's training side"*, never "no embargo applied".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Final, Literal
+
+__all__ = [
+    "QUARANTINE_ARM_PREFERENCE",
+    "SplitUnavailableReason",
+    "StrategyWalkForwardSplit",
+    "WalkForwardFoldView",
+    "derive_walk_forward_split",
+]
+
+#: Why a card carries no split. The ``ShareUnavailableReason`` contract in
+#: ``strategy_monitoring`` one field over, for the same reason it exists there: a
+#: silent absence and a measured zero are indistinguishable to a reader, so the
+#: absence is NAMED.
+#:
+#: The three are disjoint by CONSTRUCTION rather than by precedence — they are
+#: decided in one pass over a strategy's rows, and each test is reached only when
+#: the one before it did not apply:
+#:
+#: 1. ``no_in_sample_result`` — no in-sample result under the current identity
+#:    pins. The usual state for a version whose backtest has not been re-run;
+#:    it is NOT "the split was skipped".
+#: 2. ``no_split_stored`` — an in-sample result exists and carries no fold rows.
+#:    Distinct from 1 on purpose: the run happened and the split did not reach
+#:    storage, which is a different thing to chase.
+#: 3. ``invariant_violated`` — the stored rows contradict the writer's own
+#:    contract. ⚠ The only one that describes US rather than the evidence, and
+#:    the reason it is a named state rather than a raise is
+#:    ``derive_fire_rate``'s: this runs per strategy inside an aggregate
+#:    endpoint, so propagating would blank all ten cards over one bad row. The
+#:    corruption is contained to the card it belongs to and named there, because
+#:    a corruption visible only in logs is one nobody sees.
+SplitUnavailableReason = Literal[
+    "no_in_sample_result",
+    "no_split_stored",
+    "invariant_violated",
+]
+
+#: Which arm's census is rendered when more than one is stored. ``admitted`` is
+#: the unmasked universe and so the wider population; ``masked`` is the fallback
+#: rather than a second panel. ⚠ The CHOICE is not the point — naming it in the
+#: payload is. A census whose arm is implicit is a number the operator cannot
+#: attribute.
+QUARANTINE_ARM_PREFERENCE: Final[tuple[str, ...]] = ("admitted", "masked")
+
+
+@dataclass(frozen=True)
+class WalkForwardFoldView:
+    """One stored fold row, as the card reads it.
+
+    ⚠ ``first_date`` / ``last_date`` are the TEST block. See the module header.
+    """
+
+    fold_index: int
+    first_date: date
+    last_date: date
+    bar_count: int
+    embargo_bars: int
+    test_count: int
+    train_count: int
+    purged_count: int
+    embargoed_count: int
+
+
+@dataclass(frozen=True)
+class StrategyWalkForwardSplit:
+    """One strategy's split, or the named reason it has none.
+
+    ``folds`` is non-empty exactly when ``unavailable_reason`` is ``None`` — the
+    ``derive_fire_rate`` rule that *"a value is None if and only if its reason is
+    not"*, so no caller can render a half-populated panel.
+    """
+
+    folds: tuple[WalkForwardFoldView, ...] = ()
+    #: The STORED construction id, never the current constant: a split cut under
+    #: a superseded model must stay readable as that model rather than inherit
+    #: today's label (``sql/269``'s own argument for storing it per row).
+    walk_forward_model_id: str | None = None
+    fold_count: int | None = None
+    #: Whose census the counts are. See ``QUARANTINE_ARM_PREFERENCE``.
+    quarantine_arm: str | None = None
+    #: The in-sample window the folds partition. ⚠ NOT one of the six recent
+    #: evidence windows — the folds sit entirely inside the in-sample prefix and
+    #: are not the in-sample/hold-out split, so this window is the split's own.
+    window_start: date | None = None
+    window_end: date | None = None
+    unavailable_reason: SplitUnavailableReason | None = None
+
+
+def _sort_key(row: Mapping[str, Any]) -> tuple[int, int, int]:
+    """Preference order over one strategy's candidate in-sample results.
+
+    Least-first, so the caller reads it with ``min``: the preferred quarantine
+    arm, then the newest window, then the newest result.
+
+    ⚠ The last two are NOT preferences anyone should have to defend — they exist
+    so the choice is DETERMINISTIC. A tie broken by whatever order the database
+    happened to return is an accidental API semantic, and it would move under a
+    plan change nobody reviewed.
+
+    ⚠ Both "newest" terms are NEGATED ordinals, not the values. A bare
+    ``window_end`` sorts ascending under ``min`` and hands back the OLDEST split
+    — which is the opposite of the docstring, and is exactly what
+    ``test_the_newest_window_breaks_a_tie_deterministically`` caught.
+    """
+    arm = str(row["quarantine_arm"])
+    arm_rank = (
+        QUARANTINE_ARM_PREFERENCE.index(arm) if arm in QUARANTINE_ARM_PREFERENCE else len(QUARANTINE_ARM_PREFERENCE)
+    )
+    window_end: date = row["window_end"]
+    return (arm_rank, -window_end.toordinal(), -int(row["result_id"]))
+
+
+def derive_walk_forward_split(fold_rows: Sequence[Mapping[str, Any]]) -> StrategyWalkForwardSplit:
+    """Pick one strategy's representative split from its stored fold rows.
+
+    ``fold_rows`` is every ``strategy_result_folds`` row for ONE strategy's
+    current-identity in-sample results, LEFT-joined so a result with no split
+    still appears with a null ``fold_index``. That join shape is what makes
+    ``no_in_sample_result`` and ``no_split_stored`` distinguishable here rather
+    than collapsed into one "no evidence" by the query.
+    """
+    if not fold_rows:
+        return StrategyWalkForwardSplit(unavailable_reason="no_in_sample_result")
+
+    with_folds = [row for row in fold_rows if row.get("fold_index") is not None]
+    if not with_folds:
+        return StrategyWalkForwardSplit(unavailable_reason="no_split_stored")
+
+    by_result: dict[int, list[Mapping[str, Any]]] = {}
+    for row in with_folds:
+        by_result.setdefault(int(row["result_id"]), []).append(row)
+    chosen = min((rows for rows in by_result.values()), key=lambda rows: _sort_key(rows[0]))
+
+    # One split is one construction. `read_walk_forward_folds` raises on a mixed
+    # model id for this reason; a bulk reader cannot raise, so it names it.
+    model_ids = {str(row["walk_forward_model_id"]) for row in chosen}
+    fold_counts = {int(row["fold_count"]) for row in chosen}
+    if len(model_ids) > 1 or len(fold_counts) > 1:
+        return StrategyWalkForwardSplit(unavailable_reason="invariant_violated")
+
+    declared = fold_counts.pop()
+    indices = sorted(int(row["fold_index"]) for row in chosen)
+    # A split missing a fold is a cross-validation nobody ran to the end, and it
+    # would render as a complete one. `WalkForwardFolds` makes the same
+    # all-or-nothing check on the writer side; this is the read side of it.
+    if len(indices) != declared or indices != list(range(declared)):
+        return StrategyWalkForwardSplit(unavailable_reason="invariant_violated")
+
+    head = chosen[0]
+    return StrategyWalkForwardSplit(
+        folds=tuple(
+            WalkForwardFoldView(
+                fold_index=int(row["fold_index"]),
+                first_date=row["first_date"],
+                last_date=row["last_date"],
+                bar_count=int(row["bar_count"]),
+                embargo_bars=int(row["embargo_bars"]),
+                test_count=int(row["test_count"]),
+                train_count=int(row["train_count"]),
+                purged_count=int(row["purged_count"]),
+                embargoed_count=int(row["embargoed_count"]),
+            )
+            for row in sorted(chosen, key=lambda row: int(row["fold_index"]))
+        ),
+        walk_forward_model_id=model_ids.pop(),
+        fold_count=declared,
+        quarantine_arm=str(head["quarantine_arm"]),
+        window_start=head["window_start"],
+        window_end=head["window_end"],
+    )

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2436,6 +2436,75 @@ export interface StrategyRegimeCohort {
   effective_sample_size: string | null;
 }
 
+/** Why a card carries no split. Named rather than blank, because a silent
+ *  absence and a measured zero look identical to a reader (#2823).
+ *
+ * - `no_in_sample_result` — no in-sample result under the current identity
+ *   pins. The usual state for a version whose backtest has not been re-run;
+ *   it does NOT mean the split was skipped.
+ * - `no_split_stored` — the run happened and the split never reached storage.
+ * - `invariant_violated` — the stored rows contradict the writer's contract.
+ *   Describes US, not the evidence.
+ */
+export type StrategySplitUnavailableReason =
+  | "no_in_sample_result"
+  | "no_split_stored"
+  | "invariant_violated";
+
+/** One block of criterion 5's split.
+ *
+ * ⚠ `first_date` / `last_date` bound the **test** block, NOT a training
+ * interval.
+ *
+ * ⚠ The four counts are ONE population re-classified by this fold. Summing any
+ * of them across folds counts the same observations `fold_count` times, so a
+ * column total is always wrong and must never be rendered.
+ *
+ * ⚠ There is no per-fold return, score or Sharpe, by design — the split is a
+ * validity gate, not a training loop. Do not present these counts as
+ * performance.
+ *
+ * Two legitimate zeroes: `test_count` can be 0 on a fold spanning a thin era,
+ * and `embargo_bars` 0 means "nothing to measure on this fold's training side",
+ * never that the embargo was skipped.
+ */
+export interface StrategyWalkForwardFold {
+  fold_index: number;
+  first_date: string;
+  last_date: string;
+  bar_count: number;
+  /** MEASURED, on the PANEL-date axis — not instrument bars, not calendar days,
+   *  and not a declared holding period. Varies per fold. */
+  embargo_bars: number;
+  test_count: number;
+  train_count: number;
+  /** Training observations whose LABEL WINDOW overlaps the test block. */
+  purged_count: number;
+  /** Training observations STARTING in the window immediately after the test
+   *  block. A separate verdict from `purged_count`, never merged with it. */
+  embargoed_count: number;
+}
+
+/** The strategy's stored split, or the named reason it has none (#2823).
+ *
+ * ⚠ The construction is **purged K-fold over contiguous blocks**, not an
+ * anchored or rolling walk-forward — both sides of a test block carry training
+ * data, which is what leaves room for the embargo at all. Label it accordingly.
+ *
+ * `folds` is non-empty exactly when `unavailable_reason` is null.
+ */
+export interface StrategyWalkForwardSplit {
+  folds: StrategyWalkForwardFold[];
+  /** The STORED construction id, never today's constant. */
+  walk_forward_model_id: string | null;
+  fold_count: number | null;
+  /** Whose census the counts are. Geometry is arm-invariant; the census is not. */
+  quarantine_arm: string | null;
+  window_start: string | null;
+  window_end: string | null;
+  unavailable_reason: StrategySplitUnavailableReason | null;
+}
+
 export interface StrategyResultArm {
   result_version: string;
   purpose: "harness_validation" | "capital_candidate";
@@ -2553,6 +2622,8 @@ export interface StrategyOverview {
     exclusions_by_reason: Record<string, number>;
   };
   evidence_windows: StrategyEvidenceWindow[];
+  /** Criterion 5's split — per STRATEGY, not per window (#2823). */
+  walk_forward_split: StrategyWalkForwardSplit;
   prior_versions: StrategyPriorVersion[];
   /** ⚠ NOT a prior-version summary despite the name — counts rows under the
    *  CURRENT version matching no declared window. Use `prior_versions`. */

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -233,6 +233,38 @@ const OVERVIEW: StrategyOverviewResponse = {
     // fixture used to say `primary` / `holdout`, neither of which the API can
     // emit — which is why `primaryEvidence()` matching a dead id went unnoticed
     // (#2624): the fallback branch covered for it in prod and in the test alike.
+    walk_forward_split: {
+      folds: [
+        {
+          fold_index: 0,
+          first_date: "1962-01-02",
+          last_date: "1999-09-02",
+          bar_count: 4375006,
+          embargo_bars: 615,
+          test_count: 639464,
+          train_count: 1694643,
+          purged_count: 0,
+          embargoed_count: 122531,
+        },
+        {
+          fold_index: 1,
+          first_date: "1999-09-03",
+          last_date: "2009-03-19",
+          bar_count: 4373756,
+          embargo_bars: 931,
+          test_count: 581900,
+          train_count: 1541705,
+          purged_count: 597,
+          embargoed_count: 332436,
+        },
+      ],
+      walk_forward_model_id: "c5-purged-walk-forward-v1",
+      fold_count: 2,
+      quarantine_arm: "admitted",
+      window_start: "1962-01-02",
+      window_end: "2026-07-08",
+      unavailable_reason: null,
+    },
     evidence_windows: [
       { window_id: "primary-2022-plus", label: "Primary: 2022 onward", window_start: "2022-01-01", window_end: "2026-07-08", status: "complete", arms: [ARM] },
       { window_id: "year-2022", label: "Calendar 2022", window_start: "2022-01-01", window_end: "2022-12-31", status: "missing", arms: [] },
@@ -1236,6 +1268,55 @@ describe("StrategiesPage", () => {
     // either fire-rate reason, and must not read as a zero.
     expect(screen.getByText("Not measured")).toBeInTheDocument();
     expect(screen.getByText(/Result version criterion7-v1/)).toBeInTheDocument();
+  });
+
+  it("shows the purged K-fold split, and never calls it a walk-forward", async () => {
+    // #2823. `strategy_result_folds` has been written since #2240 and read by
+    // nothing but tests and scripts. ⚠ The construction is purged K-fold over
+    // contiguous blocks — `app/services/walk_forward.py` is explicit that it is
+    // "not a strictly anchored walk-forward" — so the heading must not promise
+    // one.
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+
+    await userEvent.click(await screen.findByRole("button", { name: "View evidence" }));
+
+    expect(await screen.findByText(/Purged K-fold/)).toBeInTheDocument();
+    // The census is arm-dependent even though the geometry is not, so the arm
+    // it belongs to has to be on screen with it.
+    expect(screen.getByText(/admitted universe/)).toBeInTheDocument();
+    expect(screen.getByText(/c5-purged-walk-forward-v1/)).toBeInTheDocument();
+    // "Test block", because the dates bound the HELD-OUT block; a reader who
+    // takes them for a training range has the split backwards.
+    expect(screen.getByText("Test block")).toBeInTheDocument();
+    expect(screen.getByText(/these columns do not total/i)).toBeInTheDocument();
+  });
+
+  it("names why a split is absent instead of leaving the panel blank", async () => {
+    // The `derive_fire_rate` contract one panel over: an unexplained blank and a
+    // measured zero are indistinguishable. ⚠ `no_in_sample_result` is the
+    // ORDINARY state for a version whose backtest has not been re-run, so the
+    // copy must not imply the split was skipped or failed.
+    const unsplit = structuredClone(OVERVIEW);
+    const strategy = unsplit.strategies[0]!;
+    strategy.walk_forward_split = {
+      folds: [],
+      walk_forward_model_id: null,
+      fold_count: null,
+      quarantine_arm: null,
+      window_start: null,
+      window_end: null,
+      unavailable_reason: "no_in_sample_result",
+    };
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(unsplit);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+
+    await userEvent.click(await screen.findByRole("button", { name: "View evidence" }));
+
+    expect(await screen.findByText(/No in-sample run under this version/)).toBeInTheDocument();
+    expect(screen.queryByText("Test block")).not.toBeInTheDocument();
   });
 
   it("says a periodic strategy was never asked rather than showing it declined", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -17,6 +17,7 @@ import type {
   FiredSignal,
   FiredSignalsResponse,
   StrategyEvidenceWindow,
+  StrategySplitUnavailableReason,
   StrategyFireRate,
   StrategyOverview,
   StrategyOverviewResponse,
@@ -246,6 +247,115 @@ function RegimeBreakdown({ arm }: { arm: StrategyResultArm }) {
               No trades in {absent.map((regime) => REGIME_LABELS[regime].toLowerCase()).join(", ")}.
             </p>
           ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+const SPLIT_UNAVAILABLE_LABELS: Record<StrategySplitUnavailableReason, string> = {
+  // NOT "the split was skipped" — the ordinary state for a version whose
+  // backtest has not been re-run under today's identity pins.
+  no_in_sample_result: "No in-sample run under this version",
+  // Distinct from the above on purpose: the run happened, the split did not
+  // reach storage. A different thing to chase.
+  no_split_stored: "In-sample run stored no split",
+  // Describes US, not the evidence — same contract as the fire-rate card.
+  invariant_violated: "Split inconsistent — refused",
+};
+
+/** Criterion 5's split, per STRATEGY (#2823).
+ *
+ * `strategy_result_folds` has been written since #2240 and read by nothing but
+ * tests and scripts, so the evidence that the in-sample panel was actually
+ * purged and embargoed has never reached this page. #2817 closed the same gap
+ * on the per-regime cohorts.
+ *
+ * ⚠ THE HEADING SAYS "PURGED K-FOLD", NOT "WALK-FORWARD", DELIBERATELY.
+ * `app/services/walk_forward.py`: the design is *"ch. 7's purged K-fold over
+ * contiguous time blocks, not a strictly anchored walk-forward"* — both sides of
+ * a test block carry training data, and an anchored design has none after it,
+ * which would delete the embargo. Calling it rolling or anchored here would
+ * describe a construction we do not run.
+ *
+ * ⚠ EACH ROW IS A TEST BLOCK. `first_date`/`last_date` bound the block held OUT,
+ * not a training interval.
+ *
+ * ⚠ NO COLUMN TOTALS, AND NONE MAY BE ADDED. Each fold re-classifies the WHOLE
+ * observation population into test/train/purged/embargoed, so a sum down any
+ * column counts the same observations `fold_count` times over.
+ *
+ * ⚠ NO PERFORMANCE FIGURE EXISTS HERE, by design — the split is a validity
+ * gate, not a training loop, and a per-fold Sharpe would invite the
+ * "which fold did best" search criterion 6 exists to bound. Nothing on this
+ * panel may be worded as a return.
+ *
+ * Two zeroes that are measurements: `test_count` 0 on a fold spanning a thin
+ * era, and `embargo_bars` 0 meaning "nothing to measure on this fold's training
+ * side" — never "no embargo applied". Both render as plain zeroes rather than
+ * dashes for that reason. */
+function WalkForwardSplitPanel({ strategy }: { strategy: StrategyOverview }) {
+  const split = strategy.walk_forward_split;
+  return (
+    <div className="mt-4 border-t border-slate-200 pt-3 dark:border-slate-800">
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+        Purged K-fold{" "}
+        <span className="font-normal normal-case tracking-normal">
+          · contiguous in-sample blocks, purged and embargoed
+        </span>
+      </h4>
+      {split.unavailable_reason !== null ? (
+        <p className="mt-2 text-xs text-slate-500">
+          {SPLIT_UNAVAILABLE_LABELS[split.unavailable_reason]}.
+        </p>
+      ) : (
+        <>
+          <p className="mt-1 text-xs text-slate-500">
+            {split.fold_count} folds over {formatDate(split.window_start)}–{formatDate(split.window_end)} ·{" "}
+            {/* The arm is NAMED. The geometry is arm-invariant but the census is
+                not, so a count whose arm is implicit is one the reader cannot
+                attribute. */}
+            {split.quarantine_arm} universe · {split.walk_forward_model_id}
+          </p>
+          <table className="mt-2 w-full text-xs tabular-nums">
+            <thead className="text-slate-500">
+              <tr className="text-left">
+                {/* "Test block", not "Fold" alone — the dates are the held-out
+                    block and readers assume a training range otherwise. */}
+                <th className="font-medium">Test block</th>
+                <th className="font-medium">Bars</th>
+                <th className="font-medium">Tested</th>
+                <th className="font-medium">Trained</th>
+                <th className="font-medium">Purged</th>
+                <th className="font-medium">Embargoed</th>
+              </tr>
+            </thead>
+            <tbody className="text-slate-700 dark:text-slate-200">
+              {split.folds.map((fold) => (
+                <tr key={fold.fold_index} className="border-t border-slate-100 dark:border-slate-800/60">
+                  <td className="py-1">
+                    {formatDate(fold.first_date)}–{formatDate(fold.last_date)}
+                  </td>
+                  <td className="py-1">{formatNumber(fold.bar_count, 0)}</td>
+                  <td className="py-1">{formatNumber(fold.test_count, 0)}</td>
+                  <td className="py-1">{formatNumber(fold.train_count, 0)}</td>
+                  <td className="py-1">{formatNumber(fold.purged_count, 0)}</td>
+                  <td className="py-1">
+                    {formatNumber(fold.embargoed_count, 0)}
+                    {/* The embargo WIDTH beside the count it produced: the count
+                        alone cannot be judged without knowing how wide a window
+                        it came from, and the width is measured per fold. */}
+                    <span className="text-slate-500"> · {formatNumber(fold.embargo_bars, 0)} bar window</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="mt-2 text-[10px] text-slate-500">
+            Purged = training observations whose label window overlaps the test block. Embargoed = training
+            observations starting immediately after it. Each fold re-classifies the whole population, so these
+            columns do not total.
+          </p>
         </>
       )}
     </div>
@@ -1475,6 +1585,12 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
         <p className={strategy.scan.status === "rotated" ? "mt-2" : undefined}>
           No completed valid evidence is available under the current version. {failures[0] ?? "The research run has not finished."}
         </p>
+        {/* ⚠ RENDERED ON THE BLANK BRANCH TOO, and that is the point. The split
+            belongs to the in-sample panel and is independent of whether any
+            hold-out arm survived the identity pins — so on a card with no arms
+            it may be the only stored evidence there is. Measured 2026-08-21:
+            all ten cards were in exactly that state. */}
+        <WalkForwardSplitPanel strategy={strategy} />
         <PriorVersionsBlock strategy={strategy} />
       </div>
     );
@@ -1515,6 +1631,7 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
         </div>
       </div>
       <RegimeBreakdown arm={arm} />
+      <WalkForwardSplitPanel strategy={strategy} />
       <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 border-t border-slate-200 pt-3 text-xs text-slate-500 dark:border-slate-800">
         <span>Evidence windows complete: <strong className="text-slate-700 dark:text-slate-200">{completed}/{strategy.evidence_windows.length}</strong></span>
         <span>Forward observations: <strong className="text-slate-700 dark:text-slate-200">{strategy.attribution.fired_entries}</strong></span>

--- a/tests/test_strategy_walk_forward_evidence.py
+++ b/tests/test_strategy_walk_forward_evidence.py
@@ -1,0 +1,202 @@
+"""#2823 — picking a strategy's representative split, and naming its absence.
+
+Pure: every case is a list of row dicts, so none of this needs Postgres. The
+decisions under test are the two that can be wrong on this path — WHICH stored
+result represents the card, and WHAT is said when none does.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from app.services.strategy_walk_forward_evidence import derive_walk_forward_split
+
+_WINDOW_START = date(1962, 1, 2)
+_WINDOW_END = date(2026, 7, 8)
+
+
+def _fold_row(
+    *,
+    result_id: int,
+    fold_index: int | None,
+    quarantine_arm: str = "admitted",
+    fold_count: int = 2,
+    model_id: str = "c5-purged-walk-forward-v1",
+    window_end: date = _WINDOW_END,
+    train_count: int = 1_000,
+) -> dict[str, Any]:
+    """One `_WALK_FORWARD_SPLIT_SQL` row. `fold_index=None` is the LEFT-JOIN miss."""
+    row: dict[str, Any] = {
+        "strategy_id": "s1-time-series-momentum",
+        "result_id": result_id,
+        "quarantine_arm": quarantine_arm,
+        "window_start": _WINDOW_START,
+        "window_end": window_end,
+        "fold_index": fold_index,
+    }
+    if fold_index is None:
+        return row | dict.fromkeys(
+            (
+                "walk_forward_model_id",
+                "fold_count",
+                "first_date",
+                "last_date",
+                "bar_count",
+                "embargo_bars",
+                "test_count",
+                "train_count",
+                "purged_count",
+                "embargoed_count",
+            )
+        )
+    return row | {
+        "walk_forward_model_id": model_id,
+        "fold_count": fold_count,
+        "first_date": date(1990 + fold_index, 1, 1),
+        "last_date": date(1990 + fold_index, 12, 31),
+        "bar_count": 4_375_006,
+        "embargo_bars": 615,
+        "test_count": 639_464,
+        "train_count": train_count,
+        "purged_count": 0,
+        "embargoed_count": 122_530,
+    }
+
+
+def _split(*rows: dict[str, Any]) -> Any:
+    return derive_walk_forward_split(list(rows))
+
+
+class TestNamedAbsence:
+    def test_no_rows_at_all_is_no_in_sample_result(self) -> None:
+        """The usual state for a version whose backtest has not been re-run."""
+        split = _split()
+        assert split.unavailable_reason == "no_in_sample_result"
+        assert split.folds == ()
+
+    def test_a_result_with_no_folds_is_a_different_state(self) -> None:
+        """The run happened and the split did not reach storage.
+
+        Collapsing this into `no_in_sample_result` would hide a real gap behind
+        the benign one — which is why the SQL LEFT JOINs rather than INNER JOINs.
+        """
+        split = _split(_fold_row(result_id=1, fold_index=None))
+        assert split.unavailable_reason == "no_split_stored"
+        assert split.folds == ()
+
+    def test_every_absence_leaves_every_field_null(self) -> None:
+        """`derive_fire_rate`'s rule: a value is None iff its reason is not."""
+        for split in (_split(), _split(_fold_row(result_id=1, fold_index=None))):
+            assert split.folds == ()
+            assert split.walk_forward_model_id is None
+            assert split.fold_count is None
+            assert split.quarantine_arm is None
+            assert split.window_start is None
+            assert split.window_end is None
+
+
+class TestInvariantViolations:
+    """Contained to the card and NAMED — never raised.
+
+    `read_walk_forward_folds` raises on a mixed split because it reads one
+    result. This runs per strategy inside an aggregate endpoint, so a raise
+    would blank all ten cards over one bad row.
+    """
+
+    def test_two_constructions_on_one_result(self) -> None:
+        split = _split(
+            _fold_row(result_id=1, fold_index=0, model_id="c5-purged-walk-forward-v1"),
+            _fold_row(result_id=1, fold_index=1, model_id="c5-purged-walk-forward-v2"),
+        )
+        assert split.unavailable_reason == "invariant_violated"
+        assert split.folds == ()
+
+    def test_disagreeing_fold_counts(self) -> None:
+        split = _split(
+            _fold_row(result_id=1, fold_index=0, fold_count=2),
+            _fold_row(result_id=1, fold_index=1, fold_count=3),
+        )
+        assert split.unavailable_reason == "invariant_violated"
+
+    def test_a_missing_fold_is_a_cross_validation_nobody_finished(self) -> None:
+        """Two declared, one stored — it would otherwise render as complete."""
+        split = _split(_fold_row(result_id=1, fold_index=0, fold_count=2))
+        assert split.unavailable_reason == "invariant_violated"
+
+    def test_a_gap_in_the_indices(self) -> None:
+        """Right COUNT, wrong SET: 0 and 2 of a 2-fold split is still incomplete."""
+        split = _split(
+            _fold_row(result_id=1, fold_index=0, fold_count=2),
+            _fold_row(result_id=1, fold_index=2, fold_count=2),
+        )
+        assert split.unavailable_reason == "invariant_violated"
+
+
+class TestArmSelection:
+    def test_admitted_wins_over_masked(self) -> None:
+        """The unmasked universe is the wider population, and it is NAMED."""
+        split = _split(
+            _fold_row(result_id=1, fold_index=0, quarantine_arm="masked", train_count=1_694_103),
+            _fold_row(result_id=1, fold_index=1, quarantine_arm="masked", train_count=1_694_103),
+            _fold_row(result_id=2, fold_index=0, quarantine_arm="admitted", train_count=1_694_643),
+            _fold_row(result_id=2, fold_index=1, quarantine_arm="admitted", train_count=1_694_643),
+        )
+        assert split.unavailable_reason is None
+        assert split.quarantine_arm == "admitted"
+        assert [fold.train_count for fold in split.folds] == [1_694_643, 1_694_643]
+
+    def test_masked_alone_is_used_rather_than_refused(self) -> None:
+        split = _split(
+            _fold_row(result_id=1, fold_index=0, quarantine_arm="masked"),
+            _fold_row(result_id=1, fold_index=1, quarantine_arm="masked"),
+        )
+        assert split.unavailable_reason is None
+        assert split.quarantine_arm == "masked"
+
+    def test_a_foldless_result_never_masks_a_stored_split(self) -> None:
+        """Ordering is folds-first, so the preferred arm cannot win while empty."""
+        split = _split(
+            _fold_row(result_id=9, fold_index=None, quarantine_arm="admitted"),
+            _fold_row(result_id=1, fold_index=0, quarantine_arm="masked"),
+            _fold_row(result_id=1, fold_index=1, quarantine_arm="masked"),
+        )
+        assert split.unavailable_reason is None
+        assert split.quarantine_arm == "masked"
+        assert len(split.folds) == 2
+
+    def test_the_newest_window_breaks_a_tie_deterministically(self) -> None:
+        """A tie settled by database return order is an accidental API semantic."""
+        older = date(2024, 9, 27)
+        split = _split(
+            _fold_row(result_id=1, fold_index=0, window_end=older),
+            _fold_row(result_id=1, fold_index=1, window_end=older),
+            _fold_row(result_id=2, fold_index=0, window_end=_WINDOW_END),
+            _fold_row(result_id=2, fold_index=1, window_end=_WINDOW_END),
+        )
+        assert split.window_end == _WINDOW_END
+
+
+class TestRenderedSplit:
+    def test_folds_come_back_in_index_order_whatever_the_row_order(self) -> None:
+        split = _split(
+            _fold_row(result_id=1, fold_index=1),
+            _fold_row(result_id=1, fold_index=0),
+        )
+        assert [fold.fold_index for fold in split.folds] == [0, 1]
+
+    def test_the_stored_construction_is_reported_not_todays_constant(self) -> None:
+        """A split cut under a superseded model stays readable as that model."""
+        split = _split(
+            _fold_row(result_id=1, fold_index=0, model_id="c5-purged-walk-forward-v0"),
+            _fold_row(result_id=1, fold_index=1, model_id="c5-purged-walk-forward-v0"),
+        )
+        assert split.walk_forward_model_id == "c5-purged-walk-forward-v0"
+
+    def test_a_zero_test_count_is_a_measurement_not_a_gap(self) -> None:
+        """`sql/269`: a fold spanning a thin era can carry no STARTING observation."""
+        thin = _fold_row(result_id=1, fold_index=0) | {"test_count": 0, "embargo_bars": 0}
+        split = _split(thin, _fold_row(result_id=1, fold_index=1))
+        assert split.unavailable_reason is None
+        assert split.folds[0].test_count == 0
+        assert split.folds[0].embargo_bars == 0

--- a/tests/test_strategy_walk_forward_evidence.py
+++ b/tests/test_strategy_walk_forward_evidence.py
@@ -193,6 +193,26 @@ class TestRenderedSplit:
         )
         assert split.walk_forward_model_id == "c5-purged-walk-forward-v0"
 
+    def test_the_response_model_carries_exactly_the_derivation_s_fields(self) -> None:
+        """Drift between the dataclass and the response model fails HERE.
+
+        `_walk_forward_split_view` copies field by field, so a rename on either
+        side is a type error rather than a silent drop — but only for fields that
+        still exist on both. This pins the SETS equal, which is what catches a
+        field ADDED to the derivation and never surfaced: the endpoint would keep
+        returning a valid, quietly incomplete payload, and no request would fail.
+        """
+        from dataclasses import fields
+
+        from app.api.strategies import WalkForwardFold, WalkForwardSplit
+        from app.services.strategy_walk_forward_evidence import (
+            StrategyWalkForwardSplit,
+            WalkForwardFoldView,
+        )
+
+        assert {field.name for field in fields(StrategyWalkForwardSplit)} == set(WalkForwardSplit.model_fields)
+        assert {field.name for field in fields(WalkForwardFoldView)} == set(WalkForwardFold.model_fields)
+
     def test_a_zero_test_count_is_a_measurement_not_a_gap(self) -> None:
         """`sql/269`: a fold spanning a thin era can carry no STARTING observation."""
         thin = _fold_row(result_id=1, fold_index=0) | {"test_count": 0, "embargo_bars": 0}


### PR DESCRIPTION
## What changed

`/strategies` now renders criterion 5's stored split — the per-fold evidence that
the in-sample panel was actually purged and embargoed.

`strategy_result_folds` (`sql/269`) has been written by `store_walk_forward_folds`
since #2240. A data-access reader exists (`result_ledger.py:2417
read_walk_forward_folds`) and every one of its callers is a test or a one-off
script — no `app/api/` route, no frontend field. `sql/269`'s own header calls the
missing consumer *"the phase-6 read"*. #2817 closed the same gap one table over,
on the per-regime cohorts; this is the walk-forward-integrity half of build-queue
item 6.

## Why the join is by identity pins, not by a FK

Folds hang off `namespace = 'in_sample'` results. `_RESULTS_SQL` selects
`namespace = 'hold_out'`. So keying a fold read on the result ids `_RESULTS_SQL`
returned — #2817's pattern, and the right one there — would match nothing, always,
and the panel would read "no strategy has a split" forever.
`strategy_result_control_support` does not bridge them either: 0 rows on dev, and
its `control_result_id` is the control arm rather than the in-sample companion.

Restating the ten pins would be the #2806 shape — two copies drift, the join
silently empties, and "no walk-forward evidence" becomes indistinguishable from a
split that was never cut. They are not restated: `_WALK_FORWARD_SPLIT_SQL` binds
**the same `params` dict** `_RESULTS_SQL` binds, with the same placeholder names,
so a pin added to one is a `ProgrammingError` on the other rather than silent drift.

`LEFT JOIN`, not `INNER` — an in-sample result carrying no folds must still arrive,
or `no_split_stored` collapses into `no_in_sample_result`.

## The grain is one split per strategy — measured, not assumed

A strategy version stores **four** in-sample results, the 2x2 of `ambiguity_arm`
x `quarantine_arm`, each with its own folds. Measured on dev for
`s1-time-series-momentum` at `strategy-registry-v1+2307ee566d7b` (result ids
117-120), fold 0:

| arm | first_date | last_date | bar_count | embargo_bars | train |
| --- | --- | --- | --- | --- | --- |
| best_case / masked | 1962-01-02 | 1999-09-02 | 4,375,006 | 615 | 1,694,103 |
| best_case / admitted | 1962-01-02 | 1999-09-02 | 4,375,006 | 615 | 1,694,643 |
| worst_case / masked | 1962-01-02 | 1999-09-02 | 4,375,006 | 615 | 1,694,103 |
| worst_case / admitted | 1962-01-02 | 1999-09-02 | 4,375,006 | 615 | 1,694,643 |

The **geometry** is identical across all four — `bar_weighted_folds` reads only
the panel axis. The **census** moves with `quarantine_arm` alone; `ambiguity_arm`
is a fill-price assumption and cannot move a population (117 == 119, 118 == 120,
exactly). So one split is rendered, and the arm whose census it is, is NAMED in
the payload rather than left implicit.

## Copy corrections the source required

Every one of these reads backwards by default, and all four are load-bearing for
what the panel says:

- The construction is **purged K-fold over contiguous blocks**, NOT an anchored or
  rolling walk-forward. `app/services/walk_forward.py`: *"ch. 7's purged K-fold
  over contiguous time blocks, not a strictly anchored walk-forward"* — both sides
  of a test block carry training data, which is what leaves room for the embargo.
  The heading says "Purged K-fold".
- `first_date`/`last_date` bound the **test** block, not a training interval. The
  column header is "Test block".
- `purged` = training observations whose label window overlaps the test block.
  `embargoed` = training observations STARTING immediately after it. Separate
  verdicts, never merged.
- **The four counts are one population re-classified per fold**, so a column total
  is always wrong. Verified on dev: every S-1 fold sums to exactly **4,228,628**
  (1,026,750+2,398,068+0+803,810 = 1,148,643+1,024,208+2,542+2,053,235 = …). The
  panel states this and renders no totals.

There is no per-fold performance field and none may be added — §5.3: the split is
a validity gate, not a training loop, and a per-fold Sharpe *"would invite exactly
the 'which fold did best' search criterion 6 exists to bound"*.

## Named absence

`derive_fire_rate`'s contract, one panel over: a silent blank and a measured zero
are indistinguishable to a reader.

- `no_in_sample_result` — no in-sample result under the current pins. The ordinary
  state for a version whose backtest has not been re-run; it does NOT mean the
  split was skipped.
- `no_split_stored` — the run happened, the split never reached storage.
- `invariant_violated` — stored rows contradict the writer's contract. Contained
  to its own card and named there rather than raised: this runs per strategy inside
  an aggregate endpoint, so propagating would blank all ten cards over one bad row.

`folds` is non-empty exactly when `unavailable_reason` is null.

The panel renders on the **blank-card branch too** (`!window || !arm`), because the
split belongs to the in-sample panel and is independent of whether any hold-out arm
survived the pins. Measured 2026-08-21: all ten cards were in exactly that state
(60/60 evidence windows `missing`, 0 result arms), so on those cards this is the
only stored evidence there is.

## Verification

Dev-verified by calling the real endpoint function against the dev DB:

```
s1-time-series-momentum       4 folds  arm=admitted  model=c5-purged-walk-forward-v1  1962-01-02..2024-09-27
    fold 0: 1962-01-02..2003-09-30 bars=8,258,154 emb=1639 test=1,026,750 train=2,398,068 purged=0     embargoed=803,810
    fold 1: 2003-10-01..2011-08-02 bars=8,261,576 emb=4825 test=1,148,643 train=1,024,208 purged=2,542 embargoed=2,053,235
    fold 2: 2011-08-03..2016-09-30 bars=8,258,798 emb=4825 test=1,019,774 train=2,173,419 purged=1,974 embargoed=1,033,461
    fold 3: 2016-10-03..2021-06-28 bars=8,266,544 emb=4825 test=1,033,461 train=3,190,818 purged=4,349 embargoed=0
s10 / s2 / s3 / s4 / s5 / s6 / s7 / s8 / s9   REASON=no_in_sample_result
```

Fold 3's `embargoed = 0` is correct — nothing follows the last block. The large
embargo counts are the measured PANEL-axis embargo (`docs/review-prevention-log.md`:
measure a bound on the axis the window is cut on), and S-1 declares no
`max_hold_bars`, so a wide span is expected rather than a defect.

Backtest run 112352 is in flight and writes folds for every in-sample arm it
stores; the nine `no_in_sample_result` cards fill in as it lands.

Gates: `ruff check` / `ruff format --check` / `pyright` (0 errors) /
`pytest -m "not db"` / `pytest tests/smoke` / `pnpm typecheck` /
`pnpm test:unit` (1529 passed) — all green. Codex checkpoint 1 on the spec
(caught the anchored-vs-K-fold mislabel, the test-block reading and the
cross-fold-sum trap, all of which are fixed here) and checkpoint 2 on the diff
(no findings).

## Scope

Read-only surfacing. No migration, no writer change, no change to the split
construction. No strategy version moves — `_module_hash()` covers
`strategy_registry.py` only, and nothing here touches it.

## Security

No new authz surface. `/strategies/overview` keeps its existing session
requirement; the new statement is parameterised throughout and reads two tables
the endpoint already reads under the same pins. No user-controlled input reaches
the SQL.

Refs #2437
Closes #2823
