### PR TITLE
fix(#2767): reserve non-SEC execution capacity for the paper lifecycle

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from datetime import UTC, date, datetime
-from typing import Literal
+from typing import Any, Literal, cast
 
 import psycopg
 import psycopg.rows
@@ -256,6 +256,7 @@ class JobsProcessSubsystemHealth(BaseModel):
     last_beat_at: datetime | None
     age_seconds: float | None
     is_stale: bool
+    notes: dict[str, Any] | None
 
 
 class JobsProcessHealthResponse(BaseModel):
@@ -502,7 +503,7 @@ def _build_jobs_process_health(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT subsystem, last_beat_at
+            SELECT subsystem, last_beat_at, notes
             FROM job_runtime_heartbeat
             ORDER BY subsystem
             """
@@ -526,6 +527,7 @@ def _build_jobs_process_health(
                 last_beat_at=last_beat,
                 age_seconds=age,
                 is_stale=is_stale,
+                notes=cast(dict[str, Any] | None, row["notes"]),
             )
         )
 

--- a/app/db/pg_settings.py
+++ b/app/db/pg_settings.py
@@ -160,11 +160,25 @@ EXPECTED, not observed: #1472's RCA saw ``credential_health`` LISTEN ×3
 (a duplicate-instance bug PR3 fixes). The budget models the intended
 topology so it never blesses that bug."""
 
-JOBS_NON_SEC_MAX_CONCURRENCY: Final[int] = 2
-"""Maximum scheduled/catch-up/manual executions outside the ``sec_rate``
-lane. ``JobRuntime`` enforces this before opening any job lock or body
-connection. Two lets a long LLM thesis run coexist with portfolio/strategy
-work without reopening the cadence herd."""
+JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY: Final[int] = 1
+"""Maximum general scheduled/catch-up/manual executions outside ``sec_rate``.
+
+Long research, LLM and backfill work shares this slot. Keeping it separate
+from the paper-lifecycle reserve prevents that work from consuming the
+capacity needed to reconcile and protect demo-owned positions."""
+
+JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY: Final[int] = 1
+"""Reserved execution capacity for ``strategy_paper_cycle`` only.
+
+The job remains independently serialised by APScheduler ``max_instances=1``,
+the manual in-flight lock and its source advisory lock. This reservation only
+prevents unrelated general work from starving its connection-budget entry."""
+
+JOBS_NON_SEC_MAX_CONCURRENCY: Final[int] = JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY + JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY
+"""Total modeled non-SEC execution concurrency.
+
+The split remains exactly the prior total of two, so reserving the lifecycle
+slot does not increase PostgreSQL connection demand."""
 
 JOBS_NON_SEC_CONNECTIONS_PER_EXECUTION: Final[int] = 2
 """Worst-case connections held by one non-SEC execution: one session-scoped

--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -74,7 +74,7 @@ from app.jobs.credential_health_listener import (
 from app.jobs.heartbeat import HeartbeatWriter, heartbeat_loop
 from app.jobs.listener import ListenerState, listener_loop
 from app.jobs.locks import JOBS_PROCESS_LOCK_KEY
-from app.jobs.runtime import JobRuntime
+from app.jobs.runtime import JobRuntime, execution_slot_wait_snapshot
 from app.jobs.supervisor import supervise
 from app.security import master_key
 from app.security.secrets_crypto import set_active_key as set_broker_encryption_key
@@ -1222,10 +1222,11 @@ def serve(stop_event: threading.Event | None = None) -> int:
         # it. The fresh beats also overwrite the prior boot's stale rows
         # immediately, so a restart no longer shows a stale pid.
         for subsystem in ("scheduler", "manual_listener", "queue_drainer", "main"):
+            notes_provider = execution_slot_wait_snapshot if subsystem == "scheduler" else None
             t = threading.Thread(
                 target=heartbeat_loop,
                 args=(heartbeat, subsystem, stop_event),
-                kwargs={"tick_seconds": 10.0},
+                kwargs={"tick_seconds": 10.0, "notes_provider": notes_provider},
                 name=f"jobs-heartbeat-{subsystem}",
                 daemon=True,
             )

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -46,8 +46,9 @@ import time
 from collections.abc import Callable, Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Final
+from typing import Any, Final, TypedDict
 
 import psycopg
 import psycopg.sql
@@ -59,7 +60,10 @@ from psycopg_pool import ConnectionPool
 
 from app.config import settings
 from app.db.background_write import background_write_connection
-from app.db.pg_settings import JOBS_NON_SEC_MAX_CONCURRENCY
+from app.db.pg_settings import (
+    JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY,
+    JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY,
+)
 from app.jobs.background_pool import BackgroundConnectionPool
 from app.jobs.locks import JobAlreadyRunning, JobLock
 from app.jobs.sec_lane_gate import SEC_LANE_MAX_CONCURRENCY
@@ -649,7 +653,58 @@ _RECURRING_JOB_ID_PREFIX: Final[str] = "recurring:"
 _MAX_INSTANCES_SKIP_REASON: Final[str] = "max_instances_active"
 
 _SEC_EXECUTION_SLOTS = threading.BoundedSemaphore(SEC_LANE_MAX_CONCURRENCY)
-_NON_SEC_EXECUTION_SLOTS = threading.BoundedSemaphore(JOBS_NON_SEC_MAX_CONCURRENCY)
+_GENERAL_NON_SEC_EXECUTION_SLOTS = threading.BoundedSemaphore(JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY)
+_PAPER_LIFECYCLE_EXECUTION_SLOTS = threading.BoundedSemaphore(JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY)
+
+
+@dataclass(frozen=True, slots=True)
+class _ExecutionSlotWait:
+    job_name: str
+    lane: str
+    waiting_since: datetime
+    started_monotonic: float
+
+
+_EXECUTION_SLOT_WAITS_LOCK = threading.Lock()
+_EXECUTION_SLOT_WAITS: dict[int, _ExecutionSlotWait] = {}
+
+
+class ExecutionSlotWaitView(TypedDict):
+    job_name: str
+    lane: str
+    waiting_since: str
+    wait_age_seconds: float
+
+
+class ExecutionSlotWaitSnapshot(TypedDict):
+    execution_slot_wait_count: int
+    execution_slot_waits: list[ExecutionSlotWaitView]
+
+
+def execution_slot_wait_snapshot() -> ExecutionSlotWaitSnapshot:
+    """Return heartbeat-safe visibility for work waiting before ``job_runs``.
+
+    Slot admission deliberately precedes every database connection, so a
+    waiting fire cannot write a ``job_runs`` row without defeating the
+    connection ceiling. The scheduler heartbeat publishes this process-local
+    snapshot instead; logs also record the wait immediately and on admission.
+    """
+    observed_monotonic = time.monotonic()
+    with _EXECUTION_SLOT_WAITS_LOCK:
+        waits = tuple(_EXECUTION_SLOT_WAITS.values())
+    payload: list[ExecutionSlotWaitView] = [
+        {
+            "job_name": wait.job_name,
+            "lane": wait.lane,
+            "waiting_since": wait.waiting_since.isoformat(),
+            "wait_age_seconds": round(max(0.0, observed_monotonic - wait.started_monotonic), 3),
+        }
+        for wait in sorted(waits, key=lambda item: (item.waiting_since, item.job_name))
+    ]
+    return {
+        "execution_slot_wait_count": len(payload),
+        "execution_slot_waits": payload,
+    }
 
 
 @contextmanager
@@ -663,12 +718,45 @@ def _job_execution_slot(job_name: str) -> Iterator[None]:
         # unknown name.  For connection budgeting, the conservative safe
         # classification is the smaller non-SEC allowance.
         source = None
-    slots = _SEC_EXECUTION_SLOTS if source == "sec_rate" else _NON_SEC_EXECUTION_SLOTS
-    slots.acquire()
+    if source == "sec_rate":
+        slots = _SEC_EXECUTION_SLOTS
+        lane = "sec_rate"
+    elif job_name == JOB_STRATEGY_PAPER_CYCLE:
+        slots = _PAPER_LIFECYCLE_EXECUTION_SLOTS
+        lane = "paper_lifecycle_reserved"
+    else:
+        slots = _GENERAL_NON_SEC_EXECUTION_SLOTS
+        lane = "general_non_sec"
+
+    acquired = slots.acquire(blocking=False)
+    if not acquired:
+        thread_id = threading.get_ident()
+        wait = _ExecutionSlotWait(
+            job_name=job_name,
+            lane=lane,
+            waiting_since=datetime.now(UTC),
+            started_monotonic=time.monotonic(),
+        )
+        with _EXECUTION_SLOT_WAITS_LOCK:
+            _EXECUTION_SLOT_WAITS[thread_id] = wait
+        logger.warning("job %r waiting for %s execution capacity", job_name, lane)
+        try:
+            slots.acquire()
+            acquired = True
+        finally:
+            with _EXECUTION_SLOT_WAITS_LOCK:
+                _EXECUTION_SLOT_WAITS.pop(thread_id, None)
+        logger.info(
+            "job %r acquired %s execution capacity after %.3fs",
+            job_name,
+            lane,
+            time.monotonic() - wait.started_monotonic,
+        )
     try:
         yield
     finally:
-        slots.release()
+        if acquired:
+            slots.release()
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -169,6 +169,24 @@ export interface JobOverviewResponse {
 export interface JobsListResponse {
   checked_at: string;
   jobs: JobOverviewResponse[];
+  jobs_process: {
+    state: "healthy" | "degraded" | "down";
+    subsystems: Array<{
+      subsystem: string;
+      last_beat_at: string | null;
+      age_seconds: number | null;
+      is_stale: boolean;
+      notes: {
+        execution_slot_wait_count?: number;
+        execution_slot_waits?: Array<{
+          job_name: string;
+          lane: string;
+          waiting_since: string;
+          wait_age_seconds: number;
+        }>;
+      } | null;
+    }>;
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -141,6 +141,18 @@ function recsEmpty(): RecommendationsListResponse {
 function jobsResponse(): JobsListResponse {
   return {
     checked_at: "2026-04-16T01:00:00Z",
+    jobs_process: {
+      state: "healthy",
+      subsystems: [
+        {
+          subsystem: "scheduler",
+          last_beat_at: "2026-04-16T00:59:59Z",
+          age_seconds: 1,
+          is_stale: false,
+          notes: { execution_slot_wait_count: 0, execution_slot_waits: [] },
+        },
+      ],
+    },
     jobs: [
       {
         name: "orchestrator_full_sync",
@@ -343,6 +355,27 @@ describe("AdminPage — Background tasks collapsible", () => {
     expect(
       screen.queryByRole("button", { name: "Run Orchestrator full sync now" }),
     ).toBeNull();
+  });
+
+  it("shows execution-budget waits with the job, lane and current age", async () => {
+    const response = jobsResponse();
+    response.jobs_process.subsystems[0]!.age_seconds = 2;
+    response.jobs_process.subsystems[0]!.notes = {
+      execution_slot_wait_count: 1,
+      execution_slot_waits: [{
+        job_name: "pg_size_sample",
+        lane: "general_non_sec",
+        waiting_since: "2026-04-16T00:59:50Z",
+        wait_age_seconds: 8.4,
+      }],
+    };
+    mockedJobs.mockResolvedValue(response);
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByRole("button", { name: /Background tasks/ }));
+    expect((await screen.findByText(/pg_size_sample \(10s, general_non_sec\)/)).closest("[role='status']")).toHaveTextContent(
+      "Waiting for execution capacity: pg_size_sample (10s, general_non_sec)",
+    );
   });
 
   it("Run-now happy path: POST + refetch + Queued badge", async () => {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -166,6 +166,12 @@ export function AdminPage() {
   const backgroundJobs = (jobs.data?.jobs ?? []).filter(
     (j) => !ORCHESTRATOR_OWNED.has(j.name),
   );
+  const executionSlotWaits = (jobs.data?.jobs_process.subsystems ?? []).flatMap((subsystem) =>
+    (subsystem.notes?.execution_slot_waits ?? []).map((wait) => ({
+      ...wait,
+      wait_age_seconds: wait.wait_age_seconds + (subsystem.age_seconds ?? 0),
+    })),
+  );
 
   // ProblemsPanel surfaces failing layers with a drill-through; PR6
   // moves the orchestrator detail behind /admin/processes/orchestrator_full_sync
@@ -257,6 +263,17 @@ export function AdminPage() {
               transaction execution, position monitoring, deferred-rec
               retries, and periodic governance.
             </p>
+            {executionSlotWaits.length > 0 ? (
+              <div className="mb-3 border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200" role="status">
+                <strong>Waiting for execution capacity:</strong>{" "}
+                {executionSlotWaits.map((wait, index) => (
+                  <span key={`${wait.job_name}:${wait.waiting_since}`}>
+                    {index > 0 ? "; " : ""}
+                    {wait.job_name} ({Math.max(0, Math.floor(wait.wait_age_seconds))}s, {wait.lane})
+                  </span>
+                ))}
+              </div>
+            ) : null}
             <JobsTable items={backgroundJobs} rowState={rowState} onRun={handleRun} />
           </>
         )}

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -846,3 +846,34 @@ def test_derive_overall_status_engine_up_unchanged() -> None:
     # Engine up + everything clean → ok (default arg also engine-up).
     assert _derive_overall_status(layers, jobs, False, set(), jobs_process_down=False) == "ok"
     assert _derive_overall_status(layers, jobs, False, set()) == "ok"
+
+
+def test_jobs_process_health_preserves_execution_slot_wait_notes() -> None:
+    from app.api.system import _build_jobs_process_health
+
+    conn = _mock_conn()
+    cursor = conn.cursor.return_value.__enter__.return_value
+    cursor.fetchall.return_value = [
+        {
+            "subsystem": "scheduler",
+            "last_beat_at": _NOW - timedelta(seconds=3),
+            "notes": {
+                "execution_slot_wait_count": 1,
+                "execution_slot_waits": [
+                    {
+                        "job_name": "pg_size_sample",
+                        "lane": "general_non_sec",
+                        "waiting_since": (_NOW - timedelta(seconds=12)).isoformat(),
+                        "wait_age_seconds": 9.0,
+                    }
+                ],
+            },
+        }
+    ]
+
+    health = _build_jobs_process_health(conn, _NOW)
+
+    assert health.state == "healthy"
+    assert health.subsystems[0].age_seconds == 3
+    assert health.subsystems[0].notes is not None
+    assert health.subsystems[0].notes["execution_slot_waits"][0]["job_name"] == "pg_size_sample"

--- a/tests/test_connection_budget_sec_lane.py
+++ b/tests/test_connection_budget_sec_lane.py
@@ -33,5 +33,10 @@ def test_demand_plus_reserve_exactly_fits_usable():
 
 def test_execution_gates_fit_the_modeled_cadence_burst():
     assert pg_settings.JOBS_NON_SEC_MAX_CONCURRENCY == 2
+    assert pg_settings.JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY == 1
+    assert pg_settings.JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY == 1
+    assert pg_settings.JOBS_NON_SEC_MAX_CONCURRENCY == (
+        pg_settings.JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY + pg_settings.JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY
+    )
     assert pg_settings.JOBS_NON_SEC_CONNECTIONS_PER_EXECUTION == 2
     assert pg_settings.JOBS_BACKTEST_PROGRESS_CONNECTIONS == 1

--- a/tests/test_connection_budget_sec_lane.py
+++ b/tests/test_connection_budget_sec_lane.py
@@ -32,11 +32,14 @@ def test_demand_plus_reserve_exactly_fits_usable():
 
 
 def test_execution_gates_fit_the_modeled_cadence_burst():
+    # The three pins are the budget claim: the lifecycle reserve exists, and the
+    # TOTAL is unchanged at two so the proved PostgreSQL ceiling is not raised.
+    # ⚠ No sum-equality assert: JOBS_NON_SEC_MAX_CONCURRENCY is *defined* as
+    # GENERAL + PAPER_LIFECYCLE in app/db/pg_settings.py, so asserting the sum
+    # is vacuous — it cannot fail, and it would still pass if both parts moved.
+    # Pinning the absolute values is what actually catches a widened budget.
     assert pg_settings.JOBS_NON_SEC_MAX_CONCURRENCY == 2
     assert pg_settings.JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY == 1
     assert pg_settings.JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY == 1
-    assert pg_settings.JOBS_NON_SEC_MAX_CONCURRENCY == (
-        pg_settings.JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY + pg_settings.JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY
-    )
     assert pg_settings.JOBS_NON_SEC_CONNECTIONS_PER_EXECUTION == 2
     assert pg_settings.JOBS_BACKTEST_PROGRESS_CONNECTIONS == 1

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -233,8 +233,8 @@ class TestDistinctJobConcurrency:
 
 
 class TestConnectionBudgetExecutionGate:
-    def test_third_non_sec_execution_waits_without_opening_a_connection(self) -> None:
-        from app.jobs.runtime import _job_execution_slot
+    def test_paper_lifecycle_enters_while_general_work_waits(self) -> None:
+        from app.jobs.runtime import _job_execution_slot, execution_slot_wait_snapshot
 
         release = threading.Event()
         entered = [threading.Event() for _ in range(3)]
@@ -245,22 +245,58 @@ class TestConnectionBudgetExecutionGate:
                 release.wait(timeout=2.0)
 
         threads = [
-            threading.Thread(target=hold, args=("strategy_paper_cycle", entered[0]), daemon=True),
-            threading.Thread(target=hold, args=("thesis_refresh", entered[1]), daemon=True),
-            threading.Thread(target=hold, args=("pg_size_sample", entered[2]), daemon=True),
+            threading.Thread(target=hold, args=("thesis_refresh", entered[0]), daemon=True),
+            threading.Thread(target=hold, args=("pg_size_sample", entered[1]), daemon=True),
+            threading.Thread(target=hold, args=("strategy_paper_cycle", entered[2]), daemon=True),
         ]
         try:
             threads[0].start()
-            threads[1].start()
             assert entered[0].wait(timeout=1.0)
-            assert entered[1].wait(timeout=1.0)
+            threads[1].start()
+            assert not entered[1].wait(timeout=0.1), "second general job bypassed the one-slot budget"
+            snapshot = execution_slot_wait_snapshot()
+            assert snapshot["execution_slot_wait_count"] == 1
+            assert snapshot["execution_slot_waits"] == [
+                {
+                    "job_name": "pg_size_sample",
+                    "lane": "general_non_sec",
+                    "waiting_since": snapshot["execution_slot_waits"][0]["waiting_since"],
+                    "wait_age_seconds": snapshot["execution_slot_waits"][0]["wait_age_seconds"],
+                }
+            ]
+            assert snapshot["execution_slot_waits"][0]["wait_age_seconds"] >= 0
             threads[2].start()
-            assert not entered[2].wait(timeout=0.1)
+            assert entered[2].wait(timeout=1.0), "paper lifecycle was starved by general jobs"
+        finally:
+            release.set()
+            for thread in threads:
+                if thread.ident is not None:
+                    thread.join(timeout=1.0)
+        assert entered[1].is_set()
+        assert execution_slot_wait_snapshot()["execution_slot_waits"] == []
+
+    def test_second_paper_lifecycle_waits_for_reserved_slot(self) -> None:
+        from app.jobs.runtime import _job_execution_slot
+
+        release = threading.Event()
+        entered = [threading.Event(), threading.Event()]
+
+        def hold(marker: threading.Event) -> None:
+            with _job_execution_slot("strategy_paper_cycle"):
+                marker.set()
+                release.wait(timeout=2.0)
+
+        threads = [threading.Thread(target=hold, args=(marker,), daemon=True) for marker in entered]
+        try:
+            threads[0].start()
+            assert entered[0].wait(timeout=1.0)
+            threads[1].start()
+            assert not entered[1].wait(timeout=0.1)
         finally:
             release.set()
             for thread in threads:
                 thread.join(timeout=1.0)
-        assert entered[2].is_set()
+        assert entered[1].is_set()
 
     def test_fifth_sec_execution_waits_for_one_of_four_slots(self) -> None:
         from app.jobs.runtime import _job_execution_slot


### PR DESCRIPTION
Closes #2767
Refs #2697, #2846

## Problem

`strategy_paper_cycle` could be starved indefinitely by unrelated long-running non-SEC
work, and the starvation was **invisible**.

Execution-slot admission deliberately happens before any database connection is opened, so
a fire waiting on `_NON_SEC_EXECUTION_SLOTS` has no `job_runs` row, no connection, and no
log of why. Worse, APScheduler still counts that waiting instance as active, so every
subsequent 5-minute fire is recorded as `skipped / max_instances_active` — which reads as
"already running" when nothing is running at all.

Observed 2026-08-15: `JOBS_NON_SEC_MAX_CONCURRENCY == 2`, `strategy_backtest_run` and
`thesis_refresh` held both slots, and the 17:10 paper cycle never entered. The 17:03/17:05
cycles were healthy (`reconciled=0 managed=0 evaluated=0`) with no paper `running` row and
no paper DB connection, which rules out a stuck reconciliation body.

## Change

Split the single non-SEC semaphore into two lanes instead of bypassing it
(`app/db/pg_settings.py`):

| constant | value | covers |
| --- | ---: | --- |
| `JOBS_GENERAL_NON_SEC_MAX_CONCURRENCY` | 1 | research, LLM, backfill, evidence refresh |
| `JOBS_PAPER_LIFECYCLE_MAX_CONCURRENCY` | 1 | `strategy_paper_cycle` only |
| `JOBS_NON_SEC_MAX_CONCURRENCY` | 2 | derived — the sum |

**The total is unchanged**, so the proved PostgreSQL connection ceiling is not raised. This
reallocates existing capacity rather than adding any, which is what the ticket asked for
("recalculate and pin the total connection budget rather than simply bypassing the
semaphore").

**Conscious tradeoff:** general non-SEC work drops from two concurrent executions to one.
A long backtest and a long LLM job can no longer overlap each other. That is the cost of
guaranteeing the lifecycle slot, and it is the intended direction — safety-critical
reconciliation of demo-owned positions should not queue behind research.

### Observability

A waiting acquisition is now visible instead of looking like an unexplained missing
`running` row. `_ExecutionSlotWait` records job name, lane and wait age; the scheduler
heartbeat publishes `execution_slot_wait_snapshot()`, `/system` exposes
`execution_slot_wait_count` + `execution_slot_waits`, and the Admin page renders them.

The snapshot is **process-local by construction**, and that is deliberate: writing a
`job_runs` row for a waiter would require a connection, which is exactly the resource it is
waiting for. Logs record the wait on entry and again on admission.

## Security model

No change to any control. The reservation is scheduling-only: `strategy_paper_cycle` remains
serialised by APScheduler `max_instances=1`, the manual in-flight lock, and its source
advisory lock — a second paper cycle is still excluded, which the tests assert directly.
Broker timeouts, the kill switch, execution blocks and the live fail-closed path are
untouched, and the path stays demo-only. Nothing here can admit live capital.

## Verification

All run at `e7687737` in `~/Dev/.ebull-2767`:

| gate | result |
| --- | --- |
| `uv run ruff check .` | pass |
| `uv run ruff format --check .` | pass (1546 files) |
| `uv run pyright` | 0 errors, 0 warnings |
| `uv run pytest -m "not db"` | pass |
| `uv run pytest tests/smoke` | pass |
| `pnpm --dir frontend typecheck` | pass |
| `pnpm --dir frontend test:unit` | 136 files, 1539 tests pass |
| `codex exec review --base origin/main` | no actionable correctness defects |

Behavioural tests added: `test_paper_lifecycle_enters_while_general_work_waits` (saturates
the general lane with long jobs and proves the paper cycle still enters),
`test_second_paper_lifecycle_waits_for_reserved_slot` (proves the reserve does not weaken
per-job serialisation), and
`test_jobs_process_health_preserves_execution_slot_wait_notes`.

No schema migration, no parser or ETL change, so Definition-of-Done clauses 8-12 do not
apply.

## Provenance

This branch was written 2026-08-15 and never pushed. It surfaced in the #2846 worktree audit,
which found 192 committed-but-unpushed commits across 11 branches; all are now on origin.
Rebased clean onto `103675ac` with no conflicts.

One input has changed since the observation: `thesis_refresh` — one of the two jobs that
saturated the lane on 08-15 — is parked as of today (#2855, 9.28 GB resident at a measured
57% duty cycle on a 24 GB box). That lowers current pressure but does not remove the defect;
any long research job reproduces it.
