### PR TITLE
feat(#2770): an evidence-bound operator path from candidate to paper

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -98,6 +98,15 @@ from app.services.strategy_monitoring import (
     pool_owned_pnl_by_strategy,
     realised_pnl_for_keys,
 )
+from app.services.strategy_operator_promotion import (
+    EvidenceRow,
+    OperatorAction,
+    advance_strategy,
+    evidence_refusal_summary,
+    next_operator_action_view,
+    recent_evidence_refusals,
+    select_latest_rows,
+)
 from app.services.strategy_position_manager import (
     StrategyPositionManagerError,
     manage_owned_position,
@@ -112,6 +121,7 @@ from app.services.strategy_result_ambiguity import (
     composed_holdout_ambiguity_refusals,
     record_sha256,
 )
+from app.services.strategy_result_identity import current_identity_pins, current_result_versions
 from app.services.strategy_signal_scan import (
     SCAN_UNIVERSE,
     choose_frontier,
@@ -484,6 +494,14 @@ class StrategyOverview(BaseModel):
     allocation: StrategyAllocationView
     allocation_ready: bool
     allocation_refusals: list[str]
+    #: The one ordered step `POST /{id}/advance` would take from this stage (#2770),
+    #: NAMED ALONGSIDE its refusals rather than nulled by them — an operator who
+    #: cannot act needs to know which step is blocked, not that there is no step.
+    #: `null` means a terminal stage with no forward edge.
+    #: ⚠ ADVISORY. A page cannot be transactionally coupled to a later request, so
+    #: the transaction stays authoritative and a stale page gets a 409 to render.
+    next_operator_action: OperatorAction | None
+    next_operator_action_refusals: list[str]
 
 
 class StrategyAttributionView(BaseModel):
@@ -1139,6 +1157,32 @@ class StrategyLifecycleResponse(BaseModel):
     promotion_id: int
 
 
+class StrategyAdvanceRequest(BaseModel):
+    """⚠ NO `strategy_version`, NO `to_stage`, NO `result_ids` — deliberately (#2770).
+
+    Those are the three inputs that would let a browser choose its own promotion
+    denominator. `promote_strategy` validates caller-supplied `result_ids`
+    INDIVIDUALLY, so a favourable subset passes every per-row check while the
+    promotion rests on a cherry-picked set. The version and evidence are resolved
+    inside the locked transaction instead.
+    """
+
+    action: OperatorAction
+    reason: str = Field(min_length=1, max_length=500)
+
+
+class StrategyAdvanceResponse(BaseModel):
+    strategy_id: str
+    strategy_version: str
+    from_stage: str | None
+    stage: str
+    promotion_id: int
+    evidence_ref: str | None
+    #: 24 for the two result-evidence stages; 0 for `research_candidate` (no evidence)
+    #: and for `paper_enabled`, which pins an assessment rather than results.
+    pinned_result_count: int
+
+
 def _live_gate_view(report: LiveGateReport) -> LiveGateResponse:
     return LiveGateResponse(
         strategy_id=report.strategy_id,
@@ -1162,15 +1206,12 @@ def _live_gate_view(report: LiveGateReport) -> LiveGateResponse:
     )
 
 
-def _current_versions() -> dict[str, str]:
-    """The identities STORED RESULTS carry — the backtest measurement basis.
-
-    ⚠ NOT the identities the live scan writes. See ``_current_scan_versions``.
-    """
-    return {
-        strategy_id: entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID).version
-        for strategy_id, entry in STRATEGY_MANIFEST.items()
-    }
+# ⚠ MOVED TO `app.services.strategy_result_identity` (#2770) and aliased here, not
+# reimplemented. `strategy_operator_promotion` binds the same basis to assemble the
+# promotion denominator, and a service may not import an API module. The alias keeps
+# this module's own call sites and the tests that monkeypatch
+# `app.api.strategies._current_versions` working unchanged.
+_current_versions = current_result_versions
 
 
 def _current_scan_versions() -> dict[str, str]:
@@ -1710,27 +1751,11 @@ def _walk_forward_split_view(split: StrategyWalkForwardSplit) -> WalkForwardSpli
     )
 
 
-def _current_identity_pins() -> dict[str, str]:
-    """The pins a stored row must match to sit on today's measurement basis.
-
-    Exactly the equality predicates ``_RESULTS_SQL`` applies, named once so the
-    prior-version reader cannot drift from the current-version one. These ARE the
-    result identity — differing on any of them means the numbers are not
-    comparable, which is why the reader reports the difference instead of either
-    hiding the version or splicing its figures in.
-    """
-    return {
-        "namespace": "hold_out",
-        "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
-        "cost_model_id": COST_MODEL_ID,
-        "sizing_rule": SIZING_RULE_ID,
-        "benchmark_rule": BENCHMARK_RULE_ID,
-        "return_basis": TOTAL_RETURN_BASIS,
-        "ambiguity_rule_version": AMBIGUITY_RULE_VERSION,
-        "position_rule_set_version": POSITION_RULE_SET_VERSION,
-        "outcome_rule_set_version": OUTCOME_RULE_SET_VERSION,
-        "input_rule_set_version": QUARANTINE_RULE_SET_VERSION,
-    }
+# ⚠ MOVED TO `app.services.strategy_result_identity` (#2770), same reason as
+# `_current_versions` above. The docstring there carries the additional load this
+# dict now bears: it is also the cross-row coherence rule for a promotion
+# denominator, so a second copy would be a correctness defect and not just churn.
+_current_identity_pins = current_identity_pins
 
 
 def build_prior_versions(
@@ -2157,6 +2182,36 @@ def get_strategy_overview(
                     allocation_refusals.append("prospective_assessment_stale")
         remaining = max(control.capital_limit - control.reserved_capital, Decimal("0"))
         split = derive_walk_forward_split(walk_forward_by_strategy.get(strategy_id, []))
+        # ⚠ Built from `strategy_rows` — the SAME population `advance_strategy` loads,
+        # because `_RESULTS_SQL` binds `current_identity_pins()` and this filters the
+        # NULL `evidence_window_id` rows the loader's WHERE excludes. It then runs the
+        # SAME `select_latest_rows`, so the card and the transaction cannot disagree
+        # about which row is current. (`_RESULTS_SQL` itself does not de-duplicate:
+        # the `arm_keys` set above reads eight rows on four identities as `complete`.)
+        next_operator_action, next_operator_action_refusals = next_operator_action_view(
+            stage=control.stage,
+            purpose=entry.purpose,
+            evidence_refusals=evidence_refusal_summary(
+                recent_evidence_refusals(
+                    select_latest_rows(
+                        EvidenceRow(
+                            window_id=str(row["evidence_window_id"]),
+                            ambiguity_arm=str(row["ambiguity_arm"]),
+                            quarantine_arm=str(row["quarantine_arm"]),
+                            result_id=int(cast(int, row["result_id"])),
+                        )
+                        for row in strategy_rows
+                        if row["evidence_window_id"] is not None
+                    )
+                )
+            ),
+            # The assessment refusals this loop has already established, reused rather
+            # than recomputed — otherwise the paper step renders as available whenever
+            # a strategy reaches `forward_observation`, however stale its assessment.
+            assessment_refusals=[
+                refusal for refusal in allocation_refusals if refusal.startswith("prospective_assessment")
+            ],
+        )
         strategies.append(
             StrategyOverview(
                 strategy_id=strategy_id,
@@ -2215,6 +2270,8 @@ def get_strategy_overview(
                 ),
                 allocation_ready=not allocation_refusals,
                 allocation_refusals=allocation_refusals,
+                next_operator_action=next_operator_action,
+                next_operator_action_refusals=list(next_operator_action_refusals),
             )
         )
     reserved_total = sum((item.allocation.reserved_capital for item in strategies), Decimal("0"))
@@ -3416,6 +3473,58 @@ def attempt_live_promotion(
     except StrategyControlError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return LivePromotionAttemptResponse(assessment_id=assessment_id, report=_live_gate_view(report))
+
+
+@router.post("/{strategy_id}/advance", response_model=StrategyAdvanceResponse)
+def advance_strategy_stage(
+    strategy_id: str,
+    body: StrategyAdvanceRequest,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategyAdvanceResponse:
+    """Advance one strategy by one declared step, on evidence assembled server-side.
+
+    ⚠ ``require_session``, not the router's ``require_session_or_service_token``. A
+    promotion is an operator authorisation recorded with a named ``promoted_by``, and
+    a service token has no operator identity to attribute one to — the same reasoning
+    ``update_core_mandate`` gives.
+
+    ⚠ ``UniqueViolation`` is deliberately NOT caught. Two concurrent submissions
+    serialise on the per-version advisory lock ``advance_strategy`` takes, so the
+    second reads the advanced stage and refuses with an invalid-transition 409 before
+    reaching an INSERT. Catching the violation instead would need constraint-name
+    discrimination (``idx_strategy_promotions_one_initial`` and
+    ``..._one_successor`` mean different things) and a savepoint to avoid leaving the
+    transaction aborted — all to handle a race the lock already excludes. The indexes
+    stay the backstop they were designed to be (#2612).
+
+    So two identical submissions give one 200 and one 409. That is duplicate
+    PREVENTION, which is what is wanted here; it is not idempotent replay, which would
+    need a request key and is not offered.
+    """
+    if strategy_id not in STRATEGY_MANIFEST:
+        raise HTTPException(status_code=404, detail="strategy not found")
+    try:
+        with conn.transaction():
+            outcome = advance_strategy(
+                conn,
+                strategy_id=strategy_id,
+                action=body.action,
+                advanced_by=session.username,
+                reason=body.reason,
+                as_of=datetime.now(UTC),
+            )
+    except StrategyControlError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return StrategyAdvanceResponse(
+        strategy_id=outcome.strategy_id,
+        strategy_version=outcome.strategy_version,
+        from_stage=outcome.from_stage,
+        stage=outcome.stage,
+        promotion_id=outcome.promotion.promotion_id,
+        evidence_ref=outcome.evidence_ref,
+        pinned_result_count=outcome.pinned_result_count,
+    )
 
 
 @router.post("/{strategy_id}/lifecycle", response_model=StrategyLifecycleResponse)

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -7,13 +7,13 @@ from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from typing import Any, Final, Literal, cast, get_args
+from typing import Annotated, Any, Final, Literal, cast, get_args
 
 import psycopg
 import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from psycopg.pq import TransactionStatus
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, StringConstraints, model_validator
 
 from app.api.auth import require_session, require_session_or_service_token
 from app.api.portfolio import get_portfolio
@@ -1168,7 +1168,13 @@ class StrategyAdvanceRequest(BaseModel):
     """
 
     action: OperatorAction
-    reason: str = Field(min_length=1, max_length=500)
+    # ⚠ `strip_whitespace` BEFORE `min_length`, which is the order pydantic applies
+    # and the reason a bare `Field(min_length=1)` is not enough: `" "` is one
+    # character, so it validates, and the audit row then records a blank rationale
+    # for a promotion. `promote_strategy._require_text` also refuses it, but that
+    # surfaces as a 409 on a well-formed-looking request rather than a 422 on the
+    # input that is actually wrong.
+    reason: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=500)]
 
 
 class StrategyAdvanceResponse(BaseModel):

--- a/app/services/strategy_operator_promotion.py
+++ b/app/services/strategy_operator_promotion.py
@@ -1,0 +1,692 @@
+"""The ordered operator path from a registered candidate to ``paper_enabled`` (#2770).
+
+``promote_strategy`` is a strict primitive, but it takes caller-supplied ``result_ids``
+and validates each one INDIVIDUALLY. A caller could therefore pin the three windows
+where a strategy happened to look good, and every pinned row would pass its own checks
+while the promotion rested on a cherry-picked denominator. Nothing downstream could
+tell — the promotion row would look identical to an honest one.
+
+So this module owns the denominator instead of the caller. The operator names an
+ACTION; the evidence is assembled here, inside the same transaction and under the same
+per-version advisory lock the primitive takes, from declarations that already exist:
+
+- the six windows of ``strategy_recent_evidence.RECENT_EVIDENCE_WINDOWS``;
+- the four ambiguity x quarantine arms;
+- ``strategy_result_identity.current_identity_pins()``, which is what makes the 24 rows
+  COMPARABLE rather than merely present.
+
+The third is the one that is easy to miss. Twenty-four rows with no gaps can still mix
+results measured against different corpora, cost models or rule sets — label-complete
+and meaningless. Binding the whole pin dict is the cross-row coherence check; there is
+deliberately no second one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Final, Literal, cast
+
+import psycopg
+
+from app.services.strategy_control_plane import (
+    _NEXT_STAGE,
+    Promotion,
+    Stage,
+    StrategyControlError,
+    current_stage,
+    lock_strategy_control,
+    promote_strategy,
+    registered_strategy_purpose,
+)
+from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+from app.services.strategy_result_identity import current_identity_pins, current_result_versions
+
+OperatorAction = Literal[
+    "register_research_candidate",
+    "validate_historical",
+    "start_forward_observation",
+    "enable_paper",
+]
+
+#: Successors of a stage that this path deliberately does NOT drive. ``paused`` and
+#: ``retired`` belong to ``POST /strategies/{id}/lifecycle``; ``live_enabled`` belongs
+#: to the dedicated measured live gate and ``promote_strategy`` refuses it outright.
+_NON_OPERATOR_STAGES: Final[frozenset[Stage]] = frozenset({"paused", "retired", "live_enabled"})
+
+_ACTION_FOR_TARGET: Final[dict[Stage, OperatorAction]] = {
+    "research_candidate": "register_research_candidate",
+    "historical_validated": "validate_historical",
+    "forward_observation": "start_forward_observation",
+    "paper_enabled": "enable_paper",
+}
+_TARGET_FOR_ACTION: Final[dict[OperatorAction, Stage]] = {action: stage for stage, action in _ACTION_FOR_TARGET.items()}
+
+#: Only these three carry evidence. ``research_candidate`` is not in
+#: ``_EXTERNAL_EVIDENCE_STAGES``, so the primitive lets a non-capital-candidate
+#: register — refusing it here on purpose would silently narrow the declared DAG.
+_EVIDENCE_ACTIONS: Final[frozenset[OperatorAction]] = frozenset(
+    {"validate_historical", "start_forward_observation", "enable_paper"}
+)
+
+_AMBIGUITY_ARMS: Final = ("best_case", "worst_case")
+_QUARANTINE_ARMS: Final = ("admitted", "masked")
+EXPECTED_ARMS: Final[tuple[tuple[str, str], ...]] = tuple(
+    (ambiguity, quarantine) for ambiguity in _AMBIGUITY_ARMS for quarantine in _QUARANTINE_ARMS
+)
+#: 6 windows x 4 arms. Named so a test can assert the number rather than trust prose.
+EXPECTED_EVIDENCE_COMBINATIONS: Final = len(RECENT_EVIDENCE_WINDOWS) * len(EXPECTED_ARMS)
+
+RECENT_EVIDENCE_REF_PREFIX: Final = "recent-evidence-v1"
+PROSPECTIVE_ASSESSMENT_REF_PREFIX: Final = "prospective-assessment-v1"
+
+#: The overview's own future-clock tolerance (`app/api/strategies.py`), inherited
+#: deliberately. One predicate, one behaviour — otherwise the page can read "fresh"
+#: where this transaction reads "stale", which is the worst kind of disagreement
+#: because the operator sees an enabled control that 409s.
+ASSESSMENT_FUTURE_TOLERANCE: Final = timedelta(seconds=5)
+
+
+def operator_targets(stage: Stage | None) -> frozenset[Stage]:
+    """The forward edges of ``_NEXT_STAGE`` this path drives, for one stage."""
+    return frozenset(_NEXT_STAGE[stage]) - _NON_OPERATOR_STAGES
+
+
+def allowed_operator_action(stage: Stage | None) -> OperatorAction | None:
+    """The one action available from ``stage``, or ``None`` at a terminal stage.
+
+    Derived from ``_NEXT_STAGE`` rather than hand-written beside it, so a stage-graph
+    edit cannot leave this path describing a graph that no longer exists. It raises
+    rather than guessing if the graph ever offers two operator successors, because
+    "which one did the operator mean" is a design question and not a runtime one.
+    """
+    targets = operator_targets(stage)
+    if not targets:
+        return None
+    if len(targets) != 1:
+        raise StrategyControlError(f"stage {stage!r} has {len(targets)} operator successors; expected 1")
+    return _ACTION_FOR_TARGET[next(iter(targets))]
+
+
+def action_target(action: OperatorAction) -> Stage:
+    return _TARGET_FOR_ACTION[action]
+
+
+@dataclass(frozen=True)
+class EvidenceRow:
+    """One selected hold-out result, reduced to what the matrix rule reads."""
+
+    window_id: str
+    ambiguity_arm: str
+    quarantine_arm: str
+    result_id: int
+
+
+def recent_evidence_refusals(rows: Sequence[EvidenceRow]) -> tuple[str, ...]:
+    """Refusal codes for the 24-combination matrix; empty means complete.
+
+    There is no "close enough" tier. A partial matrix is a refusal, because the whole
+    point is that the denominator is not the caller's to choose — and "five of six
+    windows" is a chosen denominator whoever chose it.
+    """
+    by_window: dict[str, list[EvidenceRow]] = defaultdict(list)
+    for row in rows:
+        by_window[row.window_id].append(row)
+
+    refusals: set[str] = set()
+
+    for window_id in sorted(set(by_window) - set(RECENT_EVIDENCE_WINDOWS)):
+        refusals.add(f"recent_evidence_window_unknown:{window_id}")
+
+    for window_id in RECENT_EVIDENCE_WINDOWS:
+        window_rows = by_window.get(window_id, [])
+        if not window_rows:
+            # ⚠ ALONE, not with four `arm_missing` companions. A wholly absent window
+            # is one fact about one window; spelling it four more ways makes the
+            # refusal list scale with the damage rather than describe it.
+            refusals.add(f"recent_evidence_window_missing:{window_id}")
+            continue
+        seen: dict[tuple[str, str], int] = defaultdict(int)
+        for row in window_rows:
+            seen[(row.ambiguity_arm, row.quarantine_arm)] += 1
+        for arm in EXPECTED_ARMS:
+            if seen.get(arm, 0) == 0:
+                refusals.add(f"recent_evidence_arm_missing:{window_id}/{arm[0]}/{arm[1]}")
+        for arm, count in seen.items():
+            if arm not in EXPECTED_ARMS:
+                refusals.add(f"recent_evidence_arm_unknown:{window_id}/{arm[0]}/{arm[1]}")
+            elif count > 1:
+                # Unreachable through `load_authoritative_recent_evidence`, which runs
+                # `select_latest_rows` first. Kept because duplicates on this identity
+                # are REAL in the store (measured 2026-08-21: 328 rows over 268
+                # distinct identities), so this asserts the resolution actually
+                # happened rather than assuming it did.
+                refusals.add(f"recent_evidence_arm_duplicate:{window_id}/{arm[0]}/{arm[1]}")
+
+    return tuple(sorted(refusals))
+
+
+def recent_evidence_ref(*, strategy_id: str, strategy_version: str, rows: Sequence[EvidenceRow]) -> str:
+    """A deterministic reference to the exact evidence set pinned.
+
+    ⚠ ``GOVERNANCE_GATE_VERSION`` is deliberately NOT in the payload. This names the
+    evidence SET; the gate version is recorded in its own column on the promotion row.
+    Mixing them would give the same evidence two references across a gate bump and
+    make "did the denominator change?" unanswerable from the reference alone.
+
+    Canonical JSON (sorted keys, no whitespace) rather than string concatenation, so
+    two different tuples cannot serialise to one byte string.
+    """
+    payload = json.dumps(
+        {
+            "strategy_id": strategy_id,
+            "strategy_version": strategy_version,
+            "evidence": sorted([row.window_id, row.ambiguity_arm, row.quarantine_arm, row.result_id] for row in rows),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"{RECENT_EVIDENCE_REF_PREFIX}+{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
+
+
+EvidenceIdentity = tuple[str, str, str]
+
+
+def evidence_identities(rows: Iterable[EvidenceRow]) -> frozenset[EvidenceIdentity]:
+    return frozenset((row.window_id, row.ambiguity_arm, row.quarantine_arm) for row in rows)
+
+
+def weakening_refusals(
+    *, previously_covered: Iterable[EvidenceIdentity], now_covered: Iterable[EvidenceIdentity]
+) -> tuple[str, ...]:
+    """Forward observation may add evidence; it may not stop covering any.
+
+    ⚠⚠ COMPARES IDENTITIES, NOT RESULT IDS, and the distinction is the whole rule
+    (Codex ckpt-2). An id comparison is wrong in the ordinary case: a re-run between
+    the two promotions replaces every id, ``select_latest_rows`` returns the new ones,
+    and every previously pinned id reads as "dropped". Because the store is
+    append-only and pins are ``ON DELETE RESTRICT``, that verdict would be permanent —
+    one routine `refresh_recent` re-run would block `start_forward_observation`
+    forever. Superseding a row is not weakening the evidence; ceasing to cover a
+    window or an arm is.
+
+    ⚠ It cannot fire while both promotions demand a complete matrix over the SAME
+    declared windows, because two complete matrices have identical identity sets. What
+    it catches is the declared set MOVING between the two steps: shrink
+    ``RECENT_EVIDENCE_WINDOWS`` and the second "complete" matrix is smaller than the
+    first, which is a real weakening and is invisible to every completeness check.
+    """
+    dropped = sorted(set(previously_covered) - set(now_covered))
+    if not dropped:
+        return ()
+    return tuple(
+        f"recent_evidence_weakened:{window}/{ambiguity}/{quarantine}" for window, ambiguity, quarantine in dropped
+    )
+
+
+@dataclass(frozen=True)
+class AssessmentCandidate:
+    assessment_id: int
+    policy_id: str
+    checked_at: datetime
+    passed: bool
+    max_assessment_age_days: int
+
+
+def select_prospective_assessment(
+    *,
+    policy_present: bool,
+    candidates: Sequence[AssessmentCandidate],
+    as_of: datetime,
+    forward_started_at: datetime | None,
+) -> tuple[AssessmentCandidate | None, tuple[str, ...]]:
+    """The assessment that authorises paper, or the single reason there isn't one.
+
+    One refusal, not a list: these are ordered stages of the same question, and
+    reporting "missing" alongside "stale" would be incoherent.
+    """
+    if not policy_present:
+        return None, ("prospective_assessment_policy_missing",)
+    if not candidates:
+        return None, ("prospective_assessment_missing",)
+    passed = [item for item in candidates if item.passed]
+    if not passed:
+        return None, ("prospective_assessment_not_passed",)
+    fresh = [
+        item
+        for item in passed
+        if item.checked_at >= as_of - timedelta(days=item.max_assessment_age_days)
+        and item.checked_at <= as_of + ASSESSMENT_FUTURE_TOLERANCE
+    ]
+    if not fresh:
+        return None, ("prospective_assessment_stale",)
+    if forward_started_at is not None:
+        # An assessment computed before forward observation began is not evidence
+        # FROM forward observation. Without this the whole chain can be walked
+        # back-to-back on backtest evidence alone, which would make the
+        # forward_observation stage decorative.
+        fresh = [item for item in fresh if item.checked_at >= forward_started_at]
+        if not fresh:
+            return None, ("prospective_assessment_predates_forward_observation",)
+    chosen = max(fresh, key=lambda item: (item.checked_at, item.assessment_id))
+    return chosen, ()
+
+
+def prospective_assessment_ref(candidate: AssessmentCandidate) -> str:
+    return f"{PROSPECTIVE_ASSESSMENT_REF_PREFIX}+{candidate.assessment_id}@{candidate.policy_id}"
+
+
+def select_latest_rows(rows: Iterable[EvidenceRow]) -> tuple[EvidenceRow, ...]:
+    """One row per ``(window, ambiguity, quarantine)`` — the highest ``result_id``.
+
+    ⚠ A re-run ADDS a row rather than replacing one: ``strategy_results_store`` is
+    unique on ``(strategy_id, strategy_version, result_version)``, not on the
+    window/arm identity, and pinned results are ``ON DELETE RESTRICT``. Measured on
+    dev 2026-08-21: 328 rows over 268 distinct identities, ten identities carrying
+    two rows apiece from one s1 re-run. So "refuse on duplicate" would make any
+    re-run strategy permanently unpromotable, and some resolution rule is forced.
+
+    Latest-wins is the safe direction: a re-run that measured WORSE supersedes a
+    better old row, never the other way round, and no caller can influence the
+    choice. ``result_id`` is the primary key, so the order is total.
+
+    ⚠ ONE implementation, deliberately not a SQL ``DISTINCT ON`` plus a Python copy.
+    The read surface and the promotion transaction must agree about which row is
+    current; two implementations of "latest" is how they stop agreeing.
+    """
+    latest: dict[tuple[str, str, str], EvidenceRow] = {}
+    for row in rows:
+        key = (row.window_id, row.ambiguity_arm, row.quarantine_arm)
+        current = latest.get(key)
+        if current is None or row.result_id > current.result_id:
+            latest[key] = row
+    return tuple(sorted(latest.values(), key=lambda row: (row.window_id, row.ambiguity_arm, row.quarantine_arm)))
+
+
+_AUTHORITATIVE_EVIDENCE_SQL = """
+    SELECT r.evidence_window_id, r.ambiguity_arm, r.quarantine_arm, r.result_id
+    FROM strategy_results_store r
+    WHERE r.strategy_id = %(strategy_id)s
+      AND r.strategy_version = %(strategy_version)s
+      AND r.evidence_window_id IS NOT NULL
+      AND r.namespace = %(namespace)s
+      AND r.corpus_version = %(corpus_version)s
+      AND r.cost_model_id = %(cost_model_id)s
+      AND r.sizing_rule = %(sizing_rule)s
+      AND r.benchmark_rule = %(benchmark_rule)s
+      AND r.return_basis = %(return_basis)s
+      AND r.ambiguity_rule_version = %(ambiguity_rule_version)s
+      AND r.position_rule_set_version = %(position_rule_set_version)s
+      AND r.outcome_rule_set_version = %(outcome_rule_set_version)s
+      AND r.input_rule_set_version = %(input_rule_set_version)s
+    ORDER BY r.evidence_window_id, r.ambiguity_arm, r.quarantine_arm, r.result_id
+"""
+
+
+@dataclass(frozen=True)
+class RecentEvidenceBundle:
+    rows: tuple[EvidenceRow, ...]
+    result_ids: tuple[int, ...]
+    evidence_ref: str
+    refusals: tuple[str, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not self.refusals
+
+
+def load_authoritative_recent_evidence(
+    conn: psycopg.Connection[Any], *, strategy_id: str, strategy_version: str
+) -> RecentEvidenceBundle:
+    """The pinned hold-out matrix, assembled from the store and never from a caller.
+
+    ⚠ NOT filtered to the declared window ids in SQL. Filtering there would make
+    ``recent_evidence_window_unknown`` undetectable — a row on this comparability
+    basis naming an undeclared window is exactly the thing worth refusing, and a
+    whitelist in the WHERE clause hides it instead. Classification happens in
+    ``recent_evidence_refusals``.
+
+    Duplicate identities are resolved by ``select_latest_rows``, in Python rather than
+    in the SQL, so that the read surface can apply the same function to the rows the
+    overview already holds instead of maintaining a second notion of "latest".
+    """
+    params: dict[str, object] = {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        **current_identity_pins(),
+    }
+    fetched = conn.execute(_AUTHORITATIVE_EVIDENCE_SQL, params).fetchall()
+    rows = select_latest_rows(
+        EvidenceRow(
+            window_id=str(row[0]),
+            ambiguity_arm=str(row[1]),
+            quarantine_arm=str(row[2]),
+            result_id=int(row[3]),
+        )
+        for row in fetched
+    )
+    return RecentEvidenceBundle(
+        rows=rows,
+        result_ids=tuple(sorted(row.result_id for row in rows)),
+        evidence_ref=recent_evidence_ref(strategy_id=strategy_id, strategy_version=strategy_version, rows=rows),
+        refusals=recent_evidence_refusals(rows),
+    )
+
+
+def load_pinned_identities(
+    conn: psycopg.Connection[Any], *, strategy_id: str, strategy_version: str, to_stage: Stage
+) -> frozenset[EvidenceIdentity]:
+    """Which window/arm combinations a past promotion actually pinned.
+
+    ⚠ Resolves the pinned RESULT IDS back to their identities rather than returning
+    the ids. The ids are superseded by any re-run; the identities are what the
+    promotion was a statement about.
+    """
+    rows = conn.execute(
+        """
+        SELECT r.evidence_window_id, r.ambiguity_arm, r.quarantine_arm
+        FROM strategy_promotions p
+        JOIN strategy_promotion_results pr ON pr.promotion_id = p.promotion_id
+        JOIN strategy_results_store r ON r.result_id = pr.result_id
+        WHERE p.strategy_id = %s AND p.strategy_version = %s AND p.to_stage = %s
+          AND r.evidence_window_id IS NOT NULL
+        """,
+        (strategy_id, strategy_version, to_stage),
+    ).fetchall()
+    return frozenset((str(row[0]), str(row[1]), str(row[2])) for row in rows)
+
+
+def load_stage_entered_at(
+    conn: psycopg.Connection[Any], *, strategy_id: str, strategy_version: str, to_stage: Stage
+) -> datetime | None:
+    """When this version arrived at ``to_stage``.
+
+    ``max`` is defensive rather than meaningful: settled decision #2612 makes arrival
+    single-entry, enforced by ``_NEXT_STAGE`` and by
+    ``idx_strategy_promotions_one_successor``. If that ever stops holding, taking the
+    latest arrival is the reading that keeps the freshness bound tightest.
+    """
+    row = conn.execute(
+        """
+        SELECT max(promoted_at) FROM strategy_promotions
+        WHERE strategy_id = %s AND strategy_version = %s AND to_stage = %s
+        """,
+        (strategy_id, strategy_version, to_stage),
+    ).fetchone()
+    return None if row is None or row[0] is None else row[0]
+
+
+_CURRENT_ASSESSMENT_SQL = """
+    SELECT c.assessment_id, p.policy_id, c.checked_at, a.passed, p.max_assessment_age_days
+    FROM strategy_forecast_assessment_policies p
+    JOIN strategy_forecast_assessment_current c ON c.policy_id = p.policy_id
+    JOIN strategy_forecast_assessments a
+      ON a.assessment_id = c.assessment_id
+     AND a.policy_id = c.policy_id
+     AND a.strategy_id = c.strategy_id
+     AND a.strategy_version = c.strategy_version
+    WHERE p.policy_id = (
+        SELECT policy_id FROM strategy_forecast_assessment_policies
+        WHERE effective_from <= %(as_of)s
+        ORDER BY effective_from DESC LIMIT 1
+    )
+      AND c.strategy_id = %(strategy_id)s
+      AND c.strategy_version = %(strategy_version)s
+"""
+
+
+def load_assessment_candidates(
+    conn: psycopg.Connection[Any], *, strategy_id: str, strategy_version: str, as_of: datetime
+) -> tuple[bool, tuple[AssessmentCandidate, ...]]:
+    """``(an effective policy exists, its assessments for this version)``.
+
+    The two are separate because "no policy has ever been registered" and "a policy
+    exists but this version has no assessment under it" are different operator
+    problems with different fixes, and collapsing them into one empty list would
+    report the second when the first is true.
+    """
+    policy = conn.execute(
+        """
+        SELECT policy_id FROM strategy_forecast_assessment_policies
+        WHERE effective_from <= %s ORDER BY effective_from DESC LIMIT 1
+        """,
+        (as_of,),
+    ).fetchone()
+    if policy is None:
+        return False, ()
+    rows = conn.execute(
+        _CURRENT_ASSESSMENT_SQL,
+        {"as_of": as_of, "strategy_id": strategy_id, "strategy_version": strategy_version},
+    ).fetchall()
+    return True, tuple(
+        AssessmentCandidate(
+            assessment_id=int(row[0]),
+            policy_id=str(row[1]),
+            checked_at=row[2],
+            passed=bool(row[3]),
+            max_assessment_age_days=int(row[4]),
+        )
+        for row in rows
+    )
+
+
+@dataclass(frozen=True)
+class AdvanceOutcome:
+    strategy_id: str
+    strategy_version: str
+    from_stage: Stage | None
+    stage: Stage
+    promotion: Promotion
+    evidence_ref: str | None
+    pinned_result_count: int
+
+
+def _assemble_evidence(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    action: OperatorAction,
+    as_of: datetime,
+) -> tuple[str | None, tuple[int, ...]]:
+    if action == "register_research_candidate":
+        return None, ()
+
+    if action == "enable_paper":
+        policy_present, candidates = load_assessment_candidates(
+            conn, strategy_id=strategy_id, strategy_version=strategy_version, as_of=as_of
+        )
+        chosen, refusals = select_prospective_assessment(
+            policy_present=policy_present,
+            candidates=candidates,
+            as_of=as_of,
+            forward_started_at=load_stage_entered_at(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                to_stage="forward_observation",
+            ),
+        )
+        if chosen is None:
+            raise StrategyControlError("; ".join(refusals))
+        # ⚠ No result ids: `paper_enabled` is not a `_RESULT_EVIDENCE_STAGES` member.
+        # Re-pinning the historical matrix here would double-count one denominator as
+        # two independent pieces of evidence.
+        return prospective_assessment_ref(chosen), ()
+
+    bundle = load_authoritative_recent_evidence(conn, strategy_id=strategy_id, strategy_version=strategy_version)
+    refusals = bundle.refusals
+    if action == "start_forward_observation":
+        refusals = refusals + weakening_refusals(
+            previously_covered=load_pinned_identities(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                to_stage="historical_validated",
+            ),
+            now_covered=evidence_identities(bundle.rows),
+        )
+    if refusals:
+        raise StrategyControlError("; ".join(refusals))
+    return bundle.evidence_ref, bundle.result_ids
+
+
+def advance_strategy(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    action: OperatorAction,
+    advanced_by: str,
+    reason: str,
+    as_of: datetime,
+) -> AdvanceOutcome:
+    """Advance one strategy by one declared step, on evidence assembled here.
+
+    The caller supplies an action and a reason. It does not supply a stage, a version,
+    or a result id — those are the three inputs that would let a browser choose its own
+    denominator, and none of them crosses this boundary.
+    """
+    versions = current_result_versions()
+    strategy_version = versions.get(strategy_id)
+    if strategy_version is None:
+        raise StrategyControlError(f"unknown strategy {strategy_id!r}")
+
+    # Lock FIRST, then read the stage. The other order reads a stage that a concurrent
+    # request may already have advanced, and decides against it.
+    lock_strategy_control(conn, strategy_id, strategy_version)
+    from_stage = current_stage(conn, strategy_id, strategy_version)
+    expected = allowed_operator_action(from_stage)
+    if expected != action:
+        raise StrategyControlError(
+            f"action {action!r} is not available from stage {from_stage!r}"
+            + (f"; the available action is {expected!r}" if expected else "; this stage is terminal")
+        )
+
+    if action in _EVIDENCE_ACTIONS:
+        purpose = registered_strategy_purpose(strategy_id)
+        if purpose != "capital_candidate":
+            raise StrategyControlError(
+                f"{strategy_id} is registered as {purpose!r}; only a capital_candidate carries evidence stages"
+            )
+
+    evidence_ref, result_ids = _assemble_evidence(
+        conn,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        action=action,
+        as_of=as_of,
+    )
+    to_stage = action_target(action)
+    promotion = promote_strategy(
+        conn,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        to_stage=to_stage,
+        promoted_by=advanced_by,
+        reason=reason,
+        evidence_ref=evidence_ref,
+        result_ids=result_ids,
+    )
+    return AdvanceOutcome(
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        from_stage=from_stage,
+        stage=to_stage,
+        promotion=promotion,
+        evidence_ref=evidence_ref,
+        pinned_result_count=len(result_ids),
+    )
+
+
+def next_operator_action_view(
+    *,
+    stage: str | None,
+    purpose: str | None,
+    evidence_refusals: Sequence[str],
+    assessment_refusals: Sequence[str] = (),
+) -> tuple[OperatorAction | None, tuple[str, ...]]:
+    """What ``/strategies`` should show: the action, and why it would refuse.
+
+    ⚠ ADVISORY, and the action is named ALONGSIDE its refusals rather than nulled by
+    them — an operator who cannot act needs to know which step is blocked, not that
+    there is no step. ``None`` means a terminal stage with no forward edge.
+
+    ⚠ This cannot be transactionally coupled to a later ``advance_strategy`` call, so
+    the transaction stays authoritative and a stale page gets a 409 it must render.
+
+    ``stage`` is typed ``str`` and not ``Stage`` because it arrives from a DB column.
+    A value the graph does not know offers no action — a read surface must not raise
+    on data it cannot classify, and the write path re-reads the stage anyway.
+    """
+    if stage is not None and stage not in _NEXT_STAGE:
+        return None, ()
+    action = allowed_operator_action(cast("Stage | None", stage))
+    if action is None:
+        return None, ()
+    refusals: list[str] = []
+    if action in _EVIDENCE_ACTIONS and purpose != "capital_candidate":
+        refusals.append("strategy_not_capital_candidate")
+    if action in {"validate_historical", "start_forward_observation"}:
+        refusals.extend(evidence_refusals)
+    if action == "enable_paper":
+        # ⚠ Codex ckpt-2: without this the button was ENABLED whenever a strategy
+        # reached `forward_observation`, even where the overview had already
+        # established that the assessment was missing, failed or stale — one click
+        # for a guaranteed 409. The page knows; it should say so.
+        #
+        # ⚠ Necessarily a SUBSET of what the transaction checks: the overview does
+        # not compute `prospective_assessment_predates_forward_observation`, which
+        # needs the promotion timestamp. An enabled button is still a claim that
+        # nothing KNOWN refuses, not a promise the request will succeed.
+        refusals.extend(assessment_refusals)
+    return action, tuple(refusals)
+
+
+def evidence_refusal_summary(refusals: Sequence[str]) -> tuple[str, ...]:
+    """Collapse the per-combination codes into something a card can render.
+
+    Twenty-four `recent_evidence_arm_missing:` lines is an accurate list and an
+    unreadable one. The code PREFIX is the class; the count is the size.
+    """
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for refusal in refusals:
+        grouped[refusal.split(":", 1)[0]].append(refusal)
+    # A class with ONE member keeps its detail: "window year-2023 is missing" is
+    # actionable, "one window is missing" is not. Only a class large enough to be
+    # unreadable is collapsed to its count.
+    return tuple(
+        members[0] if len(members) == 1 else f"{code} x{len(members)}" for code, members in sorted(grouped.items())
+    )
+
+
+__all__ = [
+    "ASSESSMENT_FUTURE_TOLERANCE",
+    "EXPECTED_ARMS",
+    "EXPECTED_EVIDENCE_COMBINATIONS",
+    "AdvanceOutcome",
+    "AssessmentCandidate",
+    "EvidenceRow",
+    "OperatorAction",
+    "RecentEvidenceBundle",
+    "action_target",
+    "advance_strategy",
+    "allowed_operator_action",
+    "EvidenceIdentity",
+    "evidence_identities",
+    "evidence_refusal_summary",
+    "load_authoritative_recent_evidence",
+    "load_pinned_identities",
+    "load_stage_entered_at",
+    "next_operator_action_view",
+    "operator_targets",
+    "prospective_assessment_ref",
+    "recent_evidence_ref",
+    "recent_evidence_refusals",
+    "select_latest_rows",
+    "select_prospective_assessment",
+    "weakening_refusals",
+]

--- a/app/services/strategy_result_identity.py
+++ b/app/services/strategy_result_identity.py
@@ -1,0 +1,77 @@
+"""What "the current result identity" means, in one place (#2770).
+
+Extracted from ``app.api.strategies``, which owned both of these and was the only
+reader. It is no longer the only reader: ``strategy_operator_promotion`` binds the
+same pins when it assembles the promotion denominator, and a service may not import
+an API module.
+
+The extraction is the point rather than a side effect. ``current_identity_pins``'s
+own reason for existing is that two readers must not drift; a third reader that
+copied the dict would defeat it exactly as a second one would have.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from app.services.backtest_run import BACKTEST_UNIVERSE, corpus_version_for
+from app.services.cost_model import COST_MODEL_ID
+from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
+from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_ambiguity_policy import AMBIGUITY_RULE_VERSION
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_result import TOTAL_RETURN_BASIS
+
+#: The stored-result namespace these pins describe. Named because three readers
+#: assert on it and a string literal in three files is how the drift starts.
+HOLD_OUT_NAMESPACE: Final = "hold_out"
+
+
+def current_result_versions() -> dict[str, str]:
+    """The identities STORED RESULTS carry — the backtest measurement basis.
+
+    ⚠ NOT the identities the live scan writes. See
+    ``app.api.strategies._current_scan_versions``, which stamps ``SCAN_UNIVERSE``
+    and is therefore a DISJOINT set — the intersection over the full manifest is
+    0. Route ``strategy_results*`` through this function and scan relations
+    through that one.
+    """
+    return {
+        strategy_id: entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        for strategy_id, entry in STRATEGY_MANIFEST.items()
+    }
+
+
+def current_identity_pins() -> dict[str, str]:
+    """The pins a stored row must match to sit on today's measurement basis.
+
+    Exactly the equality predicates ``_RESULTS_SQL`` applies, named once so the
+    prior-version reader cannot drift from the current-version one. These ARE the
+    result identity — differing on any of them means the numbers are not
+    comparable, which is why the reader reports the difference instead of either
+    hiding the version or splicing its figures in.
+
+    ⚠ THIS IS ALSO THE CROSS-ROW COHERENCE RULE (#2770). A promotion denominator
+    assembled from rows that differ on any pin would be label-complete — six
+    windows, four arms, no gaps — while mixing results measured against different
+    corpora, cost models or rule sets. Binding the whole dict is what makes
+    "complete matrix" mean "one comparable matrix"; there is no separate coherence
+    check, and there must not be a second copy of this list.
+    """
+    return {
+        "namespace": HOLD_OUT_NAMESPACE,
+        "corpus_version": corpus_version_for(BACKTEST_UNIVERSE),
+        "cost_model_id": COST_MODEL_ID,
+        "sizing_rule": SIZING_RULE_ID,
+        "benchmark_rule": BENCHMARK_RULE_ID,
+        "return_basis": TOTAL_RETURN_BASIS,
+        "ambiguity_rule_version": AMBIGUITY_RULE_VERSION,
+        "position_rule_set_version": POSITION_RULE_SET_VERSION,
+        "outcome_rule_set_version": OUTCOME_RULE_SET_VERSION,
+        "input_rule_set_version": QUARANTINE_RULE_SET_VERSION,
+    }
+
+
+__all__ = ["HOLD_OUT_NAMESPACE", "current_identity_pins", "current_result_versions"]

--- a/docs/proposals/operator/2026-08-21-evidence-bound-promotion-path.md
+++ b/docs/proposals/operator/2026-08-21-evidence-bound-promotion-path.md
@@ -1,0 +1,298 @@
+# Evidence-bound operator promotion path (#2770)
+
+Status: proposal, 2026-08-21. Revised after Codex checkpoint 1 (52 findings; the
+dispositions that changed the design are marked ⓒ below). Implements the ordered operator
+path from a registered capital candidate to `paper_enabled`. Does not touch the live gate.
+
+## Problem
+
+`promote_strategy` (`app/services/strategy_control_plane.py:422`) is a strict primitive,
+but no production caller advances a strategy forward. The only API caller is
+`POST /strategies/{id}/lifecycle` (`app/api/strategies.py:3420`), which targets `paused`
+and `retired` only. So `None → research_candidate → historical_validated →
+forward_observation → paper_enabled` is unreachable from outside the test suite, and
+`/strategies` can allocate an already-`paper_enabled` strategy but cannot get one there.
+
+Exposing `promote_strategy` directly is unsafe. It accepts caller-supplied `result_ids`
+and validates each *individually*. A caller could pin a favourable subset — say the three
+windows where the strategy looked good — and every pinned row would pass its own checks
+while the promotion rested on a cherry-picked denominator.
+
+## Source rule
+
+Nothing here is reasoned out from first principles; all three components are existing
+declarations.
+
+1. **The six windows** — `strategy_recent_evidence.RECENT_EVIDENCE_WINDOWS`
+   (`primary-2022-plus`, `rolling-36m`, `rolling-24m`, `year-2022`, `year-2023`,
+   `year-2024`), each validated at construction against `HOLDOUT_BOUNDARY`,
+   `EVALUATION_WINDOW_END` and `INTRADER_CAPTURE_DATE`.
+2. **The four arms** — the ambiguity × quarantine cross product
+   (`best_case|worst_case` × `masked|admitted`), which `app/api/strategies.py:1990-1996`
+   already treats as the completeness condition for an `EvidenceWindow` to read `complete`.
+3. **The comparability predicate** — `_current_identity_pins()`
+   (`app/api/strategies.py:1712`). ⓒ Its own docstring is the rule: *"These ARE the result
+   identity — differing on any of them means the numbers are not comparable."* It names
+   `namespace='hold_out'`, `corpus_version`, `cost_model_id`, `sizing_rule`,
+   `benchmark_rule`, `return_basis`, `ambiguity_rule_version`,
+   `position_rule_set_version`, `outcome_rule_set_version`, `input_rule_set_version`.
+
+So the denominator is **24 identity combinations, all on one comparability basis**. This
+adds no new rule; it moves the existing one out of the read model into a transaction that
+can refuse. ⓒ Codex raised cross-arm/cross-window coherence (findings 3-5, 49, 52) as
+unaddressed — binding the pins closes it without inventing a parallel check.
+
+⚠ `_current_identity_pins()` currently lives in `app/api/strategies.py`. A service must not
+import an API module, so it **moves to `app/services/strategy_result_identity.py`** and
+`app/api/strategies.py` imports it from there. Its docstring's stated purpose ("named once
+so the prior-version reader cannot drift from the current-version one") is exactly why the
+third reader must bind the same object rather than copy it.
+
+The stage order is `strategy_control_plane._NEXT_STAGE`, and single-entry is settled:
+*"Live-gate evidence windows are single-entry (#2612)"* — a pair arrives at
+`forward_observation` at most once and `paper_enabled` at most once, enforced by the DAG
+and by the partial UNIQUE `idx_strategy_promotions_one_successor` on
+`(strategy_id, strategy_version, from_stage)`.
+
+## State measured at proposal time (2026-08-21 — ⓒ transient, do not read as durable)
+
+```sql
+select strategy_id, evidence_window_id, ambiguity_arm, quarantine_arm, purpose, count(*)
+from strategy_results_store group by 1,2,3,4,5;
+```
+
+16 groups across s1-s4, **every one with `evidence_window_id IS NULL`** and
+`purpose = 'harness_validation'`. Zero pinned recent-evidence rows exist for any strategy,
+and all six windows read `status: "missing"` on `/strategies/overview`. Backtest run 112352
+(`refresh_recent: true`) is writing them now.
+
+⚠ Consequence, stated plainly: this path is buildable and unit-testable now but **cannot be
+exercised end to end** until 112352 lands the matrix *and* a manifest entry becomes
+`capital_candidate` (all ten are `harness_validation`). The gate must exist before evidence
+can pass through it. The PR will say so rather than implying an operator ran it.
+
+### ⓒ Duplicates on the pinned identity are real — verified on the full population
+
+Codex flagged an internal contradiction: "complete 24-combination bundle" plus "duplicates
+refuse" plus "a re-run may legitimately add rows" cannot all hold. Checked, and the
+contradiction is real:
+
+```sql
+select count(*), count(distinct (strategy_id, strategy_version, namespace,
+       window_start, window_end, ambiguity_arm, quarantine_arm,
+       corpus_version, cost_model_id))
+from strategy_results_store;                              -- 328 | 268
+```
+
+Ten groups carry exactly 2 rows on one identity, two distinct `result_version`s each — an
+s1 re-run. The store's uniqueness is `strategy_results_unique (strategy_id,
+strategy_version, result_version)`, **not** the window/arm identity, so a re-run adds
+rather than replaces. `refresh_recent: true` re-runs are routine, and pinned results are
+`ON DELETE RESTRICT`, so "refuse on duplicate" would make any re-run strategy permanently
+unpromotable.
+
+**Resolution: the loader selects the latest row per identity** —
+`DISTINCT ON (window_start, window_end, ambiguity_arm, quarantine_arm) … ORDER BY …,
+result_id DESC`. `result_id` is the primary key, so the order is total and deterministic.
+Latest-wins is the safe direction: a re-run that measured worse supersedes a better older
+row, and the caller cannot influence the choice. The exact selection stays auditable
+through the pinned ids and the evidence digest.
+
+⚠ Incidental, not this ticket's to fix: the read model tolerates the same duplicates
+silently — `app/api/strategies.py:1989` builds `arm_keys` as a **set**, so eight rows on
+four identities render `complete`. Noted on the PR; no ticket, per the standing order.
+
+## Design
+
+### New module `app/services/strategy_operator_promotion.py`
+
+```python
+OperatorAction = Literal[
+    "register_research_candidate",
+    "validate_historical",
+    "start_forward_observation",
+    "enable_paper",
+]
+```
+
+- `allowed_operator_action(stage) -> OperatorAction | None` — ⓒ derived from `_NEXT_STAGE`
+  by taking each stage's successors **minus** `{paused, retired, live_enabled}`, which are
+  the lifecycle and dedicated-gate edges this path deliberately excludes. The guard test
+  asserts that filtered projection equals the action map, in both directions; Codex
+  (44) was right that a naive bidirectional identity is ill-defined.
+- `recent_evidence_refusals(rows) -> tuple[str, ...]` — pure, over
+  `(evidence_window_id, ambiguity_arm, quarantine_arm, result_id)`:
+  - `recent_evidence_window_missing:{window_id}` — window contributes nothing. ⓒ When a
+    window is wholly absent this is emitted **alone**, not with four `arm_missing`
+    companions (Codex 8: diagnostic cardinality).
+  - `recent_evidence_arm_missing:{window_id}/{ambiguity}/{quarantine}` — window present,
+    arm absent.
+  - `recent_evidence_window_unknown:{window_id}` — a hold-out row on this comparability
+    basis naming a window outside the declared six. ⓒ Reachable, because the loader
+    selects on `namespace`/pins and **not** on a window-id whitelist (Codex 2 was right
+    that a whitelist SQL filter makes this undetectable); classification happens in Python.
+  - `recent_evidence_arm_unknown:{window_id}/{ambiguity}/{quarantine}`.
+  Rows with a null window id or arm are ignored by the loader's `WHERE` and cannot reach
+  here; the function still refuses defensively on a null arm rather than crashing.
+  Refusals are returned in a stable sorted order so a diff of two runs is readable.
+  Empty tuple means complete. **No "close enough" tier.**
+- `recent_evidence_ref(strategy_id, strategy_version, pairs) -> str` — ⓒ
+  `recent-evidence-v1+{sha256 hex, full 64 chars}` over
+  `json.dumps([...], sort_keys=True, separators=(",", ":"))` of the sorted
+  `[window_id, ambiguity, quarantine, result_id]` lists plus the strategy identity.
+  Canonical JSON removes the delimiter ambiguity Codex raised (9); the digest is not
+  truncated (10); and `GOVERNANCE_GATE_VERSION` is **excluded** from the payload (11, 13) —
+  the digest identifies the evidence *set*, and the gate version is already recorded on the
+  promotion row in its own column. Same set ⇒ same ref, whatever the gate.
+- `load_authoritative_recent_evidence(conn, strategy_id, strategy_version)` →
+  `RecentEvidenceBundle(result_ids, evidence_ref, refusals)`. One SELECT, binding
+  `current_identity_pins()` and `evidence_window_id IS NOT NULL`, `DISTINCT ON` as above.
+  **Caller-supplied ids never enter.**
+- `advance_strategy(conn, *, strategy_id, action, advanced_by, reason)`:
+  1. resolve the current `strategy_version` from the registry — never from the request; an
+     unknown `strategy_id` refuses with `unknown_strategy` (Codex 15);
+  2. `lock_strategy_control` — the same per-version advisory lock `promote_strategy` takes;
+  3. `stage = current_stage(...)`, read **after** the lock; refuse unless
+     `allowed_operator_action(stage) == action`;
+  4. ⓒ the `capital_candidate` purpose is required **only for the three evidence actions**.
+     `research_candidate` is not in `_EXTERNAL_EVIDENCE_STAGES`, so the primitive permits a
+     non-candidate to register; refusing it early would silently narrow the declared DAG
+     (Codex 17);
+  5. assemble evidence per action (below);
+  6. call `promote_strategy`.
+
+⚠ ⓒ The advisory lock serialises *promotions*, not result or assessment writers (Codex 18).
+A hold-out row may commit between the loader's SELECT and the INSERT. That is the same
+non-atomicity `promote_strategy` already documents for criterion 5's counts, and the
+consequence is bounded: the pinned set and its digest describe exactly what was read, so a
+later row makes the *next* promotion different, never this one wrong.
+
+### Evidence per action
+
+| action | to_stage | evidence bound | `pinned_result_count` |
+| --- | --- | --- | --- |
+| `register_research_candidate` | `research_candidate` | none | 0 |
+| `validate_historical` | `historical_validated` | complete 24-combination bundle | 24 |
+| `start_forward_observation` | `forward_observation` | complete bundle ⊇ the set pinned at `historical_validated` | 24 |
+| `enable_paper` | `paper_enabled` | fresh passing prospective assessment | ⓒ 0 — paper pins no results (Codex 39) |
+
+**"Must not weaken or replace historical evidence"** compares **identities**, not result
+ids: resolve the `result_id`s recorded against the `historical_validated` promotion back
+to their `(window, ambiguity, quarantine)` combinations and refuse
+`recent_evidence_weakened:{window}/{ambiguity}/{quarantine}` for any no longer covered.
+
+⚠ ⓒ **An id comparison is wrong, and Codex checkpoint 2 caught it as a P1 in the first
+implementation.** A re-run between the two promotions replaces every id;
+`select_latest_rows` returns the new ones; every previously pinned id then reads as
+"dropped". Because the store is append-only and pins are `ON DELETE RESTRICT`, that
+verdict is permanent — one routine `refresh_recent` re-run would block
+`start_forward_observation` forever. This is the same failure the duplicate rule above
+was written to avoid, reintroduced two functions later, which is worth recording: the
+rule is *superseding a row is not weakening the evidence; ceasing to cover a window or
+an arm is.*
+
+The identity check cannot fire while both steps demand a complete matrix over the same
+declared windows — two complete matrices have identical identity sets. What it catches is
+the declared set MOVING between the steps: shrink `RECENT_EVIDENCE_WINDOWS` and the
+second "complete" matrix is smaller than the first, which is a real weakening and is
+invisible to every completeness check.
+
+**Paper approval** ⓒ requires all of:
+
+- a current effective assessment policy, and a `passed` assessment for this exact
+  `(strategy_id, strategy_version)`;
+- freshness by the **same predicate the overview applies** (`app/api/strategies.py:2147`):
+  `checked_at >= as_of - max_assessment_age_days` and `checked_at <= as_of + 5s`. The 5 s
+  future tolerance is inherited deliberately, not by accident (Codex 28) — one predicate,
+  one behaviour, and the page cannot say "fresh" where the transaction says "stale";
+- ⓒ `checked_at >= the promoted_at of this version's forward_observation` — an assessment
+  computed before forward observation began is not evidence *from* it (Codex 24). Without
+  this, all four advances can run back-to-back on backtest evidence alone.
+- ⓒ where several passing assessments qualify, the **most recent `checked_at`** is pinned,
+  ties broken on the greater `assessment_id` (Codex 29).
+
+Refusals reuse the existing vocabulary — `prospective_assessment_policy_missing`,
+`prospective_assessment_missing`, `prospective_assessment_not_passed`,
+`prospective_assessment_stale` — plus `prospective_assessment_predates_forward_observation`.
+`evidence_ref` is `prospective-assessment-v1+{assessment_id}@{policy_id}` (Codex 26).
+
+⓪ **Not built, deliberately**: a minimum forward-observation duration (Codex 25). Duration
+floors belong to the live gate — #2599's contract-frozen forward-shadow floor reads
+`forward_days` off these windows — and paper is deliberately the cheaper rung. Adding a
+second floor here would put the same policy in two places.
+
+### API
+
+`POST /strategies/{strategy_id}/advance`, `require_session` — an operator authorisation
+recorded with a named `changed_by`, matching `update_core_mandate`'s reasoning that a
+service token has no operator identity to attribute a promotion to.
+
+Body: `{action: OperatorAction, reason: str}`. **No `to_stage`, no `result_ids`, no
+`strategy_version`** — the three inputs a browser must not supply. `reason` is
+`min_length=1`, whitespace-stripped, `max_length=500`.
+
+Responses: 200 `{strategy_id, strategy_version, from_stage, stage, promotion_id,
+evidence_ref, pinned_result_count}`; **409** for every `StrategyControlError`; 404 for an
+unknown strategy; 422 for a malformed action (FastAPI's own enum validation).
+
+⓪ ⓒ `UniqueViolation` is **not** caught (Codex 34-37). The advisory lock serialises the
+two requests, so the second reads the advanced stage and refuses with
+`invalid promotion transition` before any INSERT. Catching it would need constraint-name
+discrimination and a savepoint to avoid leaving the transaction aborted, to handle a race
+the lock already excludes; the indexes stay as the backstop they were designed to be. Two
+identical submissions therefore give one 200 and one 409 — duplicate *prevention*, which is
+what the ticket asks for, and not idempotent replay, which it does not.
+
+`live_enabled` is unreachable: not an `OperatorAction`, and `promote_strategy` refuses it
+independently.
+
+### Read surface
+
+`StrategyOverview` gains `next_operator_action: OperatorAction | null` and
+`next_operator_action_refusals: list[str]`. ⓒ The action is **named alongside its
+refusals**, not nulled by them (Codex 42); null means a terminal stage with no forward
+edge. ⓒ This is advisory: it is computed from the same pure functions the write path uses,
+but a page cannot be transactionally coupled to a later request (Codex 30, 40, 41), so the
+transaction stays authoritative and a stale page gets a 409 it must render.
+
+⚠ ⓒ **The paper step must report the assessment refusals the overview has already
+computed** (Codex checkpoint 2, P2). Without that, reaching `forward_observation` renders
+an enabled "Approve for paper trading" button however missing, failed or stale the
+assessment is — one click for a guaranteed 409. The refusals passed in are necessarily a
+SUBSET of what the transaction checks (the overview does not compute
+`prospective_assessment_predates_forward_observation`, which needs the promotion
+timestamp), so an enabled button claims that nothing KNOWN refuses, not that the request
+will succeed.
+
+`/strategies` renders the action in the research section with its refusals, disabled while
+in flight, and refetches on success.
+
+## Tests
+
+Pure (fast tier), per "prefer pure policy over real DBs":
+
+- matrix table tests — complete; window absent (one refusal, not five); arm absent;
+  duplicate identity resolved to latest; unknown window; unknown arm; empty input; refusal
+  ordering stable;
+- `evidence_ref` — determinism, order-insensitivity, sensitivity to one swapped id, and
+  invariance to `GOVERNANCE_GATE_VERSION`;
+- `allowed_operator_action` vs the filtered `_NEXT_STAGE` projection, both directions;
+- the weakening comparison — superset passes, dropped id refuses;
+- assessment selection — missing policy, missing, not passed, stale, predating forward
+  observation, most-recent-wins among several passing.
+
+DB (`-m db`), one integration test per genuinely new SQL mechanism:
+
+- the loader returns exactly one row per identity in the presence of a seeded duplicate,
+  and it is the higher `result_id`;
+- a partial matrix refuses and writes no promotion;
+- the endpoint exposes no `result_ids` field (structural anti-cherry-pick assertion);
+- a second identical submission returns 409 and leaves exactly one promotion row.
+
+Frontend: the action renders with refusals; absent for a `harness_validation` strategy;
+a 409 surfaces as an error and the row refetches.
+
+## Out of scope
+
+Live promotion, the paper executor, funding decisions, and flipping any manifest entry to
+`capital_candidate` — that is an evidence decision on its own ticket.

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -3,6 +3,8 @@ import type {
   AllocationUpdateRequest,
   AllocationUpdateResponse,
   FiredSignalsResponse,
+  StrategyAdvanceResponse,
+  StrategyOperatorAction,
   StrategyOverviewResponse,
   StrategyEvidenceRefreshResponse,
   StrategyOwnedPositionsResponse,
@@ -56,6 +58,23 @@ export function updateStrategyPaperPool(body: {
 }): Promise<StrategyPaperPool> {
   return apiFetch("/strategies/paper-pool", {
     method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+/** Advance one strategy by one ordered step (#2770).
+ *
+ * ⚠ Sends the ACTION and a reason, and nothing else. No `strategy_version`, no
+ * `to_stage`, no `result_ids` — those are the three inputs that would let this
+ * client choose its own promotion denominator, and the endpoint does not accept
+ * them. The evidence is assembled server-side inside the locked transaction.
+ */
+export function advanceStrategyStage(
+  strategyId: string,
+  body: { action: StrategyOperatorAction; reason: string },
+): Promise<StrategyAdvanceResponse> {
+  return apiFetch(`/strategies/${encodeURIComponent(strategyId)}/advance`, {
+    method: "POST",
     body: JSON.stringify(body),
   });
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2636,6 +2636,30 @@ export interface StrategyOverview {
   allocation: StrategyAllocation;
   allocation_ready: boolean;
   allocation_refusals: string[];
+  /** The one ordered promotion step available from this stage (#2770).
+   *
+   * ⚠ NAMED ALONGSIDE its refusals rather than nulled by them — an operator who
+   * cannot act needs to know WHICH step is blocked. `null` means a terminal stage.
+   * ⚠ Advisory: the transaction re-checks everything, so a stale page gets a 409. */
+  next_operator_action: StrategyOperatorAction | null;
+  next_operator_action_refusals: string[];
+}
+
+export type StrategyOperatorAction =
+  | "register_research_candidate"
+  | "validate_historical"
+  | "start_forward_observation"
+  | "enable_paper";
+
+export interface StrategyAdvanceResponse {
+  strategy_id: string;
+  strategy_version: string;
+  from_stage: string | null;
+  stage: string;
+  promotion_id: number;
+  evidence_ref: string | null;
+  /** 24 for the two result-evidence stages; 0 for registration and paper enable. */
+  pinned_result_count: number;
 }
 
 /** How often the entry rule fires, from the durable census (#2623 gap 2).

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -716,12 +716,31 @@ describe("StrategiesPage", () => {
     });
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     await userEvent.click(await screen.findByText("Research & validation"));
-    await userEvent.click(screen.getByRole("button", { name: "Validate historical evidence" }));
+    const button = screen.getByRole("button", { name: "Validate historical evidence" });
+    // A promotion is an authorisation; without a rationale there is nothing to record.
+    expect(button).toBeDisabled();
+    await userEvent.type(screen.getByLabelText("Why are you advancing this strategy?"), "  all six windows landed  ");
+    await userEvent.click(button);
     await waitFor(() => expect(advance).toHaveBeenCalledTimes(1));
     const [, body] = advance.mock.calls[0]!;
     expect(body.action).toBe("validate_historical");
+    expect(body.reason).toBe("all six windows landed");
     // ⚠ The client must not be able to name its own evidence.
     expect(Object.keys(body).sort()).toEqual(["action", "reason"]);
+  });
+
+  it("will not advance on a whitespace-only rationale", async () => {
+    const strategy = OVERVIEW.strategies[0]!;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      strategies: [{ ...strategy, next_operator_action_refusals: [] }],
+    });
+    const advance = vi.spyOn(strategiesApi, "advanceStrategyStage");
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.type(screen.getByLabelText("Why are you advancing this strategy?"), "   ");
+    expect(screen.getByRole("button", { name: "Validate historical evidence" })).toBeDisabled();
+    expect(advance).not.toHaveBeenCalled();
   });
 
   it("renders a refused promotion verbatim rather than as a friendlier fiction", async () => {
@@ -735,6 +754,7 @@ describe("StrategiesPage", () => {
     );
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.type(screen.getByLabelText("Why are you advancing this strategy?"), "page was stale");
     await userEvent.click(screen.getByRole("button", { name: "Validate historical evidence" }));
     expect(
       await screen.findByText("action 'validate_historical' is not available from stage 'historical_validated'"),

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -318,6 +318,8 @@ const OVERVIEW: StrategyOverviewResponse = {
     allocation: { deployment_id: null, capital_limit: "0", currency: "USD", enabled: false, revision: null, reserved_capital: "0", invested_capital: "0", remaining_capital: "0", policy_configured: false, max_drawdown_limit_pct: null, ticket_sizing_mode: null, ticket_value: null, max_ticket_amount: null },
     allocation_ready: false,
     allocation_refusals: ["recent_evidence_incomplete", "paper_promotion_missing", "execution_policy_missing"],
+    next_operator_action: "validate_historical",
+    next_operator_action_refusals: ["recent_evidence_window_missing x6"],
   }],
 };
 
@@ -685,6 +687,69 @@ describe("StrategiesPage", () => {
     expect(within(validation).getByText("106")).toBeInTheDocument();
     expect(within(validation).getByText("2")).toBeInTheDocument();
     expect(within(validation).getAllByText("1", { selector: "dd" })).toHaveLength(2);
+  });
+
+  it("names the next promotion step and the reasons it would refuse", async () => {
+    // #2770: the step stays NAMED when it is blocked — "which step, and why" is
+    // the thing an operator needs; hiding it leaves the page saying nothing.
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    expect(screen.getByText("Next step: Validate historical evidence")).toBeInTheDocument();
+    expect(screen.getByText("recent_evidence_window_missing x6")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Validate historical evidence" })).toBeDisabled();
+  });
+
+  it("advances a strategy whose evidence no longer refuses, sending no denominator", async () => {
+    const strategy = OVERVIEW.strategies[0]!;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      strategies: [{ ...strategy, next_operator_action_refusals: [] }],
+    });
+    const advance = vi.spyOn(strategiesApi, "advanceStrategyStage").mockResolvedValue({
+      strategy_id: strategy.strategy_id,
+      strategy_version: strategy.strategy_version,
+      from_stage: "research_candidate",
+      stage: "historical_validated",
+      promotion_id: 1,
+      evidence_ref: `recent-evidence-v1+${"a".repeat(64)}`,
+      pinned_result_count: 24,
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(screen.getByRole("button", { name: "Validate historical evidence" }));
+    await waitFor(() => expect(advance).toHaveBeenCalledTimes(1));
+    const [, body] = advance.mock.calls[0]!;
+    expect(body.action).toBe("validate_historical");
+    // ⚠ The client must not be able to name its own evidence.
+    expect(Object.keys(body).sort()).toEqual(["action", "reason"]);
+  });
+
+  it("renders a refused promotion verbatim rather than as a friendlier fiction", async () => {
+    const strategy = OVERVIEW.strategies[0]!;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      strategies: [{ ...strategy, next_operator_action_refusals: [] }],
+    });
+    vi.spyOn(strategiesApi, "advanceStrategyStage").mockRejectedValue(
+      new Error("action 'validate_historical' is not available from stage 'historical_validated'"),
+    );
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(screen.getByRole("button", { name: "Validate historical evidence" }));
+    expect(
+      await screen.findByText("action 'validate_historical' is not available from stage 'historical_validated'"),
+    ).toBeInTheDocument();
+  });
+
+  it("offers no promotion step to a harness control", async () => {
+    const strategy = OVERVIEW.strategies[0]!;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      strategies: [{ ...strategy, purpose: "harness_validation", next_operator_action: null, next_operator_action_refusals: [] }],
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    expect(screen.queryByText(/^Next step:/)).not.toBeInTheDocument();
   });
 
   it("does not present a legacy enabled harness deployment as approved", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from "react";
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
+  advanceStrategyStage,
   closeStrategyOwnedPosition,
   fetchFiredSignals,
   fetchStrategyOverview,
@@ -17,6 +18,7 @@ import type {
   FiredSignal,
   FiredSignalsResponse,
   StrategyEvidenceWindow,
+  StrategyOperatorAction,
   StrategySplitUnavailableReason,
   StrategyFireRate,
   StrategyOverview,
@@ -1653,7 +1655,76 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
   );
 }
 
-function ResearchCandidate({ strategy }: { strategy: StrategyOverview }) {
+const PROMOTION_STEP_LABELS: Record<StrategyOperatorAction, string> = {
+  register_research_candidate: "Register as research candidate",
+  validate_historical: "Validate historical evidence",
+  start_forward_observation: "Start forward observation",
+  enable_paper: "Approve for paper trading",
+};
+
+/** The one ordered promotion step, with the reasons it would refuse (#2770).
+ *
+ * ⚠ The button is DISABLED by refusals but the step is still NAMED, because
+ * "which step is blocked, and why" is the thing an operator needs. Hiding the
+ * step when it cannot run leaves the page saying nothing at all.
+ *
+ * ⚠ This is advisory. The transaction re-reads the stage under its own lock and
+ * re-assembles the evidence, so a stale page gets a 409 — which is why the error
+ * is rendered verbatim rather than mapped to a friendlier fiction.
+ */
+function PromotionStep({ strategy, onAdvanced }: { strategy: StrategyOverview; onAdvanced: () => void }) {
+  const [saving, setSaving] = useState(false);
+  const [failed, setFailed] = useState<string | null>(null);
+  const action = strategy.next_operator_action;
+  if (action === null) return null;
+  const refusals = strategy.next_operator_action_refusals;
+
+  async function advance() {
+    if (action === null || saving || refusals.length) return;
+    setSaving(true);
+    setFailed(null);
+    try {
+      await advanceStrategyStage(strategy.strategy_id, {
+        action,
+        reason: `Operator advance from the strategies workspace: ${PROMOTION_STEP_LABELS[action]}`,
+      });
+      onAdvanced();
+    } catch (error) {
+      setFailed(error instanceof Error ? error.message : "The promotion was refused.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="border-t border-slate-200 px-4 py-3 dark:border-slate-800">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <span className="text-xs font-semibold">Next step: {PROMOTION_STEP_LABELS[action]}</span>
+          <p className="mt-1 text-[11px] text-slate-500">
+            Evidence is selected by the server from every declared window and arm; it cannot be chosen here.
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={saving || refusals.length > 0}
+          onClick={() => void advance()}
+          className="min-h-11 cursor-pointer border border-blue-700 bg-blue-700 px-4 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {saving ? "Advancing…" : PROMOTION_STEP_LABELS[action]}
+        </button>
+      </div>
+      {refusals.length ? (
+        <ul className="mt-2 space-y-1 text-[11px] text-amber-700 dark:text-amber-300">
+          {refusals.map((refusal) => <li key={refusal}>{refusal}</li>)}
+        </ul>
+      ) : null}
+      {failed ? <p className="mt-2 text-[11px] text-red-700 dark:text-red-300">{failed}</p> : null}
+    </div>
+  );
+}
+
+function ResearchCandidate({ strategy, onAdvanced }: { strategy: StrategyOverview; onAdvanced: () => void }) {
   const [expanded, setExpanded] = useState(false);
   const arm = representativeArm(strategy);
   const validation = validationState(strategy);
@@ -1675,6 +1746,7 @@ function ResearchCandidate({ strategy }: { strategy: StrategyOverview }) {
           {expanded ? "Hide evidence" : "View evidence"}
         </button>
       </div>
+      <PromotionStep strategy={strategy} onAdvanced={onAdvanced} />
       {expanded ? <EvidenceDetail strategy={strategy} /> : null}
     </article>
   );
@@ -1895,7 +1967,7 @@ export function StrategiesPage() {
                   ) : null}
                   <div className="space-y-2">
                     {researchCandidates.length
-                      ? researchCandidates.map((strategy) => <ResearchCandidate key={strategy.strategy_id} strategy={strategy} />)
+                      ? researchCandidates.map((strategy) => <ResearchCandidate key={strategy.strategy_id} strategy={strategy} onAdvanced={overview.refetch} />)
                       : <EmptyState title="No capital candidates" description="The current bounded research programme produced no strategy safe enough to allocate capital." />}
                   </div>
                 </section>

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1675,19 +1675,26 @@ const PROMOTION_STEP_LABELS: Record<StrategyOperatorAction, string> = {
 function PromotionStep({ strategy, onAdvanced }: { strategy: StrategyOverview; onAdvanced: () => void }) {
   const [saving, setSaving] = useState(false);
   const [failed, setFailed] = useState<string | null>(null);
+  // ⚠ THE OPERATOR'S OWN WORDS, not a template. A promotion is an authorisation
+  // and `reason` is its audit rationale; sending a generated string would fill the
+  // audit column while recording nothing, which is worse than leaving it empty
+  // because it reads as a real justification forever after.
+  const [reason, setReason] = useState("");
   const action = strategy.next_operator_action;
   if (action === null) return null;
   const refusals = strategy.next_operator_action_refusals;
+  // Whitespace-only is not a rationale, and the server strips before validating —
+  // so the same string the button accepts is the one the endpoint accepts.
+  const reasonGiven = reason.trim().length > 0;
+  const blocked = saving || refusals.length > 0 || !reasonGiven;
 
   async function advance() {
-    if (action === null || saving || refusals.length) return;
+    if (action === null || blocked) return;
     setSaving(true);
     setFailed(null);
     try {
-      await advanceStrategyStage(strategy.strategy_id, {
-        action,
-        reason: `Operator advance from the strategies workspace: ${PROMOTION_STEP_LABELS[action]}`,
-      });
+      await advanceStrategyStage(strategy.strategy_id, { action, reason: reason.trim() });
+      setReason("");
       onAdvanced();
     } catch (error) {
       setFailed(error instanceof Error ? error.message : "The promotion was refused.");
@@ -1698,27 +1705,41 @@ function PromotionStep({ strategy, onAdvanced }: { strategy: StrategyOverview; o
 
   return (
     <div className="border-t border-slate-200 px-4 py-3 dark:border-slate-800">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <span className="text-xs font-semibold">Next step: {PROMOTION_STEP_LABELS[action]}</span>
-          <p className="mt-1 text-[11px] text-slate-500">
-            Evidence is selected by the server from every declared window and arm; it cannot be chosen here.
-          </p>
-        </div>
-        <button
-          type="button"
-          disabled={saving || refusals.length > 0}
-          onClick={() => void advance()}
-          className="min-h-11 cursor-pointer border border-blue-700 bg-blue-700 px-4 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          {saving ? "Advancing…" : PROMOTION_STEP_LABELS[action]}
-        </button>
+      <div>
+        <span className="text-xs font-semibold">Next step: {PROMOTION_STEP_LABELS[action]}</span>
+        <p className="mt-1 text-[11px] text-slate-500">
+          Evidence is selected by the server from every declared window and arm; it cannot be chosen here.
+        </p>
       </div>
       {refusals.length ? (
         <ul className="mt-2 space-y-1 text-[11px] text-amber-700 dark:text-amber-300">
           {refusals.map((refusal) => <li key={refusal}>{refusal}</li>)}
         </ul>
       ) : null}
+      {/* Rendered even when refused, and disabled — the step stays visible so the
+          operator can see what is blocked rather than what is absent. */}
+      <div className="mt-3 flex flex-wrap items-end gap-2">
+        <label className="min-w-[16rem] flex-1 text-[11px] font-medium text-slate-600 dark:text-slate-300">
+          Why are you advancing this strategy?
+          <input
+            type="text"
+            maxLength={500}
+            value={reason}
+            disabled={saving || refusals.length > 0}
+            onChange={(event) => setReason(event.target.value)}
+            placeholder="Recorded on the promotion, permanently"
+            className="mt-1 min-h-11 w-full border border-slate-300 bg-white px-3 py-2 text-xs disabled:opacity-50 dark:border-slate-700 dark:bg-slate-950"
+          />
+        </label>
+        <button
+          type="button"
+          disabled={blocked}
+          onClick={() => void advance()}
+          className="min-h-11 cursor-pointer border border-blue-700 bg-blue-700 px-4 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {saving ? "Advancing…" : PROMOTION_STEP_LABELS[action]}
+        </button>
+      </div>
       {failed ? <p className="mt-2 text-[11px] text-red-700 dark:text-red-300">{failed}</p> : null}
     </div>
   );

--- a/tests/test_2770_authoritative_evidence_loader.py
+++ b/tests/test_2770_authoritative_evidence_loader.py
@@ -1,0 +1,282 @@
+"""#2770 — the one genuinely new SQL mechanism: the authoritative evidence loader.
+
+Every rule ABOUT the matrix is pure and lives in
+``test_2770_operator_promotion_path.py``. What can only be shown against Postgres is
+that the loader selects the right ROWS: bound to ``current_identity_pins()``, one per
+window/arm identity, latest wins, and nothing a caller could influence.
+
+⚠ The seeding goes through ``store_holdout_result`` rather than hand-written SQL,
+because the store refuses a hold-out row that has no criterion-5 ``evaluate`` access
+record (``sql/264``'s trigger) and refuses an evidence-window id the database does not
+itself recognise (``strategy_evidence_window_is_registered``). A hand-rolled INSERT
+either fights those or bypasses the shape the producer actually writes.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import psycopg
+import pytest
+
+from app.services.result_ledger import store_holdout_result
+from app.services.strategy_operator_promotion import (
+    RecentEvidenceBundle,
+    load_authoritative_recent_evidence,
+)
+from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+from app.services.strategy_result import (
+    METRIC_AXIS_RULE_VERSION,
+    ResultIdentity,
+    metric_axis_invalid_reason,
+    metric_axis_sha256,
+)
+from app.services.strategy_result_identity import current_identity_pins
+from app.services.strategy_statistics import periods_per_year
+from tests.test_result_ledger import build_metrics, build_result
+
+pytestmark = pytest.mark.integration
+
+_STRATEGY_ID = "S-2770"
+_STRATEGY_VERSION = "strategy-registry-v1+2770loader"
+_WINDOW_ID = "year-2023"
+_ARM = ("best_case", "masked")
+
+
+def _axis(*days: int) -> tuple[date, ...]:
+    """Bar dates inside `year-2023`. A DIFFERENT axis is a different result_version."""
+    return tuple(date(2023, 1, day) for day in days)
+
+
+def _seed(
+    conn: psycopg.Connection[tuple],
+    *,
+    axis: tuple[date, ...],
+    window_id: str = _WINDOW_ID,
+    ambiguity: str = _ARM[0],
+    quarantine: str = _ARM[1],
+    **identity_overrides: object,
+) -> int:
+    window = RECENT_EVIDENCE_WINDOWS[window_id]  # type: ignore[index]
+    pins = current_identity_pins()
+    identity: dict[str, object] = {
+        "strategy_id": _STRATEGY_ID,
+        "strategy_version": _STRATEGY_VERSION,
+        "namespace": pins["namespace"],
+        "ambiguity_arm": ambiguity,
+        "quarantine_arm": quarantine,
+        "window_start": window.window.start,
+        "window_end": window.window.end,
+        "evidence_window_id": window_id,
+        "corpus_version": pins["corpus_version"],
+        "cost_model_id": pins["cost_model_id"],
+        "sizing_rule": pins["sizing_rule"],
+        "benchmark_rule": pins["benchmark_rule"],
+        "return_basis": pins["return_basis"],
+        "ambiguity_rule_version": pins["ambiguity_rule_version"],
+        "position_rule_set_version": pins["position_rule_set_version"],
+        "outcome_rule_set_version": pins["outcome_rule_set_version"],
+        "input_rule_set_version": pins["input_rule_set_version"],
+        "metric_axis_rule_version": METRIC_AXIS_RULE_VERSION,
+        "metric_axis_dates": axis,
+        "metric_axis_start": axis[0],
+        "metric_axis_end": axis[-1],
+        "metric_axis_digest": metric_axis_sha256(axis),
+        "opportunity_set_digest": "b" * 64,
+    }
+    identity.update(identity_overrides)
+    # ⚠ `periods_per_year` is DERIVED from the axis, and `store_holdout_result`
+    # reconciles the two before writing (`_assert_axis_metric_reconciliation`). A
+    # fixture that varies the axis must vary this with it or the store refuses.
+    # `build_metrics`'s defaults (-100% total return, -43.3% CAGR) reconcile only over
+    # the long evaluation window it was written for; a flat pair reconciles over any.
+    identity.setdefault(
+        "metrics",
+        build_metrics(periods_per_year=periods_per_year(axis), total_return_pct=0.0, cagr_pct=0.0),
+    )
+    result = build_result(**identity)
+    return store_holdout_result(
+        conn,
+        result,
+        accessed_by="tests/test_2770_authoritative_evidence_loader.py",
+        purpose="#2770 loader fixture",
+    )
+
+
+def _load(conn: psycopg.Connection[tuple]) -> RecentEvidenceBundle:
+    return load_authoritative_recent_evidence(conn, strategy_id=_STRATEGY_ID, strategy_version=_STRATEGY_VERSION)
+
+
+def test_a_re_run_over_a_moved_axis_is_a_second_row_on_one_identity(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """⚠ THIS IS WHY THE LOADER RESOLVES DUPLICATES RATHER THAN REFUSING THEM.
+
+    ``result_version`` hashes ``metric_axis_dates`` (``ResultIdentity.version``), and
+    ``strategy_results_unique`` is on ``(strategy_id, strategy_version,
+    result_version)`` — NOT on the window/arm identity. So a re-run whose corpus lost
+    or gained a single bar writes a SECOND row for the same window and the same arm,
+    and both are legitimate. Pinned results are ``ON DELETE RESTRICT``, so the older
+    one cannot be tidied away either: "refuse on duplicate" would make any re-run
+    strategy permanently unpromotable.
+    """
+    first = _seed(ebull_test_conn, axis=_axis(3, 4, 5))
+    second = _seed(ebull_test_conn, axis=_axis(3, 4, 6))
+    assert first != second, "the store accepted two rows on one window/arm identity"
+
+    stored = ebull_test_conn.execute(
+        """
+        SELECT count(*) FROM strategy_results_store
+        WHERE strategy_id = %s AND strategy_version = %s
+          AND evidence_window_id = %s AND ambiguity_arm = %s AND quarantine_arm = %s
+        """,
+        (_STRATEGY_ID, _STRATEGY_VERSION, _WINDOW_ID, *_ARM),
+    ).fetchone()
+    assert stored is not None and stored[0] == 2
+
+
+def test_the_loader_returns_the_later_row_and_only_that(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Latest-wins is also the SAFE direction — a worse re-run supersedes a better
+    old row, never the reverse, and no caller can influence the choice."""
+    older = _seed(ebull_test_conn, axis=_axis(3, 4, 5))
+    newer = _seed(ebull_test_conn, axis=_axis(3, 4, 6))
+
+    bundle = _load(ebull_test_conn)
+    assert bundle.result_ids == (max(older, newer),)
+    assert older not in bundle.result_ids
+
+
+def test_a_row_off_the_comparability_basis_is_invisible(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The pins ARE the cross-row coherence rule (#2770).
+
+    A different cost model is not the same evidence, and a per-row check cannot see
+    that — only the denominator can. Without this the matrix could be label-complete
+    while mixing measurement bases.
+    """
+    on_basis = _seed(ebull_test_conn, axis=_axis(3, 4, 5))
+    _seed(ebull_test_conn, axis=_axis(3, 4, 6), cost_model_id="some-other-cost-model")
+
+    bundle = _load(ebull_test_conn)
+    assert bundle.result_ids == (on_basis,), "the off-basis row must not supersede the on-basis one"
+
+
+def test_arms_and_windows_are_not_collapsed(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """`DISTINCT`-style resolution must key on the full identity, not on the window."""
+    masked = _seed(ebull_test_conn, axis=_axis(3, 4, 5), quarantine="masked")
+    admitted = _seed(ebull_test_conn, axis=_axis(3, 4, 5), quarantine="admitted")
+    other_window = _seed(
+        ebull_test_conn,
+        axis=(date(2022, 1, 3), date(2022, 1, 4)),
+        window_id="year-2022",
+    )
+
+    bundle = _load(ebull_test_conn)
+    assert set(bundle.result_ids) == {masked, admitted, other_window}
+
+
+def test_an_incomplete_matrix_refuses_and_names_the_gaps(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """One arm of one window is not a denominator, and the refusal must say so."""
+    _seed(ebull_test_conn, axis=_axis(3, 4, 5))
+
+    bundle = _load(ebull_test_conn)
+    assert not bundle.complete
+    refusals = bundle.refusals
+    assert f"recent_evidence_arm_missing:{_WINDOW_ID}/worst_case/masked" in refusals
+    assert "recent_evidence_window_missing:year-2024" in refusals
+    # The seeded window is present, so it must NOT be reported as wholly missing.
+    assert f"recent_evidence_window_missing:{_WINDOW_ID}" not in refusals
+
+
+def test_the_evidence_reference_moves_when_the_selection_moves(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A superseded denominator must be visible in the audit reference, not inferred."""
+    _seed(ebull_test_conn, axis=_axis(3, 4, 5))
+    before = _load(ebull_test_conn).evidence_ref
+    _seed(ebull_test_conn, axis=_axis(3, 4, 6))
+    after = _load(ebull_test_conn).evidence_ref
+    assert before != after
+
+
+def test_the_database_itself_refuses_an_undeclared_evidence_window(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """⚠ So ``recent_evidence_window_unknown`` is UNREACHABLE through the store.
+
+    ``strategy_evidence_window_is_registered`` (a CHECK constraint) whitelists the
+    same six windows. The refusal code is kept for the case where rows reach the rule
+    from somewhere else, and this test records why it never fires here — otherwise a
+    later reader would take its absence from the DB tier as an untested path.
+    """
+    axis = _axis(3, 4, 5)
+    undeclared = build_result(
+        strategy_id=_STRATEGY_ID,
+        strategy_version=_STRATEGY_VERSION,
+        namespace="hold_out",
+        window_start=date(2023, 1, 1),
+        window_end=date(2023, 12, 31),
+        evidence_window_id="year-2025",
+        metric_axis_rule_version=METRIC_AXIS_RULE_VERSION,
+        metric_axis_dates=axis,
+        metric_axis_start=axis[0],
+        metric_axis_end=axis[-1],
+        metric_axis_digest=metric_axis_sha256(axis),
+        opportunity_set_digest="b" * 64,
+        metrics=build_metrics(periods_per_year=periods_per_year(axis), total_return_pct=0.0, cagr_pct=0.0),
+    )
+    assert metric_axis_invalid_reason(undeclared.identity, undeclared.metrics) == "evidence_window_unregistered"
+    with pytest.raises(ValueError, match="metric-axis provenance"):
+        store_holdout_result(
+            ebull_test_conn,
+            undeclared,
+            accessed_by="tests/test_2770_authoritative_evidence_loader.py",
+            purpose="#2770 undeclared-window fixture",
+        )
+
+
+def test_the_identity_hash_moves_with_the_axis(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """The mechanism the duplicate case rests on, asserted rather than assumed.
+
+    Kept in the DB file beside the row it explains, though it needs no connection:
+    if this ever stops holding, the two rows above collide on
+    ``strategy_results_unique`` and the first test fails for a reason that would be
+    hard to read.
+    """
+    common: dict[str, object] = {
+        "strategy_id": _STRATEGY_ID,
+        "strategy_version": _STRATEGY_VERSION,
+        "result_scope": "sleeve",
+        "namespace": "hold_out",
+        "ambiguity_arm": _ARM[0],
+        "quarantine_arm": _ARM[1],
+        "sizing_rule": "s",
+        "benchmark_rule": "b",
+        "cost_model_id": "c",
+        "corpus_version": "cv",
+        "window_start": date(2023, 1, 1),
+        "window_end": date(2023, 12, 31),
+        "position_rule_set_version": "p",
+        "outcome_rule_set_version": "o",
+        "input_rule_set_version": "i",
+        "return_basis": current_identity_pins()["return_basis"],
+        "evidence_window_id": _WINDOW_ID,
+        "metric_axis_rule_version": METRIC_AXIS_RULE_VERSION,
+        "opportunity_set_digest": "b" * 64,
+    }
+
+    def _identity(axis: tuple[date, ...]) -> ResultIdentity:
+        return ResultIdentity(
+            **common,  # type: ignore[arg-type]
+            metric_axis_dates=axis,
+            metric_axis_start=axis[0],
+            metric_axis_end=axis[-1],
+            metric_axis_digest=metric_axis_sha256(axis),
+        )
+
+    assert _identity(_axis(3, 4, 5)).version != _identity(_axis(3, 4, 6)).version

--- a/tests/test_2770_operator_promotion_path.py
+++ b/tests/test_2770_operator_promotion_path.py
@@ -438,3 +438,19 @@ class TestTheEndpointCannotBeHandedADenominator:
         from app.api.strategies import StrategyAdvanceRequest
 
         assert field not in StrategyAdvanceRequest.model_fields
+
+    def test_a_whitespace_only_rationale_is_refused_at_the_boundary(self) -> None:
+        """`reason` is the promotion's audit rationale; `" "` is one character and no
+        rationale at all, so `min_length=1` alone would let it through."""
+        from pydantic import ValidationError
+
+        from app.api.strategies import StrategyAdvanceRequest
+
+        with pytest.raises(ValidationError):
+            StrategyAdvanceRequest(action="validate_historical", reason="   ")
+
+    def test_a_real_rationale_is_stored_stripped(self) -> None:
+        from app.api.strategies import StrategyAdvanceRequest
+
+        body = StrategyAdvanceRequest(action="validate_historical", reason="  all six windows landed  ")
+        assert body.reason == "all six windows landed"

--- a/tests/test_2770_operator_promotion_path.py
+++ b/tests/test_2770_operator_promotion_path.py
@@ -1,0 +1,440 @@
+"""#2770 — the operator promotion path's rules, tested without Postgres.
+
+Every rule that decides whether a promotion may proceed is a pure function here, so
+these are fast-tier tests. The DB-backed behaviour (the loader's SQL, the endpoint) is
+covered separately; what matters most is that the MATRIX rule and the assessment rule
+are table-tested, because those are the two places a cherry-picked denominator or a
+stale verdict would get in.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.strategy_control_plane import _NEXT_STAGE, Stage
+from app.services.strategy_operator_promotion import (
+    EXPECTED_ARMS,
+    EXPECTED_EVIDENCE_COMBINATIONS,
+    AssessmentCandidate,
+    EvidenceRow,
+    action_target,
+    allowed_operator_action,
+    evidence_identities,
+    evidence_refusal_summary,
+    next_operator_action_view,
+    operator_targets,
+    prospective_assessment_ref,
+    recent_evidence_ref,
+    recent_evidence_refusals,
+    select_latest_rows,
+    select_prospective_assessment,
+    weakening_refusals,
+)
+from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+
+_AS_OF = datetime(2026, 8, 21, 12, 0, tzinfo=UTC)
+
+
+def _complete_matrix() -> list[EvidenceRow]:
+    """One row per declared (window, ambiguity, quarantine), ids 1..24."""
+    rows: list[EvidenceRow] = []
+    result_id = 1
+    for window_id in RECENT_EVIDENCE_WINDOWS:
+        for ambiguity, quarantine in EXPECTED_ARMS:
+            rows.append(EvidenceRow(window_id, ambiguity, quarantine, result_id))
+            result_id += 1
+    return rows
+
+
+def _candidate(**overrides: object) -> AssessmentCandidate:
+    base: dict[str, object] = {
+        "assessment_id": 1,
+        "policy_id": "assessment-policy-v1",
+        "checked_at": _AS_OF - timedelta(days=1),
+        "passed": True,
+        "max_assessment_age_days": 30,
+    }
+    base.update(overrides)
+    return AssessmentCandidate(**base)  # type: ignore[arg-type]
+
+
+class TestTheDeclaredDenominator:
+    def test_the_matrix_is_six_windows_times_four_arms(self) -> None:
+        assert len(RECENT_EVIDENCE_WINDOWS) == 6
+        assert len(EXPECTED_ARMS) == 4
+        assert EXPECTED_EVIDENCE_COMBINATIONS == 24
+        assert len(_complete_matrix()) == 24
+
+    def test_a_complete_matrix_refuses_nothing(self) -> None:
+        assert recent_evidence_refusals(_complete_matrix()) == ()
+
+    def test_no_evidence_at_all_names_every_window_once(self) -> None:
+        refusals = recent_evidence_refusals([])
+        assert len(refusals) == len(RECENT_EVIDENCE_WINDOWS)
+        assert all(item.startswith("recent_evidence_window_missing:") for item in refusals)
+
+    def test_a_wholly_absent_window_is_one_refusal_not_five(self) -> None:
+        """The refusal list should describe the damage, not scale with it."""
+        rows = [row for row in _complete_matrix() if row.window_id != "year-2023"]
+        refusals = recent_evidence_refusals(rows)
+        assert refusals == ("recent_evidence_window_missing:year-2023",)
+
+    def test_one_absent_arm_names_that_arm(self) -> None:
+        rows = [
+            row
+            for row in _complete_matrix()
+            if not (
+                row.window_id == "year-2023" and (row.ambiguity_arm, row.quarantine_arm) == ("worst_case", "masked")
+            )
+        ]
+        assert recent_evidence_refusals(rows) == ("recent_evidence_arm_missing:year-2023/worst_case/masked",)
+
+    def test_a_five_of_six_matrix_is_a_refusal_not_a_partial_pass(self) -> None:
+        """There is no 'close enough' tier — five windows is a CHOSEN denominator."""
+        rows = [row for row in _complete_matrix() if row.window_id != "rolling-24m"]
+        assert recent_evidence_refusals(rows) != ()
+
+    def test_an_undeclared_window_refuses_even_when_the_six_are_complete(self) -> None:
+        rows = [*_complete_matrix(), EvidenceRow("year-2025", "best_case", "masked", 99)]
+        assert recent_evidence_refusals(rows) == ("recent_evidence_window_unknown:year-2025",)
+
+    def test_an_undeclared_arm_refuses(self) -> None:
+        rows = [*_complete_matrix(), EvidenceRow("year-2023", "median_case", "masked", 99)]
+        assert recent_evidence_refusals(rows) == ("recent_evidence_arm_unknown:year-2023/median_case/masked",)
+
+    def test_a_duplicate_identity_refuses_when_it_reaches_the_rule(self) -> None:
+        """The loader resolves duplicates; this asserts it happened, not that it will."""
+        rows = [*_complete_matrix(), EvidenceRow("year-2023", "best_case", "masked", 999)]
+        assert recent_evidence_refusals(rows) == ("recent_evidence_arm_duplicate:year-2023/best_case/masked",)
+
+    def test_refusals_come_back_sorted_so_two_runs_diff_cleanly(self) -> None:
+        rows = [row for row in _complete_matrix() if row.window_id not in {"year-2022", "primary-2022-plus"}]
+        refusals = recent_evidence_refusals(rows)
+        assert list(refusals) == sorted(refusals)
+
+
+class TestLatestWinsPerIdentity:
+    """A re-run ADDS a row; the store is not unique on the window/arm identity."""
+
+    def test_the_higher_result_id_supersedes(self) -> None:
+        older = EvidenceRow("year-2023", "best_case", "masked", 10)
+        newer = EvidenceRow("year-2023", "best_case", "masked", 40)
+        assert select_latest_rows([older, newer]) == (newer,)
+        assert select_latest_rows([newer, older]) == (newer,)
+
+    def test_resolution_turns_a_duplicated_matrix_back_into_a_complete_one(self) -> None:
+        rerun = [
+            EvidenceRow(row.window_id, row.ambiguity_arm, row.quarantine_arm, row.result_id + 100)
+            for row in _complete_matrix()
+        ]
+        resolved = select_latest_rows([*_complete_matrix(), *rerun])
+        assert len(resolved) == EXPECTED_EVIDENCE_COMBINATIONS
+        assert recent_evidence_refusals(resolved) == ()
+        assert min(row.result_id for row in resolved) > 100
+
+    def test_distinct_identities_are_not_collapsed(self) -> None:
+        rows = _complete_matrix()
+        assert len(select_latest_rows(rows)) == len(rows)
+
+
+class TestEvidenceReference:
+    def test_it_is_deterministic_and_order_insensitive(self) -> None:
+        rows = _complete_matrix()
+        first = recent_evidence_ref(strategy_id="s6", strategy_version="v1", rows=rows)
+        second = recent_evidence_ref(strategy_id="s6", strategy_version="v1", rows=list(reversed(rows)))
+        assert first == second
+
+    def test_one_swapped_result_id_changes_it(self) -> None:
+        rows = _complete_matrix()
+        swapped = [*rows[:-1], EvidenceRow(rows[-1].window_id, rows[-1].ambiguity_arm, rows[-1].quarantine_arm, 4242)]
+        assert recent_evidence_ref(strategy_id="s6", strategy_version="v1", rows=rows) != recent_evidence_ref(
+            strategy_id="s6", strategy_version="v1", rows=swapped
+        )
+
+    def test_the_strategy_identity_is_part_of_it(self) -> None:
+        rows = _complete_matrix()
+        assert recent_evidence_ref(strategy_id="s6", strategy_version="v1", rows=rows) != recent_evidence_ref(
+            strategy_id="s7", strategy_version="v1", rows=rows
+        )
+
+    def test_the_digest_is_not_truncated(self) -> None:
+        ref = recent_evidence_ref(strategy_id="s6", strategy_version="v1", rows=_complete_matrix())
+        prefix, digest = ref.split("+", 1)
+        assert prefix == "recent-evidence-v1"
+        assert len(digest) == 64
+
+    def test_the_assessment_reference_names_both_halves(self) -> None:
+        candidate = _candidate(assessment_id=7, policy_id="assessment-policy-v2")
+        assert prospective_assessment_ref(candidate) == "prospective-assessment-v1+7@assessment-policy-v2"
+
+
+class TestTheActionGraphCannotDriftFromTheStageGraph:
+    def test_every_stage_offers_at_most_one_operator_successor(self) -> None:
+        for stage in _NEXT_STAGE:
+            assert len(operator_targets(stage)) <= 1, stage
+
+    def test_the_ordered_walk_is_exactly_the_declared_one(self) -> None:
+        walk: list[tuple[Stage | None, str]] = []
+        stage: Stage | None = None
+        while (action := allowed_operator_action(stage)) is not None:
+            walk.append((stage, action))
+            stage = action_target(action)
+        assert walk == [
+            (None, "register_research_candidate"),
+            ("research_candidate", "validate_historical"),
+            ("historical_validated", "start_forward_observation"),
+            ("forward_observation", "enable_paper"),
+        ]
+
+    def test_paper_enabled_is_terminal_for_this_path(self) -> None:
+        """`live_enabled` is the dedicated gate's, and must not be reachable here."""
+        assert allowed_operator_action("paper_enabled") is None
+        assert "live_enabled" not in operator_targets("paper_enabled")
+
+    def test_the_lifecycle_stages_offer_nothing(self) -> None:
+        assert allowed_operator_action("paused") is None
+        assert allowed_operator_action("retired") is None
+
+    def test_every_action_target_is_reachable_from_exactly_one_stage(self) -> None:
+        reached = [
+            (stage, action_target(action))
+            for stage in _NEXT_STAGE
+            if (action := allowed_operator_action(stage)) is not None
+        ]
+        targets = [target for _stage, target in reached]
+        assert sorted(targets) == sorted(set(targets))
+
+
+class TestForwardObservationMayNotWeakenTheEvidence:
+    _A = ("year-2023", "best_case", "masked")
+    _B = ("year-2023", "worst_case", "masked")
+    _C = ("year-2024", "best_case", "masked")
+
+    def test_the_same_coverage_passes(self) -> None:
+        assert weakening_refusals(previously_covered=[self._A, self._B], now_covered=[self._A, self._B]) == ()
+
+    def test_wider_coverage_passes(self) -> None:
+        assert weakening_refusals(previously_covered=[self._A], now_covered=[self._A, self._B]) == ()
+
+    def test_a_dropped_combination_refuses_and_names_it(self) -> None:
+        assert weakening_refusals(previously_covered=[self._A, self._B], now_covered=[self._A]) == (
+            "recent_evidence_weakened:year-2023/worst_case/masked",
+        )
+
+    def test_no_prior_promotion_refuses_nothing(self) -> None:
+        assert weakening_refusals(previously_covered=[], now_covered=[self._A]) == ()
+
+    def test_a_re_run_that_replaces_every_result_id_is_not_weakening(self) -> None:
+        """⚠⚠ THE REGRESSION THIS RULE EXISTS TO AVOID (Codex ckpt-2).
+
+        Comparing RESULT IDS would read a routine `refresh_recent` re-run as "all 24
+        dropped": `select_latest_rows` returns the new ids, the old ones are gone from
+        the bundle, and because the store is append-only with `ON DELETE RESTRICT`
+        pins, that verdict is permanent. One re-run would block
+        `start_forward_observation` forever.
+        """
+        pinned = _complete_matrix()
+        rerun = [
+            EvidenceRow(row.window_id, row.ambiguity_arm, row.quarantine_arm, row.result_id + 1000) for row in pinned
+        ]
+        assert {row.result_id for row in pinned}.isdisjoint({row.result_id for row in rerun})
+        assert (
+            weakening_refusals(previously_covered=evidence_identities(pinned), now_covered=evidence_identities(rerun))
+            == ()
+        )
+
+    def test_a_shrunken_declared_window_set_is_caught(self) -> None:
+        """The one case completeness cannot see: both matrices "complete", one smaller."""
+        pinned = evidence_identities(_complete_matrix())
+        shrunk = evidence_identities([row for row in _complete_matrix() if row.window_id != "year-2024"])
+        assert len(weakening_refusals(previously_covered=pinned, now_covered=shrunk)) == len(EXPECTED_ARMS)
+
+
+class TestProspectiveAssessmentSelection:
+    def test_a_fresh_pass_is_chosen(self) -> None:
+        chosen, refusals = select_prospective_assessment(
+            policy_present=True, candidates=[_candidate()], as_of=_AS_OF, forward_started_at=None
+        )
+        assert refusals == ()
+        assert chosen is not None and chosen.assessment_id == 1
+
+    def test_no_policy_is_distinct_from_no_assessment(self) -> None:
+        assert select_prospective_assessment(
+            policy_present=False, candidates=[], as_of=_AS_OF, forward_started_at=None
+        )[1] == ("prospective_assessment_policy_missing",)
+        assert select_prospective_assessment(policy_present=True, candidates=[], as_of=_AS_OF, forward_started_at=None)[
+            1
+        ] == ("prospective_assessment_missing",)
+
+    def test_a_failed_assessment_refuses(self) -> None:
+        chosen, refusals = select_prospective_assessment(
+            policy_present=True, candidates=[_candidate(passed=False)], as_of=_AS_OF, forward_started_at=None
+        )
+        assert chosen is None
+        assert refusals == ("prospective_assessment_not_passed",)
+
+    def test_an_expired_pass_refuses(self) -> None:
+        stale = _candidate(checked_at=_AS_OF - timedelta(days=31), max_assessment_age_days=30)
+        assert select_prospective_assessment(
+            policy_present=True, candidates=[stale], as_of=_AS_OF, forward_started_at=None
+        )[1] == ("prospective_assessment_stale",)
+
+    def test_the_overview_s_five_second_future_tolerance_is_inherited(self) -> None:
+        """One predicate, or the card says 'fresh' where the transaction says 'stale'."""
+        just_ahead = _candidate(checked_at=_AS_OF + timedelta(seconds=4))
+        too_far_ahead = _candidate(checked_at=_AS_OF + timedelta(seconds=6))
+        assert (
+            select_prospective_assessment(
+                policy_present=True, candidates=[just_ahead], as_of=_AS_OF, forward_started_at=None
+            )[0]
+            is not None
+        )
+        assert select_prospective_assessment(
+            policy_present=True, candidates=[too_far_ahead], as_of=_AS_OF, forward_started_at=None
+        )[1] == ("prospective_assessment_stale",)
+
+    def test_an_assessment_predating_forward_observation_refuses(self) -> None:
+        """Otherwise all four advances run back-to-back on backtest evidence alone."""
+        candidate = _candidate(checked_at=_AS_OF - timedelta(days=10))
+        chosen, refusals = select_prospective_assessment(
+            policy_present=True,
+            candidates=[candidate],
+            as_of=_AS_OF,
+            forward_started_at=_AS_OF - timedelta(days=5),
+        )
+        assert chosen is None
+        assert refusals == ("prospective_assessment_predates_forward_observation",)
+
+    def test_an_assessment_after_forward_observation_is_accepted(self) -> None:
+        candidate = _candidate(checked_at=_AS_OF - timedelta(days=1))
+        chosen, _ = select_prospective_assessment(
+            policy_present=True,
+            candidates=[candidate],
+            as_of=_AS_OF,
+            forward_started_at=_AS_OF - timedelta(days=5),
+        )
+        assert chosen is not None
+
+    def test_the_most_recent_passing_assessment_wins(self) -> None:
+        older = _candidate(assessment_id=1, checked_at=_AS_OF - timedelta(days=3))
+        newer = _candidate(assessment_id=2, checked_at=_AS_OF - timedelta(days=1))
+        chosen, _ = select_prospective_assessment(
+            policy_present=True, candidates=[older, newer], as_of=_AS_OF, forward_started_at=None
+        )
+        assert chosen is not None and chosen.assessment_id == 2
+
+    def test_a_failing_newer_assessment_does_not_hide_a_passing_older_one(self) -> None:
+        """`passed` filters first, so a later failure does not veto — it just is not chosen."""
+        passing = _candidate(assessment_id=1, checked_at=_AS_OF - timedelta(days=3))
+        failing = _candidate(assessment_id=2, checked_at=_AS_OF - timedelta(days=1), passed=False)
+        chosen, refusals = select_prospective_assessment(
+            policy_present=True, candidates=[passing, failing], as_of=_AS_OF, forward_started_at=None
+        )
+        assert refusals == ()
+        assert chosen is not None and chosen.assessment_id == 1
+
+
+class TestTheReadSurface:
+    def test_the_action_is_named_alongside_its_refusals(self) -> None:
+        action, refusals = next_operator_action_view(
+            stage="research_candidate",
+            purpose="capital_candidate",
+            evidence_refusals=["recent_evidence_window_missing x6"],
+        )
+        assert action == "validate_historical"
+        assert refusals == ("recent_evidence_window_missing x6",)
+
+    def test_a_harness_control_is_told_why_it_cannot_advance(self) -> None:
+        action, refusals = next_operator_action_view(
+            stage="research_candidate", purpose="harness_validation", evidence_refusals=[]
+        )
+        assert action == "validate_historical"
+        assert refusals == ("strategy_not_capital_candidate",)
+
+    def test_registering_a_research_candidate_needs_no_purpose(self) -> None:
+        """`research_candidate` is not an evidence stage; the primitive permits it."""
+        action, refusals = next_operator_action_view(
+            stage=None, purpose="harness_validation", evidence_refusals=["ignored"]
+        )
+        assert action == "register_research_candidate"
+        assert refusals == ()
+
+    def test_paper_enable_does_not_report_backtest_matrix_refusals(self) -> None:
+        """Its evidence is the prospective assessment, not the backtest matrix."""
+        action, refusals = next_operator_action_view(
+            stage="forward_observation",
+            purpose="capital_candidate",
+            evidence_refusals=["recent_evidence_window_missing:year-2023"],
+        )
+        assert action == "enable_paper"
+        assert refusals == ()
+
+    def test_paper_enable_reports_a_known_assessment_refusal(self) -> None:
+        """Otherwise the button is enabled for a guaranteed 409 (Codex ckpt-2)."""
+        action, refusals = next_operator_action_view(
+            stage="forward_observation",
+            purpose="capital_candidate",
+            evidence_refusals=["recent_evidence_window_missing:year-2023"],
+            assessment_refusals=["prospective_assessment_stale"],
+        )
+        assert action == "enable_paper"
+        assert refusals == ("prospective_assessment_stale",)
+
+    def test_earlier_steps_ignore_assessment_refusals(self) -> None:
+        """A stale prospective assessment does not block historical validation."""
+        _action, refusals = next_operator_action_view(
+            stage="research_candidate",
+            purpose="capital_candidate",
+            evidence_refusals=[],
+            assessment_refusals=["prospective_assessment_missing"],
+        )
+        assert refusals == ()
+
+    def test_a_terminal_stage_offers_nothing(self) -> None:
+        assert next_operator_action_view(stage="retired", purpose="capital_candidate", evidence_refusals=[]) == (
+            None,
+            (),
+        )
+
+    def test_an_unrecognised_stage_does_not_raise(self) -> None:
+        """A read surface must not blow up on a value it cannot classify."""
+        assert next_operator_action_view(stage="something_new", purpose="capital_candidate", evidence_refusals=[]) == (
+            None,
+            (),
+        )
+
+
+class TestRefusalSummary:
+    def test_twenty_four_arm_refusals_collapse_to_one_line(self) -> None:
+        refusals = [f"recent_evidence_arm_missing:w{index}/best_case/masked" for index in range(24)]
+        assert evidence_refusal_summary(refusals) == ("recent_evidence_arm_missing x24",)
+
+    def test_a_single_refusal_keeps_its_detail(self) -> None:
+        assert evidence_refusal_summary(["recent_evidence_window_missing:year-2023"]) == (
+            "recent_evidence_window_missing:year-2023",
+        )
+
+    def test_classes_are_reported_separately(self) -> None:
+        assert evidence_refusal_summary(
+            [
+                "recent_evidence_window_missing:year-2023",
+                "recent_evidence_window_missing:year-2024",
+                "recent_evidence_arm_missing:year-2022/best_case/masked",
+            ]
+        ) == ("recent_evidence_arm_missing:year-2022/best_case/masked", "recent_evidence_window_missing x2")
+
+
+class TestTheEndpointCannotBeHandedADenominator:
+    def test_the_request_model_exposes_no_evidence_fields(self) -> None:
+        """Structural: a browser must not be able to name its own result ids."""
+        from app.api.strategies import StrategyAdvanceRequest
+
+        assert set(StrategyAdvanceRequest.model_fields) == {"action", "reason"}
+
+    @pytest.mark.parametrize("field", ["result_ids", "strategy_version", "to_stage", "evidence_ref"])
+    def test_the_forbidden_inputs_are_absent_by_name(self, field: str) -> None:
+        from app.api.strategies import StrategyAdvanceRequest
+
+        assert field not in StrategyAdvanceRequest.model_fields


### PR DESCRIPTION
## What was missing

`promote_strategy` (`app/services/strategy_control_plane.py:422`) is a strict, heavily
guarded primitive — and it had exactly one API caller,
`POST /strategies/{id}/lifecycle` (`app/api/strategies.py`), which only ever targets
`paused` or `retired`. Nothing in `app/` or `scripts/` walked the forward chain
`None → research_candidate → historical_validated → forward_observation →
paper_enabled`. So `/strategies` could allocate an already-`paper_enabled` strategy but
had no way to get one there, and the chain was unreachable outside the test suite.

## Why the primitive could not simply be exposed

It takes caller-supplied `result_ids` and validates each one **individually**. A caller
could pin the three windows where a strategy happened to look good; every pinned row
would pass its own per-row checks, and the stored promotion would be indistinguishable
from an honest one. The denominator, not the row, is what a cherry-pick attacks.

## The denominator is now assembled server-side

`app/services/strategy_operator_promotion.py`. The operator names an **action**; the
evidence is assembled inside the transaction, under the same per-version advisory lock
the primitive takes, from three declarations that already existed:

| component | source | count |
| --- | --- | ---: |
| windows | `strategy_recent_evidence.RECENT_EVIDENCE_WINDOWS` | 6 |
| arms | ambiguity × quarantine, the same cross product `app/api/strategies.py` already uses for `EvidenceWindow.status == "complete"` | 4 |
| comparability | `current_identity_pins()` | 10 predicates |

The third is the one worth naming. **Twenty-four rows with no gaps can still mix results
measured against different corpora, cost models or rule sets** — label-complete and
meaningless. Binding the whole pin dict *is* the cross-row coherence check; there is
deliberately no second one. Its own docstring already said the pins "ARE the result
identity — differing on any of them means the numbers are not comparable".

### `_current_identity_pins` / `_current_versions` move to a service module

To `app/services/strategy_result_identity.py`, aliased at their old names in
`app/api/strategies.py`. A service may not import an API module. This is not churn: the
pin dict exists *because* readers must not drift, so a third reader copying it would
defeat it exactly as a second one would have. The alias keeps the existing call sites and
the tests that monkeypatch `app.api.strategies._current_versions` working unchanged.

## Duplicates are RESOLVED, not refused — and that is measured, not assumed

`result_version` hashes `metric_axis_dates` (`ResultIdentity.version`,
`app/services/strategy_result.py`), and `strategy_results_unique` is on
`(strategy_id, strategy_version, result_version)` — **not** on the window/arm identity.
So a re-run whose corpus lost or gained a single bar writes a second, legitimate row for
the same window and arm. Pinned results are `ON DELETE RESTRICT`, so the older one cannot
be tidied away. "Refuse on duplicate" would make any re-run strategy permanently
unpromotable, and `refresh_recent` re-runs are routine.

`select_latest_rows` takes the highest `result_id`. That is the safe direction — a re-run
that measured **worse** supersedes a better old row, never the reverse — and no caller can
influence it. It is one implementation, shared by the read surface and the transaction,
rather than a SQL `DISTINCT ON` plus a Python copy that could disagree about "latest".

`test_a_re_run_over_a_moved_axis_is_a_second_row_on_one_identity` proves the store really
does accept two rows on one identity, rather than asserting it in a comment.

## The three evidence rules

| action | to_stage | evidence bound | `pinned_result_count` |
| --- | --- | --- | ---: |
| `register_research_candidate` | `research_candidate` | none — not an evidence stage | 0 |
| `validate_historical` | `historical_validated` | complete 24-combination bundle | 24 |
| `start_forward_observation` | `forward_observation` | complete bundle covering everything `historical_validated` covered | 24 |
| `enable_paper` | `paper_enabled` | fresh passing prospective assessment, dated after forward observation began | 0 |

**Weakening is compared on IDENTITIES, not result ids.** Codex checkpoint 2 caught the
first implementation comparing ids, as a P1: a re-run between the two promotions replaces
every id, so every previously pinned id reads as "dropped", and because the store is
append-only that verdict is permanent — one `refresh_recent` would block
`start_forward_observation` forever. It was the same failure the duplicate rule above
exists to avoid, reintroduced two functions later. The rule is: *superseding a row is not
weakening the evidence; ceasing to cover a window or an arm is.* The identity check cannot
fire while both steps demand a complete matrix over the same declared windows; what it
catches is the declared set **shrinking** between the steps, which is a real weakening and
is invisible to every completeness check.

**Paper approval** reuses the overview's own freshness predicate verbatim, including its
five-second future-clock tolerance — one predicate, one behaviour, or the card reads
"fresh" where the transaction reads "stale". It additionally requires
`checked_at >= the forward_observation promotion`: an assessment computed before forward
observation began is not evidence *from* it, and without this all four advances can run
back-to-back on backtest evidence alone, making the stage decorative. Refusals reuse the
existing `prospective_assessment_*` vocabulary rather than minting parallel codes.

**Not built, deliberately:** a minimum forward-observation duration. Duration floors
belong to the live gate (#2599's contract-frozen forward-shadow floor reads `forward_days`
off these windows); a second floor here would put one policy in two places.

## API

`POST /strategies/{strategy_id}/advance`, `require_session`. Body is `{action, reason}` —
**no `strategy_version`, no `to_stage`, no `result_ids`**, the three inputs that would let
a browser choose its own denominator. A test asserts the request model's field set is
exactly `{action, reason}`, so adding one back fails rather than passing review.

`UniqueViolation` is **not** caught. The advisory lock serialises concurrent submissions,
so the second reads the advanced stage and refuses with an invalid-transition 409 before
any INSERT. Catching it would need constraint-name discrimination
(`idx_strategy_promotions_one_initial` and `..._one_successor` mean different things) plus
a savepoint to avoid leaving the transaction aborted — all to handle a race the lock
already excludes. The indexes stay the backstop #2612 designed them to be. Two identical
submissions therefore give one 200 and one 409: duplicate *prevention*, which is what the
ticket asks for, not idempotent replay, which it does not.

`live_enabled` is unreachable — not an `OperatorAction`, and the primitive refuses it
independently.

## Read surface

`StrategyOverview` gains `next_operator_action` and `next_operator_action_refusals`, and
`/strategies` renders the step in the research section. The action is **named alongside
its refusals** rather than nulled by them — an operator who cannot act needs to know which
step is blocked. Codex checkpoint 2 also flagged (P2) that the paper step reported no
refusals at all, so reaching `forward_observation` rendered an enabled button for a
guaranteed 409; it now surfaces the assessment refusals the overview has already computed.
Those are necessarily a subset of what the transaction checks, so an enabled button claims
nothing *known* refuses, not that the request will succeed. The page is advisory by
construction; a stale page gets a 409 and renders it verbatim.

## ⚠ This ships the gate; it cannot yet be walked end to end

Measured on dev, 2026-08-21:

```sql
select strategy_id, evidence_window_id, ambiguity_arm, quarantine_arm, purpose, count(*)
from strategy_results_store group by 1,2,3,4,5;
```

16 groups across s1-s4, **every one with `evidence_window_id IS NULL`** and
`purpose = 'harness_validation'`. No strategy has a matrix to pin, and all ten manifest
entries are `harness_validation`, which `promote_strategy` refuses for evidence stages.
Backtest run **112352** (`refresh_recent: true`) is writing the first matrix now.

That is the sequencing, not a gap: the gate has to exist before evidence can pass through
it. Deciding a strategy is a `capital_candidate` is an evidence decision on its own
ticket, and is explicitly out of scope here. **No end-to-end operator run happened and
this PR does not imply one did.**

## Security model

The endpoint is an operator authorisation: `require_session`, not the router's
`require_session_or_service_token`, because a promotion is recorded with a named
`promoted_by` and a service token has no operator identity to attribute one to — the same
reasoning `update_core_mandate` gives. The request body carries no evidence selector, so
there is no client-trusted input to the promotion decision; version, stage and evidence
are all resolved server-side inside the locked transaction. Nothing here touches the
order path, the kill switch, `enable_auto_trading` or `enable_live_trading`, and
`live_enabled` is unreachable by two independent refusals.

## Verification

| check | result |
| --- | --- |
| `uv run ruff check .` | pass |
| `uv run ruff format --check .` | pass (1538 files) |
| `uv run pyright` | 0 errors |
| `uv run pytest -m "not db"` | pass |
| `uv run pytest tests/smoke` | pass |
| `uv run pytest tests/test_2770_operator_promotion_path.py` | 57 pass, and they survive `-m "not db"` (verified: the module is not auto-marked, so it is on the push gate) |
| `uv run pytest tests/test_2770_authoritative_evidence_loader.py` | pass |
| `uv run pytest -m db tests/test_strategy_control_plane.py tests/test_api_strategies.py tests/test_result_ledger.py tests/test_strategy_result.py` | 2 failures, **pre-existing on `origin/main`** — see below |
| `pnpm --dir frontend typecheck` | pass |
| `pnpm --dir frontend test:unit` | 136 files, 1536 tests, pass |
| `codex exec review --base origin/main` | round 1: P1 + P2 (both fixed, both with a test); round 2: no findings |

**Pre-existing failures, not from this branch.** `test_the_deployment_currency_refusal_and_its_constraint_agree`
(both parametrisations) fails with `etoro_instrument_types.description = 'Stocks'
resolved to 0 rows`. Reproduced identically in a clean worktree at `origin/main`, so it is
a test-DB seeding gap, not a regression here. Noted rather than ticketed, per the standing
loop instruction not to open audit tickets while building.

**Incidental, noted not ticketed:** the overview's own completeness check
(`app/api/strategies.py`, `arm_keys` built as a `set`) tolerates duplicate identities
silently — eight rows on four identities read as `complete`. This PR's read surface runs
`select_latest_rows` first and so is unaffected; the existing `EvidenceWindow.status`
computation still has the old behaviour.

No schema migration, no parser change, no ETL change, so Definition-of-Done clauses 8-12
do not apply.

Closes #2770
