### PR TITLE
feature(#2603): the core sleeve gets a producer — step 3b-3

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -76,6 +76,7 @@ from app.services.sync_orchestrator.types import OrchestratorFenceHeld
 from app.workers.scheduler import (
     JOB_ATTRIBUTION_SUMMARY,
     JOB_CBOE_VIX_REFRESH,
+    JOB_CORE_REBALANCE_OBSERVATION,
     JOB_CUSIP_EXTID_SWEEP,
     JOB_CUSIP_UNIVERSE_BACKFILL,
     JOB_DAILY_CANDLE_REFRESH,
@@ -148,6 +149,7 @@ from app.workers.scheduler import (
     attribution_summary_job,
     cboe_vix_refresh,
     compute_next_run,
+    core_rebalance_observation,
     cusip_extid_sweep,
     cusip_universe_backfill,
     daily_candle_refresh,
@@ -364,6 +366,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     JOB_STRATEGY_OUTCOME_RESOLUTION: _adapt_zero_arg(strategy_outcome_resolution),
     JOB_STRATEGY_OBSERVATION_RETENTION: _adapt_zero_arg(strategy_observation_retention),
     JOB_STRATEGY_PAPER_CYCLE: _adapt_zero_arg(strategy_paper_cycle),
+    JOB_CORE_REBALANCE_OBSERVATION: _adapt_zero_arg(core_rebalance_observation),
     # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY and NOT in
     # SCHEDULED_JOBS: criterion 5 requires a hold-out purpose no cron fire can
     # supply. ⚠ Registered NATIVELY, not through ``_adapt_zero_arg`` — the body

--- a/app/services/strategy_core_rebalance_intent.py
+++ b/app/services/strategy_core_rebalance_intent.py
@@ -4,13 +4,23 @@
 that caller: load the live mandate, evaluate against an observed sleeve, write one
 append-only row.
 
-⚠⚠ AUTHORISES NOTHING, and mechanically so rather than by promise: no table has a
-foreign key to ``strategy_core_rebalance_intents`` and no other module reads it, so
-no code path can turn a row here into an order.  ``tests/test_core_rebalance_intent_
-has_no_readers.py`` asserts both halves.  The reading side arrives with the slice
-that adds the trade linkage and the position-manager change together -- in that
-order deliberately, because a writable core trade the manager cannot see is worse
-than no core trade at all (#2437's standing pattern).
+⚠⚠ CORRECTED 2026-08-22 (#2603 step 3b-3).  This said "AUTHORISES NOTHING, and
+mechanically so rather than by promise: no table has a foreign key to
+``strategy_core_rebalance_intents`` and no other module reads it".  Both halves are
+now false -- ``sql/349`` added ``strategy_trades.core_rebalance_intent_id``, and
+``app/services/strategy_core_submission_gate.py`` reads the table.  The reading side
+arrived as promised; the promise was not re-read when it did.  ⚠ It also cited
+``tests/test_core_rebalance_intent_has_no_readers.py`` as asserting both halves --
+**that file does not exist** anywhere in the repo, so the claim was never enforced by
+anything.  A named enforcement is only as good as its existence.
+
+What holds instead, weaker on purpose: a row here is submission-gate INPUT, not
+authority.  The gate has no acting caller in ``app/`` or ``scripts/``, so no path runs
+from a row to an order.  That is a fact about today's call graph, not a mechanical
+impossibility -- and saying so is the point, because the previous wording survived the
+change that falsified it by sounding structural.
+
+The producer is ``app/workers/scheduler.py::core_rebalance_observation``.
 
 ⚠ What this does NOT provide, so it is an owed obligation rather than a silence:
 no in-flight suppression (the allocator is stateless and will re-recommend a trade

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5425,7 +5425,7 @@ def core_rebalance_observation() -> None:
     Spec: ``docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md``
     """
     from app.providers.implementations.etoro_broker import EtoroBrokerProvider
-    from app.services.strategy_core_mandate import load_core_mandate
+    from app.services.strategy_core_mandate import CORE_MANDATE_ADVISORY_LOCK, load_core_mandate
     from app.services.strategy_core_rebalance_intent import record_core_rebalance_intent
     from app.services.strategy_core_sleeve import observe_core_sleeve
 
@@ -5477,6 +5477,40 @@ def core_rebalance_observation() -> None:
         state = observe_core_sleeve(snapshot, core_instrument_id=core_instrument_id)
 
         with connect_job() as conn:
+            # ⚠⚠ The sleeve was observed for the mandate read BEFORE the HTTP
+            # call, and `record_core_rebalance_intent` loads the mandate again.
+            # A revision landing in between would be evaluated and ATTRIBUTED to
+            # the newer one -- and only the instrument-changing case is caught by
+            # `sleeve_instrument_mismatch`. A revision that moves the target, the
+            # band, the reserve or the floor while keeping the instrument would
+            # produce a verdict that looks entirely normal and describes a sleeve
+            # nobody observed under it.
+            #
+            # `configure_core_mandate` takes this same xact lock, so taking it
+            # here serialises the two. Re-reading WITHOUT it would not fix the
+            # race: READ COMMITTED gives each statement a fresh snapshot, so a
+            # writer can still commit between the re-read and the INSERT. Held
+            # for two fast reads and one INSERT, NEVER across the broker
+            # round-trip -- which is why the mandate is pre-read on a separate
+            # connection rather than under this lock.
+            conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_MANDATE_ADVISORY_LOCK)
+            current = load_core_mandate(conn)
+            if current is None or current.event_id != mandate.event_id:
+                # Not a fault, so nothing raises: the operator reconfigured the
+                # mandate during the round-trip and the next tick is correct.
+                # The tick is dropped rather than misattributed, and the note
+                # says which -- a zero-row success here is a REPORTED skip, not
+                # the silent no-op the failure paths above refuse to become.
+                conn.rollback()
+                was = "removed" if current is None else f"revision {current.revision}"
+                logger.warning(
+                    "%s: mandate moved to %s during the broker round-trip; dropping this observation",
+                    JOB_CORE_REBALANCE_OBSERVATION,
+                    was,
+                )
+                tracker.row_count = 0
+                tracker.note = f"skipped: mandate event {mandate.event_id} -> {was} during observation"
+                return
             intent = record_core_rebalance_intent(
                 conn,
                 state=state,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -395,6 +395,10 @@ JOB_STRATEGY_HALT_FEED_REFRESH = "strategy_halt_feed_refresh"
 JOB_CBOE_VIX_REFRESH = "cboe_vix_refresh"
 # #2450 — bounded demo execution/reconciliation/owned-position health loop.
 JOB_STRATEGY_PAPER_CYCLE = "strategy_paper_cycle"
+# #2603 item 3 step 3b-3 — observe the core sleeve and store one rebalance
+# verdict. Produces submission-gate INPUT, never authority: nothing invokes
+# the gate, and the only provider call is informational.
+JOB_CORE_REBALANCE_OBSERVATION = "core_rebalance_observation"
 # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY, and NOT because it is
 # expensive: half an hour is a scheduled job's workload. The reasons are
 # governance — criterion 5 requires a hold-out purpose a cron fire cannot
@@ -2168,6 +2172,32 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "polling updates five bounded rows rather than appending heartbeats."
         ),
         cadence=Cadence.every_n_minutes(interval=5),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_CORE_REBALANCE_OBSERVATION,
+        display_name="Core/cash rebalance observation (#2603)",
+        # Lane ``etoro`` and not ``strategy_execution``: the only external call
+        # is an eToro read, and ``etoro`` is the lane that owns that budget.
+        # ``strategy_execution`` is held by strategy_paper_cycle every five
+        # minutes, so a daily job landing there is a daily job that skips.
+        source="etoro",
+        description=(
+            "Daily — observe the core sleeve from one informational eToro "
+            "account-risk snapshot and store one append-only rebalance "
+            "verdict, including holds and refusals. Demo-only. Skips without "
+            "any broker call when no mandate carries a core instrument."
+        ),
+        # 22:45 UTC — after the US close (~21:00 UTC), the same anchor
+        # db_eod_snapshot records for its 22:30 slot, and 15 min after it.
+        # ⚠ The offset is scheduling hygiene, not an invariant: overrun,
+        # catch-up and manual dispatch can still overlap and the LANE is what
+        # serialises. ⚠ Daily means each CALENDAR day, so this also fires on
+        # weekends and holidays; those ticks record a true flat re-observation.
+        # Gating on us_market_status would be wrong — settled-decisions permits
+        # a non-US core instrument whose venue we have no calendar for.
+        cadence=Cadence.daily(hour=22, minute=45),
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
     ),
@@ -5364,6 +5394,101 @@ def strategy_paper_cycle() -> None:
             f"reconciled={result.reconciled_orders} managed={result.managed_positions} "
             f"evaluated={result.evaluated_signals} active_blocks={result.active_health_blocks} "
             f"halt_source_pub_at={halt_snapshot.source_pub_at.isoformat()}"
+        )
+
+
+def core_rebalance_observation() -> None:
+    """Observe the core sleeve and store one rebalance verdict (#2603 step 3b-3).
+
+    The chain ``get_account_risk_snapshot -> observe_core_sleeve ->
+    record_core_rebalance_intent`` was complete and had no caller; this is that
+    caller and the whole of it.  It sizes nothing, quotes no cost and submits
+    nothing.
+
+    ⚠ It produces submission-gate INPUT, not authority.
+    ``strategy_core_submission_gate`` reads ``strategy_core_rebalance_intents``
+    (that module's own SELECT, and ``sql/349``'s FK from ``strategy_trades``),
+    so the "no module reads it" line in ``sql/348`` is stale.  What holds is
+    that the gate has no acting caller, and that the one provider method used
+    here is informational -- ``refuse_broker_mutation_if_unattended`` is
+    deliberately not reached (#2645).
+
+    Failures PROPAGATE rather than being caught and noted.  An unobservable
+    sleeve and an unavailable broker are both genuine faults, and there is no
+    primary work here to protect by swallowing them -- the observation IS the
+    work.  A job that no-ops and reports success is invisible to every
+    automated check this repo has.  Consequence, so it is not later read as a
+    defect: those ticks are visible in ``job_runs`` and NOT in
+    ``strategy_core_rebalance_intents``, because no ``CoreSleeveState`` can be
+    constructed at all and the table requires an observed sleeve.
+
+    Spec: ``docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md``
+    """
+    from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+    from app.services.strategy_core_mandate import load_core_mandate
+    from app.services.strategy_core_rebalance_intent import record_core_rebalance_intent
+    from app.services.strategy_core_sleeve import observe_core_sleeve
+
+    # `strategy_core_mandate_events.mode` is CHECK-pinned to 'paper' (sql/349),
+    # so observing a REAL account would attribute a live book's drift to a
+    # paper policy. `get_account_risk_snapshot` already refuses a non-demo
+    # provider outright; this check exists so that case records a clean
+    # PREREQ_SKIP instead of an exception.
+    if settings.etoro_env != "demo":
+        _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, "core rebalance observation requires demo environment")
+        return
+    creds = _load_etoro_credentials(JOB_CORE_REBALANCE_OBSERVATION)
+    if creds is None:
+        _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, "etoro credentials missing")
+        return
+
+    # Mandate read on its own short-lived conn BEFORE the provider session — no
+    # DB conn held across HTTP (#1593 spec PR-1 plan).
+    with connect_job() as mandate_conn:
+        mandate = load_core_mandate(mandate_conn)
+
+    # ⚠ The skip is recorded from the BODY, not only via the registry
+    # `prerequisite`, because manual dispatch bypasses the registry path.
+    #
+    # ⚠ `enabled` is deliberately NOT part of this test. A disabled mandate
+    # still has an instrument, so the sleeve is observable, and the record that
+    # accumulates while a mandate is disabled is what an operator needs at the
+    # moment they re-enable it. Skipping here would also leave
+    # `core_mandate_disabled` producible by the allocator and reachable from no
+    # producer — the shape step 3b-2 item 1 already had to delete once.
+    if mandate is None or mandate.core_instrument_id is None:
+        # Reaching `core_mandate_absent` / `core_instrument_unset` would need a
+        # fabricated CoreSleeveState — an invented instrument id and two
+        # invented valuations — purely to hang a reason code on. It is the
+        # FABRICATION that is refused, not the recording: both facts are fully
+        # derivable from `strategy_core_mandate_events` without a broker call.
+        detail = "no core mandate configured" if mandate is None else "core mandate has no core instrument"
+        _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, detail)
+        return
+
+    core_instrument_id = mandate.core_instrument_id
+    with _tracked_job(JOB_CORE_REBALANCE_OBSERVATION) as tracker:
+        # `env="demo"` literally, not `settings.etoro_env` again: re-reading a
+        # mutable setting between check and use is the gap strategy_paper_cycle
+        # closes the same way.
+        with EtoroBrokerProvider(api_key=creds[0], user_key=creds[1], env="demo") as broker:
+            snapshot = broker.get_account_risk_snapshot()
+
+        state = observe_core_sleeve(snapshot, core_instrument_id=core_instrument_id)
+
+        with connect_job() as conn:
+            intent = record_core_rebalance_intent(
+                conn,
+                state=state,
+                recorded_by=JOB_CORE_REBALANCE_OBSERVATION,
+            )
+            conn.commit()
+
+        tracker.row_count = 1
+        tracker.note = (
+            f"intent_id={intent.core_rebalance_intent_id} action={intent.decision.action} "
+            f"reason={intent.decision.reason_code or '-'} instrument={core_instrument_id} "
+            f"mandate_event={intent.core_mandate_event_id}"
         )
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5437,13 +5437,18 @@ def core_rebalance_observation() -> None:
     if settings.etoro_env != "demo":
         _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, "core rebalance observation requires demo environment")
         return
-    creds = _load_etoro_credentials(JOB_CORE_REBALANCE_OBSERVATION)
-    if creds is None:
-        _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, "etoro credentials missing")
-        return
-
     # Mandate read on its own short-lived conn BEFORE the provider session — no
     # DB conn held across HTTP (#1593 spec PR-1 plan).
+    #
+    # ⚠ BEFORE the credential load, and that ordering is deliberate rather than
+    # incidental (review nitpick on PR #2853). `_load_etoro_credentials`
+    # decrypts two secrets and writes a credential-access audit row for each,
+    # so running it first makes every no-mandate tick — which is EVERY tick
+    # until #2833 declares the sleeve — touch secrets storage and append audit
+    # noise for a job that was always going to skip. It also picks the better
+    # reason when both are true: "no core mandate configured" is the actionable
+    # fact, where "etoro credentials missing" would send triage at the wrong
+    # thing.
     with connect_job() as mandate_conn:
         mandate = load_core_mandate(mandate_conn)
 
@@ -5464,6 +5469,11 @@ def core_rebalance_observation() -> None:
         # derivable from `strategy_core_mandate_events` without a broker call.
         detail = "no core mandate configured" if mandate is None else "core mandate has no core instrument"
         _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, detail)
+        return
+
+    creds = _load_etoro_credentials(JOB_CORE_REBALANCE_OBSERVATION)
+    if creds is None:
+        _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, "etoro credentials missing")
         return
 
     core_instrument_id = mandate.core_instrument_id

--- a/docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md
+++ b/docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md
@@ -217,13 +217,25 @@ revision that changes `core_target_pct`, `rebalance_band_pct`, `liquidity_reserv
 `min_rebalance_amount` while keeping the instrument is **not detected at all** — the
 observation is attributed to the new revision by `core_mandate_event_id`.
 
-That is accepted for this slice, with the reason: the attribution error is bounded by the
-duration of one HTTP call, the window requires an operator reconfiguring the mandate
-inside it, and the row records `core_mandate_event_id` so the pairing is at least legible
-after the fact. Holding `CORE_MANDATE_ADVISORY_LOCK` across a network round-trip is the
-alternative and is worse. **The freshness bound that actually closes this is the one
-`strategy_core_rebalance_intent.py` already declares as owed — the executor bounding
-`evaluated_at` inside one lock hold — and it belongs to the submission slice, not here.**
+⚠ The first draft accepted that as bounded-and-legible. Codex checkpoint 2 raised it as a
+P2 and it is **closed instead**, because the close is cheap: the recording connection takes
+`CORE_MANDATE_ADVISORY_LOCK` — the same lock `configure_core_mandate` takes
+(`strategy_core_mandate.py:365`) — re-reads the mandate under it, and drops the tick with a
+logged note if `event_id` moved.
+
+Two things about that shape are load-bearing:
+
+- **Re-reading without the lock is not a fix.** psycopg's default isolation is READ
+  COMMITTED, so each statement gets a fresh snapshot and a writer can still commit between
+  the re-read and the INSERT. The check-then-write window would just be narrower.
+- **The lock is never held across the HTTP call**, which is why the mandate is pre-read on
+  a separate short-lived connection rather than under it. It covers two fast reads and one
+  INSERT.
+
+Dropping the tick is the right loss: an operator reconfigured the mandate inside a
+round-trip, the next tick is correct, and a misattributed row would outlive the confusion
+that produced it. It records as a zero-row success with a note naming the moved event —
+a REPORTED skip, not the silent no-op the failure paths above refuse to become.
 
 Duplicate intents from repeated manual dispatch are likewise not a new problem:
 `strategy_core_submission_gate.py:150` supersedes any intent with a newer one before

--- a/docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md
+++ b/docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md
@@ -1,0 +1,267 @@
+# The core rebalance observation job (#2603 item 3, step 3b-3)
+
+Status: proposed, 2026-08-22. Codex checkpoint 1 run; the findings it produced are folded
+in below and the four rebutted ones are named with their reasons.
+
+## What this is
+
+The **producer**. `#2603` has shipped ten modules for the core/cash arm and the chain they
+form is complete:
+
+```
+broker.get_account_risk_snapshot()          # informational read, demo-only at the provider
+  -> observe_core_sleeve(snapshot, core_instrument_id=...)   -> CoreSleeveState
+  -> record_core_rebalance_intent(conn, state=..., recorded_by=...)
+       -> load_core_mandate(conn) + evaluate_core_rebalance(...)
+       -> one append-only row in strategy_core_rebalance_intents
+```
+
+Nothing invokes it. `app/services/strategy_core_sleeve.py` and
+`app/services/strategy_core_sizing.py` have **no caller anywhere in `app/` or
+`scripts/`**, and `strategy_core_rebalance_intents` holds **0 rows** on dev.
+
+This slice adds one scheduled job that runs that chain and nothing else.
+
+## Measured before speccing (dev DB, 2026-08-22)
+
+| query | result |
+| --- | --- |
+| `select count(*) from strategy_core_mandate_events` | **0** — no mandate has ever been configured |
+| `select count(*) from strategy_core_rebalance_intents` | **0** |
+| `strategy_core_eligibility_proofs`, latest per instrument | 3434 / 3418 / 3417 `underlying`; 3000 (SPY) `not_underlying` / `no_underlying_arm` |
+
+So the job **no-ops until a mandate exists**, and that is the correct build order rather
+than a gap: declaring the sleeve — which instrument, what target weight, what band — is
+`#2833` (R5b phase 1, "the boring sleeve goes live-capable"). Phase 0 owns the machinery;
+phase 1 declares what it manages. Stated here so the no-op is read as a sequence and not
+as another unwired control.
+
+## ⚠⚠ What an intent row IS, corrected
+
+`sql/348`'s header says *"no table has a foreign key to it and no module reads it, so no
+code path can turn a row into an action"*, and `strategy_core_rebalance_intent.py` repeats
+it. **The second half is no longer true.** `sql/349` added
+`strategy_trades.core_rebalance_intent_id` (an FK), and
+`strategy_core_submission_gate.py:142` `SELECT`s from the table to decide whether a stored
+verdict may become an order. Both docstrings are stale and this slice corrects them.
+
+What is still true, and is the actual safety statement:
+
+- The submission gate **has no acting caller** — nothing in `app/` or `scripts/` invokes
+  it, so no path runs from an intent row to an order.
+- This job calls exactly one provider method, `get_account_risk_snapshot`, which is
+  informational. `app/security/unattended_guard.py::refuse_broker_mutation_if_unattended`
+  is not reached because no mutating method is called, by design (#2645: guarding
+  informational reads was the other half of that error).
+
+So the honest claim is **"this job produces gate INPUT, not authority"** — not "authorises
+nothing". Writing the weaker-sounding true thing matters here because the stale version is
+what a reader would otherwise carry forward.
+
+## Scope
+
+One job, `core_rebalance_observation`:
+
+1. Refuse unless `settings.etoro_env == "demo"` → `_record_prereq_skip`.
+2. Load eToro credentials; `_record_prereq_skip` if absent.
+3. On a short-lived connection, `load_core_mandate`. `_record_prereq_skip` — **without any
+   broker call** — when there is no mandate row, or `core_instrument_id IS NULL`.
+4. Open a broker session pinned to `env="demo"`, with **no DB connection held across the
+   HTTP call**, and call `get_account_risk_snapshot()`.
+5. `observe_core_sleeve(snapshot, core_instrument_id=mandate.core_instrument_id)`.
+6. On a fresh connection, `record_core_rebalance_intent(conn, state=..., recorded_by=<job
+   name>)` and commit.
+
+Registry entry: `source="etoro"`, `cadence=Cadence.daily(hour=22, minute=45)`,
+`catch_up_on_boot=False`, `prerequisite=_bootstrap_complete`.
+
+Explicitly **not** in scope: sizing (`strategy_core_sizing`), the broker half of the
+refusal vocabulary (account-risk availability as a stored refusal, what-if cost
+assessment, the broker minimum, broker rejection), in-flight suppression, submission, and
+any order.
+
+## Source rule
+
+The choices below have no external regulator — but that is a claim about *these* choices,
+not a blanket one. The allocator's own boundary-targeting rule already cites a documented
+portfolio-rebalancing formulation, and the repo has a market-session rule
+(`market_calendar.us_market_status`) which `strategy_core_preflight` applies at submission
+time. Neither governs an observation cadence, which is what is fixed by construction here.
+
+### Cadence: daily, 22:45 UTC
+
+**Monitoring frequency is not rebalancing frequency, and only the second is a policy
+choice.** The mandate already carries the rebalance rule — `rebalance_band_pct` around
+`core_target_pct`, a threshold rule — and that band decides whether a trade happens. This
+job decides only *how often the drift is looked at*.
+
+Daily is the coarsest cadence that observes **each calendar day exactly once**. ⚠ Not
+"each trading session": a daily cron also fires on weekends and US holidays, and those
+ticks record a real (flat) re-observation of the same marks rather than nothing. That is
+accepted, not overlooked — an appended `hold` on a Sunday is a true statement about the
+sleeve, and gating on `us_market_status` would be wrong anyway, because
+`docs/settled-decisions.md` permits a non-US-listed core instrument whose venue this repo
+has no calendar for.
+
+22:45 UTC is after the US close (~21:00 UTC), the same anchor `db_eod_snapshot` records
+for its 22:30 slot, and 15 minutes after it. ⚠ **The offset is scheduling hygiene, not an
+invariant** — overrun, manual dispatch and catch-up can still overlap, and the lane is
+what actually serialises.
+
+⚠ It does **not** follow that the marks are "session-final". `snapshot.observed_at` is our
+receipt time and the payload carries no broker valuation stamp at all (measured
+2026-08-14, `strategy_core_sleeve.py:67-70`). Firing after the close makes it *likely* the
+marks reflect that session; nothing in the payload proves it, and no downstream rule here
+depends on it.
+
+⚠ The cost is one eToro request per day against the `etoro` lane's budget, not zero.
+`daily_portfolio_sync` already calls `get_account_risk_snapshot()` in demo, so this is a
+knowing duplication: folding the observation into that job would couple the core arm's
+evidence to the portfolio sync's failure modes and cadence anchor, and the second request
+is negligible against the lane's budget.
+
+### Lane: `etoro`
+
+The job's only external call is an eToro read, and `etoro` is the lane that owns eToro
+request budget. The alternative, `strategy_execution`, is held by `strategy_paper_cycle`
+every five minutes — a daily job landing on a busy lane is a daily job that skips. At
+22:45 the `etoro` lane's scheduled occupants (`quotes_refresh` hourly at :23,
+`daily_portfolio_sync`, `nightly_universe_sync`) do not fire.
+
+### Which refusals this producer can and cannot reach
+
+`CoreRebalanceReasonCode` has eleven members. This job reaches nine. The two it cannot:
+
+- **`core_instrument_unset`** and **`core_mandate_absent`** — both mean there is no
+  instrument id, and `observe_core_sleeve` needs one. Reaching them would require
+  fabricating a `CoreSleeveState` (an invented instrument id and two invented valuations)
+  purely to hang a reason code on, and `strategy_core_rebalance_intents` would then hold a
+  fabricated valuation. **It is the fabrication that is refused, not the recording** —
+  both facts are fully derivable from `strategy_core_mandate_events` without a broker
+  call.
+
+⚠ **`core_mandate_disabled` IS reached**, deliberately, and this is the one place the
+cheap choice was not taken. A disabled mandate still has an instrument, so the sleeve is
+observable, and the record that accumulates *while* a mandate is disabled is what an
+operator needs at the moment they re-enable it. Skipping on `enabled = false` would save
+one request a day and make the disabled window a hole indistinguishable from "the job was
+down". It would also leave `core_mandate_disabled` producible by the allocator and
+reachable from no producer — the shape `#2603` already had to delete once
+(`cost_exceeds_available_cash`, step 3b-2 item 1).
+
+⚠ Precisely what a disabled row stores: `core_rebalance_intent_shape_matches_action`
+(`sql/348:145`) requires **every derived field NULL on a refusal** — `core_pct`,
+`target_pct`, `lower_pct`, `upper_pct`, `effective_floor`, `floor_source`,
+`reserve_breached`, `reserve_margin_pct`. What survives is `core_market_value`,
+`cash_balance`, `currency` and `state_as_of`. The core weight is therefore not *stored*
+while disabled; it is *arithmetic on the two stored components*
+(`core_market_value / (core_market_value + cash_balance)`). Said explicitly because
+"records the drift" would otherwise read as a column that is not there.
+
+### Demo-only
+
+`strategy_core_mandate_events.mode` is `CHECK (mode = 'paper')` (`sql/349:137`). Observing
+a **real** account and stamping the verdict against a paper mandate would attribute a live
+book's drift to a paper policy.
+
+Two guards, and the outer one exists only for the audit row: `get_account_risk_snapshot`
+already raises `TradingPreflightParseError` when `self._env != "demo"`
+(`etoro_broker.py:828`), so a real-environment run fails closed at the provider regardless.
+The job checks `settings.etoro_env` first so that case records a clean `PREREQ_SKIP`
+instead of an exception, matching `strategy_paper_cycle` verbatim, and constructs the
+provider with the literal `env="demo"` rather than re-reading the setting — the same
+check/use gap `strategy_paper_cycle` closes.
+
+⚠ `load_core_mandate` does **not** select `mode`, so the job relies on the schema CHECK
+rather than on a value it read. That reliance is bound by a test asserting the CHECK still
+pins `mode` to `'paper'` — the same device
+`test_the_migration_reason_codes_match_the_allocator_vocabulary` already uses for the
+reason-code vocabulary. If `mode` ever widens, that test fails and this job's assumption
+surfaces before the widening merges.
+
+### A failed observation is a FAILED JOB, not a quiet success
+
+`CoreSleeveObservationError` (naive timestamp, unreported or undocumented account
+currency, duplicate instrument row, direct short) and a failed
+`get_account_risk_snapshot()` both **propagate**. `_tracked_job` records the run as a
+failure with the exception.
+
+Neither is caught-and-noted, and the reason is the repo's own worst monitoring failure
+mode: *a job that no-ops and reports success is invisible to every automated check we
+have.* There is no primary work here to protect by swallowing — the observation **is** the
+work — so the pattern `daily_portfolio_sync` uses (catch, warn, continue) does not apply.
+
+⚠ Consequence, stated so it is not later read as a defect: **an unobservable sleeve is
+visible in `job_runs`, not in `strategy_core_rebalance_intents`.** A reader counting rows
+in the intents table is counting successful observations, not scheduled ticks. Nothing is
+stored for these cases because no `CoreSleeveState` can be constructed at all, and the
+table requires an observed sleeve.
+
+The `state_as_of <= evaluated_at` CHECK (`sql/348:205`) is in the same class: `state_as_of`
+is the application host's receipt clock and `evaluated_at` is the database's
+`clock_timestamp()`, so a large enough skew between the two hosts makes the INSERT fail.
+That surfaces as a failed job run, which is the correct outcome — it is a real clock fault
+and must not be papered over by relaxing the constraint or by rewriting the observation
+time.
+
+## The mandate-revision race
+
+Step 3 loads the mandate to learn the instrument; step 6's
+`record_core_rebalance_intent` loads it again inside its own transaction. A revision
+landing between them is evaluated against the newer mandate.
+
+⚠ The first draft of this spec claimed that race always yields `sleeve_instrument_mismatch`.
+**It does not.** `_state_refusal` runs after the mandate-level checks, so a revision that
+is newly disabled, policy-unsupported or invalid returns *its own* code first, and a
+revision that changes `core_target_pct`, `rebalance_band_pct`, `liquidity_reserve_pct` or
+`min_rebalance_amount` while keeping the instrument is **not detected at all** — the
+observation is attributed to the new revision by `core_mandate_event_id`.
+
+That is accepted for this slice, with the reason: the attribution error is bounded by the
+duration of one HTTP call, the window requires an operator reconfiguring the mandate
+inside it, and the row records `core_mandate_event_id` so the pairing is at least legible
+after the fact. Holding `CORE_MANDATE_ADVISORY_LOCK` across a network round-trip is the
+alternative and is worse. **The freshness bound that actually closes this is the one
+`strategy_core_rebalance_intent.py` already declares as owed — the executor bounding
+`evaluated_at` inside one lock hold — and it belongs to the submission slice, not here.**
+
+Duplicate intents from repeated manual dispatch are likewise not a new problem:
+`strategy_core_submission_gate.py:150` supersedes any intent with a newer one before
+acting on it.
+
+## Acceptance
+
+- The job appears in `SCHEDULED_JOBS` and in `app/jobs/runtime.py`'s dispatch map.
+- With no mandate configured (dev's current state), one dispatch writes a `PREREQ_SKIP`
+  `job_runs` row and makes **no broker call**. ⚠ The skip is recorded from inside the job
+  body, not only via the registry `prerequisite`, because manual dispatch bypasses the
+  registry path.
+- With a mandate carrying an instrument, one dispatch writes exactly one
+  `strategy_core_rebalance_intents` row whose `recorded_by` is the job name — *unless* the
+  snapshot is unobservable or the broker read fails, in which case the job fails and no
+  row is written.
+- ⚠ The end-to-end run against a configured mandate is **not** exercised on dev in this
+  slice, because no mandate exists to configure without pre-empting `#2833`'s declaration.
+  The wiring is covered by tests; the first live row arrives with `#2833`.
+
+## Codex checkpoint-1 findings rebutted, with reasons
+
+- *"No maximum observation age is enforced; a stale snapshot can create intent authority."*
+  `observed_at` is assigned by the provider as `datetime.now(UTC)` immediately after the
+  response returns (`etoro_broker.py:837`), so within one job run it is now by
+  construction. A staleness bound would be checking the clock against itself. The
+  freshness that matters is the *intent's* age at submission, which is the owed bound
+  named above and belongs to the submission slice.
+- *"No market-calendar prerequisite despite `us_market_status` existing."* Applying a US
+  calendar would refuse a non-US core instrument that `docs/settled-decisions.md`
+  explicitly permits. `strategy_core_preflight` already owns the session question at
+  submission time, including `core_unsupported_market_session` for exactly that case.
+- *"Pending orders / in-flight rebalances can produce duplicate or reserve-breaching
+  trades."* True of the arc, not of this slice: no trade is produced. In-flight
+  suppression is a declared owed obligation of `strategy_core_rebalance_intent.py` and is
+  owned by the submission gate.
+- *"Non-US / other-timezone core instruments are omitted."* Same seam as above.
+
+## Refs
+
+Refs #2603. Refs #2833. Refs #2437.

--- a/sql/348_core_rebalance_intents.sql
+++ b/sql/348_core_rebalance_intents.sql
@@ -4,20 +4,12 @@
 -- rebalance EVALUATION -- the mandate-driven analogue of
 -- `strategy_entry_preflights`, which is signal-driven and cannot carry this.
 --
--- ⚠⚠ CORRECTED 2026-08-22 (#2603 step 3b-3).  This header used to read "no
--- table has a foreign key to it and no module reads it, so no code path can
--- turn a row into an action".  BOTH HALVES ARE NOW FALSE: sql/349 added
--- `strategy_trades.core_rebalance_intent_id`, and
--- `app/services/strategy_core_submission_gate.py` SELECTs from this table to
--- decide whether a stored verdict may become an order.  The reading side did
--- arrive as promised; the promise was not re-read when it did.
---
--- What holds instead, and it is weaker on purpose: a row here is submission-gate
--- INPUT, not authority.  The gate has no acting caller anywhere in `app/` or
--- `scripts/`, so no path runs from a row here to an order.  That is a fact about
--- today's call graph rather than a mechanical impossibility, which is exactly
--- why it is written this way -- the previous wording survived the change that
--- falsified it because it sounded structural.
+-- ⚠⚠ THIS TABLE AUTHORISES NOTHING, and that is mechanical rather than a
+-- promise: no table has a foreign key to it and no module reads it, so no code
+-- path can turn a row into an action.  The reading side arrives in the next
+-- slice together with the position-manager change that makes the resulting
+-- position visible -- deliberately in that order, because a writable core trade
+-- the manager cannot see is worse than no core trade at all.
 --
 -- Why not a synthetic `strategy_signals` row instead: #2603 scope clause 5 says
 -- the core path "reads mandate + current positions only; never reads

--- a/sql/348_core_rebalance_intents.sql
+++ b/sql/348_core_rebalance_intents.sql
@@ -4,12 +4,20 @@
 -- rebalance EVALUATION -- the mandate-driven analogue of
 -- `strategy_entry_preflights`, which is signal-driven and cannot carry this.
 --
--- ⚠⚠ THIS TABLE AUTHORISES NOTHING, and that is mechanical rather than a
--- promise: no table has a foreign key to it and no module reads it, so no code
--- path can turn a row into an action.  The reading side arrives in the next
--- slice together with the position-manager change that makes the resulting
--- position visible -- deliberately in that order, because a writable core trade
--- the manager cannot see is worse than no core trade at all.
+-- ⚠⚠ CORRECTED 2026-08-22 (#2603 step 3b-3).  This header used to read "no
+-- table has a foreign key to it and no module reads it, so no code path can
+-- turn a row into an action".  BOTH HALVES ARE NOW FALSE: sql/349 added
+-- `strategy_trades.core_rebalance_intent_id`, and
+-- `app/services/strategy_core_submission_gate.py` SELECTs from this table to
+-- decide whether a stored verdict may become an order.  The reading side did
+-- arrive as promised; the promise was not re-read when it did.
+--
+-- What holds instead, and it is weaker on purpose: a row here is submission-gate
+-- INPUT, not authority.  The gate has no acting caller anywhere in `app/` or
+-- `scripts/`, so no path runs from a row here to an order.  That is a fact about
+-- today's call graph rather than a mechanical impossibility, which is exactly
+-- why it is written this way -- the previous wording survived the change that
+-- falsified it because it sounded structural.
 --
 -- Why not a synthetic `strategy_signals` row instead: #2603 scope clause 5 says
 -- the core path "reads mandate + current positions only; never reads

--- a/sql/364_core_rebalance_intent_reader_correction.sql
+++ b/sql/364_core_rebalance_intent_reader_correction.sql
@@ -1,0 +1,45 @@
+-- 364_core_rebalance_intent_reader_correction.sql
+--
+-- #2603 step 3b-3.  A COMMENT-only migration correcting a stale safety claim.
+--
+-- `sql/348`'s header and table comment both say of
+-- `strategy_core_rebalance_intents`: "no table has a foreign key to it and no
+-- module reads it, so no code path can turn a row into an action".  BOTH HALVES
+-- ARE NOW FALSE:
+--
+--   * `sql/349` added `strategy_trades.core_rebalance_intent_id`, an FK to this
+--     table;
+--   * `app/services/strategy_core_submission_gate.py` SELECTs from it to decide
+--     whether a stored verdict may become an order.
+--
+-- The reading side arrived exactly as sql/348 promised it would.  The promise
+-- was not re-read when it did, and it survived because it SOUNDED structural --
+-- "mechanical rather than a promise" is what a reader trusts and stops checking.
+--
+-- ⚠ Why a new file rather than an edit to sql/348: the migration runner pins
+-- each applied file's content_sha256, so editing an applied migration -- even
+-- its comments -- fails the boot check with "content changed since applied".
+-- A COMMENT ON is idempotent and re-issuing it is the cheapest correct way to
+-- put the true text where `\d+` shows it.
+--
+-- What holds instead, deliberately weaker: a row here is submission-gate INPUT,
+-- not authority.  The gate has no acting caller anywhere in `app/` or
+-- `scripts/`, so no path runs from a row to an order.  That is a fact about
+-- today's call graph, NOT a mechanical impossibility -- and saying so is the
+-- point.
+--
+-- The producer is `app/workers/scheduler.py::core_rebalance_observation`.
+--
+-- Spec: docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md
+
+COMMENT ON TABLE strategy_core_rebalance_intents IS
+    'Append-only record of every core/cash rebalance EVALUATION, including holds '
+    'and refusals -- a verdict is evidence, and a sleeve correctly holding for a '
+    'month is the normal case. Written by '
+    'app/workers/scheduler.py::core_rebalance_observation. '
+    'A row is submission-gate INPUT, not authority: strategy_trades has an FK to '
+    'this table (sql/349) and strategy_core_submission_gate reads it, but that '
+    'gate has no acting caller, so no code path runs from a row here to an order. '
+    'That is a fact about the current call graph, not a mechanical impossibility '
+    '-- sql/348''s original claim that nothing reads this table was true when '
+    'written and is not true now.';

--- a/tests/test_2603_core_rebalance_observation_job.py
+++ b/tests/test_2603_core_rebalance_observation_job.py
@@ -24,7 +24,6 @@ from app.services.strategy_core_mandate import CoreMandate
 from app.services.strategy_core_sleeve import CoreSleeveObservationError
 from app.workers.scheduler import JOB_CORE_REBALANCE_OBSERVATION, core_rebalance_observation
 
-
 _UNSET: Any = object()
 
 

--- a/tests/test_2603_core_rebalance_observation_job.py
+++ b/tests/test_2603_core_rebalance_observation_job.py
@@ -81,6 +81,7 @@ class _Harness:
         env: str = "demo",
         creds: tuple[str, str] | None = ("key", "ukey"),
         mandate: CoreMandate | None | Any = _UNSET,
+        mandate_after: CoreMandate | None | Any = _UNSET,
         observe: Any = None,
         snapshot_error: Exception | None = None,
     ) -> dict[str, MagicMock]:
@@ -90,6 +91,13 @@ class _Harness:
             mandate = _mandate()
         if snapshot_error is not None:
             self.broker.get_account_risk_snapshot.side_effect = snapshot_error
+
+        # The job loads the mandate twice — once before the HTTP call to learn
+        # the instrument, once under the advisory lock to confirm it has not
+        # moved. ``mandate_after`` is the second answer.
+        load_kwargs: dict[str, Any] = (
+            {"return_value": mandate} if mandate_after is _UNSET else {"side_effect": [mandate, mandate_after]}
+        )
 
         observe_kwargs: dict[str, Any] = (
             {"side_effect": observe} if isinstance(observe, Exception) else {"return_value": observe or _state()}
@@ -102,7 +110,7 @@ class _Harness:
             patch("app.workers.scheduler._tracked_job", return_value=self.tracker),
             patch("app.workers.scheduler.connect_job", return_value=self.conn),
             patch("app.providers.implementations.etoro_broker.EtoroBrokerProvider", return_value=self.broker) as prov,
-            patch("app.services.strategy_core_mandate.load_core_mandate", return_value=mandate) as load,
+            patch("app.services.strategy_core_mandate.load_core_mandate", **load_kwargs) as load,
             patch("app.services.strategy_core_sleeve.observe_core_sleeve", **observe_kwargs) as obs,
             patch(
                 "app.services.strategy_core_rebalance_intent.record_core_rebalance_intent",
@@ -167,6 +175,55 @@ class TestTheDeliberateNonRefusal:
         harness.broker.get_account_risk_snapshot.assert_called_once()
         calls["record"].assert_called_once()
         calls["skip"].assert_not_called()
+
+
+class TestTheMandateRevisionRace:
+    """A revision landing during the broker round-trip.
+
+    ⚠ ``sleeve_instrument_mismatch`` catches only the instrument-changing case.
+    A revision that moves the target, band, reserve or floor while KEEPING the
+    instrument produces a verdict that looks entirely normal and describes a
+    sleeve nobody observed under it — which is why the event id is re-checked
+    under the same advisory lock ``configure_core_mandate`` takes.
+    """
+
+    def test_a_same_instrument_reconfiguration_drops_the_tick_rather_than_misattributing_it(self) -> None:
+        harness = _Harness()
+        moved = CoreMandate(
+            event_id=8,
+            revision=2,
+            enabled=True,
+            base_currency="USD",
+            core_instrument_id=3417,  # unchanged — the case the allocator cannot see
+            core_target_pct=Decimal("80"),
+            liquidity_reserve_pct=Decimal("5"),
+            rebalance_band_pct=Decimal("5"),
+            min_rebalance_amount=Decimal("50"),
+            policy_version="core-mandate-v1",
+        )
+        calls = harness.run(mandate_after=moved)
+        calls["record"].assert_not_called()
+        harness.conn.rollback.assert_called_once()
+        assert "skipped" in harness.tracker.note
+        assert harness.tracker.row_count == 0
+
+    def test_a_mandate_deleted_during_the_round_trip_drops_the_tick(self) -> None:
+        harness = _Harness()
+        calls = harness.run(mandate_after=None)
+        calls["record"].assert_not_called()
+        harness.conn.rollback.assert_called_once()
+
+    def test_the_recheck_holds_the_same_advisory_lock_configure_takes(self) -> None:
+        """Re-reading without the lock is a check-then-write window, not a fix:
+        READ COMMITTED gives each statement a fresh snapshot, so a writer can
+        still commit between the re-read and the INSERT."""
+        from app.services.strategy_core_mandate import CORE_MANDATE_ADVISORY_LOCK
+
+        harness = _Harness()
+        harness.run()
+        locks = [c for c in harness.conn.execute.call_args_list if "pg_advisory_xact_lock" in str(c.args[0])]
+        assert len(locks) == 1
+        assert locks[0].args[1] == CORE_MANDATE_ADVISORY_LOCK
 
 
 class TestTheHappyPath:

--- a/tests/test_2603_core_rebalance_observation_job.py
+++ b/tests/test_2603_core_rebalance_observation_job.py
@@ -1,0 +1,276 @@
+"""The core rebalance observation job (#2603 step 3b-3).
+
+The chain ``get_account_risk_snapshot -> observe_core_sleeve ->
+record_core_rebalance_intent`` was complete and had no caller. These tests pin the
+caller's decisions: what it refuses without touching the broker, what it deliberately
+does NOT refuse, and that a failure is a failed job rather than a quiet success.
+
+No live database or network calls — every dependency is patched.
+
+Spec: ``docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md``
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.strategy_core_allocator import CoreSleeveState
+from app.services.strategy_core_mandate import CoreMandate
+from app.services.strategy_core_sleeve import CoreSleeveObservationError
+from app.workers.scheduler import JOB_CORE_REBALANCE_OBSERVATION, core_rebalance_observation
+
+
+_UNSET: Any = object()
+
+
+def _mandate(*, enabled: bool = True, core_instrument_id: int | None = 3417) -> CoreMandate:
+    return CoreMandate(
+        event_id=7,
+        revision=1,
+        enabled=enabled,
+        base_currency="USD",
+        core_instrument_id=core_instrument_id,
+        core_target_pct=Decimal("60"),
+        liquidity_reserve_pct=Decimal("5"),
+        rebalance_band_pct=Decimal("5"),
+        min_rebalance_amount=Decimal("50"),
+        policy_version="core-mandate-v1",
+    )
+
+
+def _state(core_instrument_id: int = 3417) -> CoreSleeveState:
+    return CoreSleeveState(
+        core_instrument_id=core_instrument_id,
+        core_market_value=Decimal("6000"),
+        cash_balance=Decimal("4000"),
+        currency="USD",
+        as_of=datetime(2026, 8, 22, 22, 45, tzinfo=UTC),
+    )
+
+
+class _Harness:
+    """One dispatch of the job body with every collaborator patched."""
+
+    def __init__(self) -> None:
+        self.broker = MagicMock()
+        self.broker.__enter__ = MagicMock(return_value=self.broker)
+        self.broker.__exit__ = MagicMock(return_value=False)
+
+        self.tracker = MagicMock()
+        self.tracker.__enter__ = MagicMock(return_value=self.tracker)
+        self.tracker.__exit__ = MagicMock(return_value=False)
+
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        self.conn = conn
+
+        self.intent = MagicMock()
+        self.intent.core_rebalance_intent_id = 11
+        self.intent.core_mandate_event_id = 7
+        self.intent.decision.action = "hold"
+        self.intent.decision.reason_code = None
+
+    def run(
+        self,
+        *,
+        env: str = "demo",
+        creds: tuple[str, str] | None = ("key", "ukey"),
+        mandate: CoreMandate | None | Any = _UNSET,
+        observe: Any = None,
+        snapshot_error: Exception | None = None,
+    ) -> dict[str, MagicMock]:
+        # ⚠ A sentinel, not ``None``: "no mandate configured" is one of the cases
+        # under test, so the default cannot be spelled the same way as it.
+        if mandate is _UNSET:
+            mandate = _mandate()
+        if snapshot_error is not None:
+            self.broker.get_account_risk_snapshot.side_effect = snapshot_error
+
+        observe_kwargs: dict[str, Any] = (
+            {"side_effect": observe} if isinstance(observe, Exception) else {"return_value": observe or _state()}
+        )
+
+        with (
+            patch("app.workers.scheduler.settings.etoro_env", env),
+            patch("app.workers.scheduler._load_etoro_credentials", return_value=creds),
+            patch("app.workers.scheduler._record_prereq_skip") as skip,
+            patch("app.workers.scheduler._tracked_job", return_value=self.tracker),
+            patch("app.workers.scheduler.connect_job", return_value=self.conn),
+            patch("app.providers.implementations.etoro_broker.EtoroBrokerProvider", return_value=self.broker) as prov,
+            patch("app.services.strategy_core_mandate.load_core_mandate", return_value=mandate) as load,
+            patch("app.services.strategy_core_sleeve.observe_core_sleeve", **observe_kwargs) as obs,
+            patch(
+                "app.services.strategy_core_rebalance_intent.record_core_rebalance_intent",
+                return_value=self.intent,
+            ) as record,
+        ):
+            core_rebalance_observation()
+
+        return {"skip": skip, "provider": prov, "load": load, "observe": obs, "record": record}
+
+
+class TestRefusalsThatCostNoBrokerCall:
+    """Each of these must skip BEFORE the provider is constructed.
+
+    A refusal that still spends a request is not free, and the reason these are
+    checked on the provider rather than on the response is that a MagicMock broker
+    answers happily either way.
+    """
+
+    def test_a_real_environment_skips_without_touching_the_broker(self) -> None:
+        calls = _Harness().run(env="real")
+        calls["provider"].assert_not_called()
+        assert calls["skip"].call_args[0][0] == JOB_CORE_REBALANCE_OBSERVATION
+        assert "demo" in calls["skip"].call_args[0][1]
+
+    def test_missing_credentials_skip_without_touching_the_broker(self) -> None:
+        calls = _Harness().run(creds=None)
+        calls["provider"].assert_not_called()
+        assert "credentials" in calls["skip"].call_args[0][1]
+
+    def test_no_mandate_skips_without_touching_the_broker(self) -> None:
+        """Spending a request to learn a fact about our OWN configuration table.
+
+        ``core_mandate_absent`` is fully derivable from
+        ``strategy_core_mandate_events``, and reaching it here would need a
+        fabricated CoreSleeveState to hang the code on.
+        """
+        calls = _Harness().run(mandate=None)
+        calls["provider"].assert_not_called()
+        calls["record"].assert_not_called()
+        assert "no core mandate" in calls["skip"].call_args[0][1]
+
+    def test_a_mandate_without_an_instrument_skips_without_touching_the_broker(self) -> None:
+        calls = _Harness().run(mandate=_mandate(core_instrument_id=None))
+        calls["provider"].assert_not_called()
+        calls["record"].assert_not_called()
+        assert "no core instrument" in calls["skip"].call_args[0][1]
+
+
+class TestTheDeliberateNonRefusal:
+    def test_a_disabled_mandate_is_still_observed_and_recorded(self) -> None:
+        """⚠ The one place the cheap choice was not taken, and the test that
+        defends it.
+
+        Skipping on ``enabled = False`` would save one request a day and make the
+        disabled window a hole indistinguishable from "the job was down" — and it
+        would leave ``core_mandate_disabled`` producible by the allocator and
+        reachable from no producer, which is the shape step 3b-2 item 1 deleted.
+        """
+        harness = _Harness()
+        calls = harness.run(mandate=_mandate(enabled=False))
+        harness.broker.get_account_risk_snapshot.assert_called_once()
+        calls["record"].assert_called_once()
+        calls["skip"].assert_not_called()
+
+
+class TestTheHappyPath:
+    def test_one_dispatch_records_exactly_one_intent_stamped_with_the_job_name(self) -> None:
+        harness = _Harness()
+        calls = harness.run()
+        calls["record"].assert_called_once()
+        kwargs = calls["record"].call_args.kwargs
+        assert kwargs["recorded_by"] == JOB_CORE_REBALANCE_OBSERVATION
+        assert kwargs["state"].core_instrument_id == 3417
+        harness.conn.commit.assert_called_once()
+
+    def test_the_mandate_instrument_is_what_gets_observed(self) -> None:
+        """The sleeve is observed for the mandate's instrument, not the one the
+        allocator happens to find later — the pairing is the whole point of the
+        pre-read."""
+        harness = _Harness()
+        calls = harness.run(mandate=_mandate(core_instrument_id=3434), observe=_state(3434))
+        assert calls["observe"].call_args.kwargs["core_instrument_id"] == 3434
+
+    def test_the_provider_is_pinned_to_demo_rather_than_re_reading_the_setting(self) -> None:
+        """Check/use gap: the guard reads ``settings.etoro_env`` and the
+        construction must not read it a second time, or a mutation between the two
+        opens a real account under a demo verdict."""
+        calls = _Harness().run()
+        assert calls["provider"].call_args.kwargs["env"] == "demo"
+
+    def test_no_db_connection_is_held_across_the_http_call(self) -> None:
+        """#1593 — the mandate read and the intent write are separate short-lived
+        connections either side of the provider session."""
+        harness = _Harness()
+        order: list[str] = []
+        harness.conn.__exit__ = MagicMock(side_effect=lambda *_: order.append("conn_closed") or False)
+        harness.broker.get_account_risk_snapshot.side_effect = lambda: order.append("http") or MagicMock()
+
+        harness.run()
+
+        # closed, http, closed — the HTTP call sits between two closed connections.
+        assert order == ["conn_closed", "http", "conn_closed"]
+
+
+class TestFailuresAreFailures:
+    """⚠ Not caught-and-noted. A job that no-ops and reports success is invisible
+    to every automated check this repo has, and there is no primary work here to
+    protect by swallowing — the observation IS the work."""
+
+    def test_an_unavailable_broker_propagates_and_records_nothing(self) -> None:
+        harness = _Harness()
+        with pytest.raises(RuntimeError, match="etoro down"):
+            harness.run(snapshot_error=RuntimeError("etoro down"))
+        # The tracked block is still open when it raises, so the job_runs row is
+        # finalised as a failure by ``_tracked_job``'s own __exit__.
+        harness.tracker.__exit__.assert_called_once()
+
+    def test_an_unobservable_sleeve_propagates_and_records_nothing(self) -> None:
+        harness = _Harness()
+        with pytest.raises(CoreSleeveObservationError):
+            harness.run(observe=CoreSleeveObservationError("direct short on the core instrument"))
+
+
+def test_the_job_is_registered_and_invocable() -> None:
+    """A body with no registry entry never fires; one with no invoker cannot be
+    triggered from the admin UI. Both are silent."""
+    from app.jobs.runtime import _INVOKERS
+    from app.workers.scheduler import SCHEDULED_JOBS
+
+    entry = next((j for j in SCHEDULED_JOBS if j.name == JOB_CORE_REBALANCE_OBSERVATION), None)
+    assert entry is not None, "core_rebalance_observation missing from SCHEDULED_JOBS"
+    assert JOB_CORE_REBALANCE_OBSERVATION in _INVOKERS
+
+
+def test_the_lane_is_etoro_and_not_strategy_execution() -> None:
+    """``strategy_execution`` is held by strategy_paper_cycle every five minutes,
+    so a daily job on that lane is a daily job that skips. The only external call
+    here is an eToro read, and ``etoro`` is the lane that owns that budget."""
+    from app.workers.scheduler import SCHEDULED_JOBS
+
+    entry = next(j for j in SCHEDULED_JOBS if j.name == JOB_CORE_REBALANCE_OBSERVATION)
+    assert entry.source == "etoro"
+
+
+def test_the_mandate_mode_check_still_pins_paper() -> None:
+    """The job's demo-only guard rests on a value it never reads.
+
+    ``load_core_mandate`` does not SELECT ``mode``, so nothing in the job
+    observes that the mandate it is evaluating is a PAPER one — it relies on
+    ``sql/349``'s CHECK making every row paper by construction. That reliance is
+    invisible at the call site, which is exactly why it is bound here: if ``mode``
+    ever widens, this fails and the assumption surfaces before the widening
+    merges, rather than after a live book's drift has been attributed to a paper
+    policy.
+    """
+    from pathlib import Path
+
+    sql = (Path(__file__).resolve().parents[1] / "sql" / "349_core_trade_arc.sql").read_text()
+    assert "CHECK (mode = 'paper')" in sql
+
+
+def test_the_job_does_not_catch_up_on_boot() -> None:
+    """``catch_up_on_boot`` defaults to True in ``ScheduledJob``. Left at the
+    default, a restart appends an off-schedule observation whose marks are
+    whatever the broker happens to hold at boot."""
+    from app.workers.scheduler import SCHEDULED_JOBS
+
+    entry = next(j for j in SCHEDULED_JOBS if j.name == JOB_CORE_REBALANCE_OBSERVATION)
+    assert entry.catch_up_on_boot is False

--- a/tests/test_2603_core_rebalance_observation_job.py
+++ b/tests/test_2603_core_rebalance_observation_job.py
@@ -105,7 +105,7 @@ class _Harness:
 
         with (
             patch("app.workers.scheduler.settings.etoro_env", env),
-            patch("app.workers.scheduler._load_etoro_credentials", return_value=creds),
+            patch("app.workers.scheduler._load_etoro_credentials", return_value=creds) as load_creds,
             patch("app.workers.scheduler._record_prereq_skip") as skip,
             patch("app.workers.scheduler._tracked_job", return_value=self.tracker),
             patch("app.workers.scheduler.connect_job", return_value=self.conn),
@@ -119,7 +119,14 @@ class _Harness:
         ):
             core_rebalance_observation()
 
-        return {"skip": skip, "provider": prov, "load": load, "observe": obs, "record": record}
+        return {
+            "skip": skip,
+            "provider": prov,
+            "load": load,
+            "observe": obs,
+            "record": record,
+            "load_creds": load_creds,
+        }
 
 
 class TestRefusalsThatCostNoBrokerCall:
@@ -158,6 +165,20 @@ class TestRefusalsThatCostNoBrokerCall:
         calls["provider"].assert_not_called()
         calls["record"].assert_not_called()
         assert "no core instrument" in calls["skip"].call_args[0][1]
+
+    def test_a_no_mandate_tick_never_reaches_secrets_storage(self) -> None:
+        """The mandate check precedes the credential load, deliberately.
+
+        ``_load_etoro_credentials`` decrypts two secrets and writes a
+        credential-access audit row for each. Running it first makes every
+        no-mandate tick — which is EVERY tick until #2833 declares the sleeve —
+        touch secrets storage and append audit noise for a job that was always
+        going to skip. It also picks the better reason when both are true: "no
+        core mandate configured" is the actionable fact.
+        """
+        calls = _Harness().run(mandate=None, creds=None)
+        calls["load_creds"].assert_not_called()
+        assert "no core mandate" in calls["skip"].call_args[0][1]
 
 
 class TestTheDeliberateNonRefusal:

--- a/tests/test_2603_core_rebalance_observation_job.py
+++ b/tests/test_2603_core_rebalance_observation_job.py
@@ -191,9 +191,45 @@ class TestTheHappyPath:
     def test_the_provider_is_pinned_to_demo_rather_than_re_reading_the_setting(self) -> None:
         """Check/use gap: the guard reads ``settings.etoro_env`` and the
         construction must not read it a second time, or a mutation between the two
-        opens a real account under a demo verdict."""
-        calls = _Harness().run()
-        assert calls["provider"].call_args.kwargs["env"] == "demo"
+        opens a real account under a demo verdict.
+
+        ⚠ The obvious form of this test — run the harness, assert
+        ``env == "demo"`` — passes under BOTH spellings, because the harness has
+        already set ``settings.etoro_env`` to ``"demo"`` and the two are then
+        equal. Revert-probed: swapping the literal for ``settings.etoro_env``
+        left it green. So the setting is mutated *between* the guard and the
+        construction, in the one place that runs between them, and the assertion
+        is on the value that survives that mutation. (Prevention-log shape: a
+        test written against the one-member set cannot tell the two apart.)
+        """
+        from app.workers import scheduler
+
+        harness = _Harness()
+
+        def flip_env_then_answer(_job_name: str) -> tuple[str, str]:
+            scheduler.settings.etoro_env = "real"  # type: ignore[misc]
+            return ("key", "ukey")
+
+        with (
+            patch("app.workers.scheduler.settings.etoro_env", "demo"),
+            patch("app.workers.scheduler._load_etoro_credentials", side_effect=flip_env_then_answer),
+            patch("app.workers.scheduler._record_prereq_skip"),
+            patch("app.workers.scheduler._tracked_job", return_value=harness.tracker),
+            patch("app.workers.scheduler.connect_job", return_value=harness.conn),
+            patch(
+                "app.providers.implementations.etoro_broker.EtoroBrokerProvider",
+                return_value=harness.broker,
+            ) as provider,
+            patch("app.services.strategy_core_mandate.load_core_mandate", return_value=_mandate()),
+            patch("app.services.strategy_core_sleeve.observe_core_sleeve", return_value=_state()),
+            patch(
+                "app.services.strategy_core_rebalance_intent.record_core_rebalance_intent",
+                return_value=harness.intent,
+            ),
+        ):
+            core_rebalance_observation()
+
+        assert provider.call_args.kwargs["env"] == "demo"
 
     def test_no_db_connection_is_held_across_the_http_call(self) -> None:
         """#1593 — the mandate read and the intent write are separate short-lived


### PR DESCRIPTION
## What this is

`#2603` has shipped ten modules for the core/cash arm and the chain they form is complete:

```
broker.get_account_risk_snapshot()          # informational read, demo-only at the provider
  -> observe_core_sleeve(snapshot, core_instrument_id=...)   -> CoreSleeveState
  -> record_core_rebalance_intent(conn, state=..., recorded_by=...)
       -> load_core_mandate(conn) + evaluate_core_rebalance(...)
       -> one append-only row in strategy_core_rebalance_intents
```

Nothing invoked it. `strategy_core_sleeve.py` and `strategy_core_sizing.py` had **no caller anywhere in `app/` or `scripts/`**, and `strategy_core_rebalance_intents` holds **0 rows** on dev. This adds the producer — one daily job — and nothing else.

Sizes nothing, quotes no cost, submits nothing.

## Measured before speccing (dev DB, 2026-08-22)

| query | result |
| --- | --- |
| `select count(*) from strategy_core_mandate_events` | **0** — no mandate ever configured |
| `select count(*) from strategy_core_rebalance_intents` | **0** |
| `strategy_core_eligibility_proofs`, latest per instrument | 3434 / 3418 / 3417 `underlying`; 3000 (SPY) `not_underlying` / `no_underlying_arm` |

So the job **no-ops until a mandate exists**, and that is the build order rather than a gap: declaring the sleeve — which instrument, what weight, what band — is `#2833` (R5b phase 1). Phase 0 owns the machinery; phase 1 declares what it manages. Stated so the no-op reads as a sequence, not as another unwired control.

## ⚠⚠ Two stale safety claims corrected

`sql/348` and `strategy_core_rebalance_intent.py` both said *"no table has a foreign key to it and no module reads it, so no code path can turn a row into an action"*. **Both halves are false**: `sql/349` added `strategy_trades.core_rebalance_intent_id`, and `strategy_core_submission_gate.py:142` SELECTs from the table. The reading side arrived exactly as `sql/348` promised; the promise was not re-read when it did, and it survived because it *sounded* structural.

The docstring also named `tests/test_core_rebalance_intent_has_no_readers.py` as the enforcement of both halves. **That file does not exist anywhere in the repo** — the claim was never enforced by anything.

What holds instead, deliberately weaker: **a row is submission-gate INPUT, not authority.** The gate has no acting caller, so no path runs from a row to an order. That is a fact about today's call graph, not a mechanical impossibility.

⚠ The correction ships as `sql/364` (a `COMMENT ON TABLE` re-issue) rather than an edit to `sql/348`: the migration runner pins `content_sha256`, so editing an applied migration — even its comments — fails the boot check. Caught by `tests/smoke`, not by review.

## Security model

Unchanged, and this is the whole of it. The only provider method called is `get_account_risk_snapshot`, which is informational and already refuses a non-demo provider outright (`etoro_broker.py:828`). `refuse_broker_mutation_if_unattended` is deliberately not reached — guarding informational reads was the other half of the #2645 error. No order endpoint, no position mutation, no kill-switch interaction.

## Decisions, and the construction behind each

**Cadence — daily, 22:45 UTC, lane `etoro`.** Monitoring frequency is not rebalancing frequency; the mandate's `rebalance_band_pct` is the rebalance rule and this job only decides how often drift is looked at. Daily is the coarsest cadence that observes each **calendar** day once. ⚠ Not "each trading session" — a daily cron also fires on weekends and holidays, and those ticks record a true flat re-observation. Gating on `us_market_status` would be wrong: `docs/settled-decisions.md` permits a non-US core instrument whose venue we have no calendar for. 22:45 is after the US close, the anchor `db_eod_snapshot` records for its 22:30 slot. ⚠ The offset is scheduling hygiene, not an invariant — the lane is what serialises. `etoro` and not `strategy_execution`, which `strategy_paper_cycle` holds every five minutes: a daily job on a busy lane is a daily job that skips.

⚠ It does **not** follow that the marks are session-final. `observed_at` is our receipt time and the payload carries no broker valuation stamp (`strategy_core_sleeve.py:67-70`). Nothing here depends on it.

**A disabled mandate is still observed.** The one place the cheap choice was not taken. A disabled mandate still has an instrument, so the sleeve is observable, and the record accumulating *while* disabled is what an operator needs when they re-enable. Skipping would make the disabled window indistinguishable from "the job was down", and would leave `core_mandate_disabled` producible by the allocator and reachable from no producer — the shape step 3b-2 item 1 already deleted (`cost_exceeds_available_cash`). ⚠ Precisely what a disabled row stores: `core_rebalance_intent_shape_matches_action` requires every derived field NULL on a refusal, so the weight is not *stored* while disabled — it is arithmetic on `core_market_value` and `cash_balance`.

**`core_instrument_unset` / `core_mandate_absent` are unreachable from this producer.** Both mean there is no instrument id and `observe_core_sleeve` needs one. Reaching them would require fabricating a `CoreSleeveState` — an invented instrument id and two invented valuations — to hang a code on. It is the fabrication that is refused, not the recording; both facts are derivable from `strategy_core_mandate_events` without a broker call.

**A failed observation is a FAILED JOB.** `CoreSleeveObservationError` and a failed snapshot both propagate; `_tracked_job` records the failure. There is no primary work here to protect by swallowing — the observation *is* the work — and a job that no-ops and reports success is invisible to every automated check this repo has. ⚠ Consequence: an unobservable sleeve is visible in `job_runs`, **not** in `strategy_core_rebalance_intents`. A reader counting rows there is counting successful observations, not scheduled ticks.

**`mode` is relied on but never read.** `load_core_mandate` does not SELECT `mode`; the demo-only guard rests on `sql/349`'s `CHECK (mode = 'paper')`. That invisible reliance is bound by a test on the CHECK, so a widening fails before it merges.

## The mandate-revision race — closed, not accepted

The spec's first draft accepted it as bounded. Codex checkpoint 2 raised it as P2 and it is closed instead.

The sleeve is observed for the mandate read *before* the HTTP call; `record_core_rebalance_intent` loads the mandate again. `sleeve_instrument_mismatch` catches only the instrument-changing case — a revision moving the target, band, reserve or floor while keeping the instrument produces a verdict that looks entirely normal and describes a sleeve nobody observed under it.

Fix: the recording connection takes `CORE_MANDATE_ADVISORY_LOCK` — the same xact lock `configure_core_mandate` takes (`strategy_core_mandate.py:365`) — re-reads the mandate under it, and drops the tick with a logged note if `event_id` moved. ⚠ Re-reading *without* the lock is not a fix: READ COMMITTED gives each statement a fresh snapshot, so a writer can still commit between the re-read and the INSERT. The lock is never held across the HTTP call, which is why the mandate is pre-read on a separate short-lived connection.

Dropping the tick is the right loss — the next tick is correct, and a misattributed row would outlive the confusion that produced it. It records as a zero-row success with a note naming the moved event: a REPORTED skip, not a silent no-op.

## Verification

- `ruff check` / `ruff format --check` / `pyright` — clean.
- `pytest -m "not db"` — green. `pytest tests/smoke` — green (it is what caught the migration checksum failure).
- **Revert-probes: 6/6 caught, clean control.** disabled-mandate non-refusal · `catch_up_on_boot=False` · the demo pin · swallow-instead-of-propagate · the `event_id` re-check · the advisory lock.
- ⚠ One probe initially **failed to catch**: `test_the_provider_is_pinned_to_demo_...` asserted `env == "demo"` while the harness had already set `settings.etoro_env` to `"demo"`, so both spellings passed. Rewritten to mutate the setting *between* the guard and the construction. Prevention-log shape: a test written against the one-member set cannot tell the two apart.
- ⚠ **Not exercised end-to-end on dev**: no mandate exists to configure without pre-empting `#2833`'s declaration. The wiring is covered by tests; the first live row arrives with `#2833`. `sql/364` is applied on dev and the corrected `COMMENT ON TABLE` verified via `obj_description`.

## Codex checkpoint-1 findings rebutted, with reasons

- *No maximum observation age.* `observed_at` is assigned as `datetime.now(UTC)` at receipt (`etoro_broker.py:837`), so within one run it is now by construction; a bound would check the clock against itself. The freshness that matters is the intent's age at submission, which `strategy_core_rebalance_intent.py` already declares as owed and belongs to the submission slice.
- *No market-calendar prerequisite.* Would refuse a non-US core instrument that settled-decisions permits; `strategy_core_preflight` owns the session question at submission.
- *Pending orders / in-flight rebalances.* True of the arc, not this slice — no trade is produced. In-flight suppression is the submission gate's.

Spec: `docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md`

Refs #2603. Refs #2833. Refs #2437.
