### PR TITLE
feature(#2843): the autonomy flag, and the approver that reads it

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -624,6 +624,8 @@ class StrategyPaperPoolView(BaseModel):
     enabled: bool
     capital_limit: Decimal
     capital_mode: Literal["fixed", "compound"]
+    #: #2843. Who may approve a stage promotion under this authority.
+    approval_mode: Literal["manual", "autonomous"]
     effective_capital: Decimal | None
     currency: Literal["USD"] = "USD"
     reserved_capital: Decimal
@@ -759,6 +761,12 @@ class StrategyPaperPoolUpdateRequest(BaseModel):
     capital_limit: Decimal = Field(ge=0, max_digits=18, decimal_places=6)
     capital_mode: Literal["fixed", "compound"] = "fixed"
     risk_profile: Literal["unconfigured", "cautious", "balanced", "growth"]
+    #: #2843. ⚠⚠ ``None`` means CARRY THE CURRENT VALUE FORWARD, resolved from
+    #: ``load_paper_pool`` inside the same locked transaction. It does NOT mean
+    #: ``"manual"``. Omission is the common case for every existing client and for
+    #: every edit that is not about approval; making it a reset would let an
+    #: unrelated capital-limit change silently revoke autonomy and report success.
+    approval_mode: Literal["manual", "autonomous"] | None = None
     reason: str = Field(min_length=1, max_length=1000)
 
     @model_validator(mode="after")
@@ -767,6 +775,8 @@ class StrategyPaperPoolUpdateRequest(BaseModel):
             raise ValueError("enabled paper pool requires positive capital")
         if self.enabled and self.risk_profile == "unconfigured":
             raise ValueError("enabled paper pool requires a configured portfolio risk mandate")
+        if self.approval_mode == "autonomous" and self.risk_profile == "unconfigured":
+            raise ValueError("autonomous approval requires a configured portfolio risk mandate")
         return self
 
 
@@ -2378,6 +2388,7 @@ def get_strategy_overview(
             enabled=paper_pool.enabled,
             capital_limit=paper_pool.capital_limit,
             capital_mode=paper_pool.capital_mode,
+            approval_mode=paper_pool.approval_mode,
             effective_capital=effective_pool_capital,
             reserved_capital=reserved_total,
             invested_capital=invested_total,
@@ -3118,16 +3129,20 @@ def update_strategy_paper_pool(
             if body.enabled and not current_pool.enabled and readiness is not None and not readiness.ready:
                 raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
             runtime = get_runtime_config(conn)
+            # #2843: omitted means UNCHANGED, so the resolved value -- never the raw
+            # request field -- is what both the change test and the INSERT see.
+            approval_mode = body.approval_mode if body.approval_mode is not None else current_pool.approval_mode
             pool_changed = (
                 current_pool.enabled != body.enabled
                 or current_pool.capital_limit != body.capital_limit
                 or current_pool.capital_mode != body.capital_mode
                 or current_pool.mandate.risk_profile != body.risk_profile
+                or current_pool.approval_mode != approval_mode
             )
             automation_changed = runtime.enable_auto_trading != body.enabled
             if not pool_changed and not automation_changed:
                 raise StrategyControlError(
-                    "automation change must alter enabled state, capital limit, capital mode, or mandate"
+                    "automation change must alter enabled state, capital limit, capital mode, mandate, or approval mode"
                 )
             if pool_changed:
                 configure_paper_pool(
@@ -3136,6 +3151,7 @@ def update_strategy_paper_pool(
                     capital_limit=body.capital_limit,
                     capital_mode=body.capital_mode,
                     risk_profile=body.risk_profile,
+                    approval_mode=approval_mode,
                     changed_by=session.username,
                     reason=body.reason,
                 )

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -776,8 +776,15 @@ class StrategyPaperPoolUpdateRequest(BaseModel):
             raise ValueError("enabled paper pool requires positive capital")
         if self.enabled and self.risk_profile == "unconfigured":
             raise ValueError("enabled paper pool requires a configured portfolio risk mandate")
-        if self.approval_mode == "autonomous" and self.risk_profile == "unconfigured":
-            raise ValueError("autonomous approval requires a configured portfolio risk mandate")
+        # ⚠ NO autonomous-needs-a-mandate CHECK HERE, deliberately (review NITPICK on
+        # PR #2856). The rule cannot be stated completely at this layer: a request may
+        # OMIT `approval_mode` and carry an existing `autonomous` forward while setting
+        # `risk_profile="unconfigured"`, and a validator cannot see the stored value.
+        # A check that fires on the literal field only would enforce the rule on one
+        # path and not the other — worse than absent, because it reads as coverage.
+        # `configure_paper_pool` owns it in full, against the RESOLVED mode, and its
+        # StrategyControlError is already mapped to a 409 here. Same reasoning
+        # `CoreMandateUpdateRequest` gives for carrying shape and no invariants.
         return self
 
 

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -65,6 +65,7 @@ from app.services.strategy_control_plane import (
     lock_strategy_control,
     mandate_for_profile,
     promote_strategy,
+    resolve_approval_mode,
 )
 from app.services.strategy_core_eligibility import CoreEligibilityError
 from app.services.strategy_core_mandate import (
@@ -3130,8 +3131,9 @@ def update_strategy_paper_pool(
                 raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
             runtime = get_runtime_config(conn)
             # #2843: omitted means UNCHANGED, so the resolved value -- never the raw
-            # request field -- is what both the change test and the INSERT see.
-            approval_mode = body.approval_mode if body.approval_mode is not None else current_pool.approval_mode
+            # request field -- is what both the change test and the INSERT see. The
+            # rule is a named function so it has a test surface; see its docstring.
+            approval_mode = resolve_approval_mode(body.approval_mode, current_pool.approval_mode)
             pool_changed = (
                 current_pool.enabled != body.enabled
                 or current_pool.capital_limit != body.capital_limit

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -130,6 +130,7 @@ from app.workers.scheduler import (
     JOB_SEC_N_PORT_INGEST,
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
     JOB_SEED_COST_MODELS,
+    JOB_STRATEGY_AUTONOMOUS_PROMOTION,
     JOB_STRATEGY_BACKTEST_RUN,
     JOB_STRATEGY_HALT_FEED_REFRESH,
     JOB_STRATEGY_INTRADAY_HARVEST,
@@ -203,6 +204,7 @@ from app.workers.scheduler import (
     sec_n_port_ingest,
     sec_nport_filer_directory_sync,
     seed_cost_models,
+    strategy_autonomous_promotion,
     strategy_backtest_run,
     strategy_halt_feed_refresh,
     strategy_intraday_harvest,
@@ -367,6 +369,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     JOB_STRATEGY_OBSERVATION_RETENTION: _adapt_zero_arg(strategy_observation_retention),
     JOB_STRATEGY_PAPER_CYCLE: _adapt_zero_arg(strategy_paper_cycle),
     JOB_CORE_REBALANCE_OBSERVATION: _adapt_zero_arg(core_rebalance_observation),
+    JOB_STRATEGY_AUTONOMOUS_PROMOTION: _adapt_zero_arg(strategy_autonomous_promotion),
     # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY and NOT in
     # SCHEDULED_JOBS: criterion 5 requires a hold-out purpose no cron fire can
     # supply. ⚠ Registered NATIVELY, not through ``_adapt_zero_arg`` — the body

--- a/app/services/strategy_autonomous_promotion.py
+++ b/app/services/strategy_autonomous_promotion.py
@@ -42,6 +42,7 @@ from typing import Any, Final
 import psycopg
 
 from app.services.strategy_control_plane import (
+    PAPER_ALLOCATOR_ADVISORY_LOCK,
     PaperPool,
     Stage,
     StrategyControlError,
@@ -155,6 +156,18 @@ def _reason(pool: PaperPool) -> str:
     return f"autonomous advance under approval_mode=autonomous (pool event {pool.event_id}, {AUTONOMY_POLICY_VERSION})"
 
 
+class _AuthorityRevoked(Exception):
+    """The pool stopped authorising a policy approver part-way through a cycle.
+
+    Distinct from ``_Refused``: that is one strategy's evidence failing, this is the
+    authority itself going away, and it ends the cycle rather than the strategy.
+    """
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
 class _Refused(Exception):
     """Carries one strategy's refusal out of its transaction block, rolling it back.
 
@@ -174,7 +187,6 @@ def _advance_one(
     *,
     strategy_id: str,
     strategy_version: str,
-    pool: PaperPool,
     as_of: datetime,
 ) -> tuple[AutonomousAdvance | None, str | None]:
     """One strategy, in its OWN transaction.
@@ -183,8 +195,26 @@ def _advance_one(
     unrelated failure on the last strategy roll back every promotion before it, and
     would make the iteration order decide who advances.  Committing per strategy is
     also what makes the report describe what is durably true.
+
+    ⚠⚠ THE AUTHORITY IS RE-READ HERE, UNDER THE ALLOCATOR LOCK, AND NOT INHERITED
+    FROM THE CYCLE (Codex ckpt-2, P1).  Per-strategy transactions are exactly what
+    creates the hole: an operator who switches the pool to ``manual`` mid-cycle
+    commits between two promotions, and a cycle-level snapshot would keep approving
+    on authority that no longer exists.  ``configure_paper_pool`` takes the same
+    ``PAPER_ALLOCATOR_ADVISORY_LOCK``, so taking it here is what makes a revocation
+    and an approval serialise rather than interleave.
+
+    ⚠ Lock ORDER is allocator-then-strategy, matching `strategy_paper_executor`
+    (`_allocator_lock`, then `decide_funding`'s `_lock_strategy`).  `advance_strategy`
+    takes the per-strategy lock below, so acquiring the pool lock first keeps one
+    global order and cannot invert against the executor.
     """
     with conn.transaction():
+        conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
+        pool = load_paper_pool(conn)
+        revoked = cycle_precondition_refusal(pool)
+        if revoked is not None:
+            raise _AuthorityRevoked(revoked)
         action, skip = planned_action(current_stage(conn, strategy_id, strategy_version))
         if action is None:
             assert skip is not None
@@ -230,6 +260,12 @@ def run_autonomous_promotion_cycle(conn: psycopg.Connection[Any], *, as_of: date
 
     Strategies are visited in sorted id order so the report is stable, not because the
     order carries meaning -- each one commits independently.
+
+    ⚠ The read below is a CHEAP EXIT, not the control.  It answers "is there anything
+    to do" without taking a lock; ``_advance_one`` re-reads the authority under
+    ``PAPER_ALLOCATOR_ADVISORY_LOCK`` before every single promotion, and that is what
+    actually gates one.  Deleting this read would change nothing but the cost of a
+    manual-mode tick.
     """
     pool = load_paper_pool(conn)
     refusal = cycle_precondition_refusal(pool)
@@ -240,15 +276,21 @@ def run_autonomous_promotion_cycle(conn: psycopg.Connection[Any], *, as_of: date
 
     advanced: list[AutonomousAdvance] = []
     refusals: list[tuple[str, str]] = []
+    revoked: str | None = None
     for strategy_id, strategy_version in sorted(current_result_versions().items()):
         try:
             outcome, skip = _advance_one(
                 conn,
                 strategy_id=strategy_id,
                 strategy_version=strategy_version,
-                pool=pool,
                 as_of=as_of,
             )
+        except _AuthorityRevoked as exc:
+            # STOP, do not continue to the next strategy: the authority is gone for
+            # all of them, and the promotions already committed stay committed --
+            # each was approved while the authority still held.
+            revoked = exc.code
+            break
         except _Refused as exc:
             refusals.append((strategy_id, exc.detail))
             continue
@@ -256,6 +298,13 @@ def run_autonomous_promotion_cycle(conn: psycopg.Connection[Any], *, as_of: date
             advanced.append(outcome)
         elif skip is not None:
             refusals.append((strategy_id, skip))
+    if revoked is not None:
+        return AutonomousPromotionReport(
+            approval_mode=load_paper_pool(conn).approval_mode,
+            skipped_reason=revoked,
+            advanced=tuple(advanced),
+            refusals=tuple(refusals),
+        )
     return AutonomousPromotionReport(
         approval_mode=pool.approval_mode,
         skipped_reason=None,

--- a/app/services/strategy_autonomous_promotion.py
+++ b/app/services/strategy_autonomous_promotion.py
@@ -266,7 +266,24 @@ def run_autonomous_promotion_cycle(conn: psycopg.Connection[Any], *, as_of: date
     ``PAPER_ALLOCATOR_ADVISORY_LOCK`` before every single promotion, and that is what
     actually gates one.  Deleting this read would change nothing but the cost of a
     manual-mode tick.
+
+    ⚠⚠ REQUIRES AN AUTOCOMMIT CONNECTION, and refuses without one (Codex ckpt-2, P1).
+    On a transactional connection psycopg's ``conn.transaction()`` opens a SAVEPOINT
+    rather than a transaction, which silently breaks BOTH properties this function
+    claims: promotions stop committing independently (a late failure rolls back the
+    earlier ones this call already reported as advanced), and
+    ``pg_advisory_xact_lock`` is held for the whole cycle instead of one strategy --
+    so a mid-cycle operator revocation would block on the job rather than serialise
+    with it.  Neither is visible in the source shape; both are a property of the
+    CALLER's connection mode, which is why this is checked rather than documented.
     """
+    if not conn.autocommit:
+        raise StrategyControlError(
+            "run_autonomous_promotion_cycle requires an autocommit connection: on a "
+            "transactional one every per-strategy conn.transaction() is only a SAVEPOINT, "
+            "so promotions do not commit independently and the allocator lock is held "
+            "for the whole cycle"
+        )
     pool = load_paper_pool(conn)
     refusal = cycle_precondition_refusal(pool)
     if refusal is not None:

--- a/app/services/strategy_autonomous_promotion.py
+++ b/app/services/strategy_autonomous_promotion.py
@@ -1,0 +1,276 @@
+"""The policy approver — the second caller of the stage machine (#2843).
+
+The person-gate this replaces was never a check.  Measured before writing this:
+
+    grep -rn 'advance_strategy(' app/ scripts/ | grep -v 'def advance_strategy'
+      app/api/strategies.py:3542
+
+``advance_strategy`` assembles every piece of evidence itself -- the 24-combination
+hold-out matrix, the identity pins, the prospective assessment, the weakening check --
+and takes from its caller only ``(strategy_id, action, advanced_by, reason, as_of)``.
+Its one production caller is ``POST /strategies/{id}/advance``, behind
+``Depends(require_session)``, stamping ``advanced_by=session.username``.  **The
+person-gate was exactly that: the only path in is an authenticated HTTP request, and
+the username it stamps is the approval.**
+
+So the operator's flag (settled decision 2026-08-22, "Live-capital approval is a mandate
+FLAG, not a person-gate") does not need to touch a single gate.  It needs a second
+caller, and this is it.  Nothing here evaluates evidence; it decides only WHO is asking.
+
+⚠ This module cannot choose its own denominator, and that is structural rather than
+careful: ``advance_strategy`` accepts no ``to_stage``, no ``strategy_version`` and no
+``result_ids``.  Those are the three inputs #2770 deliberately removed from the caller's
+reach, and removing them is what makes a headless caller safe to add at all.
+
+⚠ What bounds forward observation is NOT here.  ``select_prospective_assessment``
+refuses ``prospective_assessment_predates_forward_observation``, so ``paper_enabled`` is
+unreachable until an assessment is computed after forward observation began.  No
+minimum stage-dwell constant is introduced here, deliberately: all six
+``RECENT_EVIDENCE_WINDOWS`` end at or before ``INTRADER_CAPTURE_DATE`` (2024-09-27), so
+the historical matrix is frozen and elapsed time cannot change it.  A dwell threshold
+would be an invented constant guarding a quantity that does not move.
+
+Spec: ``docs/proposals/ta/2026-08-22-autonomy-approval-mode.md``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Final
+
+import psycopg
+
+from app.services.strategy_control_plane import (
+    PaperPool,
+    Stage,
+    StrategyControlError,
+    current_stage,
+    load_paper_pool,
+    registered_strategy_purpose,
+)
+from app.services.strategy_operator_promotion import (
+    OperatorAction,
+    advance_strategy,
+    allowed_operator_action,
+)
+from app.services.strategy_result_identity import current_result_versions
+
+#: The policy that approves.  Bumped when the rule set below changes -- the population
+#: of promotions it has stamped is irrelevant, exactly as ``CORE_MANDATE_POLICY_VERSION``
+#: reasons about its own bump.
+AUTONOMY_POLICY_VERSION: Final = "autonomy-v1"
+
+#: Stamped into ``strategy_promotions.promoted_by`` in place of an operator username.
+#: This constant has a PERSISTER on this branch (``_advance_one`` below) -- a version
+#: stamp whose only occurrence is its own definition is decorative, per the
+#: prevention-log entry on declared-but-unwired symbols.
+AUTONOMOUS_APPROVER: Final = f"policy@{AUTONOMY_POLICY_VERSION}"
+
+#: The actions this approver may take.  ``register_research_candidate`` is absent on
+#: purpose: it carries no evidence, so a policy that acts on evidence has nothing to act
+#: on.  Registration stays an operator action.
+AUTONOMOUS_ACTIONS: Final[frozenset[OperatorAction]] = frozenset(
+    {"validate_historical", "start_forward_observation", "enable_paper"}
+)
+
+
+@dataclass(frozen=True)
+class AutonomousAdvance:
+    strategy_id: str
+    strategy_version: str
+    from_stage: Stage | None
+    stage: Stage
+    promotion_id: int
+    evidence_ref: str | None
+
+
+@dataclass(frozen=True)
+class AutonomousPromotionReport:
+    """What one cycle did, and why it did not do the rest.
+
+    ``skipped_reason`` is cycle-level: it is set exactly when the authority itself
+    refused, in which case no strategy was examined at all.
+    """
+
+    approval_mode: str
+    skipped_reason: str | None
+    advanced: tuple[AutonomousAdvance, ...]
+    refusals: tuple[tuple[str, str], ...]
+
+    @property
+    def refusal_codes(self) -> tuple[str, ...]:
+        """Distinct codes, sorted -- what a job note should carry.
+
+        A cycle that advanced nothing must say WHY rather than report a bare zero;
+        the per-strategy detail is in ``refusals`` and is not worth a table.
+        """
+        return tuple(sorted({code for _, code in self.refusals}))
+
+
+def cycle_precondition_refusal(pool: PaperPool) -> str | None:
+    """Why this authority may not approve anything, or ``None``.
+
+    Pure, so all three refusals are table-testable without a database.
+
+    ``paper_pool_disabled`` is a decision and not an oversight.  The flag is an
+    attribute of a capital authority; an operator who has disabled the pool has
+    withdrawn the authority the flag qualifies, and a policy approver advancing
+    strategies toward ``paper_enabled`` against a withdrawn authority is the wrong
+    direction to fail in.
+    """
+    if pool.approval_mode != "autonomous":
+        return "approval_mode_manual"
+    if not pool.mandate.configured:
+        # Unreachable through `configure_paper_pool`, which refuses the pair, and
+        # through sql/365's CHECK.  Kept because `PaperPool` is publicly constructible
+        # and this is the read side of a safety flag.
+        return "mandate_unconfigured"
+    if not pool.enabled:
+        return "paper_pool_disabled"
+    return None
+
+
+def planned_action(stage: Stage | None) -> tuple[OperatorAction | None, str | None]:
+    """``(action to take, skip code)`` for one strategy's current stage.
+
+    Pure.  Exactly one of the two is ``None``.  Advisory only -- ``advance_strategy``
+    re-reads the stage under its own lock and stays authoritative, so this never
+    duplicates a gate, only classifies a skip for the report.
+    """
+    action = allowed_operator_action(stage)
+    if action is None:
+        return None, "stage_terminal"
+    if action not in AUTONOMOUS_ACTIONS:
+        return None, "action_not_evidence_backed"
+    return action, None
+
+
+def _reason(pool: PaperPool) -> str:
+    """Deterministic and bounded.
+
+    ``strategy_promotions.reason`` is ``TEXT`` with only a ``<> ''`` CHECK
+    (``sql/281:37``), so there is no length cliff; the bound is for legibility.
+    """
+    return f"autonomous advance under approval_mode=autonomous (pool event {pool.event_id}, {AUTONOMY_POLICY_VERSION})"
+
+
+class _Refused(Exception):
+    """Carries one strategy's refusal out of its transaction block, rolling it back.
+
+    ``advance_strategy`` raises inside ``conn.transaction()``.  Catching it there and
+    returning would COMMIT the block; letting it escape as itself would be
+    indistinguishable from a fault.  A private exception rolls the one strategy back
+    and is caught by the cycle, which is the behaviour wanted in both halves.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+def _advance_one(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    pool: PaperPool,
+    as_of: datetime,
+) -> tuple[AutonomousAdvance | None, str | None]:
+    """One strategy, in its OWN transaction.
+
+    ⚠ Per-strategy and not per-cycle.  A cycle-wide transaction would let an
+    unrelated failure on the last strategy roll back every promotion before it, and
+    would make the iteration order decide who advances.  Committing per strategy is
+    also what makes the report describe what is durably true.
+    """
+    with conn.transaction():
+        action, skip = planned_action(current_stage(conn, strategy_id, strategy_version))
+        if action is None:
+            assert skip is not None
+            return None, skip
+        if registered_strategy_purpose(strategy_id) != "capital_candidate":
+            # Advisory duplicate of `advance_strategy`'s own check, kept only so the
+            # report distinguishes "not a capital candidate" from an evidence refusal.
+            return None, "strategy_not_capital_candidate"
+        try:
+            outcome = advance_strategy(
+                conn,
+                strategy_id=strategy_id,
+                action=action,
+                advanced_by=AUTONOMOUS_APPROVER,
+                reason=_reason(pool),
+                as_of=as_of,
+            )
+        except StrategyControlError as exc:
+            # A refusal is this job's NORMAL output, not a fault -- the same reading
+            # `strategy_signal_scan._commit_strategy` gives a per-strategy failure.
+            raise _Refused(str(exc)) from exc
+    return (
+        AutonomousAdvance(
+            strategy_id=outcome.strategy_id,
+            strategy_version=outcome.strategy_version,
+            from_stage=outcome.from_stage,
+            stage=outcome.stage,
+            promotion_id=outcome.promotion.promotion_id,
+            evidence_ref=outcome.evidence_ref,
+        ),
+        None,
+    )
+
+
+def run_autonomous_promotion_cycle(conn: psycopg.Connection[Any], *, as_of: datetime) -> AutonomousPromotionReport:
+    """Advance every eligible strategy by at most one step, on policy authority.
+
+    **At most one step per strategy per cycle** -- hygiene, not a safety invariant, and
+    worth being blunt about which.  It keeps one report line per strategy and stops a
+    tick acting on a stage it has just created.  It does NOT bound elapsed time: manual
+    dispatch, catch-up and a cadence change all defeat it.  The elapsed-time bound that
+    does hold is the prospective-assessment rule named in the module docstring.
+
+    Strategies are visited in sorted id order so the report is stable, not because the
+    order carries meaning -- each one commits independently.
+    """
+    pool = load_paper_pool(conn)
+    refusal = cycle_precondition_refusal(pool)
+    if refusal is not None:
+        return AutonomousPromotionReport(
+            approval_mode=pool.approval_mode, skipped_reason=refusal, advanced=(), refusals=()
+        )
+
+    advanced: list[AutonomousAdvance] = []
+    refusals: list[tuple[str, str]] = []
+    for strategy_id, strategy_version in sorted(current_result_versions().items()):
+        try:
+            outcome, skip = _advance_one(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                pool=pool,
+                as_of=as_of,
+            )
+        except _Refused as exc:
+            refusals.append((strategy_id, exc.detail))
+            continue
+        if outcome is not None:
+            advanced.append(outcome)
+        elif skip is not None:
+            refusals.append((strategy_id, skip))
+    return AutonomousPromotionReport(
+        approval_mode=pool.approval_mode,
+        skipped_reason=None,
+        advanced=tuple(advanced),
+        refusals=tuple(refusals),
+    )
+
+
+__all__ = [
+    "AUTONOMOUS_ACTIONS",
+    "AUTONOMOUS_APPROVER",
+    "AUTONOMY_POLICY_VERSION",
+    "AutonomousAdvance",
+    "AutonomousPromotionReport",
+    "cycle_precondition_refusal",
+    "planned_action",
+    "run_autonomous_promotion_cycle",
+]

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -44,6 +44,11 @@ Stage = Literal[
 Mode = Literal["paper", "live"]
 CapitalMode = Literal["fixed", "compound"]
 RiskProfile = Literal["unconfigured", "cautious", "balanced", "growth"]
+#: Who may approve a stage promotion under the current mandate (#2843).  ``manual``
+#: is an authenticated operator only; ``autonomous`` additionally admits the policy
+#: approver in ``app.services.strategy_autonomous_promotion``.  The evidence bars are
+#: identical under both -- the flag flips WHO approves, never WHAT qualifies.
+ApprovalMode = Literal["manual", "autonomous"]
 TicketSizingMode = Literal["percent", "fixed"]
 
 GOVERNANCE_GATE_VERSION = "strategy-governance-v2+edge-evidence"
@@ -197,6 +202,9 @@ class PaperPool:
     currency: str = "USD"
     capital_mode: CapitalMode = "fixed"
     mandate: PortfolioMandate = UNCONFIGURED_MANDATE
+    #: #2843.  Defaults to the safe value so a ``PaperPool`` constructed in a test or
+    #: an unconfigured install can never read as autonomous.
+    approval_mode: ApprovalMode = "manual"
 
 
 def load_paper_pool(conn: psycopg.Connection[Any]) -> PaperPool:
@@ -206,7 +214,7 @@ def load_paper_pool(conn: psycopg.Connection[Any]) -> PaperPool:
                mandate_policy_version,risk_profile,target_volatility_pct,
                max_portfolio_drawdown_pct,max_loss_per_position_pct,max_daily_loss_pct,
                active_risk_budget_pct,cash_reserve_pct,max_concurrent_positions,
-               shorts_allowed,leverage_allowed
+               shorts_allowed,leverage_allowed,approval_mode
         FROM strategy_paper_pool_events
         ORDER BY strategy_paper_pool_event_id DESC
         LIMIT 1
@@ -234,6 +242,7 @@ def load_paper_pool(conn: psycopg.Connection[Any]) -> PaperPool:
         str(row[3]),
         cast(CapitalMode, row[4]),
         mandate,
+        cast(ApprovalMode, row[16]),
     )
 
 
@@ -244,19 +253,35 @@ def configure_paper_pool(
     capital_limit: Decimal,
     capital_mode: CapitalMode = "fixed",
     risk_profile: RiskProfile,
+    approval_mode: ApprovalMode,
     changed_by: str,
     reason: str,
 ) -> PaperPool:
-    """Append one material shared paper-capital authority revision."""
+    """Append one material shared paper-capital authority revision.
+
+    ⚠⚠ ``approval_mode`` is REQUIRED and has no default, unlike ``capital_mode``
+    beside it.  A default would make every unrelated capital or risk edit silently
+    revoke autonomy -- a caller that simply does not mention the field would write
+    ``manual`` over an operator's ``autonomous`` and report success.  Requiring it
+    forces each caller to resolve the value, and the type checker finds every one.
+    The API's own resolution is "omitted means unchanged", not "omitted means
+    manual"; see ``update_strategy_paper_pool``.
+    """
     _require_text(changed_by, "changed_by")
     _require_text(reason, "reason")
     if not capital_limit.is_finite() or capital_limit < 0 or (enabled and capital_limit <= 0):
         raise StrategyControlError("enabled paper pool requires a positive finite USD capital limit")
     if capital_mode not in {"fixed", "compound"}:
         raise StrategyControlError("capital_mode must be fixed or compound")
+    if approval_mode not in {"manual", "autonomous"}:
+        raise StrategyControlError("approval_mode must be manual or autonomous")
     mandate = mandate_for_profile(risk_profile)
     if enabled and not mandate.configured:
         raise StrategyControlError("enabled paper pool requires a configured portfolio risk mandate")
+    if approval_mode == "autonomous" and not mandate.configured:
+        # sql/365's CHECK is the backstop, not the mechanism: `PaperPool` is
+        # publicly constructible and this function is reachable without the API.
+        raise StrategyControlError("autonomous approval requires a configured portfolio risk mandate")
     # Conflict with the executor's session lock so a pause/lower cannot race an
     # already-sized order between its authority read and demo broker submit.
     conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
@@ -266,9 +291,10 @@ def configure_paper_pool(
         and current.capital_limit == capital_limit
         and current.capital_mode == capital_mode
         and current.mandate == mandate
+        and current.approval_mode == approval_mode
     ):
         raise StrategyControlError(
-            "paper pool change must alter enabled state, capital limit, capital mode, or mandate"
+            "paper pool change must alter enabled state, capital limit, capital mode, mandate, or approval mode"
         )
     if current.event_id is not None and capital_limit < current.capital_limit:
         # A lower principal is an external withdrawal from the virtual sleeve,
@@ -326,11 +352,15 @@ def configure_paper_pool(
             mandate_policy_version,risk_profile,target_volatility_pct,
             max_portfolio_drawdown_pct,max_loss_per_position_pct,max_daily_loss_pct,
             active_risk_budget_pct,cash_reserve_pct,max_concurrent_positions,
-            shorts_allowed,leverage_allowed
+            shorts_allowed,leverage_allowed,approval_mode
         )
-        VALUES (%s,%s,'USD',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        VALUES (%s,%s,'USD',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         RETURNING strategy_paper_pool_event_id
         """,
+        # ⚠ THREE positional lists that must stay aligned: the column list above,
+        # the placeholder count, and this tuple.  #2623 shipped a value into the
+        # wrong column by appending at a different ordinal in one of them.
+        # `approval_mode` is appended LAST in all three.
         (
             enabled,
             capital_limit,
@@ -348,10 +378,11 @@ def configure_paper_pool(
             mandate.max_concurrent_positions,
             mandate.shorts_allowed,
             mandate.leverage_allowed,
+            approval_mode,
         ),
     ).fetchone()
     assert row is not None
-    return PaperPool(int(row[0]), enabled, capital_limit, "USD", capital_mode, mandate)
+    return PaperPool(int(row[0]), enabled, capital_limit, "USD", capital_mode, mandate, approval_mode)
 
 
 @dataclass(frozen=True)
@@ -1190,6 +1221,7 @@ def release_exact_position(
 
 
 __all__ = [
+    "ApprovalMode",
     "Deployment",
     "ExecutionPolicy",
     "GOVERNANCE_GATE_VERSION",

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -181,6 +181,20 @@ _MANDATE_PROFILES: dict[RiskProfile, PortfolioMandate] = {
 }
 
 
+def resolve_approval_mode(requested: ApprovalMode | None, current: ApprovalMode) -> ApprovalMode:
+    """What an update should WRITE, given what it asked for and what is stored (#2843).
+
+    ⚠⚠ ``None`` means UNCHANGED, never ``"manual"``, and the distinction is the whole
+    reason this is a named function rather than an inline ternary.  Omitting the field
+    is the common case for every existing client and for every edit that is not about
+    approval; reading omission as a reset would let an unrelated capital-limit change
+    silently revoke autonomy and report success.  A ternary spelled the other way is a
+    one-character difference with no test surface, so the rule gets a name, a docstring
+    and a table test.
+    """
+    return current if requested is None else requested
+
+
 def mandate_for_profile(risk_profile: RiskProfile) -> PortfolioMandate:
     """Resolve a presentation label to the exact immutable v1 limits.
 
@@ -1244,6 +1258,7 @@ __all__ = [
     "lock_strategy_control",
     "promote_strategy",
     "registered_strategy_purpose",
+    "resolve_approval_mode",
     "record_order_position_execution",
     "release_exact_position",
 ]

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5568,10 +5568,12 @@ def strategy_autonomous_promotion() -> None:
     stage promotion, not whether anything trades.  The evidence bars all live inside
     ``advance_strategy`` and this job relaxes none of them.
 
-    ⚠ ``run_autonomous_promotion_cycle`` opens ONE TRANSACTION PER STRATEGY, so
-    ``connect_job()`` is passed a connection it commits repeatedly rather than one
-    transaction wrapping the cycle.  That is the point: an unexpected failure on the
-    last strategy must not roll back the promotions before it.
+    ⚠⚠ ``autocommit=True`` IS LOAD-BEARING, not a default copied from a neighbour.
+    ``run_autonomous_promotion_cycle`` opens one transaction per strategy, and on a
+    transactional connection psycopg would make each of those a SAVEPOINT inside one
+    outer transaction instead -- promotions would stop committing independently and
+    the per-strategy allocator lock would be held for the whole cycle.  The service
+    refuses a non-autocommit connection rather than trusting this call site.
 
     Failures other than a per-strategy ``StrategyControlError`` PROPAGATE.  The
     decision is the whole of the work here, so swallowing an error would make a
@@ -5580,7 +5582,7 @@ def strategy_autonomous_promotion() -> None:
     from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
 
     with _tracked_job(JOB_STRATEGY_AUTONOMOUS_PROMOTION) as tracker:
-        with connect_job() as conn:
+        with connect_job(autocommit=True) as conn:
             report = run_autonomous_promotion_cycle(conn, as_of=datetime.now(UTC))
         tracker.row_count = len(report.advanced)
         if report.skipped_reason is not None:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -399,6 +399,10 @@ JOB_STRATEGY_PAPER_CYCLE = "strategy_paper_cycle"
 # verdict. Produces submission-gate INPUT, never authority: nothing invokes
 # the gate, and the only provider call is informational.
 JOB_CORE_REBALANCE_OBSERVATION = "core_rebalance_observation"
+# #2843 — the policy approver. Advances each eligible strategy by at most one
+# stage when the mandate carries approval_mode='autonomous'. Reads a flag and
+# calls the existing evidence-bound path; evaluates no evidence of its own.
+JOB_STRATEGY_AUTONOMOUS_PROMOTION = "strategy_autonomous_promotion"
 # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY, and NOT because it is
 # expensive: half an hour is a scheduled job's workload. The reasons are
 # governance — criterion 5 requires a hold-out purpose a cron fire cannot
@@ -2130,6 +2134,27 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "daily counts are durable; quote outcomes retain their compact cost attribution."
         ),
         cadence=Cadence.daily(hour=7, minute=5),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_STRATEGY_AUTONOMOUS_PROMOTION,
+        display_name="Autonomous stage promotion (#2843)",
+        # Lane `strategy_scan` and not `strategy_execution`: this is DB-only
+        # governance work with no broker call, and `strategy_execution` is held by
+        # strategy_paper_cycle every five minutes, so a daily job landing there is a
+        # daily job that skips. 07:20 puts it behind the 06:45 scan / 06:55 outcome /
+        # 07:05 retention passes rather than racing them.
+        source="strategy_scan",
+        description=(
+            "Daily 07:20 UTC — when the mandate carries approval_mode='autonomous', "
+            "advance each eligible strategy by at most one declared stage on the "
+            "evidence advance_strategy assembles, stamping promoted_by="
+            "policy@<autonomy version> instead of an operator username. Skips the "
+            "whole cycle under manual approval, an unconfigured mandate or a "
+            "disabled pool. Relaxes no evidence bar and never reaches live_enabled."
+        ),
+        cadence=Cadence.daily(hour=7, minute=20),
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
     ),
@@ -5533,6 +5558,38 @@ def core_rebalance_observation() -> None:
             f"intent_id={intent.core_rebalance_intent_id} action={intent.decision.action} "
             f"reason={intent.decision.reason_code or '-'} instrument={core_instrument_id} "
             f"mandate_event={intent.core_mandate_event_id}"
+        )
+
+
+def strategy_autonomous_promotion() -> None:
+    """Advance eligible strategies on policy authority (#2843).
+
+    DB only.  No broker call and no external lane -- this decides WHO approved a
+    stage promotion, not whether anything trades.  The evidence bars all live inside
+    ``advance_strategy`` and this job relaxes none of them.
+
+    ⚠ ``run_autonomous_promotion_cycle`` opens ONE TRANSACTION PER STRATEGY, so
+    ``connect_job()`` is passed a connection it commits repeatedly rather than one
+    transaction wrapping the cycle.  That is the point: an unexpected failure on the
+    last strategy must not roll back the promotions before it.
+
+    Failures other than a per-strategy ``StrategyControlError`` PROPAGATE.  The
+    decision is the whole of the work here, so swallowing an error would make a
+    no-op indistinguishable from success.
+    """
+    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
+
+    with _tracked_job(JOB_STRATEGY_AUTONOMOUS_PROMOTION) as tracker:
+        with connect_job() as conn:
+            report = run_autonomous_promotion_cycle(conn, as_of=datetime.now(UTC))
+        tracker.row_count = len(report.advanced)
+        if report.skipped_reason is not None:
+            tracker.note = f"skipped={report.skipped_reason} approval_mode={report.approval_mode}"
+            return
+        # A cycle that advanced nothing must say WHY rather than report a bare zero.
+        tracker.note = (
+            f"advanced={len(report.advanced)} refused={len(report.refusals)} "
+            f"codes={','.join(report.refusal_codes) or '-'}"
         )
 
 

--- a/docs/proposals/ta/2026-08-22-autonomy-approval-mode.md
+++ b/docs/proposals/ta/2026-08-22-autonomy-approval-mode.md
@@ -1,0 +1,253 @@
+# `approval_mode` — the autonomy flag and its first headless approver (#2843)
+
+Status: proposed, 2026-08-22. Prerequisites #2844 (`a23c9628`) and #2829 (`103675ac`) are merged.
+
+## What the person-gate actually is
+
+Measured, not recalled:
+
+```
+grep -rn 'advance_strategy(' app/ scripts/ | grep -v 'def advance_strategy'
+  app/api/strategies.py:3542
+```
+
+`advance_strategy` (`app/services/strategy_operator_promotion.py:538`) assembles every
+piece of evidence itself — the 24-combination hold-out matrix, the identity pins, the
+prospective assessment, the weakening check — and takes from its caller only
+`(strategy_id, action, advanced_by, reason, as_of)`. Its one production caller is
+`POST /strategies/{id}/advance`, which stamps `advanced_by=session.username` behind
+`Depends(require_session)`.
+
+**So the person-gate is: the only path into the stage machine is an authenticated HTTP
+request, and the username it stamps is the approval.** Nothing else. `decide_funding`
+is already headless; `record_live_promotion_attempt` is separately blocked on the broker
+contract (`strategy_live_gate.py:782`) and is out of scope here.
+
+That is what makes this slice small: the flag touches **no gate**. It supplies a
+**second caller**.
+
+## Source rule
+
+Not an SEC/market-data decision — no external formulation governs it. The governing rule
+is the operator's own settled decision (`docs/settled-decisions.md`, 2026-08-22,
+"Live-capital approval is a mandate FLAG, not a person-gate"): *the flag flips WHO
+approves, never WHAT qualifies.* Every constant below is fixed by construction and
+frozen in `AUTONOMY_POLICY_VERSION`.
+
+## Full-population state (dev, 2026-08-22)
+
+```sql
+select count(*) from strategy_paper_pool_events;   -- 0
+select count(*) from strategy_promotions;          -- 0
+```
+
+Zero rows in both. There are no legacy events to accommodate, no `promoted_by` values to
+reconcile, and no promotion this change can retroactively reclassify. The migration can
+therefore be strict rather than legacy-tolerant.
+
+## Schema — `sql/365`
+
+`approval_mode` goes on `strategy_paper_pool_events`, beside `capital_mode`,
+`capital_limit` and the `risk_profile` mandate columns added by `sql/311`. It is not a
+new table and not a new capital surface: #2844's lesson was that minting a parallel
+vocabulary for something already stored is the defect, and the mandate is already stored
+here.
+
+```sql
+ALTER TABLE strategy_paper_pool_events
+    ADD COLUMN IF NOT EXISTS approval_mode TEXT NOT NULL DEFAULT 'manual';
+
+-- DROP-then-ADD, matching sql/311's own pattern: a bare ADD CONSTRAINT is not
+-- rerunnable and a replayed migration would fail on the existing name.
+ALTER TABLE strategy_paper_pool_events
+    DROP CONSTRAINT IF EXISTS strategy_paper_pool_approval_mode;
+ALTER TABLE strategy_paper_pool_events
+    ADD CONSTRAINT strategy_paper_pool_approval_mode CHECK (
+        approval_mode IN ('manual', 'autonomous')
+        -- An unconfigured mandate authorises nothing, so it cannot authorise a
+        -- policy approver either.  `risk_profile <> 'unconfigured'` is the exact
+        -- definition of `PortfolioMandate.configured`, and it is only as strong
+        -- as sql/311's `strategy_paper_pool_mandate_shape`, which is what forces
+        -- a non-`unconfigured` profile to carry complete v1 limits.  Declared
+        -- dependency: this constraint is meaningful only while that one stands.
+        AND (approval_mode = 'manual' OR risk_profile <> 'unconfigured')
+    );
+```
+
+Default `manual`, per the ticket ("likely for people testing it first"). Append-only, so
+the flag is versioned by the table's own shape — the authority in force at any promotion
+is the latest event at or before it.
+
+⚠ The default is what makes this safe on a populated database, and the dev row count is
+not the argument. sql/311 deliberately preserves legacy `enabled` + `unconfigured` rows;
+every one of them takes `approval_mode = 'manual'` and satisfies the new CHECK unchanged.
+Only a NEW row can be `autonomous`, and a new row goes through `configure_paper_pool`.
+
+⚠ "Latest by event id" is the authority, and that is safe here rather than by assumption:
+`configure_paper_pool` takes `PAPER_ALLOCATOR_ADVISORY_LOCK` for the whole transaction, so
+two revisions cannot commit out of id order.
+
+## Service
+
+### 1. The flag — `strategy_control_plane.py`
+
+- `ApprovalMode = Literal["manual", "autonomous"]`, beside `CapitalMode`.
+- `PaperPool.approval_mode: ApprovalMode = "manual"`; read in `load_paper_pool`.
+- `configure_paper_pool(..., approval_mode: ApprovalMode)` — **required keyword, no
+  default.** ⚠⚠ A default would make every unrelated capital or risk edit silently
+  revoke autonomy: the existing `PUT /strategies/paper-pool` does not pass the field, so
+  the next capital-limit change would write `manual` over an operator's `autonomous`
+  without saying so. Requiring it forces each caller to decide, and the type checker
+  finds every one.
+- Validated, included in the material-change comparison (otherwise flipping only the flag
+  raises "must alter …"), and written in the INSERT. ⚠ Three positional lists to keep
+  aligned (column list, placeholders, tuple) per the #2623 prevention entry.
+- Refused in the service, not only by the CHECK: `autonomous` with an unconfigured
+  mandate raises `StrategyControlError`. `PaperPool` is publicly constructible, so the
+  DB constraint is the backstop and not the mechanism.
+
+### 1b. The API — `PUT /strategies/paper-pool`
+
+`StrategyPaperPoolUpdateRequest.approval_mode: ApprovalMode | None = None`, where
+**`None` means "carry the current value forward"**, resolved from `load_paper_pool`
+inside the same locked transaction. Omission is the common case for every existing
+client and for every edit that is not about approval; it must mean *unchanged*, never
+*reset to manual*. The resolved value — not the request field — is what the
+material-change comparison and the INSERT see.
+
+⚠ `require_session` stays. Flipping the flag to `autonomous` is itself an operator
+authorisation and is the last one the operator makes; a service token has no identity to
+attribute it to.
+
+### 2. The reader — `app/services/strategy_autonomous_promotion.py` (new)
+
+Shipped in the same change, per the prevention entry on declared-but-unwired symbols
+(log §"A declared-but-unwired symbol is a claim with no subject"). A flag with no reader
+is the defect this repo keeps shipping.
+
+- `AUTONOMY_POLICY_VERSION = "autonomy-v1"`.
+- `AUTONOMOUS_APPROVER = f"policy@{AUTONOMY_POLICY_VERSION}"` — persisted as
+  `strategy_promotions.promoted_by`, which is the audit the ticket asks for
+  (`approved_by: policy@<flag-version>`). The constant has a persister on this branch;
+  `grep -rn AUTONOMOUS_APPROVER app tests` returns the writer, not only the definition.
+- `run_autonomous_promotion_cycle(conn, *, as_of) -> AutonomousPromotionReport`.
+
+Preconditions, read once per cycle from one `load_paper_pool`:
+
+| condition | outcome |
+| --- | --- |
+| `approval_mode != 'autonomous'` | whole cycle skips, code `approval_mode_manual` |
+| mandate unconfigured | whole cycle skips, code `mandate_unconfigured` |
+| `not pool.enabled` | whole cycle skips, code `paper_pool_disabled` |
+
+The third is a decision, not an oversight. The flag is an attribute of a capital
+authority; an operator who has disabled the pool has withdrawn the authority the flag
+qualifies, and a policy approver advancing strategies toward `paper_enabled` against a
+withdrawn authority is the wrong direction to fail in.
+
+Then, per manifest strategy with a current result version, **each in its own
+transaction**:
+
+1. `allowed_operator_action(current_stage(...))`. `None` (terminal) → skip.
+2. **Only `_EVIDENCE_ACTIONS`.** `register_research_candidate` carries no evidence, so a
+   policy that acts on evidence has nothing to act on; registration stays manual. Skip
+   code `action_not_evidence_backed`.
+3. `advance_strategy(..., advanced_by=AUTONOMOUS_APPROVER, reason=<generated>)`.
+   `StrategyControlError` is **recorded, not raised** — a refusal is this job's normal
+   output, exactly as `strategy_signal_scan._commit_strategy` treats a per-strategy
+   failure.
+
+⚠ **One transaction per strategy, not one per cycle.** A cycle-wide transaction makes an
+unrelated failure on the last strategy roll back every promotion before it, and makes the
+manifest iteration order decide who advances. Per-strategy commits also mean the report
+describes what is durably true.
+
+**At most one step per strategy per cycle** — hygiene, not a safety invariant, and it is
+worth being blunt about which. It keeps one report line per strategy and stops a tick
+acting on a stage it just created. It does **not** bound elapsed time: manual dispatch,
+catch-up and a cadence change all defeat it.
+
+What actually bounds forward observation is already in the code and is not this
+caller's to add: `select_prospective_assessment` refuses
+`prospective_assessment_predates_forward_observation`, so `paper_enabled` is unreachable
+until an assessment is computed *after* forward observation began.
+
+⚠ **No minimum stage-dwell constant is introduced, deliberately.** The first draft of
+this spec proposed one. It has no construction: all six `RECENT_EVIDENCE_WINDOWS` end at
+or before `INTRADER_CAPTURE_DATE` (2024-09-27), so the historical matrix is frozen and
+elapsed time cannot change it. A dwell threshold would have been an invented constant
+guarding a quantity that does not move — the exact failure "source-rule before design"
+exists to catch.
+
+The cycle drives at most as far as `paper_enabled`. `live_enabled` is refused outright by
+`promote_strategy` and belongs to the measured live gate; this change does not touch it.
+
+The generated `reason` is deterministic and bounded:
+`f"autonomous advance under approval_mode=autonomous (pool event {event_id}, {AUTONOMY_POLICY_VERSION})"`.
+`strategy_promotions.reason` is `TEXT` with only a `<> ''` CHECK (`sql/281:37`), so there
+is no length cliff; the bound is for legibility.
+
+### 3. The glue — `strategy_autonomous_promotion` job
+
+`app/workers/scheduler.py`, daily. No broker call and no external lane — DB only, so it
+does not go in `strategy_execution`, which `strategy_paper_cycle` holds every five
+minutes (a daily job landing in a busy lane is a daily job that skips; the #2603 job
+records the same reasoning).
+
+`tracker.note` carries `advanced=<n> skipped=<n>` plus the **distinct refusal codes**, so
+a cycle that advanced nothing says *why* rather than reporting a bare zero. A per-strategy
+refusal table is deliberately not minted: a refusal is the steady state here, so that
+table would be a heartbeat log, and `strategy_promotions` already records every advance
+that happened.
+
+An unexpected error (not a `StrategyControlError`) propagates. A job that no-ops and
+reports success is invisible to every automated check this repo has.
+
+## What does NOT change
+
+- The execution guard, kill switch, `EXIT` never blocked, `sandbox_exceeded` (#2844).
+  None of them is reachable from this diff.
+- Every evidence bar inside `advance_strategy` / `promote_strategy`. This change adds a
+  caller and reads a flag; it removes no check and relaxes no threshold. The autonomous
+  caller supplies no `to_stage`, no `strategy_version` and no `result_ids` — the three
+  inputs #2770 removed from the caller's reach — so there is no parameter through which a
+  policy could choose its own denominator.
+- `POST /strategies/{id}/advance` keeps `require_session`. Manual approval remains
+  available under either flag value.
+
+## Tests
+
+Pure-logic first, per the repo's lean-test rule:
+
+- `approval_mode` validation table (`manual`/`autonomous` × configured/unconfigured
+  mandate × enabled/disabled).
+- The cycle-precondition function as a pure mapping from a `PaperPool` to `None` or a skip
+  code, so all three refusals are table-tested without a DB.
+- The per-strategy step planner as a pure function over `(stage, purpose)` → action or
+  skip code, so the evidence-actions-only rule is table-tested without a DB.
+- One DB test: a strategy at `historical_validated` with a complete matrix advances
+  exactly one stage under `autonomous` and zero under `manual`, and the real
+  `strategy_promotions` row carries `promoted_by = 'policy@autonomy-v1'`. ⚠ Asserted
+  against the stored row, not against arguments passed to a mock — an argument-equality
+  test proves the call shape and nothing about the evidence actually assembled.
+- One DB test that the cycle records a refusal rather than raising when the matrix is
+  incomplete, and that no promotion row is written.
+- One DB test that omitting `approval_mode` on `PUT /strategies/paper-pool` carries an
+  existing `autonomous` forward instead of resetting it.
+
+## Out of scope (named, not forgotten)
+
+- **The alert-validity contract** (§ on #2843) is independently buildable. Splitting it
+  keeps this diff to flag + approver, which is the pairing the prevention entry requires
+  be shipped together.
+- **Per-strategy / per-version autonomy scope.** There is one pool and one mandate, so
+  authority is account-wide by construction; a per-strategy allowlist would be a second
+  authority surface, which is the #2844 defect. Raised by Codex ckpt-1 and rejected on
+  that ground, not overlooked.
+- **How long forward observation must last.** `checked_at >= forward_started_at` permits
+  an assessment computed one second after the promotion, so the effective floor is one
+  assessment-job cadence. Pre-existing, identical on the manual path, and widening this
+  ticket to fix it would turn a flag into a governance redesign. Noted on #2843.
+- **`current_result_versions()` is code-derived**, so a deploy can change which version
+  the cycle has authority over without a mandate revision. Also pre-existing and
+  identical on the manual path.

--- a/docs/proposals/ta/2026-08-22-autonomy-approval-mode.md
+++ b/docs/proposals/ta/2026-08-22-autonomy-approval-mode.md
@@ -115,6 +115,12 @@ client and for every edit that is not about approval; it must mean *unchanged*, 
 *reset to manual*. The resolved value — not the request field — is what the
 material-change comparison and the INSERT see.
 
+The rule is `strategy_control_plane.resolve_approval_mode(requested, current)`, a named
+pure function rather than an inline ternary, because the wrong spelling is a
+one-character difference with no test surface. Table-tested; revert-probed by inverting
+it to `"manual" if requested is None`, which fails
+`test_resolve_approval_mode[None-autonomous-autonomous]`.
+
 ⚠ `require_session` stays. Flipping the flag to `autonomous` is itself an operator
 authorisation and is the last one the operator makes; a service token has no identity to
 attribute it to.

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -1169,6 +1169,39 @@ agent; operator reaffirmed. The reversal is theirs to make and is made.
 - Operator alerts become refusal-surfaces with a validity contract (one-sentence
   decision + complete evidence + recommendation + safe default). No routine check-ins.
 
+⚠ **Where the flag actually landed, and what the person-gate actually was** (#2843,
+implemented 2026-08-22). `approval_mode` is a column on `strategy_paper_pool_events`,
+beside `capital_mode` and the `sql/311` mandate columns — the same table #2844 declined
+to duplicate. Append-only, so the authority in force at any promotion is the latest
+event at or before it.
+
+The gate it replaces was **one place**: `advance_strategy` assembles all of its own
+evidence and its only production caller was `POST /strategies/{id}/advance`, behind
+`require_session`, stamping `advanced_by=session.username`. So the flag touches no gate.
+It supplies a second caller — `app/services/strategy_autonomous_promotion.py`, run daily
+by the `strategy_autonomous_promotion` job — which stamps
+`promoted_by = policy@autonomy-v1` instead of a username.
+
+| what | value |
+| --- | --- |
+| approver stamp | `AUTONOMOUS_APPROVER` = `policy@autonomy-v1` |
+| actions the policy may take | exactly `_EVIDENCE_ACTIONS`, asserted by equality so the two cannot drift. `register_research_candidate` carries no evidence and stays manual |
+| cycle-level refusals | `approval_mode_manual`, `mandate_unconfigured`, `paper_pool_disabled` |
+| furthest stage reachable | `paper_enabled`. `live_enabled` is refused by `promote_strategy` itself |
+
+⚠ **`approval_mode` omitted on `PUT /strategies/paper-pool` means UNCHANGED, not
+`manual`** (`resolve_approval_mode`). Reading omission as a reset would let an unrelated
+capital-limit edit silently revoke autonomy and return 200.
+
+⚠ **No minimum stage-dwell constant was introduced, deliberately.** A draft proposed
+one; it has no construction, because all six `RECENT_EVIDENCE_WINDOWS` end at or before
+`INTRADER_CAPTURE_DATE` (2024-09-27) and the historical matrix therefore cannot change
+with elapsed time. What bounds forward observation is
+`prospective_assessment_predates_forward_observation`, which already existed. ⚠ That
+rule permits an assessment computed one second after the promotion, so the effective
+floor is one assessment-job cadence — pre-existing, identical on the manual path, and
+noted on #2843 rather than fixed there.
+
 ## 2026-08-22 — The allocation boundary is the ONLY safety net (operator)
 
 *"This won't be on the total pot … either an expanding pot or always limited to the

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -54,6 +54,9 @@ export function updateStrategyPaperPool(body: {
   capital_limit: string;
   capital_mode: "fixed" | "compound";
   risk_profile: "unconfigured" | "cautious" | "balanced" | "growth";
+  /** #2843. OMITTED MEANS UNCHANGED, not `"manual"` — the server carries the
+   * current value forward. Never send `"manual"` to mean "I have no opinion". */
+  approval_mode?: "manual" | "autonomous";
   reason: string;
 }): Promise<StrategyPaperPool> {
   return apiFetch("/strategies/paper-pool", {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2857,6 +2857,8 @@ export interface StrategyPaperPool {
   enabled: boolean;
   capital_limit: string;
   capital_mode: "fixed" | "compound";
+  /** #2843. Who may approve a stage promotion under this authority. */
+  approval_mode: "manual" | "autonomous";
   effective_capital: string | null;
   currency: "USD";
   reserved_capital: string;

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -879,6 +879,30 @@ describe("StrategiesPage", () => {
     await waitFor(() => expect(update).toHaveBeenCalledWith({ enabled: false, capital_limit: "1500.000000", capital_mode: "fixed", approval_mode: "manual", risk_profile: "balanced", reason: "Automated strategy workspace update" }));
   });
 
+  it("cannot submit autonomous approval against an unconfigured mandate", async () => {
+    // #2843, review NITPICK on PR #2856. The `autonomous` option is disabled while the
+    // profile is unconfigured, but that only guards the CHOICE — switching the profile
+    // afterwards left an already-chosen `autonomous` submittable, and the operator saw
+    // a raw 409 from the server rather than a form that would not offer the pair.
+    const update = vi.spyOn(strategiesApi, "updateStrategyPaperPool").mockResolvedValue({
+      ...OVERVIEW.paper_pool,
+      approval_mode: "autonomous",
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const approval = await screen.findByLabelText("Promotion approval");
+    fireEvent.change(approval, { target: { value: "autonomous" } });
+    expect(approval).toHaveValue("autonomous");
+
+    fireEvent.change(screen.getByLabelText("Risk profile"), { target: { value: "unconfigured" } });
+
+    // The select itself follows the derived value, so the invalid pair is never shown.
+    expect(approval).toHaveValue("manual");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ approval_mode: "manual", risk_profile: "unconfigured" }),
+    ));
+  });
+
   it("shows exact mandate limits and submits a changed risk profile", async () => {
     const update = vi.spyOn(strategiesApi, "updateStrategyPaperPool").mockResolvedValue({
       ...OVERVIEW.paper_pool,

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -149,6 +149,7 @@ const OVERVIEW: StrategyOverviewResponse = {
     enabled: false,
     capital_limit: "1000.000000",
     capital_mode: "fixed",
+    approval_mode: "manual",
     effective_capital: "1000.000000",
     currency: "USD",
     reserved_capital: "0.000000",
@@ -875,7 +876,7 @@ describe("StrategiesPage", () => {
     expect(input.parentElement).toHaveClass("w-48");
     fireEvent.change(input, { target: { value: "1500" } });
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(update).toHaveBeenCalledWith({ enabled: false, capital_limit: "1500.000000", capital_mode: "fixed", risk_profile: "balanced", reason: "Automated strategy workspace update" }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith({ enabled: false, capital_limit: "1500.000000", capital_mode: "fixed", approval_mode: "manual", risk_profile: "balanced", reason: "Automated strategy workspace update" }));
   });
 
   it("shows exact mandate limits and submits a changed risk profile", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1314,6 +1314,7 @@ function AutomationControl({
   const [enabled, setEnabled] = useState(pool.enabled && overview.execution_enabled);
   const [limit, setLimit] = useState(pool.capital_limit);
   const [capitalMode, setCapitalMode] = useState(pool.capital_mode);
+  const [approvalMode, setApprovalMode] = useState(pool.approval_mode);
   const [riskProfile, setRiskProfile] = useState(pool.mandate.risk_profile);
   const [saving, setSaving] = useState(false);
   const [failed, setFailed] = useState(false);
@@ -1321,14 +1322,23 @@ function AutomationControl({
     setEnabled(pool.enabled && overview.execution_enabled);
     setLimit(pool.capital_limit);
     setCapitalMode(pool.capital_mode);
+    setApprovalMode(pool.approval_mode);
     setRiskProfile(pool.mandate.risk_profile);
-  }, [pool.enabled, pool.capital_limit, pool.capital_mode, pool.mandate.risk_profile, overview.execution_enabled]);
+  }, [
+    pool.enabled,
+    pool.capital_limit,
+    pool.capital_mode,
+    pool.approval_mode,
+    pool.mandate.risk_profile,
+    overview.execution_enabled,
+  ]);
   const parsed = Number(limit);
   const valid = Number.isFinite(parsed) && parsed >= 0 && (!enabled || parsed > 0);
   const effectiveEnabled = pool.enabled && overview.execution_enabled;
   const dirty = enabled !== effectiveEnabled
     || parsed !== Number(pool.capital_limit)
     || capitalMode !== pool.capital_mode
+    || approvalMode !== pool.approval_mode
     || riskProfile !== pool.mandate.risk_profile;
   // ⚠ `overview.execution_enabled` is this form's OUTPUT, never its input
   // (#2766). `PUT /strategies/paper-pool` writes `runtime_config
@@ -1355,6 +1365,7 @@ function AutomationControl({
         enabled,
         capital_limit: parsed.toFixed(6),
         capital_mode: capitalMode,
+        approval_mode: approvalMode,
         risk_profile: riskProfile,
         reason: "Automated strategy workspace update",
       });
@@ -1408,6 +1419,23 @@ function AutomationControl({
             >
               <option value="fixed">Keep principal limit fixed</option>
               <option value="compound">Reinvest realised P&amp;L</option>
+            </select>
+          </label>
+          {/* #2843. This selects WHO may approve a stage promotion, never WHAT
+              qualifies — every evidence bar is identical under both values.
+              `autonomous` needs a configured risk profile, mirroring the
+              server's own refusal rather than restating its reasoning. */}
+          <label className="w-56 text-xs font-medium text-slate-600 dark:text-slate-300">
+            Promotion approval
+            <select
+              value={approvalMode}
+              onChange={(event) => setApprovalMode(event.target.value as "manual" | "autonomous")}
+              className="mt-1 min-h-11 w-full border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+            >
+              <option value="manual">Operator approves each stage</option>
+              <option value="autonomous" disabled={riskProfile === "unconfigured"}>
+                Approve on evidence, hands off
+              </option>
             </select>
           </label>
           <label className="w-48 text-xs font-medium text-slate-600 dark:text-slate-300">

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1335,10 +1335,18 @@ function AutomationControl({
   const parsed = Number(limit);
   const valid = Number.isFinite(parsed) && parsed >= 0 && (!enabled || parsed > 0);
   const effectiveEnabled = pool.enabled && overview.execution_enabled;
+  // #2843. An unconfigured mandate cannot carry a policy approver, so an
+  // `unconfigured` selection means `manual` whatever the approval select last held.
+  // DERIVED, not reset in an effect: an effect rewriting `approvalMode` would
+  // clobber the operator's own selection the moment they picked a profile again,
+  // and it would need the previous value to undo itself. The server owns the rule
+  // (`configure_paper_pool`, mapped to a 409) — this only stops the form OFFERING
+  // an invalid pair and then surfacing a raw 409 for it.
+  const effectiveApprovalMode = riskProfile === "unconfigured" ? "manual" : approvalMode;
   const dirty = enabled !== effectiveEnabled
     || parsed !== Number(pool.capital_limit)
     || capitalMode !== pool.capital_mode
-    || approvalMode !== pool.approval_mode
+    || effectiveApprovalMode !== pool.approval_mode
     || riskProfile !== pool.mandate.risk_profile;
   // ⚠ `overview.execution_enabled` is this form's OUTPUT, never its input
   // (#2766). `PUT /strategies/paper-pool` writes `runtime_config
@@ -1365,7 +1373,7 @@ function AutomationControl({
         enabled,
         capital_limit: parsed.toFixed(6),
         capital_mode: capitalMode,
-        approval_mode: approvalMode,
+        approval_mode: effectiveApprovalMode,
         risk_profile: riskProfile,
         reason: "Automated strategy workspace update",
       });
@@ -1428,7 +1436,7 @@ function AutomationControl({
           <label className="w-56 text-xs font-medium text-slate-600 dark:text-slate-300">
             Promotion approval
             <select
-              value={approvalMode}
+              value={effectiveApprovalMode}
               onChange={(event) => setApprovalMode(event.target.value as "manual" | "autonomous")}
               className="mt-1 min-h-11 w-full border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
             >

--- a/sql/365_strategy_paper_pool_approval_mode.sql
+++ b/sql/365_strategy_paper_pool_approval_mode.sql
@@ -1,0 +1,60 @@
+-- 365_strategy_paper_pool_approval_mode.sql
+--
+-- #2843.  The autonomy flag: `approval_mode` on the mandate.
+--
+-- Operator decision 2026-08-22 (docs/settled-decisions.md, "Live-capital
+-- approval is a mandate FLAG, not a person-gate"), reversing the prior
+-- person-gate.  Under `autonomous` the engine approves promotions on evidence
+-- alone.  The flag flips WHO approves; it flips nothing about WHAT qualifies.
+--
+-- ⚠ WHY THIS TABLE AND NOT A NEW ONE.  The mandate is already stored here:
+-- sql/311 hung the whole portfolio-risk mandate off `strategy_paper_pool_events`
+-- as columns, and #2844 established that minting a parallel surface for
+-- something already stored is the defect (it added no column at all, because
+-- `capital_limit`/`capital_mode` already were the operator's "assigned capital,
+-- capped or expanding").  This is an append-only operator-change table, so the
+-- flag inherits its versioning and its audit trail from the table's own shape:
+-- the authority in force at any promotion is the latest event at or before it.
+--
+-- ⚠ "Latest by event id" is safe rather than assumed: `configure_paper_pool`
+-- holds `PAPER_ALLOCATOR_ADVISORY_LOCK` for its whole transaction, so two
+-- revisions cannot commit out of id order.
+--
+-- Measured on dev, the only database:
+--   select count(*) from strategy_paper_pool_events;  -> 0
+--   select count(*) from strategy_promotions;         -> 0
+-- Nothing to backfill and no promotion this can retroactively reclassify.
+--
+-- ⚠ The dev row count is NOT the safety argument, because it is a fact about
+-- one database.  The DEFAULT is.  sql/311 deliberately preserves legacy
+-- `enabled` + `unconfigured` events; every such row takes `approval_mode =
+-- 'manual'` and satisfies the CHECK below unchanged.  Only a NEW row can be
+-- `autonomous`, and a new row goes through `configure_paper_pool`.
+
+ALTER TABLE strategy_paper_pool_events
+    ADD COLUMN IF NOT EXISTS approval_mode TEXT NOT NULL DEFAULT 'manual';
+
+-- DROP-then-ADD, matching sql/311's own pattern.  A bare `ADD CONSTRAINT` is
+-- not rerunnable: a replayed or partially applied migration fails on the
+-- existing constraint name rather than converging.
+ALTER TABLE strategy_paper_pool_events
+    DROP CONSTRAINT IF EXISTS strategy_paper_pool_approval_mode;
+ALTER TABLE strategy_paper_pool_events
+    ADD CONSTRAINT strategy_paper_pool_approval_mode CHECK (
+        approval_mode IN ('manual', 'autonomous')
+        -- An unconfigured mandate authorises nothing, so it cannot authorise a
+        -- policy approver either.
+        --
+        -- ⚠ DECLARED DEPENDENCY.  `risk_profile <> 'unconfigured'` is the exact
+        -- definition of `PortfolioMandate.configured`, and it is only as strong
+        -- as sql/311's `strategy_paper_pool_mandate_shape` -- that constraint is
+        -- what forces a non-`unconfigured` profile to carry complete, in-range
+        -- v1 limits.  This clause is meaningful only while that one stands.
+        AND (approval_mode = 'manual' OR risk_profile <> 'unconfigured')
+    );
+
+COMMENT ON COLUMN strategy_paper_pool_events.approval_mode IS
+    'Who may approve a stage promotion under this authority: manual = an authenticated '
+    'operator only; autonomous = additionally the policy approver in '
+    'app/services/strategy_autonomous_promotion.py, which stamps promoted_by = '
+    'policy@<AUTONOMY_POLICY_VERSION>. Evidence bars are identical under both (#2843).';

--- a/tests/test_2843_autonomy_approval_mode.py
+++ b/tests/test_2843_autonomy_approval_mode.py
@@ -1,0 +1,124 @@
+"""#2843 — the autonomy flag's pure rules.
+
+⚠ SPLIT FROM `tests/test_2843_autonomy_approval_mode_db.py` DELIBERATELY, NOT FOR
+TIDINESS. `tests/conftest.py` auto-applies the `db` marker per MODULE, so one DB test
+in this file would drag every rule below out of the fast pre-push gate. These are the
+rules that must run on every push: they are what stops the policy approver quietly
+gaining an action or losing a refusal.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.strategy_autonomous_promotion import (
+    AUTONOMOUS_ACTIONS,
+    AUTONOMOUS_APPROVER,
+    AUTONOMY_POLICY_VERSION,
+    cycle_precondition_refusal,
+    planned_action,
+)
+from app.services.strategy_control_plane import (
+    UNCONFIGURED_MANDATE,
+    ApprovalMode,
+    PaperPool,
+    Stage,
+    mandate_for_profile,
+)
+from app.services.strategy_operator_promotion import _EVIDENCE_ACTIONS, _NEXT_STAGE
+
+_CONFIGURED = mandate_for_profile("balanced")
+
+
+def _pool(*, approval_mode: ApprovalMode = "autonomous", enabled: bool = True, configured: bool = True) -> PaperPool:
+    return PaperPool(
+        event_id=1,
+        enabled=enabled,
+        capital_limit=Decimal("1000"),
+        currency="USD",
+        capital_mode="fixed",
+        mandate=_CONFIGURED if configured else UNCONFIGURED_MANDATE,
+        approval_mode=approval_mode,
+    )
+
+
+@pytest.mark.parametrize(
+    ("pool", "expected"),
+    [
+        (_pool(), None),
+        (_pool(approval_mode="manual"), "approval_mode_manual"),
+        (_pool(configured=False), "mandate_unconfigured"),
+        (_pool(enabled=False), "paper_pool_disabled"),
+        # Manual wins over every other refusal: an authority that is not asking for a
+        # policy approver has no further question to answer.
+        (_pool(approval_mode="manual", enabled=False, configured=False), "approval_mode_manual"),
+    ],
+)
+def test_cycle_precondition_refusal(pool: PaperPool, expected: str | None) -> None:
+    assert cycle_precondition_refusal(pool) == expected
+
+
+def test_a_default_constructed_pool_is_never_autonomous() -> None:
+    """The read side of a safety flag must fail closed on an unconfigured install.
+
+    `load_paper_pool` returns exactly this shape when the table is empty, which is
+    the state every install starts in and the state dev is in today.
+    """
+    assert cycle_precondition_refusal(PaperPool(None, False, Decimal("0"))) == "approval_mode_manual"
+
+
+@pytest.mark.parametrize(
+    ("stage", "expected_action", "expected_skip"),
+    [
+        (None, None, "action_not_evidence_backed"),
+        ("research_candidate", "validate_historical", None),
+        ("historical_validated", "start_forward_observation", None),
+        ("forward_observation", "enable_paper", None),
+        ("paper_enabled", None, "stage_terminal"),
+        ("live_enabled", None, "stage_terminal"),
+        ("paused", None, "stage_terminal"),
+        ("retired", None, "stage_terminal"),
+    ],
+)
+def test_planned_action(stage: Stage | None, expected_action: str | None, expected_skip: str | None) -> None:
+    assert planned_action(stage) == (expected_action, expected_skip)
+
+
+def test_planned_action_is_total_over_the_declared_stage_graph() -> None:
+    """No stage may make the planner raise.
+
+    A stage the planner cannot classify would abort the whole cycle on the first
+    strategy that reached it, which is a far worse failure than a skip.
+    """
+    for stage in _NEXT_STAGE:
+        action, skip = planned_action(stage)
+        assert (action is None) != (skip is None)
+
+
+def test_registration_is_not_a_policy_action() -> None:
+    """`register_research_candidate` carries no evidence, so a policy approver acting
+    on evidence has nothing to act on. Asserted from the graph rather than restated:
+    the entry stage's action must be the one the planner refuses."""
+    assert planned_action(None) == (None, "action_not_evidence_backed")
+
+
+def test_autonomous_actions_are_exactly_the_evidence_actions() -> None:
+    """⚠ The whole safety argument for this module in one assertion.
+
+    The policy approver may take an action IFF that action carries evidence. Writing
+    the set out by hand would let the two drift the moment a stage is added — a new
+    evidence action silently outside policy reach, or worse, a zero-evidence action
+    silently inside it. Equality is what keeps "approves on evidence" true by
+    construction rather than by review.
+    """
+    assert AUTONOMOUS_ACTIONS == _EVIDENCE_ACTIONS
+
+
+def test_the_approver_stamp_is_a_usable_promoted_by() -> None:
+    """`promote_strategy` runs `_require_text(promoted_by, ...)`, so an empty or
+    whitespace stamp would refuse every autonomous promotion at the last step."""
+    assert AUTONOMOUS_APPROVER == f"policy@{AUTONOMY_POLICY_VERSION}"
+    assert AUTONOMOUS_APPROVER.strip() == AUTONOMOUS_APPROVER
+    assert AUTONOMOUS_APPROVER.strip() != ""

--- a/tests/test_2843_autonomy_approval_mode.py
+++ b/tests/test_2843_autonomy_approval_mode.py
@@ -26,6 +26,7 @@ from app.services.strategy_control_plane import (
     PaperPool,
     Stage,
     mandate_for_profile,
+    resolve_approval_mode,
 )
 from app.services.strategy_operator_promotion import _EVIDENCE_ACTIONS, _NEXT_STAGE
 
@@ -122,3 +123,20 @@ def test_the_approver_stamp_is_a_usable_promoted_by() -> None:
     assert AUTONOMOUS_APPROVER == f"policy@{AUTONOMY_POLICY_VERSION}"
     assert AUTONOMOUS_APPROVER.strip() == AUTONOMOUS_APPROVER
     assert AUTONOMOUS_APPROVER.strip() != ""
+
+
+@pytest.mark.parametrize(
+    ("requested", "current", "expected"),
+    [
+        # ⚠ THE ONE THAT MATTERS. Every existing client of PUT /strategies/paper-pool
+        # omits the field, so if omission meant "manual" the next capital-limit edit
+        # would silently revoke autonomy and return 200.
+        (None, "autonomous", "autonomous"),
+        (None, "manual", "manual"),
+        ("autonomous", "manual", "autonomous"),
+        ("manual", "autonomous", "manual"),
+        ("autonomous", "autonomous", "autonomous"),
+    ],
+)
+def test_resolve_approval_mode(requested: ApprovalMode | None, current: ApprovalMode, expected: ApprovalMode) -> None:
+    assert resolve_approval_mode(requested, current) == expected

--- a/tests/test_2843_autonomy_approval_mode_db.py
+++ b/tests/test_2843_autonomy_approval_mode_db.py
@@ -1,0 +1,320 @@
+"""#2843 — the autonomy flag and its approver, against a real database.
+
+The pure half lives in `tests/test_2843_autonomy_approval_mode.py`; see its header
+for why the split is load-bearing rather than tidy.
+
+⚠ EVERY ASSERTION HERE IS AGAINST A STORED ROW, never against arguments handed to a
+mock. An argument-equality test would prove the call shape and nothing about the
+evidence `advance_strategy` actually assembled — which is the only thing worth
+proving about a caller whose entire job is to be indistinguishable from an operator
+except in WHO it stamps.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_control_plane import (
+    StrategyControlError,
+    configure_paper_pool,
+    load_paper_pool,
+)
+from app.services.strategy_forecast_assessment import FORECAST_POLICY_VERSION
+from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
+
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
+
+_STRATEGY_ID = "S-GOV"
+_VERSION = "autonomy-flag-v1"
+_NOW = datetime(2026, 8, 22, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _only_this_strategy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cycle's POPULATION is manifest-derived config, so it is the one thing
+    stubbed here. Everything downstream of it -- stage read, purpose check, evidence
+    assembly, promotion write -- runs for real against the database."""
+    from app.services import strategy_autonomous_promotion, strategy_operator_promotion
+
+    for module in (strategy_autonomous_promotion, strategy_operator_promotion):
+        # ⚠ BOTH. `advance_strategy` resolves the version from its OWN module-level
+        # import, so patching only the cycle's copy leaves it raising "unknown
+        # strategy" -- which passes a naive "did it refuse?" assertion for entirely
+        # the wrong reason.
+        monkeypatch.setattr(module, "current_result_versions", lambda: {_STRATEGY_ID: _VERSION})
+
+
+def _seed_forward_observation(conn: psycopg.Connection[Any]) -> None:
+    """Seed the lifecycle directly, as `tests/test_2612_...` does and for the same
+    reason: reaching `forward_observation` through `promote_strategy` needs pinned
+    results carrying #2505 edge evidence and #2621 frozen-universe records, none of
+    which the flag depends on. The LAST hop -- the one under test -- is taken for
+    real."""
+    conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id,strategy_version,from_stage,to_stage,gate_version,
+            evidence_ref,promoted_by,reason,promoted_at
+        ) VALUES
+          (%(s)s,%(v)s,NULL,'research_candidate','test-v1',NULL,'operator','registered',
+           %(now)s - interval '40 days'),
+          (%(s)s,%(v)s,'research_candidate','historical_validated','test-v1','hist','operator','history',
+           %(now)s - interval '39 days'),
+          (%(s)s,%(v)s,'historical_validated','forward_observation','test-v1','fwd','operator','observe',
+           %(now)s - interval '38 days')
+        """,
+        {"s": _STRATEGY_ID, "v": _VERSION, "now": _NOW},
+    )
+
+
+def _seed_passing_assessment(conn: psycopg.Connection[Any], *, checked_at: datetime = _NOW) -> None:
+    """One fresh, passing, post-forward-observation prospective assessment.
+
+    Shape copied from `tests/test_strategy_paper_executor.py::_authorise_forecast_scope`
+    rather than reinvented -- two spellings of "a passing assessment" is how the two
+    drift.
+    """
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_calibrations (
+            calibration_id,model_version,holdout_start,holdout_end,sample_size,
+            brier_score,calibration_error,passed,evidence_ref
+        ) VALUES ('test-calibration-v1','test-model-v1','2024-01-01','2024-06-30',100,
+                  0.1,0.05,true,'synthetic autonomy fixture only')
+        ON CONFLICT (calibration_id) DO NOTHING
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_policies (
+            policy_id,effective_from,recent_window_days,minimum_resolved_forecasts,
+            adaptive_calibration_bins,max_normalized_brier_score,min_brier_skill_score,
+            max_classwise_calibration_error,max_ambiguous_rate,max_unresolved_rate,
+            max_pending_rate,max_assessment_age_days,evidence_ref
+        ) VALUES ('test-autonomy-policy-v1',%s - interval '1 day',90,30,5,0.2,0.01,0.1,0.05,0.05,0.2,2,
+                  'synthetic autonomy fixture only')
+        ON CONFLICT (policy_id) DO NOTHING
+        """,
+        (checked_at,),
+    )
+    assessment = conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessments (
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,resolver_version,
+            input_rule_set_version,window_start,window_end,evidence_hash,
+            total_forecasts,resolved_forecasts,target_first_count,stop_first_count,timeout_count,
+            ambiguous_count,unresolved_count,pending_count,normalized_brier_score,
+            baseline_normalized_brier_score,brier_skill_score,max_classwise_calibration_error,
+            ambiguous_rate,unresolved_rate,pending_rate,passed,reason_codes
+        ) VALUES (
+            'test-autonomy-policy-v1',%s,%s,%s,'test-model-v1','test-calibration-v1','test-setup-v1',
+            'test-exit-v1',%s,%s,%s::date-89,%s::date,'synthetic-autonomy',
+            30,30,10,10,10,0,0,0,0,0.33333333,1,0,0,0,0,true,'[]'::jsonb
+        ) RETURNING assessment_id
+        """,
+        (
+            _STRATEGY_ID,
+            _VERSION,
+            FORECAST_POLICY_VERSION,
+            FORECAST_OUTCOME_RESOLVER_VERSION,
+            QUARANTINE_RULE_SET_VERSION,
+            checked_at,
+            checked_at,
+        ),
+    ).fetchone()
+    assert assessment is not None
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_current (
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,resolver_version,
+            input_rule_set_version,assessment_id,checked_at
+        ) VALUES (
+            'test-autonomy-policy-v1',%s,%s,%s,'test-model-v1','test-calibration-v1','test-setup-v1',
+            'test-exit-v1',%s,%s,%s,%s
+        )
+        """,
+        (
+            _STRATEGY_ID,
+            _VERSION,
+            FORECAST_POLICY_VERSION,
+            FORECAST_OUTCOME_RESOLVER_VERSION,
+            QUARANTINE_RULE_SET_VERSION,
+            int(assessment[0]),
+            checked_at,
+        ),
+    )
+
+
+def _configure(conn: psycopg.Connection[Any], *, approval_mode: str, enabled: bool = True) -> None:
+    configure_paper_pool(
+        conn,
+        enabled=enabled,
+        capital_limit=Decimal("1000"),
+        capital_mode="fixed",
+        risk_profile="balanced",
+        approval_mode=approval_mode,  # type: ignore[arg-type]
+        changed_by="operator",
+        reason="autonomy flag test",
+    )
+
+
+def _stage_rows(conn: psycopg.Connection[Any]) -> list[tuple[Any, ...]]:
+    return conn.execute(
+        "SELECT to_stage,promoted_by FROM strategy_promotions "
+        "WHERE strategy_id=%s AND strategy_version=%s ORDER BY promotion_id",
+        (_STRATEGY_ID, _VERSION),
+    ).fetchall()
+
+
+# --------------------------------------------------------------------------- flag
+
+
+def test_the_flag_round_trips_through_the_event_table(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    _configure(ebull_test_conn, approval_mode="autonomous")
+    assert load_paper_pool(ebull_test_conn).approval_mode == "autonomous"
+
+
+def test_autonomous_is_refused_without_a_configured_mandate(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """The service refuses before sql/365's CHECK sees it, so the operator gets a
+    named error rather than a raw constraint violation."""
+    with pytest.raises(StrategyControlError, match="autonomous approval requires a configured"):
+        configure_paper_pool(
+            ebull_test_conn,
+            enabled=False,
+            capital_limit=Decimal("0"),
+            capital_mode="fixed",
+            risk_profile="unconfigured",
+            approval_mode="autonomous",
+            changed_by="operator",
+            reason="should refuse",
+        )
+
+
+def test_flipping_only_the_flag_is_a_material_change(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """Without `approval_mode` in the change comparison, turning autonomy on while
+    changing nothing else would raise "must alter ..." and be unreachable."""
+    _configure(ebull_test_conn, approval_mode="manual")
+    _configure(ebull_test_conn, approval_mode="autonomous")
+    assert load_paper_pool(ebull_test_conn).approval_mode == "autonomous"
+
+
+# ------------------------------------------------------------------------- cycle
+
+
+@pytest.mark.parametrize(
+    ("approval_mode", "enabled", "expected"),
+    [
+        ("manual", True, "approval_mode_manual"),
+        ("autonomous", False, "paper_pool_disabled"),
+    ],
+)
+def test_the_cycle_skips_whole_and_writes_nothing(
+    ebull_test_conn: psycopg.Connection[Any], approval_mode: str, enabled: bool, expected: str
+) -> None:
+    """Every precondition is exercised against a strategy that WOULD otherwise
+    advance — the assessment is seeded and passing — so a skip here is the flag
+    refusing, not the evidence."""
+    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
+
+    _seed_forward_observation(ebull_test_conn)
+    _seed_passing_assessment(ebull_test_conn)
+    _configure(ebull_test_conn, approval_mode=approval_mode, enabled=enabled)
+    before = _stage_rows(ebull_test_conn)
+
+    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+
+    assert report.skipped_reason == expected
+    assert report.advanced == ()
+    # ⚠ Both halves. "Reported a skip" and "wrote nothing" are different claims, and
+    # the flag is only a control if the second one holds.
+    assert _stage_rows(ebull_test_conn) == before
+
+
+def test_an_autonomous_cycle_advances_one_stage_and_stamps_the_policy(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The whole ticket, asserted on the stored row.
+
+    `paper_enabled` is reached through the real `advance_strategy` -> `promote_strategy`
+    path, so every gate those apply ran. What differs from an operator click is one
+    column.
+    """
+    from app.services.strategy_autonomous_promotion import AUTONOMOUS_APPROVER, run_autonomous_promotion_cycle
+
+    _seed_forward_observation(ebull_test_conn)
+    _seed_passing_assessment(ebull_test_conn)
+    _configure(ebull_test_conn, approval_mode="autonomous")
+
+    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+
+    assert report.skipped_reason is None
+    assert [advance.stage for advance in report.advanced] == ["paper_enabled"]
+    rows = _stage_rows(ebull_test_conn)
+    assert rows[-1] == ("paper_enabled", AUTONOMOUS_APPROVER)
+    assert AUTONOMOUS_APPROVER == "policy@autonomy-v1"
+    # Every earlier row is still the operator's. The flag adds an approver; it does
+    # not rewrite history or reattribute anything.
+    assert {row[1] for row in rows[:-1]} == {"operator"}
+
+
+def test_a_second_cycle_takes_no_further_step(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """At most one step per strategy per cycle, and `paper_enabled` is terminal for
+    this approver -- `live_enabled` belongs to the measured live gate."""
+    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
+
+    _seed_forward_observation(ebull_test_conn)
+    _seed_passing_assessment(ebull_test_conn)
+    _configure(ebull_test_conn, approval_mode="autonomous")
+    run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+    after_first = _stage_rows(ebull_test_conn)
+
+    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW + timedelta(days=1))
+
+    assert report.advanced == ()
+    assert report.refusals == ((_STRATEGY_ID, "stage_terminal"),)
+    assert _stage_rows(ebull_test_conn) == after_first
+
+
+def test_a_refused_strategy_is_recorded_not_raised_and_writes_nothing(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """No assessment exists, so `enable_paper` refuses. A refusal is this job's
+    normal output; it must neither raise nor leave a partial row behind."""
+    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
+
+    _seed_forward_observation(ebull_test_conn)
+    _configure(ebull_test_conn, approval_mode="autonomous")
+    before = _stage_rows(ebull_test_conn)
+
+    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+
+    assert report.skipped_reason is None
+    assert report.advanced == ()
+    assert len(report.refusals) == 1
+    assert "prospective_assessment" in report.refusals[0][1]
+    assert _stage_rows(ebull_test_conn) == before
+
+
+def test_a_stale_assessment_still_refuses_under_autonomy(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """⚠ The load-bearing negative. The flag flips WHO approves, never WHAT
+    qualifies: an assessment the operator path would be refused on must refuse the
+    policy path identically."""
+    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
+
+    _seed_forward_observation(ebull_test_conn)
+    # max_assessment_age_days = 2 on the seeded policy.
+    _seed_passing_assessment(ebull_test_conn, checked_at=_NOW - timedelta(days=5))
+    _configure(ebull_test_conn, approval_mode="autonomous")
+
+    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+
+    assert report.advanced == ()
+    assert report.refusals == ((_STRATEGY_ID, "prospective_assessment_stale"),)

--- a/tests/test_2843_autonomy_approval_mode_db.py
+++ b/tests/test_2843_autonomy_approval_mode_db.py
@@ -167,6 +167,23 @@ def _configure(conn: psycopg.Connection[Any], *, approval_mode: str, enabled: bo
     )
 
 
+def _run(conn: psycopg.Connection[Any], *, as_of: datetime = _NOW) -> Any:
+    """Commit the seed, then run the cycle on an AUTOCOMMIT connection.
+
+    ⚠ Not a fixture convenience. The service refuses a transactional connection,
+    because `conn.transaction()` degrades to a SAVEPOINT inside an open transaction
+    and both of the cycle's commit properties quietly stop holding. Exercising it any
+    other way would test a mode production never runs in. Safe here: every table
+    these tests touch is in `_PLANNER_TABLES`, which the fixture resets before and
+    after each test.
+    """
+    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
+
+    conn.commit()
+    conn.autocommit = True
+    return run_autonomous_promotion_cycle(conn, as_of=as_of)
+
+
 def _stage_rows(conn: psycopg.Connection[Any]) -> list[tuple[Any, ...]]:
     return conn.execute(
         "SELECT to_stage,promoted_by FROM strategy_promotions "
@@ -223,14 +240,12 @@ def test_the_cycle_skips_whole_and_writes_nothing(
     """Every precondition is exercised against a strategy that WOULD otherwise
     advance — the assessment is seeded and passing — so a skip here is the flag
     refusing, not the evidence."""
-    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
-
     _seed_forward_observation(ebull_test_conn)
     _seed_passing_assessment(ebull_test_conn)
     _configure(ebull_test_conn, approval_mode=approval_mode, enabled=enabled)
     before = _stage_rows(ebull_test_conn)
 
-    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+    report = _run(ebull_test_conn)
 
     assert report.skipped_reason == expected
     assert report.advanced == ()
@@ -248,13 +263,13 @@ def test_an_autonomous_cycle_advances_one_stage_and_stamps_the_policy(
     path, so every gate those apply ran. What differs from an operator click is one
     column.
     """
-    from app.services.strategy_autonomous_promotion import AUTONOMOUS_APPROVER, run_autonomous_promotion_cycle
+    from app.services.strategy_autonomous_promotion import AUTONOMOUS_APPROVER
 
     _seed_forward_observation(ebull_test_conn)
     _seed_passing_assessment(ebull_test_conn)
     _configure(ebull_test_conn, approval_mode="autonomous")
 
-    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+    report = _run(ebull_test_conn)
 
     assert report.skipped_reason is None
     assert [advance.stage for advance in report.advanced] == ["paper_enabled"]
@@ -269,15 +284,13 @@ def test_an_autonomous_cycle_advances_one_stage_and_stamps_the_policy(
 def test_a_second_cycle_takes_no_further_step(ebull_test_conn: psycopg.Connection[Any]) -> None:
     """At most one step per strategy per cycle, and `paper_enabled` is terminal for
     this approver -- `live_enabled` belongs to the measured live gate."""
-    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
-
     _seed_forward_observation(ebull_test_conn)
     _seed_passing_assessment(ebull_test_conn)
     _configure(ebull_test_conn, approval_mode="autonomous")
-    run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+    _run(ebull_test_conn)
     after_first = _stage_rows(ebull_test_conn)
 
-    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW + timedelta(days=1))
+    report = _run(ebull_test_conn, as_of=_NOW + timedelta(days=1))
 
     assert report.advanced == ()
     assert report.refusals == ((_STRATEGY_ID, "stage_terminal"),)
@@ -289,13 +302,11 @@ def test_a_refused_strategy_is_recorded_not_raised_and_writes_nothing(
 ) -> None:
     """No assessment exists, so `enable_paper` refuses. A refusal is this job's
     normal output; it must neither raise nor leave a partial row behind."""
-    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
-
     _seed_forward_observation(ebull_test_conn)
     _configure(ebull_test_conn, approval_mode="autonomous")
     before = _stage_rows(ebull_test_conn)
 
-    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+    report = _run(ebull_test_conn)
 
     assert report.skipped_reason is None
     assert report.advanced == ()
@@ -308,14 +319,12 @@ def test_a_stale_assessment_still_refuses_under_autonomy(ebull_test_conn: psycop
     """⚠ The load-bearing negative. The flag flips WHO approves, never WHAT
     qualifies: an assessment the operator path would be refused on must refuse the
     policy path identically."""
-    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
-
     _seed_forward_observation(ebull_test_conn)
     # max_assessment_age_days = 2 on the seeded policy.
     _seed_passing_assessment(ebull_test_conn, checked_at=_NOW - timedelta(days=5))
     _configure(ebull_test_conn, approval_mode="autonomous")
 
-    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+    report = _run(ebull_test_conn)
 
     assert report.advanced == ()
     assert report.refusals == ((_STRATEGY_ID, "prospective_assessment_stale"),)
@@ -335,7 +344,6 @@ def test_authority_revoked_mid_cycle_stops_the_cycle(
     interleaving a concurrent `configure_paper_pool` produces.
     """
     from app.services import strategy_autonomous_promotion
-    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
 
     _seed_forward_observation(ebull_test_conn)
     _seed_passing_assessment(ebull_test_conn)
@@ -352,7 +360,7 @@ def test_authority_revoked_mid_cycle_stops_the_cycle(
 
     monkeypatch.setattr(strategy_autonomous_promotion, "load_paper_pool", _revoke_after_first_read)
 
-    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+    report = _run(ebull_test_conn)
 
     assert report.skipped_reason == "approval_mode_manual"
     assert report.advanced == ()
@@ -360,3 +368,15 @@ def test_authority_revoked_mid_cycle_stops_the_cycle(
     assert _stage_rows(ebull_test_conn) == before
     # ⚠ The re-read must be a SECOND read. One read means the authority was inherited.
     assert calls["n"] >= 2
+
+
+def test_a_transactional_connection_is_refused(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """⚠ Codex ckpt-2 P1, second round. The failure this guards is invisible in the
+    source: `conn.transaction()` reads as a transaction and silently becomes a
+    SAVEPOINT once one is open, so both commit properties stop holding with no
+    diagnostic. A caller that gets the connection mode wrong must be told."""
+    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
+
+    assert not ebull_test_conn.autocommit
+    with pytest.raises(StrategyControlError, match="requires an autocommit connection"):
+        run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)

--- a/tests/test_2843_autonomy_approval_mode_db.py
+++ b/tests/test_2843_autonomy_approval_mode_db.py
@@ -12,6 +12,7 @@ except in WHO it stamps.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
@@ -318,3 +319,44 @@ def test_a_stale_assessment_still_refuses_under_autonomy(ebull_test_conn: psycop
 
     assert report.advanced == ()
     assert report.refusals == ((_STRATEGY_ID, "prospective_assessment_stale"),)
+
+
+def test_authority_revoked_mid_cycle_stops_the_cycle(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """⚠ Codex ckpt-2 P1. Per-strategy transactions are what create this hole: an
+    operator switching the pool to `manual` commits BETWEEN two promotions, and a
+    cycle-level authority snapshot would keep approving on authority that no longer
+    exists.
+
+    The race is made deterministic by stubbing the READ, not the evidence: the first
+    call (the cycle's cheap exit) sees `autonomous`, the second (the per-strategy
+    re-read under `PAPER_ALLOCATOR_ADVISORY_LOCK`) sees `manual`. That is exactly the
+    interleaving a concurrent `configure_paper_pool` produces.
+    """
+    from app.services import strategy_autonomous_promotion
+    from app.services.strategy_autonomous_promotion import run_autonomous_promotion_cycle
+
+    _seed_forward_observation(ebull_test_conn)
+    _seed_passing_assessment(ebull_test_conn)
+    _configure(ebull_test_conn, approval_mode="autonomous")
+    before = _stage_rows(ebull_test_conn)
+
+    real_load = strategy_autonomous_promotion.load_paper_pool
+    calls = {"n": 0}
+
+    def _revoke_after_first_read(conn: psycopg.Connection[Any]) -> Any:
+        pool = real_load(conn)
+        calls["n"] += 1
+        return pool if calls["n"] == 1 else replace(pool, approval_mode="manual")
+
+    monkeypatch.setattr(strategy_autonomous_promotion, "load_paper_pool", _revoke_after_first_read)
+
+    report = run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+
+    assert report.skipped_reason == "approval_mode_manual"
+    assert report.advanced == ()
+    # The whole point: nothing was promoted on revoked authority.
+    assert _stage_rows(ebull_test_conn) == before
+    # ⚠ The re-read must be a SECOND read. One read means the authority was inherited.
+    assert calls["n"] >= 2

--- a/tests/test_2843_autonomy_approval_mode_db.py
+++ b/tests/test_2843_autonomy_approval_mode_db.py
@@ -380,3 +380,32 @@ def test_a_transactional_connection_is_refused(ebull_test_conn: psycopg.Connecti
     assert not ebull_test_conn.autocommit
     with pytest.raises(StrategyControlError, match="requires an autocommit connection"):
         run_autonomous_promotion_cycle(ebull_test_conn, as_of=_NOW)
+
+
+def test_downgrading_the_mandate_cannot_leave_a_carried_forward_autonomous(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The exact case the PR #2856 review nitpick names.
+
+    A request that OMITS `approval_mode` carries the stored `autonomous` forward, so a
+    Pydantic validator reading the literal field sees `None` and passes. The rule is
+    therefore enforced where it can see the RESOLVED value — here — and this asserts
+    that the path the validator cannot cover still refuses.
+    """
+    from app.services.strategy_control_plane import resolve_approval_mode
+
+    _configure(ebull_test_conn, approval_mode="autonomous")
+    carried = resolve_approval_mode(None, load_paper_pool(ebull_test_conn).approval_mode)
+    assert carried == "autonomous"
+
+    with pytest.raises(StrategyControlError, match="autonomous approval requires a configured"):
+        configure_paper_pool(
+            ebull_test_conn,
+            enabled=False,
+            capital_limit=Decimal("1000"),
+            capital_mode="fixed",
+            risk_profile="unconfigured",
+            approval_mode=carried,
+            changed_by="operator",
+            reason="downgrade the mandate while autonomy is on",
+        )

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -1099,6 +1099,7 @@ def test_paper_principal_cannot_be_withdrawn_below_committed_capital(
         enabled=True,
         capital_limit=Decimal("1000"),
         risk_profile="balanced",
+        approval_mode="manual",
         changed_by="operator",
         reason="fund virtual sleeve",
     )
@@ -1109,6 +1110,7 @@ def test_paper_principal_cannot_be_withdrawn_below_committed_capital(
             enabled=False,
             capital_limit=Decimal("99"),
             risk_profile="balanced",
+            approval_mode="manual",
             changed_by="operator",
             reason="invalid withdrawal",
         )
@@ -1126,6 +1128,7 @@ def test_enabled_paper_pool_requires_and_persists_exact_versioned_mandate(
             enabled=True,
             capital_limit=Decimal("1000"),
             risk_profile="unconfigured",
+            approval_mode="manual",
             changed_by="operator",
             reason="missing mandate",
         )
@@ -1135,6 +1138,7 @@ def test_enabled_paper_pool_requires_and_persists_exact_versioned_mandate(
         enabled=True,
         capital_limit=Decimal("1000"),
         risk_profile="balanced",
+        approval_mode="manual",
         changed_by="operator",
         reason="balanced mandate",
     )

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -157,6 +157,7 @@ def _seed(
             enabled=True,
             capital_limit=Decimal("2000"),
             risk_profile="balanced",
+            approval_mode="manual",
             changed_by="test",
             reason="shared paper pool fixture",
         )
@@ -971,6 +972,7 @@ def test_shared_paper_pool_is_a_master_switch_and_hard_cap(
         enabled=True,
         capital_limit=Decimal("400"),
         risk_profile="balanced",
+        approval_mode="manual",
         changed_by="operator",
         reason="bounded shared pot",
     )
@@ -1299,6 +1301,7 @@ def test_shared_paper_pool_excludes_future_live_reservations(
         enabled=True,
         capital_limit=Decimal("400"),
         risk_profile="balanced",
+        approval_mode="manual",
         changed_by="operator",
         reason="paper-only shared pot",
     )


### PR DESCRIPTION
`approval_mode: manual | autonomous` on the mandate, plus the headless caller that
acts on it. Shipped in one PR per the prevention-log entry on declared-but-unwired
symbols: a flag with no reader is the defect this repo keeps shipping.

Closes #2843. Refs #2844, #2829, #2437, #2846.
Spec: `docs/proposals/ta/2026-08-22-autonomy-approval-mode.md`.

## What the person-gate actually was

Measured, not recalled:

```
grep -rn 'advance_strategy(' app/ scripts/ | grep -v 'def advance_strategy'
  app/api/strategies.py:3542
```

`advance_strategy` (#2770) assembles every piece of evidence itself — the
24-combination hold-out matrix, the identity pins, the prospective assessment, the
weakening check — and takes from its caller only
`(strategy_id, action, advanced_by, reason, as_of)`. Its one production caller is
`POST /strategies/{id}/advance`, behind `Depends(require_session)`, stamping
`advanced_by=session.username`.

**So the person-gate was: the only path into the stage machine is an authenticated
HTTP request, and the username it stamps is the approval.** That is why this diff
touches no gate. It supplies a second caller.

It is also why a headless caller is safe to add at all: `advance_strategy` accepts no
`to_stage`, no `strategy_version` and no `result_ids` — the three inputs #2770
deliberately removed from the caller's reach — so there is no parameter through which
a policy could choose its own denominator.

## The diff

| | |
| --- | --- |
| `sql/365` | `approval_mode TEXT NOT NULL DEFAULT 'manual'` on `strategy_paper_pool_events`, `CHECK` in `('manual','autonomous')` and autonomous ⇒ configured mandate |
| `strategy_control_plane` | `ApprovalMode`, `PaperPool.approval_mode`, `configure_paper_pool(approval_mode=...)`, `resolve_approval_mode` |
| `strategy_autonomous_promotion` (new) | `AUTONOMOUS_APPROVER = policy@autonomy-v1`, the cycle, its refusal codes |
| `app/workers/scheduler` + `app/jobs/runtime` | `strategy_autonomous_promotion`, daily 07:20 UTC, `strategy_scan` lane |
| `app/api/strategies` | `approval_mode` on the pool view and the update request |
| `frontend/` | reads the field; a "Promotion approval" select in the existing Automation form |

**Why this table.** The mandate is already stored here — `sql/311` hung the whole
portfolio-risk mandate off `strategy_paper_pool_events` as columns, and #2844
established that minting a parallel surface for something already stored is the
defect. It is append-only, so the flag inherits versioning and audit from the table's
shape: the authority in force at any promotion is the latest event at or before it.

**Scope.** The cycle drives at most as far as `paper_enabled`; `live_enabled` is
refused outright by `promote_strategy` and belongs to the measured live gate. The
alert-validity contract on #2843 is independently buildable and is not in this slice.

## Security model

This changes **who may approve a stage promotion**, and nothing else.

- **No evidence bar moves.** The autonomous path calls the same `advance_strategy` →
  `promote_strategy` chain the operator button calls, with the same arguments except
  `promoted_by`. `test_a_stale_assessment_still_refuses_under_autonomy` is the
  load-bearing negative: evidence the operator path would be refused on refuses the
  policy path identically.
- **The policy may take an action IFF that action carries evidence.**
  `AUTONOMOUS_ACTIONS == _EVIDENCE_ACTIONS` is asserted by equality rather than
  written out, so a future stage cannot land a zero-evidence action inside policy
  reach. `register_research_candidate` stays manual.
- **Three fail-closed preconditions**, re-read under the allocator lock before *every*
  promotion: `approval_mode_manual`, `mandate_unconfigured`, `paper_pool_disabled`.
  A default-constructed `PaperPool` — what `load_paper_pool` returns on an empty table,
  which is dev today — reads as `manual`.
- **The execution guard, kill switch, `EXIT`-never-blocked and `sandbox_exceeded`
  (#2844) are untouched.** Nothing in this diff is reachable from the order path.
- **Every autonomous promotion writes the same immutable row an operator approval
  would**, differing in one column: `promoted_by = policy@autonomy-v1`.
- Default is `manual`, and only an authenticated operator (`require_session`) can
  change it.

## Full-population state (dev, before)

```sql
select count(*) from strategy_paper_pool_events;  -- 0
select count(*) from strategy_promotions;         -- 0
```

Nothing to backfill and no promotion this can retroactively reclassify. ⚠ The dev row
count is **not** the migration's safety argument — that is one database. The DEFAULT
is: `sql/311` deliberately preserves legacy `enabled` + `unconfigured` events, every
one of which takes `manual` and satisfies the new CHECK unchanged. Only a NEW row can
be `autonomous`, and a new row goes through `configure_paper_pool`.

## Two things the reviews caught that the code did not show

**1. A default on `approval_mode` would have silently revoked autonomy.**
`configure_paper_pool` takes it as a *required* keyword. With a default, every
unrelated capital or risk edit would write `manual` over an operator's `autonomous`
and return 200 — and it would typecheck. Making it required had pyright enumerate all
7 call sites. The API's own resolution is `resolve_approval_mode`: **omitted means
unchanged, never `manual`** (a named function, not an inline ternary, because the
wrong spelling is one character with no test surface).

**2. `conn.transaction()` is a SAVEPOINT when a transaction is already open.**
Per-strategy transactions were added so a late failure could not roll back earlier
promotions — but on a non-autocommit connection psycopg makes each one a savepoint,
which breaks *both* properties the function claims: promotions stop committing
independently, and `pg_advisory_xact_lock` is held for the whole cycle rather than one
strategy. Invisible in the source shape; it is a property of the caller's connection
mode. The service now **refuses** a transactional connection, the job passes
`connect_job(autocommit=True)`, and the DB tests run on a real autocommit connection
so they exercise production's mode.

Related: the authority is re-read **inside each promotion transaction, under
`PAPER_ALLOCATOR_ADVISORY_LOCK`** — the lock `configure_paper_pool` takes — so an
operator revoking autonomy mid-cycle serialises with the job instead of being ignored.
Lock order is allocator-then-strategy, matching `strategy_paper_executor`.

## No invented constant

A draft of the spec proposed `AUTONOMOUS_MIN_STAGE_DWELL = 1 day` to stop a cycle
chaining stages. It was **removed for having no construction**: all six
`RECENT_EVIDENCE_WINDOWS` end at or before `INTRADER_CAPTURE_DATE` (2024-09-27), so
the historical matrix is frozen and elapsed time cannot change it. A dwell threshold
would have guarded a quantity that does not move. What actually bounds forward
observation already existed — `prospective_assessment_predates_forward_observation`.

⚠ Stated plainly rather than glossed: "at most one step per strategy per cycle" is
**hygiene, not a safety invariant**. Manual dispatch, catch-up and a cadence change
all defeat it. And `checked_at >= forward_started_at` permits an assessment computed
one second after the promotion, so the effective forward-observation floor is one
assessment-job cadence — pre-existing, identical on the manual path, and noted on
#2843 rather than widened into this ticket.

## Tests

Pure tier (18 tests, `tests/test_2843_autonomy_approval_mode.py`) — precondition
table, stage planner totality, `AUTONOMOUS_ACTIONS == _EVIDENCE_ACTIONS`, the approver
stamp, `resolve_approval_mode`. Split from the DB module deliberately: the `db` marker
is per-module, and these are the rules that must run on every push.

DB tier (`..._db.py`) — **every assertion is against a stored row, never against
arguments handed to a mock.** Flag round-trip; autonomous refused without a configured
mandate; flag-only edit is a material change; each cycle-level skip writes nothing;
a real advance to `paper_enabled` stamping `policy@autonomy-v1` with earlier rows still
attributed to `operator`; a second cycle takes no further step; a refusal is recorded
not raised; a stale assessment still refuses; mid-cycle revocation stops the cycle; a
transactional connection is refused.

Revert-probed (committed first each time): ignoring the flag fails 4 tests; inverting
`resolve_approval_mode` fails `[None-autonomous-autonomous]`; dropping the mid-cycle
re-read fails `test_authority_revoked_mid_cycle_stops_the_cycle`.

## Gates

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` ·
`pytest tests/smoke` · `pnpm typecheck` · `pnpm test:unit` (1538) — all green.
DB tier on the touched modules green except two **pre-existing** failures,
`test_the_deployment_currency_refusal_and_its_constraint_agree[...]`, which reproduce
identically on `origin/main` in a throwaway worktree (a missing `etoro_instrument_types`
seed in the worker DB). Not introduced here and not in scope.

Codex ckpt-1 on the spec and ckpt-2 on the diff both run; ckpt-2's two P1s are the
numbered items above, and the re-run is clean.

## Operator note — no runbook step

No parser, ETL or ownership/observations path is touched, so Definition-of-Done
clauses 8–12 do not apply and no `sec_rebuild` is needed. The jobs daemon **does**
want a restart to pick up the new scheduled job.

⚠ Nothing turns autonomy on. `approval_mode` defaults to `manual`, dev holds zero pool
events, and no strategy is a `capital_candidate` in production today — so the new job
skips with `approval_mode_manual` until an operator sets the flag in the Automation
form.
