### PR TITLE
fix(#2766): the first paper-automation enable required its own output

### DIFF
--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -739,8 +739,64 @@ describe("StrategiesPage", () => {
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
     expect(master).not.toBeChecked();
+  });
+
+  it("performs the first automation enable from the default global-flag-false state", async () => {
+    // The repository ships `runtime_config.enable_auto_trading = false` and an
+    // unfunded, disabled pool. #2766: the page used to require that flag before
+    // it would call the endpoint that sets it, so this path was unreachable.
+    const ready = approvedOverview();
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...ready,
+      execution_enabled: false,
+      paper_pool: { ...ready.paper_pool, enabled: false },
+    });
+    const update = vi.spyOn(strategiesApi, "updateStrategyPaperPool").mockResolvedValue({
+      ...ready.paper_pool,
+      enabled: true,
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
+    expect(master).not.toBeChecked();
+    expect(master).not.toBeDisabled();
+    await userEvent.click(master);
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: true,
+      capital_limit: "1000.000000",
+      risk_profile: "balanced",
+    })));
+  });
+
+  it("refuses the first enable while evidence readiness is false", async () => {
+    const ready = approvedOverview();
+    const update = vi.spyOn(strategiesApi, "updateStrategyPaperPool");
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...ready,
+      execution_enabled: false,
+      paper_pool: { ...ready.paper_pool, enabled: false },
+      automation_readiness: { ...ready.automation_readiness, ready: false, state: "no_capital_candidates", blockers: ["no_capital_candidates"] },
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
     expect(master).toBeDisabled();
-    expect(screen.getByText("System-wide automatic trading is off. Enable that safety control before allowing new entries.")).toBeInTheDocument();
+    expect(screen.getByText("Automation stays off until at least one strategy passes validation.")).toBeInTheDocument();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("refuses the first enable on an account that can run neither demo nor live automation", async () => {
+    const ready = approvedOverview();
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...ready,
+      demo_connection: false,
+      live_strategy_activation_available: false,
+      execution_enabled: false,
+      paper_pool: { ...ready.paper_pool, enabled: false },
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
+    expect(master).toBeDisabled();
+    expect(screen.getByText("This account cannot run strategy automation. Connect the demo account, or complete real-money activation first.")).toBeInTheDocument();
   });
 
   it("shows compact prospective evidence when automation is ready", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1267,7 +1267,17 @@ function AutomationControl({
     || parsed !== Number(pool.capital_limit)
     || capitalMode !== pool.capital_mode
     || riskProfile !== pool.mandate.risk_profile;
-  const canEnable = overview.automation_readiness.ready && overview.execution_enabled && riskProfile !== "unconfigured";
+  // ⚠ `overview.execution_enabled` is this form's OUTPUT, never its input
+  // (#2766). `PUT /strategies/paper-pool` writes `runtime_config
+  // .enable_auto_trading` and the pool's `enabled` to the SAME value in one
+  // transaction (`app/api/strategies.py::update_strategy_paper_pool`), and no
+  // other control in the app sets that flag. Requiring it here made the first
+  // enable unreachable from the repository's fail-closed default — the page
+  // demanded the flag be true before it would call the only endpoint that
+  // turns it true. The backend's own first-enable gate is `readiness.ready`,
+  // which is what this mirrors. `enable_live_trading` is untouched by the flow.
+  const accountEligible = overview.demo_connection || overview.live_strategy_activation_available;
+  const canEnable = overview.automation_readiness.ready && accountEligible && riskProfile !== "unconfigured";
   const selectedMandate = riskProfile === pool.mandate.risk_profile && pool.mandate.configured
     ? pool.mandate
     : pool.available_mandates.find((mandate) => mandate.risk_profile === riskProfile) ?? null;
@@ -1378,8 +1388,8 @@ function AutomationControl({
       </dl>
       {!canEnable ? (
         <p className="mt-4 text-xs text-amber-700 dark:text-amber-300">
-          {!overview.execution_enabled
-            ? "System-wide automatic trading is off. Enable that safety control before allowing new entries."
+          {!accountEligible
+            ? "This account cannot run strategy automation. Connect the demo account, or complete real-money activation first."
             : riskProfile === "unconfigured"
               ? "Choose a risk profile before allowing new entries."
             : "Automation stays off until at least one strategy passes validation."}


### PR DESCRIPTION
## What was wrong

`frontend/src/pages/StrategiesPage.tsx` computed:

```ts
const canEnable = overview.automation_readiness.ready && overview.execution_enabled && riskProfile !== "unconfigured";
```

`overview.execution_enabled` is `runtime_config.enable_auto_trading`. It ships
false, and the only writer with an operator-facing control is
`PUT /strategies/paper-pool` — the endpoint **this same form calls**, which sets
the pool's `enabled` and the runtime flag to the same value in one transaction
(`app/api/strategies.py::update_strategy_paper_pool`, lines 3016-3058).

So the page required the flag to be true before it would call the only thing
that turns it true. The first paper-automation enable was unreachable from the
repository's fail-closed default state.

`PATCH /config/runtime-flags` (`app/api/config.py:229`) can also set the flag,
but **no frontend control calls it** — grepping `frontend/src` for
`enable_auto_trading` outside tests returns only the type declaration
(`api/types.ts:26`) and a mock (`api/mocks.ts:54`). There was no route through
the app at all, which is what the old amber copy was pointing at: *"System-wide
automatic trading is off. Enable that safety control before allowing new
entries."* — a control that does not exist.

## What changed

`frontend/src/pages/StrategiesPage.tsx` only.

`canEnable` now mirrors the backend's own first-enable gate (`readiness.ready`,
checked in `update_strategy_paper_pool` when `body.enabled and not
current_pool.enabled`), plus:

- a configured risk profile — unchanged;
- positive capital — already enforced by `valid` (`!enabled || parsed > 0`), so
  a first enable with a zero limit is still refused;
- an account that can run automation at all —
  `demo_connection || live_strategy_activation_available`. This is the same
  disjunction the page already uses at line 1751 for its "Real-money strategy
  activation is unavailable" banner, reused rather than a new rule. Gating on
  `demo_connection` alone would lock out a future validated live account; the
  disjunction does not.

The amber refusal copy loses the circular branch and names the account-
eligibility case instead.

## What is deliberately unchanged

- **`enable_live_trading` is never written by this flow.** The endpoint's
  `update_runtime_config` call passes `enable_auto_trading` only.
- **Disabling stays available when readiness has since degraded** — `canEnable`
  gates only the enable direction (`(!canEnable && !enabled)` on the checkbox,
  `(enabled && !canEnable)` on submit).
- **Every runtime gate is untouched and still fail-closed**: global kill switch
  (active since 2026-06-28), `entry_block.execution_block_reasons`, per-strategy
  promotion/allocation refusals, broker preflight, demo-only checks. This PR
  changes one operator-facing precondition on a settings form; it does not move
  any control that stands between a signal and an order.
- The backend gate is unchanged. A request that reaches it with
  `readiness.ready` false is still refused with a 409 listing the blockers.

## Security model

The flag being set is `enable_auto_trading`, a **paper/demo** automation switch,
and this change alters only which client-side state permits the request. The
server-side authorisation (`require_session`) and the server-side refusal
(`readiness.ready` on first enable, under `pg_advisory_xact_lock`) are both
unchanged, so nothing here is a client-trusted gate — the frontend condition was
never the security boundary and is not one now. `enable_live_trading` remains
false and unreachable from this form.

## Tests

`frontend/src/pages/StrategiesPage.test.tsx`:

- `does not present automation as enabled while the system-wide guard is off` —
  kept its honest half (a pool with `execution_enabled: false` does not read as
  on), lost the half that asserted the circular disable.
- **new** `performs the first automation enable from the default
  global-flag-false state` — `readiness.ready`, `execution_enabled: false`,
  `paper_pool.enabled: false`; asserts the checkbox is enabled and that saving
  PUTs `enabled: true`.
- **new** `refuses the first enable while evidence readiness is false` — asserts
  disabled, the readiness copy, and that no request is made.
- **new** `refuses the first enable on an account that can run neither demo nor
  live automation`.

Non-vacuity: re-injecting the removed `overview.execution_enabled` clause fails
the first-enable case (1 failed / 46 passed), so the new test is load-bearing.

## Verification

| check | result |
| --- | --- |
| `pnpm --dir frontend typecheck` | pass |
| `pnpm --dir frontend test:unit` | 136 files, 1532 tests, all pass |
| `npx vitest run src/pages/StrategiesPage.test.tsx` | 47 pass (all 4 above ran, verified by name) |
| pre-push gate (ruff, ruff format, pyright, fast tier, smoke, chokepoint lints) | green |
| `codex exec review --base origin/main` | no findings |

Measured on dev before the change, confirming the state the fix targets:
`GET /strategies/overview` returns `execution_enabled: false`,
`paper_pool.enabled: false`, `paper_pool.configured: false`,
`automation_readiness.state: "no_capital_candidates"`, `demo_connection: true`.

No backend, schema, parser or ETL change, so Definition-of-Done clauses 8-12 do
not apply. Review-intensity ladder: narrow frontend diff; Codex checkpoint 2 was
run anyway because the surface is the automation-enable control.

Closes #2766
