### PR TITLE
feat(#2827): turnover, not signal, is what is killing all ten strategies

### DIFF
--- a/.autonomy/loop_prompt.md
+++ b/.autonomy/loop_prompt.md
@@ -23,6 +23,43 @@ Judge every candidate action by one question: *does this move a strategy closer 
 firing where the operator can see it?* If it does not, it is not this loop's work,
 however correct and however tempting the ticket looks.
 
+### ⚠⚠ THE STANDING ORDER CHANGED AGAIN on 2026-08-21 — READ #2827 FIRST
+
+All ten strategies now have hold-out evidence at their CURRENT versions (40 rows,
+`primary-2022-plus`, written 2026-08-21). **Every one of them loses money per trade,
+and every one trades above the cost-survival bar.**
+
+| strategy | turnover/month | cost drag %/yr | CAGR% | exp%/trade |
+| --- | ---: | ---: | ---: | ---: |
+| s2 | 44% | 2–8 | -17.2 | -7.52 |
+| s5 | 162% | 6–28 | **+28.7** | -1.12 |
+| s8 | 230% | 9–40 | **+45.0** | -0.96 |
+| s1 | 696% | 27–121 | -70.2 | -1.66 |
+
+Novy-Marx/Velikov's disqualifier is ~50%/month. The LOWEST of the ten is 44%.
+
+⚠ The per-trade expectancies cluster at roughly ONE ROUND-TRIP SPREAD (-0.83% to
+-1.76%). Ten structurally different strategies do not fail independently at the same
+magnitude — to first order these break even gross and lose the spread net.
+
+**THE OBJECTIVE IS NO LONGER "build more strategies". It is: make one strategy
+gross-positive and cheap enough to keep it.**
+
+1. **FIRST, and before building anything: measure gross vs net directly.** `sql/256`
+   carries `gross_return_pct` (see `cost_model.py:31`). The cost-drag figures above are
+   INFERRED from `turnover × band spread`, not read. If gross is flat, lower turnover
+   saves nothing and the whole direction is wrong — falsify it before investing in it.
+2. If gross is positive: **lower-turnover variants of s8 and s5**, the two with positive
+   CAGR and Sortino 4.2 / 5.5 surviving 9–40%/yr of drag. Halving turnover is worth more
+   than any new signal at these levels.
+3. Re-measure on hold-out and compare per-trade expectancy and profit factor, NOT CAGR
+   or annualised Sharpe — both flatter a skewed distribution. s8 posts +45% CAGR on a
+   NEGATIVE per-trade edge because skew is 36 and kurtosis 1,976.
+
+⚠ **Check turnover BEFORE a backtest, always.** `.claude/skills/quant/strategy-evidence.md`
+already said so. Ten strategies were built and the engine optimised 6.8x before anyone
+read the one column that disqualified all ten.
+
 ### The build queue — work it in this order
 
 Spec: `docs/proposals/ta/2026-08-14-strategy-set-s5-s10.md`. It is complete and

--- a/.claude/skills/quant/cost-aware-viability.md
+++ b/.claude/skills/quant/cost-aware-viability.md
@@ -1,0 +1,162 @@
+# Cost-aware strategy viability — the arithmetic that decides before a backtest does
+
+## When to use
+
+Before proposing, backtesting, defending or promoting ANY strategy, and before
+reading any backtest result. Read with `strategy-evidence.md`, which covers whether
+a signal family replicates at all; this file covers whether a signal that DOES
+replicate can survive being traded, and which numbers are allowed to answer that.
+
+⚠ This exists because on 2026-08-21 all ten strategies were measured on hold-out and
+every one lost money per trade, and the session's first reading of that table was
+**"two strategies work"** — from CAGR and annualised Sharpe, on a distribution with
+kurtosis 14,702. Both numbers were real. Both were the wrong ones to read.
+
+---
+
+## 1. The pre-backtest gate: turnover
+
+**Rule (Novy-Marx & Velikov 2016, "A Taxonomy of Anomalies and Their Trading Costs",
+Review of Financial Studies 29(1)):** strategies with turnover above roughly
+**50%/month** rarely survive their own trading costs, and the cost of an anomaly
+scales with its turnover far more than with its gross alpha.
+
+This is one stored column. It disqualifies faster than any backtest, and it must be
+checked FIRST.
+
+```
+turnover_per_month = turnover_annualised / 12
+```
+
+⚠ Measured 2026-08-21: the LOWEST of our ten was s2 at **44%/month**; the rest ran
+68% to **696%** (s1 turns the portfolio 83x/yr). All ten were above or at the bar
+before a single backtest was run.
+
+---
+
+## 2. Break-even arithmetic — derived, not cited
+
+Net alpha is gross alpha minus what trading costs:
+
+```
+net_alpha ≈ gross_alpha − turnover_annualised × round_trip_cost
+```
+
+Two forms of the same equation, and both are decision-grade:
+
+```
+max_viable_turnover = gross_alpha / round_trip_cost      # how often you may trade
+min_gross_edge_per_trade = round_trip_cost               # what one trade must clear
+```
+
+⚠ **`min_gross_edge_per_trade = round_trip_cost` is the whole game.** A strategy whose
+average trade does not clear one round trip is not a weak strategy, it is a losing
+one, however good its equity curve looks.
+
+Round-trip cost is NOT a guess here — `cost_model.BANDS` carries the p75 in-session
+spread actually calibrated on our universe:
+
+| price band | round-trip |
+| --- | ---: |
+| <$5 | 1.450% |
+| $5–20 | 0.571% |
+| $20–100 | 0.509% |
+| ≥$100 | 0.322% |
+
+⚠ p75 is deliberately pessimistic (75th percentile, not median). Do not "correct" it
+downward to make a strategy work — that is fitting the cost model to the result.
+
+⚠⚠ **A per-trade expectancy that sits at roughly minus-one-round-trip across SEVERAL
+structurally different strategies is a cost signature, not N independent failures.**
+Measured 2026-08-21: expectancies clustered at -0.83% to -1.76% across momentum,
+mean-reversion, breakout, cross-sectional and range strategies. Independent signal
+failures do not cluster at one magnitude. Read that pattern as "breaking even gross,
+losing the spread net" and go measure gross before concluding anything about signal.
+
+---
+
+## 3. Which metrics decide — and which lie
+
+**Decide on these:**
+
+| metric | why it is trustworthy |
+| --- | --- |
+| `expectancy_per_trade_pct` | the average trade's P&L. Cannot be flattered by compounding or by one outlier's size relative to the horizon. |
+| `profit_factor` | gross wins ÷ gross losses. **< 1.0 means the strategy loses money, full stop.** |
+| `dsr_trade_sharpe` | per-trade Sharpe, the input the deflation actually consumes |
+| `deflated_sharpe` | trials-adjusted; the promotion gate |
+
+**Do NOT decide on these:**
+
+| metric | how it lies |
+| --- | --- |
+| `cagr_pct` | compounding is dominated by the largest winners. A negative-expectancy strategy with a fat right tail posts a large positive CAGR. |
+| `sharpe` (annualised) | assumes returns are roughly iid and symmetric. Under skew 36–102 and kurtosis 1,976–14,702 it is not measuring what its name implies. |
+| `sortino` | same objection; a high Sortino next to a negative per-trade expectancy means the LOSSES are small and frequent while the wins are rare and huge — a lottery profile, not an edge. |
+| `return_vs_buy_and_hold_pct` | inherits every problem above, and over a long window is dominated by the benchmark's own compounding. |
+
+⚠⚠ **The 2026-08-21 worked example, kept because it is the exact trap:**
+
+| | s8-range-mean-reversion | s5-support-bounce |
+| --- | ---: | ---: |
+| CAGR | **+45.0%** | **+28.7%** |
+| annualised Sharpe | +0.85 | +0.58 |
+| Sortino | 4.16 | 5.48 |
+| **expectancy per trade** | **-0.96%** | **-1.12%** |
+| **profit factor** | **0.83** | **0.80** |
+| skew / kurtosis | 36.5 / 1,976 | 101.6 / 14,702 |
+| deflated Sharpe | ~0 | **7.1e-160** |
+
+Every number in the top half says "this works". Every number in the bottom half says
+"this loses money on the average trade". **The bottom half is right.**
+
+---
+
+## 4. The deflation bar, and reading it correctly
+
+`deflated_sharpe` (Bailey & López de Prado 2014, "The Deflated Sharpe Ratio",
+Journal of Portfolio Management 40(5)) adjusts for how many strategies were tried.
+
+⚠ The bar is NOT the declared trial count. Declared searches collapse to
+`dsr_independent_trials` once the measured cross-trial correlation is applied. Read
+`dsr_expected_max_sharpe` — that is the null's expected maximum, and it is the number
+to beat.
+
+⚠ Measured 2026-08-21: 274 declared searches → **`E[max SR] = 0.275`** with
+`dsr_independent_trials = 223`, `measured_trials = 10`. That bar is ORDINARY and
+reachable. Do not describe the deflation as structurally unpassable — when nothing
+passes it, that is a fact about the strategies.
+
+⚠ `dsr_independent_trials` moves with how many trials THIS run measured. Comparing a
+DSR from a 3-trial run against one from a 10-trial run compares two different bars.
+
+---
+
+## 5. The order of operations
+
+1. **Turnover.** Above ~50%/month → stop. Do not backtest it.
+2. **Break-even.** Is the expected gross edge per trade larger than one round trip in
+   the price bands the strategy will actually trade? If not → stop.
+3. **Backtest, then read `expectancy_per_trade_pct` and `profit_factor` FIRST.**
+   PF < 1.0 → stop, whatever the CAGR says.
+4. **Gross vs net.** If net is negative and roughly one round trip below zero, measure
+   gross (`sql/256`'s `gross_return_pct`) before concluding the signal is dead — the
+   fix may be turnover rather than signal.
+5. **Deflation.** Compare `dsr_trade_sharpe` against `dsr_expected_max_sharpe`.
+6. **Synthetic control.** Only for something that has cleared 1–5. §9's control is
+   1,000 equity curves per arm; paying it for a strategy that fails step 3 is waste.
+
+---
+
+## 6. Prior probabilities — do not skip this
+
+`strategy-evidence.md` carries the replication literature in full. The two numbers to
+keep in mind before proposing anything:
+
+- Hou, Xue & Zhang (2020), "Replicating Anomalies", RFS 33(5): **65–82% of 452
+  anomalies fail** under value weighting.
+- Harvey, Liu & Zhu (2016), "…and the Cross-Section of Expected Returns", RFS 29(1):
+  with a multiple-testing-adjusted bar of **t > 3.0, 9 of 313 factors survive**.
+
+A new strategy idea drawn from the standard anomaly families starts from a low prior.
+That is not pessimism, it is the base rate.

--- a/scripts/check_strategy_viability.py
+++ b/scripts/check_strategy_viability.py
@@ -1,0 +1,103 @@
+"""Run the cost-aware viability gate over stored results, in the documented order.
+
+Encodes `.claude/skills/quant/cost-aware-viability.md` so the rules are EXECUTED
+rather than remembered. Read-only.
+
+⚠ Reads `expectancy_per_trade_pct` and `profit_factor` to decide, never `cagr_pct`
+or annualised `sharpe`. On 2026-08-21 s8 posted +45.0% CAGR and Sortino 4.16 on a
+per-trade expectancy of -0.96% — skew 36.5, kurtosis 1,976. The compounded figures
+were real and were the wrong ones to read.
+
+Usage:
+    PYTHONPATH=. uv run python -m scripts.check_strategy_viability [--since-hours N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from decimal import Decimal
+
+import psycopg
+
+from app.config import settings
+from app.services.cost_model import BANDS
+
+#: Novy-Marx & Velikov (2016), RFS 29(1). Turnover above this rarely survives costs.
+MAX_MONTHLY_TURNOVER_PCT = 50.0
+
+_SQL = """
+SELECT strategy_id,
+       avg(turnover_annualised)       AS turnover,
+       avg(expectancy_per_trade_pct)  AS expectancy,
+       avg(profit_factor)             AS profit_factor,
+       avg(dsr_trade_sharpe)          AS trade_sharpe,
+       avg(dsr_expected_max_sharpe)   AS bar,
+       avg(cagr_pct)                  AS cagr,
+       avg(dsr_skewness)              AS skew,
+       avg(dsr_kurtosis)              AS kurtosis
+FROM strategy_results_store
+WHERE created_at > now() - make_interval(hours => %(hours)s)
+  AND namespace = 'hold_out'
+GROUP BY 1
+ORDER BY 3 DESC
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since-hours", type=int, default=24)
+    args = parser.parse_args()
+
+    cheapest = min(band.p75_spread_pct for band in BANDS)
+    dearest = max(band.p75_spread_pct for band in BANDS)
+
+    with psycopg.connect(settings.database_url) as conn:
+        rows = conn.execute(_SQL, {"hours": args.since_hours}).fetchall()
+
+    if not rows:
+        print(f"no hold_out results in the last {args.since_hours}h")
+        return 1
+
+    print(f"round-trip cost band: {cheapest}% (>=$100) .. {dearest}% (<$5)\n")
+    header = f"{'strategy':36}{'turn/mo':>9}{'exp%/trade':>12}{'PF':>7}{'tradeSR':>9}{'bar':>8}  verdict"
+    print(header)
+    print("-" * (len(header) + 34))
+
+    viable = 0
+    for sid, turnover, expectancy, pf, trade_sr, bar, cagr, skew, kurt in rows:
+        per_month = float(turnover) / 12 * 100
+        refusals: list[str] = []
+        # 1. turnover — the pre-backtest gate
+        if per_month > MAX_MONTHLY_TURNOVER_PCT:
+            refusals.append(f"turnover {per_month:.0f}%/mo > {MAX_MONTHLY_TURNOVER_PCT:.0f}%")
+        # 2. break-even — one trade must clear one round trip
+        if Decimal(str(expectancy)) <= 0:
+            refusals.append(f"expectancy {float(expectancy):+.2f}%/trade <= 0")
+        # 3. profit factor
+        if float(pf) < 1.0:
+            refusals.append(f"profit factor {float(pf):.2f} < 1.0")
+        # 4. deflation
+        if trade_sr is not None and bar is not None and float(trade_sr) <= float(bar):
+            refusals.append(f"trade Sharpe {float(trade_sr):+.3f} <= bar {float(bar):.3f}")
+
+        verdict = "VIABLE" if not refusals else "; ".join(refusals)
+        viable += not refusals
+        print(
+            f"{sid:36}{per_month:>8.0f}%{float(expectancy):>12.2f}{float(pf):>7.2f}"
+            f"{float(trade_sr):>9.3f}{float(bar):>8.3f}  {verdict}"
+        )
+        # ⚠ Say it out loud when the compounded figures disagree with the per-trade
+        # ones — that disagreement IS the trap this script exists for.
+        if float(cagr) > 0 and float(expectancy) <= 0:
+            print(
+                f"{'':36}⚠ CAGR {float(cagr):+.1f}% is positive on a NEGATIVE per-trade edge "
+                f"(skew {float(skew):.0f}, kurtosis {float(kurt):.0f}) — a right-tail payoff, not an edge"
+            )
+
+    print(f"\n{viable}/{len(rows)} viable")
+    return 0 if viable else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_strategy_viability.py
+++ b/scripts/check_strategy_viability.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from decimal import Decimal
 
 import psycopg
 
@@ -95,7 +94,7 @@ def main() -> int:
         if per_month > MAX_MONTHLY_TURNOVER_PCT:
             refusals.append(f"turnover {per_month:.0f}%/mo > {MAX_MONTHLY_TURNOVER_PCT:.0f}%")
         # 2. break-even — one trade must clear one round trip
-        if Decimal(str(expectancy)) <= 0:
+        if float(expectancy) <= 0:
             refusals.append(f"expectancy {float(expectancy):+.2f}%/trade <= 0")
         # 3. profit factor
         if float(pf) < 1.0:

--- a/scripts/check_strategy_viability.py
+++ b/scripts/check_strategy_viability.py
@@ -27,8 +27,34 @@ from app.services.strategy_manifest import STRATEGY_MANIFEST
 #: Novy-Marx & Velikov (2016), RFS 29(1). Turnover above this rarely survives costs.
 MAX_MONTHLY_TURNOVER_PCT = 50.0
 
+#: ⚠⚠ ``evidence_window_id`` IS IN THE GROUP BY, AND IT IS LOAD-BEARING.
+#: A registered evidence window is a MEASUREMENT WINDOW, so two of them are two
+#: different measurements of the same strategy — averaging across them produces
+#: a number that describes neither. This query grouped on ``strategy_id`` alone
+#: until 2026-08-21, and on that day the dev database held two complete 40-row
+#: hold-out runs written four hours apart:
+#:
+#:   primary-2022-plus  2022-01-01..2024-09-27  40 rows  13:56 UTC
+#:   rolling-36m        2021-09-28..2024-09-27  40 rows  18:04 UTC
+#:
+#: Both are legitimate and neither is a double-write — ``evidence_window_id`` is
+#: part of the result identity, so ``assert_no_existing_results`` correctly let
+#: the second run store beside the first. What was wrong was reading them
+#: together. Measured that day, the blend moved every strategy: s8's expectancy
+#: read -0.868 mixed against -0.778 (primary-2022-plus) and -0.958
+#: (rolling-36m), and s2 read -6.902 against -6.282 and -7.523.
+#:
+#: ⚠ It changed no VERDICT on that data, because all ten fail in both windows.
+#: That is luck, not safety: the mixed figure is closer to the bar than the
+#: better window's on every row, so the blend is capable of failing a strategy
+#: one window passes, and of passing one that only the kinder window supports.
+#:
+#: Same defect family as ``sql/256``'s header — *"EVERY AGGREGATE OVER THIS
+#: TABLE MUST PIN ONE (rule_set_version, input_rule_set_version) PAIR … an
+#: unpinned count counts one trade twice"*. The key differs; the failure does not.
 _SQL = """
-SELECT strategy_id,
+SELECT evidence_window_id,
+       strategy_id,
        avg(turnover_annualised)       AS turnover,
        avg(expectancy_per_trade_pct)  AS expectancy,
        avg(profit_factor)             AS profit_factor,
@@ -40,39 +66,31 @@ SELECT strategy_id,
 FROM strategy_results_store
 WHERE created_at > now() - make_interval(hours => %(hours)s)
   AND namespace = 'hold_out'
-GROUP BY 1
-ORDER BY 3 DESC
+  AND (%(window)s::text IS NULL OR evidence_window_id = %(window)s::text)
+GROUP BY 1, 2
+ORDER BY 1, 4 DESC
 """
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--since-hours", type=int, default=24)
-    args = parser.parse_args()
+def _verdict_block(window: str, rows: list[tuple], *, header: str) -> int:
+    """Print one evidence window's table. Returns how many strategies passed.
 
-    cheapest = min(band.p75_spread_pct for band in BANDS)
-    dearest = max(band.p75_spread_pct for band in BANDS)
-
-    with psycopg.connect(settings.database_url) as conn:
-        rows = conn.execute(_SQL, {"hours": args.since_hours}).fetchall()
-
-    if not rows:
-        print(f"no hold_out results in the last {args.since_hours}h for universe {BACKTEST_UNIVERSE}")
-        return 1
-
-    print(f"round-trip cost band: {cheapest}% (>=$100) .. {dearest}% (<$5)\n")
-    header = f"{'strategy':36}{'turn/mo':>9}{'exp%/trade':>12}{'PF':>7}{'tradeSR':>9}{'bar':>8}  verdict"
+    ⚠ ONE WINDOW PER BLOCK AND NEVER A MERGED ONE. See ``_SQL``: two registered
+    windows are two measurements, and a strategy that clears the bar in one and
+    fails in the other has told you something a single averaged row destroys.
+    """
+    print(f"\nevidence window: {window}")
     print(header)
     print("-" * (len(header) + 34))
 
-    measured = {row[0] for row in rows}
+    measured = {row[1] for row in rows}
     # ⚠ EVERY MANIFEST STRATEGY IS REPORTED, NOT ONLY THE ONES WITH ROWS. A gate
     # that omits a strategy with no evidence reads as "not shown" when it means
     # "not measured", and absent-is-not-pass is the whole point of a gate.
     missing = sorted(set(STRATEGY_MANIFEST) - measured)
 
     viable = 0
-    for sid, turnover, expectancy, pf, trade_sr, bar, cagr, skew, kurt in rows:
+    for _window, sid, turnover, expectancy, pf, trade_sr, bar, cagr, skew, kurt in rows:
         # ⚠ `avg()` over an all-NULL column returns NULL. Refuse on the missing
         # figure rather than crashing the report — a viability gate that dies on
         # sparse data tells you nothing about the strategies that DID measure.
@@ -122,9 +140,52 @@ def main() -> int:
     for sid in missing:
         print(f"{sid:36}{'':>9}{'':>12}{'':>7}{'':>9}{'':>8}  NO EVIDENCE — no hold_out rows in window")
 
-    total = len(STRATEGY_MANIFEST)
-    print(f"\n{viable}/{total} viable ({len(rows)} measured, {len(missing)} with no hold_out evidence)")
-    return 0 if viable else 2
+    print(f"  {viable}/{len(STRATEGY_MANIFEST)} viable in {window} ({len(rows)} measured, {len(missing)} unmeasured)")
+    return viable
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since-hours", type=int, default=24)
+    parser.add_argument(
+        "--evidence-window",
+        default=None,
+        help="restrict to one registered evidence window id; default reports every window separately",
+    )
+    args = parser.parse_args()
+
+    cheapest = min(band.p75_spread_pct for band in BANDS)
+    dearest = max(band.p75_spread_pct for band in BANDS)
+
+    with psycopg.connect(settings.database_url) as conn:
+        rows = conn.execute(_SQL, {"hours": args.since_hours, "window": args.evidence_window}).fetchall()
+
+    if not rows:
+        scope = f" for evidence window {args.evidence_window}" if args.evidence_window else ""
+        print(f"no hold_out results in the last {args.since_hours}h for universe {BACKTEST_UNIVERSE}{scope}")
+        return 1
+
+    print(f"round-trip cost band: {cheapest}% (>=$100) .. {dearest}% (<$5)")
+    header = f"{'strategy':36}{'turn/mo':>9}{'exp%/trade':>12}{'PF':>7}{'tradeSR':>9}{'bar':>8}  verdict"
+
+    by_window: dict[str, list[tuple]] = {}
+    for row in rows:
+        by_window.setdefault(row[0], []).append(row)
+    if len(by_window) > 1:
+        # ⚠ SAID OUT LOUD, not silently handled. The previous version averaged
+        # these together, and a reader of that table had no way to know two
+        # measurement windows had been blended into one number.
+        print(
+            f"\n⚠ {len(by_window)} evidence windows in this period: {', '.join(sorted(by_window))} — "
+            "reported SEPARATELY. Averaging across them describes neither; pass --evidence-window to pin one."
+        )
+
+    total_viable = 0
+    for window in sorted(by_window):
+        total_viable += _verdict_block(window, by_window[window], header=header)
+
+    print(f"\n{total_viable} viable strategy-window pair(s) across {len(by_window)} window(s)")
+    return 0 if total_viable else 2
 
 
 if __name__ == "__main__":

--- a/scripts/check_strategy_viability.py
+++ b/scripts/check_strategy_viability.py
@@ -21,7 +21,9 @@ from decimal import Decimal
 import psycopg
 
 from app.config import settings
+from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import BANDS
+from app.services.strategy_manifest import STRATEGY_MANIFEST
 
 #: Novy-Marx & Velikov (2016), RFS 29(1). Turnover above this rarely survives costs.
 MAX_MONTHLY_TURNOVER_PCT = 50.0
@@ -56,7 +58,7 @@ def main() -> int:
         rows = conn.execute(_SQL, {"hours": args.since_hours}).fetchall()
 
     if not rows:
-        print(f"no hold_out results in the last {args.since_hours}h")
+        print(f"no hold_out results in the last {args.since_hours}h for universe {BACKTEST_UNIVERSE}")
         return 1
 
     print(f"round-trip cost band: {cheapest}% (>=$100) .. {dearest}% (<$5)\n")
@@ -64,8 +66,29 @@ def main() -> int:
     print(header)
     print("-" * (len(header) + 34))
 
+    measured = {row[0] for row in rows}
+    # ⚠ EVERY MANIFEST STRATEGY IS REPORTED, NOT ONLY THE ONES WITH ROWS. A gate
+    # that omits a strategy with no evidence reads as "not shown" when it means
+    # "not measured", and absent-is-not-pass is the whole point of a gate.
+    missing = sorted(set(STRATEGY_MANIFEST) - measured)
+
     viable = 0
     for sid, turnover, expectancy, pf, trade_sr, bar, cagr, skew, kurt in rows:
+        # ⚠ `avg()` over an all-NULL column returns NULL. Refuse on the missing
+        # figure rather than crashing the report — a viability gate that dies on
+        # sparse data tells you nothing about the strategies that DID measure.
+        required = {
+            "turnover": turnover,
+            "expectancy_per_trade_pct": expectancy,
+            "profit_factor": pf,
+            "dsr_trade_sharpe": trade_sr,
+            "dsr_expected_max_sharpe": bar,
+        }
+        absent = sorted(name for name, value in required.items() if value is None)
+        if absent:
+            print(f"{sid:36}{'':>9}{'':>12}{'':>7}{'':>9}{'':>8}  NO VERDICT — null: {', '.join(absent)}")
+            continue
+
         per_month = float(turnover) / 12 * 100
         refusals: list[str] = []
         # 1. turnover — the pre-backtest gate
@@ -78,7 +101,7 @@ def main() -> int:
         if float(pf) < 1.0:
             refusals.append(f"profit factor {float(pf):.2f} < 1.0")
         # 4. deflation
-        if trade_sr is not None and bar is not None and float(trade_sr) <= float(bar):
+        if float(trade_sr) <= float(bar):
             refusals.append(f"trade Sharpe {float(trade_sr):+.3f} <= bar {float(bar):.3f}")
 
         verdict = "VIABLE" if not refusals else "; ".join(refusals)
@@ -89,13 +112,19 @@ def main() -> int:
         )
         # ⚠ Say it out loud when the compounded figures disagree with the per-trade
         # ones — that disagreement IS the trap this script exists for.
-        if float(cagr) > 0 and float(expectancy) <= 0:
+        if cagr is not None and float(cagr) > 0 and float(expectancy) <= 0:
+            skew_txt = f"{float(skew):.0f}" if skew is not None else "?"
+            kurt_txt = f"{float(kurt):.0f}" if kurt is not None else "?"
             print(
                 f"{'':36}⚠ CAGR {float(cagr):+.1f}% is positive on a NEGATIVE per-trade edge "
-                f"(skew {float(skew):.0f}, kurtosis {float(kurt):.0f}) — a right-tail payoff, not an edge"
+                f"(skew {skew_txt}, kurtosis {kurt_txt}) — a right-tail payoff, not an edge"
             )
 
-    print(f"\n{viable}/{len(rows)} viable")
+    for sid in missing:
+        print(f"{sid:36}{'':>9}{'':>12}{'':>7}{'':>9}{'':>8}  NO EVIDENCE — no hold_out rows in window")
+
+    total = len(STRATEGY_MANIFEST)
+    print(f"\n{viable}/{total} viable ({len(rows)} measured, {len(missing)} with no hold_out evidence)")
     return 0 if viable else 2
 
 

--- a/scripts/run_2825_decisive_holdout_evidence.py
+++ b/scripts/run_2825_decisive_holdout_evidence.py
@@ -1,0 +1,80 @@
+"""First hold-out measurement of ALL TEN strategies at their CURRENT versions.
+
+⚠ WHY THIS EXISTS. Every stored result sat at a SUPERSEDED ``strategy_version`` —
+S-5/S-6 moved on the #2780 perf work, S-2/S-10 again on #2797 — so nothing
+measured the strategies as they are now. Every claim about whether they work was
+inference from stale or in-sample numbers.
+
+⚠⚠ ALL TEN IN ONE INVOCATION, AND THAT IS NOT A CONVENIENCE. §2 puts the Deflated
+Sharpe across the whole strategy set, so ``V[SR_n]`` is a function of WHICH trials
+were measured. Running nine would deflate them against a narrower variance — a
+more confident number bought by losing evidence, which ``run_backtest``'s own
+docstring names as the failure to avoid.
+
+⚠ HOLD-OUT ONLY, by construction rather than by choice: ``_resolve_invocation_window``
+returns ``("hold_out",)`` whenever an ``evidence_window_id`` is supplied. That also
+sidesteps the s1 in-sample identity collision without deleting anything — the
+result-ambiguity trigger refuses deletion outright ("records are immutable; create
+a new result identity") and it is right to.
+
+⚠ ``synthetic_control=False`` DELIBERATELY. §9's control is 1,000 equity curves PER
+ARM on top of the corpus pass; paying that for ten strategies before knowing which
+have any edge is the waste. Controls go on whatever clears the metric bar, which is
+staging, not rework.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import psycopg
+
+from app.config import settings
+from app.services.backtest_run import BACKTEST_UNIVERSE, run_backtest
+
+WINDOW = "primary-2022-plus"
+PURPOSE = (
+    "decisive first hold-out measurement of all ten strategies at current versions; "
+    "operator-directed 2026-08-21 to establish whether any candidate has an edge"
+)
+ACCESSED_BY = "agent, operator-directed"
+
+
+def main() -> int:
+    started = time.monotonic()
+    last = [started]
+
+    def progress(event: object) -> None:
+        now = time.monotonic()
+        if now - last[0] < 60:
+            return
+        last[0] = now
+        print(f"[{now - started:7.0f}s] {event}", flush=True)
+
+    with psycopg.connect(settings.database_url) as conn:
+        report = run_backtest(
+            conn,
+            universe=BACKTEST_UNIVERSE,
+            holdout_purpose=PURPOSE,
+            holdout_accessed_by=ACCESSED_BY,
+            evidence_window_id=WINDOW,
+            synthetic_control=False,
+            release_read_locks=True,
+            progress=progress,
+        )
+        conn.commit()
+
+    print(f"\nrows written: {report.rows_written}", flush=True)
+    for arm in report.arms:
+        print(
+            f"  {arm.strategy_id:38} {arm.ambiguity_arm or 'shared':10} {arm.quarantine_arm:9} "
+            f"series={arm.series_evaluated} {arm.elapsed_s:.1f}s",
+            flush=True,
+        )
+    print(f"\ntotal {time.monotonic() - started:.0f}s", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #2827. Refs #2437.

## What this establishes

First hold-out evidence for **all ten strategies at their current versions** (`primary-2022-plus`, 2022-01-01 → 2024-09-27, `survivorship_free`, 40 rows). Every one loses money per trade, and **every one trades above the cost-survival bar** — the lowest is s2 at 44%/month against Novy-Marx & Velikov's ~50%, and s1 runs 696%.

⚠ The per-trade expectancies cluster at **-0.83% to -1.76%, roughly ONE ROUND-TRIP SPREAD**, across momentum, mean-reversion, breakout, cross-sectional and range strategies. Structurally different signals do not fail independently at one magnitude. To first order these break even gross and lose the spread net — a cost problem wearing the costume of ten separate signal failures.

## What this adds

**`.claude/skills/quant/cost-aware-viability.md`** — the arithmetic that decides viability before a backtest does, cited rather than inferred: the turnover bar, break-even (`min gross edge per trade = one round trip`, priced off `cost_model.BANDS`), the deflation bar (`dsr_expected_max_sharpe`, **not** the declared trial count — 274 declared searches collapse to 0.275, which is ordinary), and the order of operations so §9's 1,000-curve control is never paid for something failing a one-column check.

**`scripts/check_strategy_viability.py`** — runs that order over stored hold-out rows and prints a verdict per strategy with its refusals. Current output: **0/10 viable**.

⚠⚠ **The metric-selection rule is the heart of it, and it is written from a mistake made in this session.** The first reading of the results table was *"two strategies work"*, taken from CAGR +45.0% and Sortino 4.16 — on a distribution with kurtosis 1,976 and a per-trade expectancy of **-0.96%**. Both numbers were real; both were the wrong ones to read. The skill names which metrics decide, which lie, and how, and the script says so out loud whenever a positive CAGR sits on a negative per-trade edge.

## Loop objective re-pointed

From "build more strategies" to **"make one strategy gross-positive and cheap enough to keep"**, with the falsification ordered FIRST: measure `gross_return_pct` (`sql/256`) directly before investing in the turnover theory. If gross is flat, lower turnover saves nothing and the direction is wrong.

## Security model

Not touched — one new read-only script, one skill document, one prompt edit. No new input surface, no authz decision, no execution path.
