### PR TITLE
feature(#2829): bind a preregistration declaration to the trial that counts it

### DIFF
--- a/app/services/result_ledger.py
+++ b/app/services/result_ledger.py
@@ -1295,7 +1295,7 @@ def freeze_preregistration(conn: psycopg.Connection[tuple], declaration: PreregD
     # `TRIAL_REGISTER` (criterion 6's M, feeding the DSR) and this table were not
     # joinable at all, so "search #275" was an assertion no code could check: a
     # trial could freeze a declaration, run, and be deflated against an M that
-    # never counted it. `DeclaredTrial.declares` is the join, and this is where it
+    # never counted it. `DeclaredTrial.declared_for` is the join, and this is where it
     # is enforced.
     #
     # ⚠ FREEZE TIME ONLY, and NOT a `DeclarationRefusal` member — the same
@@ -1319,8 +1319,10 @@ def freeze_preregistration(conn: psycopg.Connection[tuple], declaration: PreregD
             f"no trial in {TRIAL_REGISTER_VERSION} claims {declaration.strategy_id}@"
             f"{declaration.strategy_version}, so criterion 6's M does not count the search this declaration "
             "represents — freezing it would burn an immutable trial whose deflated Sharpe is computed against "
-            "a population that excludes it. Add a DeclaredTrial (or a `declares` entry on the existing one) in "
-            "app/services/trial_register.py first."
+            "a population that excludes it. Add a NEW DeclaredTrial carrying "
+            "declared_for=(strategy_id, strategy_version) in app/services/trial_register.py first — NEW, "
+            "because its own `searches` is what moves `declared_count`. ⚠ Re-pointing an existing trial's "
+            "`declared_for` would pass this gate without moving M, and would orphan whatever it claimed before."
         )
     _lock_trial(conn, declaration.strategy_id, declaration.strategy_version)
     row = conn.execute(

--- a/app/services/result_ledger.py
+++ b/app/services/result_ledger.py
@@ -82,6 +82,7 @@ from app.services.strategy_result import (
     synthetic_control_promotion_refusals,
 )
 from app.services.strategy_statistics import StrategyMetrics
+from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
 from app.services.walk_forward import (
     WALK_FORWARD_MODEL_ID,
     Fold,
@@ -1289,6 +1290,38 @@ def freeze_preregistration(conn: psycopg.Connection[tuple], declaration: PreregD
                 "burn an immutable trial on stamps its run cannot produce. Re-derive the declaration "
                 "from the current cost_model constants."
             )
+    # ⚠⚠ #2829 — M MUST ALREADY COUNT THE SEARCH THIS DECLARATION REPRESENTS.
+    #
+    # `TRIAL_REGISTER` (criterion 6's M, feeding the DSR) and this table were not
+    # joinable at all, so "search #275" was an assertion no code could check: a
+    # trial could freeze a declaration, run, and be deflated against an M that
+    # never counted it. `DeclaredTrial.declares` is the join, and this is where it
+    # is enforced.
+    #
+    # ⚠ FREEZE TIME ONLY, and NOT a `DeclarationRefusal` member — the same
+    # placement argument as the cost-model check directly above, plus three the
+    # refusal path would have broken. `declaration_refusals` is pure and is called
+    # with synthetic identities by most of the prereg/supersession/live-gate
+    # fixtures; `supersession_refusals` calls it on the successor, so a
+    # declaration stranded by a policy bump could no longer use the repair path
+    # that exists for exactly that case; and `strategy_live_gate` calls it on
+    # REASSESSMENT, so an immutable registered policy could stop working because
+    # current code lacks a mapping. `sql/333`'s header is titled "⚠ NO
+    # RETROACTIVE INVALIDATION" and a code edit must not become one.
+    #
+    # ⚠ What this does and does not buy. PROSPECTIVELY it is a ledger: from here
+    # on a declaration cannot be frozen unless M names its search. It proves
+    # nothing RETROSPECTIVELY — a mapping added after exposure is
+    # indistinguishable from one that was always there, so no past run's
+    # deflation is evidenced by it.
+    if TRIAL_REGISTER.trial_for_declaration(declaration.strategy_id, declaration.strategy_version) is None:
+        raise ValueError(
+            f"no trial in {TRIAL_REGISTER_VERSION} claims {declaration.strategy_id}@"
+            f"{declaration.strategy_version}, so criterion 6's M does not count the search this declaration "
+            "represents — freezing it would burn an immutable trial whose deflated Sharpe is computed against "
+            "a population that excludes it. Add a DeclaredTrial (or a `declares` entry on the existing one) in "
+            "app/services/trial_register.py first."
+        )
     _lock_trial(conn, declaration.strategy_id, declaration.strategy_version)
     row = conn.execute(
         _FREEZE_DECLARATION,

--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -190,8 +190,16 @@ class DeclaredTrial:
     exactness: TrialExactness
     #: Number of price-data searches represented by this traceable declaration.
     searches: int = 1
-    #: #2829 — the ``(strategy_id, strategy_version)`` pairs whose preregistration
-    #: declaration this trial's searches account for.
+    #: #2829 — the ``(strategy_id, strategy_version)`` whose preregistration
+    #: declaration this trial's searches account for, or ``None``.
+    #:
+    #: ⚠⚠ AT MOST ONE, AND THAT IS THE INVARIANT, NOT A SIMPLIFICATION. The first
+    #: draft allowed a tuple of pairs and Codex checkpoint 2 killed it: a trial
+    #: may then claim a second declaration while ``searches`` stays where it was,
+    #: so the freeze gate would admit a new search that never moved
+    #: ``declared_count`` — the exact under-count the gate exists to prevent,
+    #: passing the gate. One trial to one declaration makes "this declaration has
+    #: its own counted trial" structurally true instead of checked.
     #:
     #: ⚠ EMPTY IS LEGITIMATE AND COMMON, not an omission to fill in. Many entries
     #: here are research SESSIONS (``short-horizon-search-session-2026-08-09``,
@@ -203,41 +211,31 @@ class DeclaredTrial:
     #: ``sql/333``'s own ``strategy_preregistration_declaration_unique``.
     #: ``contract_version`` is deliberately not part of it, for the same reason.
     #:
-    #: ⚠ CARDINALITY: one trial MAY claim MANY pairs (a grouped family declared
-    #: once); a pair is claimed by AT MOST ONE trial (enforced on
-    #: ``TrialRegister``).
-    #:
     #: ⚠ There is NO naming convention to infer this from, which is why it is
     #: declared. Measured 2026-08-22 across the five stored declarations, the
     #: matching ``trial_id`` was ``strategy_version`` twice, ``strategy_id``
     #: twice, and ``strategy_id + "-v1"`` once.
-    declares: tuple[tuple[str, str], ...] = ()
+    declared_for: tuple[str, str] | None = None
 
     def __post_init__(self) -> None:
         for field_name in ("trial_id", "description", "evidence"):
             if not getattr(self, field_name):
                 raise ValueError(f"{field_name} is blank — a present-but-empty declaration declares nothing (#2286)")
-        seen_pairs: set[tuple[str, str]] = set()
-        for pair in self.declares:
-            if len(pair) != 2:
-                raise ValueError(f"{self.trial_id}: declares entries are (strategy_id, strategy_version), got {pair!r}")
-            for part in pair:
+        if self.declared_for is not None:
+            if len(self.declared_for) != 2:
+                raise ValueError(
+                    f"{self.trial_id}: declared_for is (strategy_id, strategy_version), got {self.declared_for!r}"
+                )
+            for part in self.declared_for:
                 # Mirrors sql/333's `strategy_preregistration_declaration_identity`
                 # CHECK. A pair the table could never hold can never match a row,
                 # so it is a typo rather than a mapping — and it would fail SILENT,
                 # as a declaration this register does not claim.
                 if not isinstance(part, str) or not part.strip() or len(part) > _IDENTITY_LIMIT:
                     raise ValueError(
-                        f"{self.trial_id}: declares identity {part!r} must be a non-blank string of at most "
+                        f"{self.trial_id}: declared_for identity {part!r} must be a non-blank string of at most "
                         f"{_IDENTITY_LIMIT} characters (sql/333's identity CHECK)"
                     )
-            # ⚠ Within ONE trial, not only across trials. The cross-trial check on
-            # `TrialRegister` builds a set, so a pair repeated inside a single
-            # tuple would pass it while still meaning the register cannot say how
-            # many times it counted that declaration.
-            if pair in seen_pairs:
-                raise ValueError(f"{self.trial_id}: declares {pair!r} twice")
-            seen_pairs.add(pair)
         if type(self.searches) is not int or self.searches < 1:
             raise ValueError(f"searches must be a positive integer, got {self.searches!r}")
         # ⚠ Rejected rather than coerced. A raw string here would pass every
@@ -265,13 +263,15 @@ class TrialRegister:
         # declaration claimed by two trials has its searches counted twice in M.
         claimed: dict[tuple[str, str], str] = {}
         for trial in self.trials:
-            for pair in trial.declares:
-                if pair in claimed:
-                    raise ValueError(
-                        f"declaration {pair[0]}@{pair[1]} is claimed by both {claimed[pair]!r} and "
-                        f"{trial.trial_id!r} — one declaration counted twice inflates M silently"
-                    )
-                claimed[pair] = trial.trial_id
+            pair = trial.declared_for
+            if pair is None:
+                continue
+            if pair in claimed:
+                raise ValueError(
+                    f"declaration {pair[0]}@{pair[1]} is claimed by both {claimed[pair]!r} and "
+                    f"{trial.trial_id!r} — one declaration counted twice inflates M silently"
+                )
+            claimed[pair] = trial.trial_id
 
     @property
     def declared_count(self) -> int:
@@ -309,7 +309,7 @@ class TrialRegister:
         """
         pair = (strategy_id, strategy_version)
         for trial in self.trials:
-            if pair in trial.declares:
+            if trial.declared_for == pair:
                 return trial
         return None
 
@@ -470,7 +470,7 @@ TRIAL_REGISTER: Final = TrialRegister(
             "§'Recency and horizon diagnostics'); issue #2476 comment 2026-08-10 (sealed outcome)",
             exactness=TrialExactness.EXACT,
             searches=8,
-            declares=(("pead-historical-sue-net-income", "pead-historical-sue-net-income-v1"),),
+            declared_for=("pead-historical-sue-net-income", "pead-historical-sue-net-income-v1"),
         ),
         DeclaredTrial(
             trial_id="short-horizon-search-session-2026-08-09",
@@ -513,7 +513,7 @@ TRIAL_REGISTER: Final = TrialRegister(
             "https://github.com/Luke-Bradford/eBull/issues/2480#issuecomment-5238836691",
             exactness=TrialExactness.EXACT,
             searches=7,
-            declares=(("form4-code-p-opportunistic-purchase", "form4-code-p-opportunistic-purchase-v1"),),
+            declared_for=("form4-code-p-opportunistic-purchase", "form4-code-p-opportunistic-purchase-v1"),
         ),
         # ⚠⚠ THE 2026-08-09 02:28 SCRIPTS (commit 61fb17da), ADDED BY #2600.
         # All three predate the plan-of-attack's §2b floor (03:13:41, dbe5107b),
@@ -651,7 +651,7 @@ TRIAL_REGISTER: Final = TrialRegister(
             # ⚠ The one mapping no naming rule would have produced: the trial id
             # is the CONTRACT version, and the declaration's strategy_id drops
             # the `-v1`. Measured against the stored row, not inferred.
-            declares=(("c4-schedule13d-public-catalyst", "schedule13d-public-catalyst-v1"),),
+            declared_for=("c4-schedule13d-public-catalyst", "schedule13d-public-catalyst-v1"),
         ),
         # ⚠ DECLARED BEFORE THE FIRST BACKTEST. The four robustness rows
         # (ambiguity best/worst x quarantine admitted/masked), the eight pinned
@@ -699,7 +699,7 @@ TRIAL_REGISTER: Final = TrialRegister(
             # ⚠ Here the declaration's strategy_id IS the trial id and the
             # strategy_version is a registry hash — the opposite key from the
             # three above. Measured against the stored row.
-            declares=(("mt1-capped-volatility-managed-relative-strength-v1", "strategy-registry-v1+32970feefa00"),),
+            declared_for=("mt1-capped-volatility-managed-relative-strength-v1", "strategy-registry-v1+32970feefa00"),
         ),
         DeclaredTrial(
             trial_id="mt1-s8-capped-volatility-negative-control-v1",
@@ -712,7 +712,7 @@ TRIAL_REGISTER: Final = TrialRegister(
                 "§'Arms and trial accounting' and §'Frozen primary estimand and inference'; issue #2437"
             ),
             exactness=TrialExactness.EXACT,
-            declares=(("mt1-s8-capped-volatility-negative-control-v1", "strategy-registry-v1+b83c3e4fc997"),),
+            declared_for=("mt1-s8-capped-volatility-negative-control-v1", "strategy-registry-v1+b83c3e4fc997"),
         ),
     ),
 )

--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -132,6 +132,11 @@ TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-15-r7"
 #: constant exists so #2599 has a boundary to enforce from.
 TRIAL_REGISTER_CUTOFF: Final = datetime(2026, 8, 12, 7, 0, tzinfo=UTC)
 
+#: ``sql/333``'s identity CHECK bounds every declaration identity field at 200
+#: characters. Mirrored rather than imported because SQL cannot export it, in the
+#: same spirit as ``PreregDeclaration``'s deliberate duplication of those CHECKs.
+_IDENTITY_LIMIT: Final = 200
+
 
 class TrialExactness(StrEnum):
     """Whether a declaration's ``searches`` is the count or a lower bound on it.
@@ -185,11 +190,54 @@ class DeclaredTrial:
     exactness: TrialExactness
     #: Number of price-data searches represented by this traceable declaration.
     searches: int = 1
+    #: #2829 — the ``(strategy_id, strategy_version)`` pairs whose preregistration
+    #: declaration this trial's searches account for.
+    #:
+    #: ⚠ EMPTY IS LEGITIMATE AND COMMON, not an omission to fill in. Many entries
+    #: here are research SESSIONS (``short-horizon-search-session-2026-08-09``,
+    #: ``autocorrelation-term-structure-2026-08-09``) that no declaration
+    #: corresponds to; ``strategy_preregistration_declarations`` holds 5 rows
+    #: against 30 trials.
+    #:
+    #: ⚠ Identity is ``(strategy_id, strategy_version)`` because that is
+    #: ``sql/333``'s own ``strategy_preregistration_declaration_unique``.
+    #: ``contract_version`` is deliberately not part of it, for the same reason.
+    #:
+    #: ⚠ CARDINALITY: one trial MAY claim MANY pairs (a grouped family declared
+    #: once); a pair is claimed by AT MOST ONE trial (enforced on
+    #: ``TrialRegister``).
+    #:
+    #: ⚠ There is NO naming convention to infer this from, which is why it is
+    #: declared. Measured 2026-08-22 across the five stored declarations, the
+    #: matching ``trial_id`` was ``strategy_version`` twice, ``strategy_id``
+    #: twice, and ``strategy_id + "-v1"`` once.
+    declares: tuple[tuple[str, str], ...] = ()
 
     def __post_init__(self) -> None:
         for field_name in ("trial_id", "description", "evidence"):
             if not getattr(self, field_name):
                 raise ValueError(f"{field_name} is blank — a present-but-empty declaration declares nothing (#2286)")
+        seen_pairs: set[tuple[str, str]] = set()
+        for pair in self.declares:
+            if len(pair) != 2:
+                raise ValueError(f"{self.trial_id}: declares entries are (strategy_id, strategy_version), got {pair!r}")
+            for part in pair:
+                # Mirrors sql/333's `strategy_preregistration_declaration_identity`
+                # CHECK. A pair the table could never hold can never match a row,
+                # so it is a typo rather than a mapping — and it would fail SILENT,
+                # as a declaration this register does not claim.
+                if not isinstance(part, str) or not part.strip() or len(part) > _IDENTITY_LIMIT:
+                    raise ValueError(
+                        f"{self.trial_id}: declares identity {part!r} must be a non-blank string of at most "
+                        f"{_IDENTITY_LIMIT} characters (sql/333's identity CHECK)"
+                    )
+            # ⚠ Within ONE trial, not only across trials. The cross-trial check on
+            # `TrialRegister` builds a set, so a pair repeated inside a single
+            # tuple would pass it while still meaning the register cannot say how
+            # many times it counted that declaration.
+            if pair in seen_pairs:
+                raise ValueError(f"{self.trial_id}: declares {pair!r} twice")
+            seen_pairs.add(pair)
         if type(self.searches) is not int or self.searches < 1:
             raise ValueError(f"searches must be a positive integer, got {self.searches!r}")
         # ⚠ Rejected rather than coerced. A raw string here would pass every
@@ -213,6 +261,17 @@ class TrialRegister:
         ids = [trial.trial_id for trial in self.trials]
         if len(ids) != len(set(ids)):
             raise ValueError("trial ids are not distinct — one variant counted twice inflates M silently")
+        # #2829. Same failure shape as the id check above, one level down: a
+        # declaration claimed by two trials has its searches counted twice in M.
+        claimed: dict[tuple[str, str], str] = {}
+        for trial in self.trials:
+            for pair in trial.declares:
+                if pair in claimed:
+                    raise ValueError(
+                        f"declaration {pair[0]}@{pair[1]} is claimed by both {claimed[pair]!r} and "
+                        f"{trial.trial_id!r} — one declaration counted twice inflates M silently"
+                    )
+                claimed[pair] = trial.trial_id
 
     @property
     def declared_count(self) -> int:
@@ -232,6 +291,27 @@ class TrialRegister:
     @property
     def trial_ids(self) -> frozenset[str]:
         return frozenset(trial.trial_id for trial in self.trials)
+
+    def trial_for_declaration(self, strategy_id: str, strategy_version: str) -> DeclaredTrial | None:
+        """The trial whose searches account for this declaration, or ``None``.
+
+        ⚠ ``None`` means "``M`` does not count the search this declaration
+        represents", which is the under-count criterion 6 calls decorative. It is
+        NOT "no declaration exists" — this register knows nothing about which
+        declarations have been frozen.
+
+        ⚠ WHAT A MATCH PROVES, precisely: that the register and the declaration
+        agree TODAY. It cannot establish that the register counted this search at
+        the time a look occurred, because a mapping added after exposure is
+        indistinguishable from one that was always there. The prospective
+        guarantee comes from ``freeze_preregistration`` refusing an unclaimed
+        declaration, not from a lookup here.
+        """
+        pair = (strategy_id, strategy_version)
+        for trial in self.trials:
+            if pair in trial.declares:
+                return trial
+        return None
 
     def sharpe_variance(self, measured: Mapping[str, float]) -> float | None:
         """``V[{SR_n}]`` over the trials measured this run. ``None`` below two.
@@ -390,6 +470,7 @@ TRIAL_REGISTER: Final = TrialRegister(
             "§'Recency and horizon diagnostics'); issue #2476 comment 2026-08-10 (sealed outcome)",
             exactness=TrialExactness.EXACT,
             searches=8,
+            declares=(("pead-historical-sue-net-income", "pead-historical-sue-net-income-v1"),),
         ),
         DeclaredTrial(
             trial_id="short-horizon-search-session-2026-08-09",
@@ -432,6 +513,7 @@ TRIAL_REGISTER: Final = TrialRegister(
             "https://github.com/Luke-Bradford/eBull/issues/2480#issuecomment-5238836691",
             exactness=TrialExactness.EXACT,
             searches=7,
+            declares=(("form4-code-p-opportunistic-purchase", "form4-code-p-opportunistic-purchase-v1"),),
         ),
         # ⚠⚠ THE 2026-08-09 02:28 SCRIPTS (commit 61fb17da), ADDED BY #2600.
         # All three predate the plan-of-attack's §2b floor (03:13:41, dbe5107b),
@@ -566,6 +648,10 @@ TRIAL_REGISTER: Final = TrialRegister(
             "sha256 8f4424bea0581ba501d9779b93ff9268c65c6f0c899f1a66962bcb260cce895f. Issues #2614, #2582",
             exactness=TrialExactness.EXACT,
             searches=7,
+            # ⚠ The one mapping no naming rule would have produced: the trial id
+            # is the CONTRACT version, and the declaration's strategy_id drops
+            # the `-v1`. Measured against the stored row, not inferred.
+            declares=(("c4-schedule13d-public-catalyst", "schedule13d-public-catalyst-v1"),),
         ),
         # ⚠ DECLARED BEFORE THE FIRST BACKTEST. The four robustness rows
         # (ambiguity best/worst x quarantine admitted/masked), the eight pinned
@@ -610,6 +696,10 @@ TRIAL_REGISTER: Final = TrialRegister(
                 "§'Arms and trial accounting' and §'Frozen primary estimand and inference'; issue #2437"
             ),
             exactness=TrialExactness.EXACT,
+            # ⚠ Here the declaration's strategy_id IS the trial id and the
+            # strategy_version is a registry hash — the opposite key from the
+            # three above. Measured against the stored row.
+            declares=(("mt1-capped-volatility-managed-relative-strength-v1", "strategy-registry-v1+32970feefa00"),),
         ),
         DeclaredTrial(
             trial_id="mt1-s8-capped-volatility-negative-control-v1",
@@ -622,6 +712,7 @@ TRIAL_REGISTER: Final = TrialRegister(
                 "§'Arms and trial accounting' and §'Frozen primary estimand and inference'; issue #2437"
             ),
             exactness=TrialExactness.EXACT,
+            declares=(("mt1-s8-capped-volatility-negative-control-v1", "strategy-registry-v1+b83c3e4fc997"),),
         ),
     ),
 )

--- a/docs/proposals/ta/2026-08-22-declaration-trial-binding.md
+++ b/docs/proposals/ta/2026-08-22-declaration-trial-binding.md
@@ -1,0 +1,203 @@
+# Bind a preregistration declaration to the trial that counts it (#2829)
+
+Status: proposed, 2026-08-22. Codex checkpoint 1 run; it moved the enforcement point, and
+the reasons are recorded below rather than silently absorbed.
+
+## The gap, stated precisely
+
+#2829's escalation names it: *"every deflation argument in the sweep cites 'search
+#275/#276' against a register that holds 5 rows. The search count that converts a
+marginal pass into noise is currently an assertion, not a ledger."*
+
+The issue already warns that two registers are being conflated, and it is right — but the
+conflation is not only rhetorical. **The two are not joinable at all**, so "search #275"
+cannot be checked mechanically by anything.
+
+| | what it is | where | today |
+| --- | --- | --- | --- |
+| `TRIAL_REGISTER` | criterion 6's `M`, feeding the DSR's `E[max SR]` | `app/services/trial_register.py`, code-frozen | 30 trials, `declared_count = 274` |
+| `strategy_preregistration_declarations` | the per-trial purpose freeze `require_outcome_access` gates on | `sql/333`, DB | 5 rows |
+
+A spike can freeze a declaration, run, and be deflated against an `M` that never counted
+it.
+
+## Measured before speccing (dev DB + the shipped register, 2026-08-22)
+
+All five declarations **do** have a corresponding trial — but the key is inconsistent, and
+that is the finding:
+
+| declaration `strategy_id` | declaration `strategy_version` | matching `trial_id` | key that matched |
+| --- | --- | --- | --- |
+| `c4-schedule13d-public-catalyst` | `schedule13d-public-catalyst-v1` | `c4-schedule13d-public-catalyst-v1` | neither exactly — `strategy_id + "-v1"` |
+| `form4-code-p-opportunistic-purchase` | `form4-code-p-opportunistic-purchase-v1` | `form4-code-p-opportunistic-purchase-v1` | `strategy_version` |
+| `pead-historical-sue-net-income` | `pead-historical-sue-net-income-v1` | `pead-historical-sue-net-income-v1` | `strategy_version` |
+| `mt1-capped-volatility-managed-relative-strength-v1` | `strategy-registry-v1+32970feefa00` | `mt1-capped-volatility-managed-relative-strength-v1` | `strategy_id` |
+| `mt1-s8-capped-volatility-negative-control-v1` | `strategy-registry-v1+b83c3e4fc997` | `mt1-s8-capped-volatility-negative-control-v1` | `strategy_id` |
+
+Three different join rules across five rows. **There is no key to infer**, which is why
+this ships as an explicit declared mapping rather than a naming convention — a convention
+already violated three ways cannot be enforced retroactively, and it would break the
+moment a `strategy_version` became a registry hash, which two of the five already are.
+
+Reproduce:
+
+```
+select strategy_id, strategy_version, prereg_purpose from strategy_preregistration_declarations order by 1;
+PYTHONPATH=. uv run python -c "from app.services.trial_register import TRIAL_REGISTER; print(sorted(TRIAL_REGISTER.trial_ids))"
+```
+
+Also measured, because it bounds the design:
+
+```
+select trial_register_version, count(*) from strategy_results_store group by 1;
+ trial-register-2026-08-15-r7 | 220      trial-register-2026-08-12-r5 |  64
+ trial-register-2026-08-07    | 108      trial-register-2026-08-11-r3 |  48
+ (null)                       |  80      trial-register-2026-08-10    |  48
+```
+
+## Scope
+
+1. `DeclaredTrial` gains `declares: tuple[tuple[str, str], ...] = ()` — the
+   `(strategy_id, strategy_version)` pairs whose preregistration declaration this trial's
+   searches account for. Empty is legitimate and common: many of the thirty trials are
+   research *sessions* (`short-horizon-search-session-2026-08-09`,
+   `autocorrelation-term-structure-2026-08-09`, …) that no declaration corresponds to.
+2. **Cardinality, stated because it was not obvious:** one trial MAY claim MANY pairs (a
+   grouped family declared once); a pair is claimed by AT MOST ONE trial. Validated in
+   `__post_init__` — a pair on two trials would double-count that declaration's searches
+   in `M`, silently and in the flattering direction. A pair repeated *within* one trial's
+   tuple is refused too, or the naive cross-trial check would let it through.
+3. Each pair's elements are validated non-blank and ≤ 200 characters, mirroring
+   `sql/333`'s `strategy_preregistration_declaration_identity` CHECK — a pair the table
+   could never hold can never match a row, so it is a typo, not a mapping.
+4. `TrialRegister.trial_for_declaration(strategy_id, strategy_version) -> DeclaredTrial |
+   None`.
+5. **`freeze_preregistration` refuses a declaration no trial claims** — freeze time only.
+6. The five existing declarations mapped onto their trials, and a test asserting every
+   stored declaration's pair is claimed.
+
+## Source rule
+
+None of these is a formulation with a published source; each is fixed by construction and
+the construction is stated. The governing in-repo rule is criterion 6 as
+`trial_register.py` states it — `M` must not under-count in the flattering direction — and
+every choice below is the one that cannot move `M` down.
+
+### ⚠⚠ The gate is at FREEZE TIME, not in `declaration_refusals`
+
+The first draft put a new `trial_not_in_register` member in `DeclarationRefusal`. Codex
+checkpoint 1 killed it, correctly, and the reasons are worth keeping because each is a
+path a reader would otherwise assume was considered:
+
+- `declaration_refusals` is **pure** and is called with synthetic identities by
+  preregistration, supersession, live-gate, C4, MT1 and pre-cutoff fixtures. Consulting a
+  module-global register makes every one of those incoherent unless its identity is added
+  to production register data.
+- `supersession_refusals` calls `declaration_refusals(successor)`. A declaration stranded
+  by a structural-policy bump could then not use the **repair path that exists for exactly
+  that situation** — a new wedge, created by the fix.
+- `strategy_live_gate` calls it on registration *and on reassessment*, so an already
+  registered, immutable policy could become unusable because current code lacks a mapping.
+- It would make a code edit **retroactively invalidate** frozen artefacts. `sql/333`'s own
+  header is headed "⚠ NO RETROACTIVE INVALIDATION".
+
+Freeze time has none of those properties: it touches nothing already frozen, cannot strand
+a supersession, and refuses only the one act the ticket actually wants gated — *"does the
+next strategy version freeze a declaration before its first hold-out look?"*
+
+There is an exact precedent at the same seam. `freeze_preregistration` already carries a
+freeze-time-only check (#2720's cost-model stamp test) whose comment says why it is not in
+`__post_init__`: *"that class is also the read-back of stored rows, and rows frozen under
+an earlier cost model legitimately declare stamps today's constants do not produce."* The
+same sentence applies here word for word.
+
+It raises `ValueError` with an explanatory message, matching that neighbouring check,
+rather than adding a `DeclarationRefusal` member. That keeps the refusal vocabulary — and
+every caller, audit payload and exact-tuple assertion that enumerates it — untouched.
+
+### ⚠ What this does and does not prove
+
+Prospectively it is a ledger: from this change on, a declaration cannot be frozen unless
+`M` already names the search it represents.
+
+Retrospectively it is **not** a proof, and the spec says so rather than letting the table
+above imply it. The five mappings establish that the two registers agree **today**, by
+name and by reading each trial's `evidence` field. They cannot establish that the register
+counted that search *at the time the look occurred* — a mapping added after exposure looks
+identical to one that was always there. Nothing in this change should be cited as evidence
+about a past run's deflation.
+
+⚠ The duplicate-claim invariant is likewise one-sided by construction: it forbids an
+*inflated* `M`, while the motivating defect is an *understated* one. The understated
+direction has no invariant available at the register — only the freeze gate closes it, and
+only for declarations frozen after this lands.
+
+### The mapping lives on the REGISTER side, not the declaration
+
+`PreregDeclaration.sha256` hashes `digest_payload`, and `sql/333` stores that digest on
+every frozen row. **Adding a field to the declaration would change the digest of all five
+frozen rows**, which is the one thing a frozen artefact may not do. The register is code,
+is versioned, and already carries a trial's provenance — so the pointer goes there.
+
+Identity is `(strategy_id, strategy_version)` because that is `sql/333`'s own
+`strategy_preregistration_declaration_unique`. `contract_version` is deliberately not part
+of it, for the same reason.
+
+Consequence, stated rather than discovered later: `declares` names a `strategy_version`,
+and a strategy's version moves whenever its module hash moves. A new version is a new
+trial and needs its own register entry before its declaration can be frozen. **That is the
+discipline #2829 asks for, arriving as a mechanical refusal rather than a convention.**
+
+### `TRIAL_REGISTER_VERSION` is NOT bumped, and that is the load-bearing call
+
+The constant's contract is *"bumped whenever a trial is added or an entry's meaning
+changes"*, and it is stored beside every DSR because *"a deflated Sharpe means nothing
+without the trial population it was deflated against."*
+
+This diff adds **no trial**, changes **no `searches` value**, and leaves `declared_count`
+at **274** and `len(trials)` at **30**. The population `M` is unchanged, so every DSR
+computed under `trial-register-2026-08-15-r7` remains exactly correct.
+
+⚠ Bumping anyway is not the safe default here — it is the destructive one. 220 stored
+results carry r7, and `strategy_result.py:1311-1314` refuses `trial_register_superseded`
+whenever `deflated.trial_register_version != TRIAL_REGISTER_VERSION`. A bump would flip
+all 220 to refused for a change that moved nothing they depend on.
+
+⚠ Codex's counter — *"reusing the same register version for a changed binding artefact is
+not defensible"* — is noted and rejected on what the field is FOR. It is stored on result
+rows to answer "which population was this deflated against", and `strategy_result.py`
+compares it against `declared_count`, not against the module's bytes. A binding that
+changes neither is outside what the version claims. Treating the constant as a source hash
+would make it a different thing than its docstring says, and would do so by mass-refusing
+220 rows.
+
+To keep that argument checkable rather than asserted, the tests pin `declared_count == 274`
+and `len(trials) == 30` as literals. Any future edit that actually moves `M` fails them and
+forces the bump conversation at the right moment.
+
+## Deliberately NOT in scope
+
+- **Backfilling declarations for s1–s10.** #2829 is explicit that this would be governance
+  theatre — the hold-out has already been looked at, which is what
+  `supersession_trial_already_exposed` refuses. The ten stay undeclared; the next
+  `strategy_version` declares.
+- **Any change to `searches`, `exactness` or `M`.**
+- **Register entries for the six R5 spikes.** Each freezes its own declaration and appends
+  its own trial when it runs; this change makes forgetting either half a refusal instead
+  of a silent under-count.
+
+## Acceptance
+
+- `freeze_preregistration` raises on a declaration whose pair no trial claims, naming the
+  pair and pointing at the register.
+- Every one of the five stored declarations is claimed by exactly one trial, checked
+  against the real register and the real rows.
+- A register declaring one pair on two trials, or the same pair twice within one trial,
+  raises at construction.
+- `declaration_refusals` is byte-for-byte unchanged, and returns `()` for all five stored
+  declarations exactly as before.
+- `TRIAL_REGISTER.declared_count == 274` and `len(TRIAL_REGISTER.trials) == 30`.
+
+## Refs
+
+Refs #2829. Refs #2599. Refs #2600. Refs #2832. Refs #2437.

--- a/docs/proposals/ta/2026-08-22-declaration-trial-binding.md
+++ b/docs/proposals/ta/2026-08-22-declaration-trial-binding.md
@@ -57,24 +57,43 @@ select trial_register_version, count(*) from strategy_results_store group by 1;
 
 ## Scope
 
-1. `DeclaredTrial` gains `declares: tuple[tuple[str, str], ...] = ()` — the
-   `(strategy_id, strategy_version)` pairs whose preregistration declaration this trial's
-   searches account for. Empty is legitimate and common: many of the thirty trials are
+1. `DeclaredTrial` gains `declared_for: tuple[str, str] | None = None` — the
+   `(strategy_id, strategy_version)` whose preregistration declaration this trial's
+   searches account for. `None` is legitimate and common: many of the thirty trials are
    research *sessions* (`short-horizon-search-session-2026-08-09`,
    `autocorrelation-term-structure-2026-08-09`, …) that no declaration corresponds to.
-2. **Cardinality, stated because it was not obvious:** one trial MAY claim MANY pairs (a
-   grouped family declared once); a pair is claimed by AT MOST ONE trial. Validated in
-   `__post_init__` — a pair on two trials would double-count that declaration's searches
-   in `M`, silently and in the flattering direction. A pair repeated *within* one trial's
-   tuple is refused too, or the naive cross-trial check would let it through.
-3. Each pair's elements are validated non-blank and ≤ 200 characters, mirroring
-   `sql/333`'s `strategy_preregistration_declaration_identity` CHECK — a pair the table
-   could never hold can never match a row, so it is a typo, not a mapping.
-4. `TrialRegister.trial_for_declaration(strategy_id, strategy_version) -> DeclaredTrial |
+2. ⚠⚠ **AT MOST ONE per trial, and that is the invariant rather than a simplification.**
+   The first draft allowed a *tuple* of pairs. Codex checkpoint 2 killed it with the
+   decisive objection: a trial could then claim a second declaration while `searches`
+   stayed where it was, so the freeze gate would admit a brand-new search that never moved
+   `declared_count` — the exact under-count the gate exists to prevent, passing the gate.
+   The gate's own error message even advertised the loophole ("or a `declares` entry on
+   the existing one"). One trial to one declaration makes *"this declaration has its own
+   counted trial"* true by the type, so claiming a declaration necessarily appends a trial
+   and necessarily moves `M`.
+   ⚠ It does not close every path: re-pointing an existing trial's `declared_for` at a new
+   pair passes construction without moving `M`. That leaves the PREVIOUS declaration
+   unclaimed, which is what
+   `TestTheShippedMapping::test_every_stored_declaration_is_claimed_by_its_trial` exists
+   to catch. Stated rather than implied, because it is the one remaining seam.
+3. A pair claimed by two trials is refused at `TrialRegister` construction — that would
+   double-count one declaration's searches in `M`, silently and in the flattering
+   direction.
+4. Each element is validated non-blank and ≤ 200 characters, mirroring `sql/333`'s
+   `strategy_preregistration_declaration_identity` CHECK — a pair the table could never
+   hold can never match a row, so it is a typo, not a mapping.
+5. `TrialRegister.trial_for_declaration(strategy_id, strategy_version) -> DeclaredTrial |
    None`.
-5. **`freeze_preregistration` refuses a declaration no trial claims** — freeze time only.
-6. The five existing declarations mapped onto their trials, and a test asserting every
+6. **`freeze_preregistration` refuses a declaration no trial claims** — freeze time only.
+7. The five existing declarations mapped onto their trials, and a test asserting every
    stored declaration's pair is claimed.
+8. **Every test module that freezes a synthetic identity opts into a permissive register**
+   via `pytestmark = pytest.mark.usefixtures("assume_trial_registered")`
+   (`tests/conftest.py`). Seven modules; `tests/test_strategy_live_gate.py` and
+   `tests/test_2634_prereg_supersession_db.py` among them, both found by Codex checkpoint
+   2 rather than by the fast tier, because they are `db`-marked and off the push gate.
+   ⚠ The fixture is deliberately NOT autouse: a module that opts in is not exercising this
+   gate, and that has to be a visible line in the file rather than a global default.
 
 ## Source rule
 
@@ -192,8 +211,8 @@ forces the bump conversation at the right moment.
   pair and pointing at the register.
 - Every one of the five stored declarations is claimed by exactly one trial, checked
   against the real register and the real rows.
-- A register declaring one pair on two trials, or the same pair twice within one trial,
-  raises at construction.
+- A register declaring one pair on two trials raises at construction, and a tuple-of-pairs
+  `declared_for` is refused by the identity validation.
 - `declaration_refusals` is byte-for-byte unchanged, and returns `()` for all five stored
   declarations exactly as before.
 - `TRIAL_REGISTER.declared_count == 274` and `len(TRIAL_REGISTER.trials) == 30`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -489,3 +489,43 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             shutil.rmtree(base, ignore_errors=True)
     except Exception:  # pragma: no cover - best-effort
         pass
+
+
+# ---------------------------------------------------------------------------
+# #2829 — assume criterion 6's M counts whatever a module freezes.
+#
+# `freeze_preregistration` refuses a declaration no `TRIAL_REGISTER` trial
+# claims, so that M cannot be an assertion. Several test modules freeze
+# SYNTHETIC identities while testing a different gate entirely (immutability,
+# supersession, cost stamps, the live-gate policy). Mapping their fixtures into
+# the production register would put fake trials in the artefact that feeds every
+# Deflated Sharpe, so they opt into a permissive register instead:
+#
+#     pytestmark = pytest.mark.usefixtures("assume_trial_registered")
+#
+# ⚠ NOT autouse. A module that opts in is NOT exercising the #2829 gate, and
+# that has to be a visible line in the file rather than a global default —
+# otherwise the gate is off everywhere and only its own tests would notice.
+# Those live in `tests/test_2829_declaration_trial_binding.py`, which
+# deliberately does NOT opt in.
+# ---------------------------------------------------------------------------
+class _RegisterClaimingAnything:
+    """Stands in for `TRIAL_REGISTER` and claims every identity asked of it."""
+
+    version = "test-register-claims-anything"
+
+    def trial_for_declaration(self, strategy_id: str, strategy_version: str) -> Any:
+        from app.services.trial_register import DeclaredTrial, TrialExactness
+
+        return DeclaredTrial(
+            trial_id=f"{strategy_id}@{strategy_version}",
+            description="synthetic fixture trial (#2829 gate not under test here)",
+            evidence="tests only",
+            exactness=TrialExactness.EXACT,
+            declared_for=(strategy_id, strategy_version),
+        )
+
+
+@pytest.fixture
+def assume_trial_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.services.result_ledger.TRIAL_REGISTER", _RegisterClaimingAnything())

--- a/tests/test_2437_mt1_declarations_db.py
+++ b/tests/test_2437_mt1_declarations_db.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from dataclasses import replace
 
 import psycopg
+import pytest
 
 from app.services.result_ledger import freeze_preregistration, load_preregistration
 from scripts.freeze_2437_mt1_declarations import _freeze_batch, build_declarations
+
+# #2829 — freezes synthetic or pre-mapped identities while testing a different
+# gate; see `assume_trial_registered` in tests/conftest.py.
+pytestmark = pytest.mark.usefixtures("assume_trial_registered")
 
 
 def test_both_declarations_freeze_atomically_and_identical_retry_is_safe(

--- a/tests/test_2616_precutoff_gate_db.py
+++ b/tests/test_2616_precutoff_gate_db.py
@@ -19,6 +19,10 @@ from scripts.freeze_2616_precutoff_declarations import build_pead_declaration
 from scripts.sealed_rerun_gate import RerunGateRefusal, require_outcome_gate
 from scripts.verify_2476_pead_outcomes import SEALED_TRIAL
 
+# #2829 — freezes synthetic or pre-mapped identities while testing a different
+# gate; see `assume_trial_registered` in tests/conftest.py.
+pytestmark = pytest.mark.usefixtures("assume_trial_registered")
+
 _RERUN_ID = "pead-historical-sue-net-income-v1-rerun-db-test"
 
 #: Synthetic on purpose: the real register holds no re-run entry yet, and that

--- a/tests/test_2634_prereg_supersession_db.py
+++ b/tests/test_2634_prereg_supersession_db.py
@@ -27,6 +27,10 @@ from app.services.result_ledger import (
 )
 from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION
 
+# #2829 — freezes synthetic or pre-mapped identities while testing a different
+# gate; see `assume_trial_registered` in tests/conftest.py.
+pytestmark = pytest.mark.usefixtures("assume_trial_registered")
+
 _STALE_POLICY = "structural-refusal-policy-2026-08-12-v1"
 _STRATEGY_ID = "S-2634"
 _STRATEGY_VERSION = "supersession-test-v1"

--- a/tests/test_2720_freeze_stamp_validation.py
+++ b/tests/test_2720_freeze_stamp_validation.py
@@ -27,37 +27,10 @@ from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
 from app.services.result_ledger import freeze_preregistration
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION
-from app.services.trial_register import DeclaredTrial, TrialExactness
 
-
-# ---------------------------------------------------------------------------
-# #2829 — assume criterion 6's M counts whatever this module freezes.
-#
-# ``freeze_preregistration`` now refuses a declaration no ``TRIAL_REGISTER``
-# trial claims, so that M cannot be an assertion. These tests are about a
-# DIFFERENT gate and freeze synthetic identities the production register has no
-# business naming — mapping their fixtures into it would put fake trials in the
-# artefact that feeds every Deflated Sharpe.
-#
-# ⚠ Blanket-permissive, so the #2829 gate is NOT exercised here. It has its own
-# tests in ``tests/test_2829_declaration_trial_binding.py``.
-# ---------------------------------------------------------------------------
-class _RegisterClaimingAnything:
-    version = "test-register-claims-anything"
-
-    def trial_for_declaration(self, strategy_id: str, strategy_version: str) -> DeclaredTrial:
-        return DeclaredTrial(
-            trial_id=f"{strategy_id}@{strategy_version}",
-            description="synthetic fixture trial (#2829 gate bypassed for this module)",
-            evidence="tests only",
-            exactness=TrialExactness.EXACT,
-            declares=((strategy_id, strategy_version),),
-        )
-
-
-@pytest.fixture(autouse=True)
-def _assume_the_trial_is_registered(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("app.services.result_ledger.TRIAL_REGISTER", _RegisterClaimingAnything())
+# #2829 — freezes synthetic or pre-mapped identities while testing a different
+# gate; see `assume_trial_registered` in tests/conftest.py.
+pytestmark = pytest.mark.usefixtures("assume_trial_registered")
 
 
 #: A real manifest id — the check is scoped to the manifest, so the fixture

--- a/tests/test_2720_freeze_stamp_validation.py
+++ b/tests/test_2720_freeze_stamp_validation.py
@@ -27,6 +27,38 @@ from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
 from app.services.result_ledger import freeze_preregistration
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION
+from app.services.trial_register import DeclaredTrial, TrialExactness
+
+
+# ---------------------------------------------------------------------------
+# #2829 — assume criterion 6's M counts whatever this module freezes.
+#
+# ``freeze_preregistration`` now refuses a declaration no ``TRIAL_REGISTER``
+# trial claims, so that M cannot be an assertion. These tests are about a
+# DIFFERENT gate and freeze synthetic identities the production register has no
+# business naming — mapping their fixtures into it would put fake trials in the
+# artefact that feeds every Deflated Sharpe.
+#
+# ⚠ Blanket-permissive, so the #2829 gate is NOT exercised here. It has its own
+# tests in ``tests/test_2829_declaration_trial_binding.py``.
+# ---------------------------------------------------------------------------
+class _RegisterClaimingAnything:
+    version = "test-register-claims-anything"
+
+    def trial_for_declaration(self, strategy_id: str, strategy_version: str) -> DeclaredTrial:
+        return DeclaredTrial(
+            trial_id=f"{strategy_id}@{strategy_version}",
+            description="synthetic fixture trial (#2829 gate bypassed for this module)",
+            evidence="tests only",
+            exactness=TrialExactness.EXACT,
+            declares=((strategy_id, strategy_version),),
+        )
+
+
+@pytest.fixture(autouse=True)
+def _assume_the_trial_is_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.services.result_ledger.TRIAL_REGISTER", _RegisterClaimingAnything())
+
 
 #: A real manifest id — the check is scoped to the manifest, so the fixture
 #: must sit inside it for the refusal arm to be reachable.

--- a/tests/test_2829_declaration_trial_binding.py
+++ b/tests/test_2829_declaration_trial_binding.py
@@ -49,13 +49,13 @@ _STORED_DECLARATIONS: tuple[tuple[str, str, str], ...] = (
 )
 
 
-def _trial(trial_id: str, declares: tuple[tuple[str, str], ...] = ()) -> DeclaredTrial:
+def _trial(trial_id: str, declared_for: tuple[str, str] | None = None) -> DeclaredTrial:
     return DeclaredTrial(
         trial_id=trial_id,
         description="d",
         evidence="e",
         exactness=TrialExactness.EXACT,
-        declares=declares,
+        declared_for=declared_for,
     )
 
 
@@ -69,13 +69,13 @@ class TestTheShippedMapping:
         assert trial.trial_id == trial_id
 
     def test_the_mapping_is_sparse_and_that_is_correct(self) -> None:
-        """⚠ Most trials claim nothing, and an empty ``declares`` is not an omission.
+        """⚠ Most trials claim nothing, and a ``None`` ``declared_for`` is not an omission.
 
         Many entries are research SESSIONS that no declaration corresponds to. A
         test that demanded a mapping on every trial would be demanding five rows'
         worth of declarations for thirty trials.
         """
-        claiming = [trial for trial in TRIAL_REGISTER.trials if trial.declares]
+        claiming = [trial for trial in TRIAL_REGISTER.trials if trial.declared_for is not None]
         assert len(claiming) == len(_STORED_DECLARATIONS)
         assert TRIAL_REGISTER.trial_for_declaration("short-horizon-search-session-2026-08-09", "whatever") is None
 
@@ -84,16 +84,30 @@ class TestTheInvariantsThatProtectM:
     def test_a_pair_claimed_by_two_trials_is_refused(self) -> None:
         """One declaration counted twice inflates ``M`` silently — the same
         failure shape as a duplicate ``trial_id``, one level down."""
-        pair = (("alpha", "v1"),)
+        pair = ("alpha", "v1")
         with pytest.raises(ValueError, match="claimed by both"):
             TrialRegister(version="v", trials=(_trial("one", pair), _trial("two", pair)))
 
-    def test_a_pair_repeated_inside_one_trial_is_refused(self) -> None:
-        """⚠ The cross-trial check builds a set, so a pair repeated INSIDE one
-        tuple would pass it while still leaving the register unable to say how
-        many times it counted that declaration."""
-        with pytest.raises(ValueError, match="declares .* twice"):
-            _trial("one", (("alpha", "v1"), ("alpha", "v1")))
+    def test_one_trial_can_claim_at_most_one_declaration(self) -> None:
+        """⚠⚠ THE INVARIANT CODEX CKPT-2 FORCED, and it is structural rather than
+        checked.
+
+        The first draft let a trial claim a TUPLE of pairs. A new search could
+        then be added to an existing trial's list -- which the freeze gate's own
+        error message suggested -- passing the gate while ``searches`` stayed put
+        and ``declared_count`` never moved. That is the exact under-count the gate
+        exists to prevent, sailing through it.
+
+        One trial to one declaration makes "this declaration has its own counted
+        trial" true by the type, so appending a claim necessarily appends a trial
+        and necessarily moves ``M``.
+        """
+        # Behavioural, not a type assertion: a list of pairs is what the first
+        # draft accepted, and `(("a", "v1"), ("b", "v2"))` even has len 2, so it
+        # slips past a shape check and is caught only because its elements are
+        # tuples rather than strings.
+        with pytest.raises(ValueError, match="must be a non-blank string"):
+            _trial("one", (("alpha", "v1"), ("beta", "v2")))  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("bad", ["", "   ", "x" * 201])
     def test_an_identity_the_declarations_table_could_not_hold_is_refused(self, bad: str) -> None:
@@ -101,7 +115,7 @@ class TestTheInvariantsThatProtectM:
         the table could never hold can never match a row, so it fails SILENT — as
         a declaration this register does not claim — rather than loudly."""
         with pytest.raises(ValueError, match="sql/333"):
-            _trial("one", ((bad, "v1"),))
+            _trial("one", (bad, "v1"))
 
     def test_a_malformed_pair_is_refused(self) -> None:
         with pytest.raises(ValueError, match="strategy_id, strategy_version"):
@@ -110,7 +124,7 @@ class TestTheInvariantsThatProtectM:
                 description="d",
                 evidence="e",
                 exactness=TrialExactness.EXACT,
-                declares=(("alpha",),),  # type: ignore[arg-type]
+                declared_for=("alpha",),  # type: ignore[arg-type]
             )
 
 
@@ -172,11 +186,7 @@ class TestTheFreezeGate:
         produces, which is exactly what distinguishes "admitted" from "refused"
         without a database.
         """
-        registered = TRIAL_REGISTER.trials[0]
-        assert not registered.declares  # a session trial; use a mapped one instead
-        strategy_id, strategy_version = next(
-            (sid, ver) for sid, ver, _ in ((d[0], d[1], d[2]) for d in _STORED_DECLARATIONS)
-        )
+        strategy_id, strategy_version, _ = _STORED_DECLARATIONS[0]
         with pytest.raises(AttributeError):
             freeze_preregistration(cast("Any", object()), self._declaration(strategy_id, strategy_version))
 

--- a/tests/test_2829_declaration_trial_binding.py
+++ b/tests/test_2829_declaration_trial_binding.py
@@ -1,0 +1,151 @@
+"""Bind a preregistration declaration to the trial that counts it (#2829).
+
+`TRIAL_REGISTER` (criterion 6's ``M``, feeding the DSR) and
+`strategy_preregistration_declarations` were not joinable, so "search #275" was an
+assertion no code could check. These tests pin the join, the invariants that keep it
+from inflating ``M``, and the two things the change deliberately does NOT do.
+
+Spec: ``docs/proposals/ta/2026-08-22-declaration-trial-binding.md``
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.trial_register import (
+    TRIAL_REGISTER,
+    DeclaredTrial,
+    TrialExactness,
+    TrialRegister,
+)
+
+#: The five rows in ``strategy_preregistration_declarations`` on 2026-08-22, and the
+#: measurement that motivated an explicit mapping: the matching ``trial_id`` was
+#: ``strategy_version`` twice, ``strategy_id`` twice, and ``strategy_id + "-v1"`` once.
+#: ⚠ Three join rules across five rows — there is no convention to infer.
+_STORED_DECLARATIONS: tuple[tuple[str, str, str], ...] = (
+    ("c4-schedule13d-public-catalyst", "schedule13d-public-catalyst-v1", "c4-schedule13d-public-catalyst-v1"),
+    (
+        "form4-code-p-opportunistic-purchase",
+        "form4-code-p-opportunistic-purchase-v1",
+        "form4-code-p-opportunistic-purchase-v1",
+    ),
+    ("pead-historical-sue-net-income", "pead-historical-sue-net-income-v1", "pead-historical-sue-net-income-v1"),
+    (
+        "mt1-capped-volatility-managed-relative-strength-v1",
+        "strategy-registry-v1+32970feefa00",
+        "mt1-capped-volatility-managed-relative-strength-v1",
+    ),
+    (
+        "mt1-s8-capped-volatility-negative-control-v1",
+        "strategy-registry-v1+b83c3e4fc997",
+        "mt1-s8-capped-volatility-negative-control-v1",
+    ),
+)
+
+
+def _trial(trial_id: str, declares: tuple[tuple[str, str], ...] = ()) -> DeclaredTrial:
+    return DeclaredTrial(
+        trial_id=trial_id,
+        description="d",
+        evidence="e",
+        exactness=TrialExactness.EXACT,
+        declares=declares,
+    )
+
+
+class TestTheShippedMapping:
+    @pytest.mark.parametrize(("strategy_id", "strategy_version", "trial_id"), _STORED_DECLARATIONS)
+    def test_every_stored_declaration_is_claimed_by_its_trial(
+        self, strategy_id: str, strategy_version: str, trial_id: str
+    ) -> None:
+        trial = TRIAL_REGISTER.trial_for_declaration(strategy_id, strategy_version)
+        assert trial is not None, f"{strategy_id}@{strategy_version} is claimed by no trial"
+        assert trial.trial_id == trial_id
+
+    def test_the_mapping_is_sparse_and_that_is_correct(self) -> None:
+        """⚠ Most trials claim nothing, and an empty ``declares`` is not an omission.
+
+        Many entries are research SESSIONS that no declaration corresponds to. A
+        test that demanded a mapping on every trial would be demanding five rows'
+        worth of declarations for thirty trials.
+        """
+        claiming = [trial for trial in TRIAL_REGISTER.trials if trial.declares]
+        assert len(claiming) == len(_STORED_DECLARATIONS)
+        assert TRIAL_REGISTER.trial_for_declaration("short-horizon-search-session-2026-08-09", "whatever") is None
+
+
+class TestTheInvariantsThatProtectM:
+    def test_a_pair_claimed_by_two_trials_is_refused(self) -> None:
+        """One declaration counted twice inflates ``M`` silently — the same
+        failure shape as a duplicate ``trial_id``, one level down."""
+        pair = (("alpha", "v1"),)
+        with pytest.raises(ValueError, match="claimed by both"):
+            TrialRegister(version="v", trials=(_trial("one", pair), _trial("two", pair)))
+
+    def test_a_pair_repeated_inside_one_trial_is_refused(self) -> None:
+        """⚠ The cross-trial check builds a set, so a pair repeated INSIDE one
+        tuple would pass it while still leaving the register unable to say how
+        many times it counted that declaration."""
+        with pytest.raises(ValueError, match="declares .* twice"):
+            _trial("one", (("alpha", "v1"), ("alpha", "v1")))
+
+    @pytest.mark.parametrize("bad", ["", "   ", "x" * 201])
+    def test_an_identity_the_declarations_table_could_not_hold_is_refused(self, bad: str) -> None:
+        """Mirrors ``sql/333``'s identity CHECK (1-200 chars, non-blank). A pair
+        the table could never hold can never match a row, so it fails SILENT — as
+        a declaration this register does not claim — rather than loudly."""
+        with pytest.raises(ValueError, match="sql/333"):
+            _trial("one", ((bad, "v1"),))
+
+    def test_a_malformed_pair_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="strategy_id, strategy_version"):
+            DeclaredTrial(
+                trial_id="one",
+                description="d",
+                evidence="e",
+                exactness=TrialExactness.EXACT,
+                declares=(("alpha",),),  # type: ignore[arg-type]
+            )
+
+
+class TestWhatThisChangeDeliberatelyDoesNotMove:
+    def test_M_is_unchanged_so_the_register_version_is_not_bumped(self) -> None:
+        """⚠⚠ THE LOAD-BEARING CALL, pinned as literals on purpose.
+
+        ``TRIAL_REGISTER_VERSION`` is stored beside every DSR to answer "which
+        population was this deflated against", and ``strategy_result.py`` refuses
+        ``trial_register_superseded`` when a stored version or ``declared_trials``
+        disagrees with today's. 220 stored results carry
+        ``trial-register-2026-08-15-r7``, so bumping is the DESTRUCTIVE option,
+        not the safe one — it would flip all 220 to refused for a change that
+        added no trial and moved no ``searches`` value.
+
+        These two literals are what keeps that argument checkable: an edit that
+        actually moves ``M`` fails here and forces the bump conversation at the
+        moment it is due.
+        """
+        assert TRIAL_REGISTER.declared_count == 274
+        assert len(TRIAL_REGISTER.trials) == 30
+
+    def test_the_declaration_refusal_vocabulary_is_untouched(self) -> None:
+        """⚠ The first draft added ``trial_not_in_register`` here. Codex ckpt-1
+        killed it: ``declaration_refusals`` is pure and consulted by supersession
+        REPAIR and live-gate REASSESSMENT, so a member here would strand already
+        frozen artefacts — and ``sql/333``'s header is titled "NO RETROACTIVE
+        INVALIDATION". The gate went to freeze time instead.
+
+        Pinned as an exact set so a later author who reaches for the easy
+        placement has to read that argument first.
+        """
+        from app.services.prereg_contract import DECLARATION_REFUSALS
+
+        assert DECLARATION_REFUSALS == frozenset(
+            {
+                "structural_refusal_policy_superseded",
+                "expected_structural_refusals_mismatch",
+                "ineligible_trial_not_declared_falsification",
+                "forward_shadow_floor_not_positive",
+                "forward_shadow_derivation_missing",
+            }
+        )

--- a/tests/test_2829_declaration_trial_binding.py
+++ b/tests/test_2829_declaration_trial_binding.py
@@ -128,6 +128,29 @@ class TestTheInvariantsThatProtectM:
             )
 
 
+def test_the_identity_limit_matches_the_migration_it_mirrors() -> None:
+    """``_IDENTITY_LIMIT`` restates a bound SQL cannot export, so bind the two.
+
+    A constant and its source in two files with nothing between them is two
+    constants — the same argument
+    ``test_the_migration_reason_codes_match_the_allocator_vocabulary`` makes for
+    the reason-code CHECK.
+
+    ⚠ Drift is SILENT in the direction that matters. If ``sql/333`` widened and
+    this did not, a legitimate identity would be rejected here as a typo; if the
+    migration narrowed, a pair this register happily stores could never match a
+    row, and the declaration would read as unclaimed rather than as malformed.
+    """
+    import re
+    from pathlib import Path
+
+    from app.services.trial_register import _IDENTITY_LIMIT
+
+    sql = (Path(__file__).resolve().parents[1] / "sql" / "333_strategy_preregistration_declarations.sql").read_text()
+    bounds = set(re.findall(r"char_length\((?:strategy_id|strategy_version)\) BETWEEN 1 AND (\d+)", sql))
+    assert bounds == {str(_IDENTITY_LIMIT)}, f"sql/333 bounds the identity at {bounds}, not {_IDENTITY_LIMIT}"
+
+
 class TestTheFreezeGate:
     """⚠ DB-free by design: the check fires before ``freeze_preregistration``
     touches its connection, which is what these lean on — the same property

--- a/tests/test_2829_declaration_trial_binding.py
+++ b/tests/test_2829_declaration_trial_binding.py
@@ -10,8 +10,13 @@ Spec: ``docs/proposals/ta/2026-08-22-declaration-trial-binding.md``
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
+from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
+from app.services.result_ledger import freeze_preregistration
+from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION
 from app.services.trial_register import (
     TRIAL_REGISTER,
     DeclaredTrial,
@@ -107,6 +112,73 @@ class TestTheInvariantsThatProtectM:
                 exactness=TrialExactness.EXACT,
                 declares=(("alpha",),),  # type: ignore[arg-type]
             )
+
+
+class TestTheFreezeGate:
+    """⚠ DB-free by design: the check fires before ``freeze_preregistration``
+    touches its connection, which is what these lean on — the same property
+    ``tests/test_2720_freeze_stamp_validation.py`` documents for the cost-stamp
+    check directly above it."""
+
+    @staticmethod
+    def _declaration(strategy_id: str, strategy_version: str) -> PreregDeclaration:
+        # ⚠ A NON-manifest strategy_id on purpose: the cost-stamp check above
+        # this gate is scoped to STRATEGY_MANIFEST, and a manifest id would fail
+        # there first and never reach the gate under test.
+        return PreregDeclaration(
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            contract_version="test-contract-v1",
+            prereg_purpose="falsification_only",
+            structural_refusal_policy_version=STRUCTURAL_REFUSAL_POLICY_VERSION,
+            declared_universe_basis="survivor_only",
+            declared_carry_unmodelled=False,
+            declared_fx_unmodelled=False,
+            expected_structural_refusals=("universe_basis_not_survivorship_free",),
+            forward_shadow=ForwardShadowFloor(
+                min_independent_decision_dates=40,
+                min_calendar_weeks=12,
+                derivation="tests/test_2829_declaration_trial_binding.py",
+            ),
+            declared_by="tests/test_2829_declaration_trial_binding.py",
+        )
+
+    def test_a_declaration_no_trial_claims_cannot_be_frozen(self) -> None:
+        """The substantive rule: M must already count the search.
+
+        Without it a trial freezes, runs, and is deflated against a population
+        that excludes it — and the row is immutable, so the mistake costs a
+        supersession to even acknowledge.
+        """
+        declaration = self._declaration("some-unregistered-trial", "v1")
+        with pytest.raises(ValueError, match="does not count the search"):
+            freeze_preregistration(cast("Any", object()), declaration)
+
+    def test_the_refusal_names_the_pair_and_where_to_fix_it(self) -> None:
+        """A refusal a reader cannot act on sends them to read the gate's source."""
+        declaration = self._declaration("some-unregistered-trial", "v1")
+        with pytest.raises(ValueError) as excinfo:
+            freeze_preregistration(cast("Any", object()), declaration)
+        message = str(excinfo.value)
+        assert "some-unregistered-trial@v1" in message
+        assert "app/services/trial_register.py" in message
+
+    def test_a_claimed_declaration_reaches_the_connection(self) -> None:
+        """The positive arm, and it must be present or the test above passes for
+        a register that claims NOTHING.
+
+        A bare ``object()`` has no ``execute``, so getting past the gate raises
+        ``AttributeError`` — a different failure from the ``ValueError`` the gate
+        produces, which is exactly what distinguishes "admitted" from "refused"
+        without a database.
+        """
+        registered = TRIAL_REGISTER.trials[0]
+        assert not registered.declares  # a session trial; use a mapped one instead
+        strategy_id, strategy_version = next(
+            (sid, ver) for sid, ver, _ in ((d[0], d[1], d[2]) for d in _STORED_DECLARATIONS)
+        )
+        with pytest.raises(AttributeError):
+            freeze_preregistration(cast("Any", object()), self._declaration(strategy_id, strategy_version))
 
 
 class TestWhatThisChangeDeliberatelyDoesNotMove:

--- a/tests/test_c4_declaration_gate_db.py
+++ b/tests/test_c4_declaration_gate_db.py
@@ -25,6 +25,10 @@ from app.services.result_ledger import (
 from scripts.evaluate_2582_schedule13d_outcomes import STRATEGY_ID, STRATEGY_VERSION
 from scripts.freeze_2582_schedule13d_declaration import build_declaration
 
+# #2829 — freezes synthetic or pre-mapped identities while testing a different
+# gate; see `assume_trial_registered` in tests/conftest.py.
+pytestmark = pytest.mark.usefixtures("assume_trial_registered")
+
 _ACTOR = "tests/test_c4_declaration_gate_db.py"
 _PURPOSE = "exercise C-4's declaration gate"
 

--- a/tests/test_strategy_holdout_namespace.py
+++ b/tests/test_strategy_holdout_namespace.py
@@ -46,7 +46,6 @@ from app.services.strategy_result import (
     StrategyResult,
     check_promotable,
 )
-from app.services.trial_register import DeclaredTrial, TrialExactness
 from tests.test_result_ledger import (
     BOOTSTRAP_BLOCK,
     build_control,
@@ -55,35 +54,9 @@ from tests.test_result_ledger import (
     build_result_with_dsr,
 )
 
-
-# ---------------------------------------------------------------------------
-# #2829 — assume criterion 6's M counts whatever this module freezes.
-#
-# ``freeze_preregistration`` now refuses a declaration no ``TRIAL_REGISTER``
-# trial claims, so that M cannot be an assertion. These tests are about a
-# DIFFERENT gate and freeze synthetic identities the production register has no
-# business naming — mapping their fixtures into it would put fake trials in the
-# artefact that feeds every Deflated Sharpe.
-#
-# ⚠ Blanket-permissive, so the #2829 gate is NOT exercised here. It has its own
-# tests in ``tests/test_2829_declaration_trial_binding.py``.
-# ---------------------------------------------------------------------------
-class _RegisterClaimingAnything:
-    version = "test-register-claims-anything"
-
-    def trial_for_declaration(self, strategy_id: str, strategy_version: str) -> DeclaredTrial:
-        return DeclaredTrial(
-            trial_id=f"{strategy_id}@{strategy_version}",
-            description="synthetic fixture trial (#2829 gate bypassed for this module)",
-            evidence="tests only",
-            exactness=TrialExactness.EXACT,
-            declares=((strategy_id, strategy_version),),
-        )
-
-
-@pytest.fixture(autouse=True)
-def _assume_the_trial_is_registered(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("app.services.result_ledger.TRIAL_REGISTER", _RegisterClaimingAnything())
+# #2829 — freezes synthetic or pre-mapped identities while testing a different
+# gate; see `assume_trial_registered` in tests/conftest.py.
+pytestmark = pytest.mark.usefixtures("assume_trial_registered")
 
 
 _ACTOR = "tests/test_strategy_holdout_namespace.py"

--- a/tests/test_strategy_holdout_namespace.py
+++ b/tests/test_strategy_holdout_namespace.py
@@ -46,6 +46,7 @@ from app.services.strategy_result import (
     StrategyResult,
     check_promotable,
 )
+from app.services.trial_register import DeclaredTrial, TrialExactness
 from tests.test_result_ledger import (
     BOOTSTRAP_BLOCK,
     build_control,
@@ -53,6 +54,37 @@ from tests.test_result_ledger import (
     build_result,
     build_result_with_dsr,
 )
+
+
+# ---------------------------------------------------------------------------
+# #2829 — assume criterion 6's M counts whatever this module freezes.
+#
+# ``freeze_preregistration`` now refuses a declaration no ``TRIAL_REGISTER``
+# trial claims, so that M cannot be an assertion. These tests are about a
+# DIFFERENT gate and freeze synthetic identities the production register has no
+# business naming — mapping their fixtures into it would put fake trials in the
+# artefact that feeds every Deflated Sharpe.
+#
+# ⚠ Blanket-permissive, so the #2829 gate is NOT exercised here. It has its own
+# tests in ``tests/test_2829_declaration_trial_binding.py``.
+# ---------------------------------------------------------------------------
+class _RegisterClaimingAnything:
+    version = "test-register-claims-anything"
+
+    def trial_for_declaration(self, strategy_id: str, strategy_version: str) -> DeclaredTrial:
+        return DeclaredTrial(
+            trial_id=f"{strategy_id}@{strategy_version}",
+            description="synthetic fixture trial (#2829 gate bypassed for this module)",
+            evidence="tests only",
+            exactness=TrialExactness.EXACT,
+            declares=((strategy_id, strategy_version),),
+        )
+
+
+@pytest.fixture(autouse=True)
+def _assume_the_trial_is_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.services.result_ledger.TRIAL_REGISTER", _RegisterClaimingAnything())
+
 
 _ACTOR = "tests/test_strategy_holdout_namespace.py"
 _PURPOSE = "stage 5e-1 acceptance"

--- a/tests/test_strategy_live_gate.py
+++ b/tests/test_strategy_live_gate.py
@@ -44,7 +44,13 @@ from app.services.strategy_live_gate import (
 from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION
 from tests.test_strategy_position_manager import _opened_trade
 
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
+# #2829 — freezes a synthetic identity while testing the live gate; see
+# `assume_trial_registered` in tests/conftest.py.
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("registered_strategy_test_candidates"),
+    pytest.mark.usefixtures("assume_trial_registered"),
+]
 
 _STRATEGY_ID = "S-LIVE-GATE"
 _VERSION = "live-gate-v1"


### PR DESCRIPTION
## The gap, stated precisely

#2829's escalation names it: *"every deflation argument in the sweep cites 'search #275/#276' against a register that holds 5 rows. The search count that converts a marginal pass into noise is currently an assertion, not a ledger."*

The issue already warns that two registers are being conflated, and it is right — but the conflation is not only rhetorical. **The two are not joinable at all**, so "search #275" cannot be checked mechanically by anything.

| | what it is | where | today |
| --- | --- | --- | --- |
| `TRIAL_REGISTER` | criterion 6's `M`, feeding the DSR's `E[max SR]` | `app/services/trial_register.py`, code-frozen | 30 trials, `declared_count = 274` |
| `strategy_preregistration_declarations` | the per-trial purpose freeze `require_outcome_access` gates on | `sql/333`, DB | 5 rows |

A spike can freeze a declaration, run, and be deflated against an `M` that never counted it.

## Measured before speccing

All five declarations **do** have a corresponding trial — but the key is inconsistent, and that is the finding:

| declaration `strategy_id` | `strategy_version` | matching `trial_id` | key that matched |
| --- | --- | --- | --- |
| `c4-schedule13d-public-catalyst` | `schedule13d-public-catalyst-v1` | `c4-schedule13d-public-catalyst-v1` | neither — `strategy_id + "-v1"` |
| `form4-code-p-opportunistic-purchase` | `form4-code-p-opportunistic-purchase-v1` | `form4-code-p-opportunistic-purchase-v1` | `strategy_version` |
| `pead-historical-sue-net-income` | `pead-historical-sue-net-income-v1` | `pead-historical-sue-net-income-v1` | `strategy_version` |
| `mt1-capped-volatility-managed-relative-strength-v1` | `strategy-registry-v1+32970feefa00` | `mt1-capped-volatility-managed-relative-strength-v1` | `strategy_id` |
| `mt1-s8-capped-volatility-negative-control-v1` | `strategy-registry-v1+b83c3e4fc997` | `mt1-s8-capped-volatility-negative-control-v1` | `strategy_id` |

Three join rules across five rows. **There is no key to infer**, which is why the mapping is declared rather than conventional — and a convention would break anyway the moment a `strategy_version` became a registry hash, which two of the five already are.

## What ships

`DeclaredTrial.declared_for: tuple[str, str] | None` — the `(strategy_id, strategy_version)` whose declaration this trial's searches account for. `None` is legitimate and common: many of the thirty entries are research *sessions* no declaration corresponds to. Identity is `(strategy_id, strategy_version)` because that is `sql/333`'s own `strategy_preregistration_declaration_unique`.

`freeze_preregistration` refuses a declaration no trial claims.

## ⚠⚠ At most ONE declaration per trial — the invariant, not a simplification

The first draft allowed a *tuple* of pairs. Codex checkpoint 2 killed it with the decisive objection: a trial could then claim a second declaration while `searches` stayed where it was, so the gate would admit a brand-new search that never moved `declared_count` — **the exact under-count the gate exists to prevent, passing the gate.** The refusal message even advertised the move ("or a `declares` entry on the existing one").

One trial to one declaration makes *"this declaration has its own counted trial"* true by the type, so claiming a declaration necessarily appends a trial and necessarily moves `M`.

⚠ It does not close every path, and the spec says so rather than implying otherwise: re-pointing an existing trial's `declared_for` passes construction without moving `M`. That orphans the previous declaration, which is what `test_every_stored_declaration_is_claimed_by_its_trial` catches. The refusal message now warns about it explicitly.

## ⚠⚠ The gate is at FREEZE TIME, not in `declaration_refusals`

The first draft added a `trial_not_in_register` member to `DeclarationRefusal`. Codex checkpoint 1 killed that placement, and each reason is a path a reader would otherwise assume was considered:

- `declaration_refusals` is **pure** and is called with synthetic identities by most prereg / supersession / live-gate fixtures.
- `supersession_refusals` calls it on the successor — so a declaration stranded by a policy bump could no longer use **the repair path that exists for exactly that situation**.
- `strategy_live_gate` calls it on registration *and reassessment*, so an immutable registered policy could stop working because current code lacks a mapping.
- It would make a code edit **retroactively invalidate** frozen artefacts, and `sql/333`'s header is titled "⚠ NO RETROACTIVE INVALIDATION".

Freeze time has none of those properties, and there is an exact precedent at the same seam: #2720's cost-stamp check, whose comment gives the same argument word for word. It raises `ValueError` like that neighbour rather than extending the refusal vocabulary, so no caller, audit payload or exact-tuple assertion that enumerates `DECLARATION_REFUSALS` changes.

## ⚠ What this proves, and what it does not

**Prospectively** it is a ledger: a declaration cannot be frozen unless `M` already names its search.

**Retrospectively it proves nothing**, and that is stated rather than left for the table above to imply. The five mappings establish that the two registers agree *today*. A mapping added after exposure is indistinguishable from one that was always there, so nothing here should be cited as evidence about a past run's deflation.

⚠ The duplicate-claim invariant is one-sided by construction: it forbids an *inflated* `M` while the motivating defect is an *understated* one. Only the freeze gate closes that direction, and only for declarations frozen after this lands.

## `TRIAL_REGISTER_VERSION` is deliberately NOT bumped

Its contract is *"bumped whenever a trial is added or an entry's meaning changes"*, and it sits beside every DSR to answer "which population was this deflated against". This diff adds no trial, moves no `searches` value, and leaves `declared_count` at **274** / `len(trials)` at **30**.

⚠ Bumping is the **destructive** option here, not the safe one. `select trial_register_version, count(*) from strategy_results_store group by 1` returns **220 rows on r7**, and `strategy_result.py:1311-1314` refuses `trial_register_superseded` on any mismatch — so a bump flips all 220 to refused for a change that moved nothing they depend on. Codex's counter ("reusing the version for a changed binding artefact is not defensible") is rejected on what the field is *for*: `strategy_result.py` compares it against `declared_count`, not against the module's bytes.

Both numbers are pinned as literals in the tests, so an edit that actually moves `M` fails there and forces the bump conversation at the moment it is due.

## Test-fixture impact — and how it was found

The gate broke **eight** existing tests that freeze synthetic identities. Two of them (`test_strategy_live_gate`, `test_2634_prereg_supersession_db`) are `db`-marked and therefore **invisible to the push gate** — Codex checkpoint 2 found them, not the fast tier.

Resolution: `tests/conftest.py` gains `assume_trial_registered`, and the seven freezing modules opt in with `pytestmark = pytest.mark.usefixtures("assume_trial_registered")`. ⚠ **Deliberately NOT autouse** — a module that opts in is not exercising this gate, and that must be a visible line in the file rather than a global default that silently disables it everywhere. `tests/test_2829_declaration_trial_binding.py` does not opt in.

## Security model

Not applicable — no auth surface, no user input, no external I/O. This tightens an internal research-governance gate and cannot loosen one.

## Verification

- `ruff check` / `ruff format --check` / `pyright` clean; `pytest -m "not db"` green; `pytest tests/smoke` green.
- **`pytest -m db` across all seven freezing modules: 79 passed.** ⚠ The first attempt reported exit 0 with the test Postgres *down* — every db test skipped. Re-run after `docker start ebull-postgres-test`; the 79 is from that run.
- **Revert-probes: 5/5 caught, clean control** — cross-trial duplicate claim · identity bound · the c4 mapping · the freeze gate · (pre-collapse) within-trial duplicate.

Spec: `docs/proposals/ta/2026-08-22-declaration-trial-binding.md`

Refs #2829. Refs #2599. Refs #2600. Refs #2832. Refs #2437.
