### PR TITLE
test(#2768): prove one demo trade end to end, and fix the entry-order reconciliation join

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -2564,7 +2564,7 @@ _FIRED_SIGNALS_SQL = """
         GROUP BY sto.strategy_trade_id
     ), entry_order AS (
         SELECT DISTINCT ON (sto.strategy_trade_id)
-               sto.strategy_trade_id, ord.status
+               sto.strategy_trade_id, sto.order_id, ord.status
         FROM strategy_trade_orders sto
         JOIN orders ord ON ord.order_id = sto.order_id
         WHERE sto.purpose = 'entry'
@@ -2668,7 +2668,7 @@ _FIRED_SIGNALS_SQL = """
       ON operation.strategy_trade_id = t.strategy_trade_id
      AND ownership.ownership_count = 1
     LEFT JOIN strategy_order_reconciliation_state reconciliation
-      ON reconciliation.order_id = operation.order_id
+      ON reconciliation.order_id = COALESCE(operation.order_id, eo.order_id)
     LEFT JOIN close_history history ON history.strategy_trade_id = t.strategy_trade_id
     WHERE s.verdict = 'fired'
       AND s.strategy_version = ANY(%(versions)s)
@@ -2714,6 +2714,7 @@ def _trade_lifecycle(row: Mapping[str, object]) -> StrategyTradeLifecycle | None
 
     operation_status = row["lifecycle_operation_status"]
     reconciliation_state = row["lifecycle_reconciliation_state"]
+    reconciliation_scope = "position_operation" if row["lifecycle_operation_order_id"] is not None else "entry_order"
     if operation_status == "rejected":
         reasons.append("position_operation_rejected")
     elif operation_status == "reconcile_required":
@@ -2721,13 +2722,13 @@ def _trade_lifecycle(row: Mapping[str, object]) -> StrategyTradeLifecycle | None
     if row["lifecycle_operation_error"] is not None:
         reasons.append("position_operation_error")
     if reconciliation_state in {"not_found", "ambiguous", "error", "rejected"}:
-        reasons.append(f"position_operation_reconciliation_{reconciliation_state}")
+        reasons.append(f"{reconciliation_scope}_reconciliation_{reconciliation_state}")
     if row["lifecycle_reconciliation_error"] is not None and reconciliation_state not in {
         "not_found",
         "ambiguous",
         "error",
     }:
-        reasons.append("position_operation_reconciliation_error")
+        reasons.append(f"{reconciliation_scope}_reconciliation_error")
     reasons.extend(history_reasons)
 
     if trade_status == "failed" and ownership_count == 0:

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -1290,6 +1290,33 @@ describe("StrategiesPage", () => {
     expect(within(row).queryByText(/realised/)).not.toBeInTheDocument();
   });
 
+  it("labels an ambiguous entry-order reconciliation separately from a position operation", async () => {
+    const ambiguousEntry: FiredSignal = {
+      ...FUNDED_SIGNAL,
+      trade_lifecycle: {
+        ...FUNDED_SIGNAL.trade_lifecycle!,
+        latest_operation_type: null,
+        latest_operation_id: null,
+        latest_operation_order_id: null,
+        latest_operation_trigger: null,
+        latest_operation_status: null,
+        latest_operation_created_at: null,
+        latest_operation_submitted_at: null,
+        latest_operation_resolved_at: null,
+        latest_reconciliation_state: "ambiguous",
+        latest_reconciliation_broker_status: "multiple_matches",
+        latest_reconciliation_error: "multiple_position_executions",
+        incomplete_reasons: ["entry_order_reconciliation_ambiguous"],
+      },
+    };
+    vi.mocked(strategiesApi.fetchFiredSignals).mockResolvedValue({ items: [ambiguousEntry], next_cursor: null });
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const section = (await screen.findByText("Generated trade activity")).closest("section")!;
+    expect(within(section).getByText("Entry order has ambiguous broker reconciliation")).toBeInTheDocument();
+    expect(within(section).getByText("Reconciliation ambiguous · broker multiple matches")).toBeInTheDocument();
+  });
+
   it("renders failed and reconciliation-required trades as risk states", async () => {
     const failed: FiredSignal = {
       ...FUNDED_SIGNAL,

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -595,6 +595,10 @@ const REFUSAL_LABELS: Record<string, string> = {
   position_operation_reconciliation_not_found: "Latest operation was not found at the broker",
   position_operation_reconciliation_ambiguous: "Latest operation has ambiguous broker reconciliation",
   position_operation_reconciliation_error: "Latest operation reconciliation failed",
+  entry_order_reconciliation_not_found: "Entry order was not found at the broker",
+  entry_order_reconciliation_ambiguous: "Entry order has ambiguous broker reconciliation",
+  entry_order_reconciliation_rejected: "Entry order was rejected by the broker",
+  entry_order_reconciliation_error: "Entry order reconciliation failed",
 };
 
 function refusalLabel(refusal: string): string {
@@ -1000,6 +1004,9 @@ function StrategyActivity({
               <tbody>
                 {items.map((signal) => {
                   const funding = fundingPresentation(signal);
+                  const operationalLifecycleReasons = (signal.trade_lifecycle?.incomplete_reasons ?? []).filter(
+                    (reason) => reason.startsWith("entry_order_") || reason.startsWith("position_operation_"),
+                  );
                   return (
                     <tr key={signal.signal_id} className="border-t border-slate-200 align-top dark:border-slate-800">
                       <td className="px-4 py-3">
@@ -1053,6 +1060,9 @@ function StrategyActivity({
                               </span>
                             ) : null}
                             {signal.trade_lifecycle.latest_reconciliation_error ? <span className="block text-red-700 dark:text-red-300">{refusalLabel(signal.trade_lifecycle.latest_reconciliation_error)}</span> : null}
+                            {operationalLifecycleReasons.length > 0 ? (
+                              <span className="block text-red-700 dark:text-red-300">{operationalLifecycleReasons.map(refusalLabel).join(" · ")}</span>
+                            ) : null}
                           </>
                         ) : null}
                       </td>

--- a/tests/test_strategy_paper_runtime.py
+++ b/tests/test_strategy_paper_runtime.py
@@ -10,6 +10,8 @@ import psycopg
 import pytest
 from psycopg.pq import TransactionStatus
 
+from app.api.strategies import get_fired_signals, get_strategy_owned_positions
+from app.providers.broker import BrokerPortfolio
 from app.services.cost_model import COST_MODEL_ID
 from app.services.strategy_live_gate import assess_live_gate
 from app.services.strategy_opportunity_forecast import OpportunityForecast, record_opportunity_forecast
@@ -21,7 +23,13 @@ from app.services.strategy_paper_runtime import (
     run_strategy_paper_cycle,
 )
 from tests.test_strategy_paper_executor import _NOW, _REQUEST_ID, _authorise_forecast_scope, _broker, _seed
-from tests.test_strategy_position_manager import _opened_trade
+from tests.test_strategy_position_manager import (
+    _MANUAL_POSITION_ID,
+    _POSITION_ID,
+    _opened_trade,
+    _order_detail,
+    _position,
+)
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
@@ -111,6 +119,160 @@ def test_cycle_refreshes_health_then_executes_one_current_paper_candidate(
         ("quote_freshness", False),
         ("scan_freshness", False),
     ]
+
+
+def test_generated_demo_trade_is_auditable_through_reconciliation_and_operator_reads(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Execution-plumbing acceptance only; ``S-ALLOC`` is a synthetic test candidate."""
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    broker = _broker()
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+
+    submitted = run_strategy_paper_cycle(conn, broker=broker, now=_NOW, strategy_versions=["v1"])
+
+    assert submitted.evaluated_signals == 1
+    broker.place_demo_strategy_order.assert_called_once()
+    order_row = conn.execute(
+        """
+        SELECT t.strategy_trade_id,o.order_id,o.strategy_request_id,o.broker_order_ref,
+               pf.forecast_id,pf.ranking_member_id,pf.verdict,fd.amount
+        FROM strategy_funding_decisions fd
+        JOIN strategy_entry_preflights pf ON pf.signal_id=fd.signal_id
+        JOIN strategy_trades t ON t.funding_decision_id=fd.funding_decision_id
+        JOIN strategy_trade_orders sto ON sto.strategy_trade_id=t.strategy_trade_id
+        JOIN orders o ON o.order_id=sto.order_id
+        WHERE fd.signal_id=%s
+        """,
+        (signal_id,),
+    ).fetchone()
+    assert order_row is not None
+    trade_id, order_id, request_id, broker_order_ref, forecast_id, ranking_member_id, verdict, amount = order_row
+    assert request_id == _REQUEST_ID
+    assert broker_order_ref == "13902598"
+    assert forecast_id is not None and ranking_member_id is not None
+    assert verdict == "allocated"
+    assert amount == Decimal("50.000000")
+    conn.commit()
+
+    # The next bounded cycle observes the broker fill, claims only its exact
+    # execution and manages it. A same-instrument manual position is visible to
+    # the broker but must never be claimed by strategy ownership.
+    broker.lookup_order.return_value = _order_detail()
+    manual = _position(_MANUAL_POSITION_ID, stop=None, take=None)
+    broker.get_portfolio.return_value = BrokerPortfolio(
+        positions=(
+            _position(_POSITION_ID, stop=Decimal("95"), take=Decimal("110")),
+            manual,
+        ),
+        available_cash=Decimal("500"),
+        raw_payload={},
+    )
+    reconciled = run_strategy_paper_cycle(
+        conn,
+        broker=broker,
+        now=_NOW + timedelta(minutes=5),
+        strategy_versions=["v1"],
+    )
+
+    assert reconciled.reconciled_orders == 1
+    assert reconciled.managed_positions == 1
+    assert reconciled.evaluated_signals == 0
+    broker.place_demo_strategy_order.assert_called_once()
+    assert conn.execute(
+        """
+        SELECT ownership.broker_position_id,t.status,reconciliation.state,
+               reconciliation.broker_status
+        FROM strategy_position_ownership ownership
+        JOIN strategy_trades t ON t.strategy_trade_id=ownership.strategy_trade_id
+        JOIN strategy_trade_orders sto ON sto.strategy_trade_id=t.strategy_trade_id
+        JOIN strategy_order_reconciliation_state reconciliation ON reconciliation.order_id=sto.order_id
+        WHERE ownership.strategy_trade_id=%s
+        """,
+        (trade_id,),
+    ).fetchall() == [(_POSITION_ID, "open", "resolved", "Filled")]
+    assert conn.execute(
+        "SELECT count(*) FROM strategy_position_ownership WHERE broker_position_id=%s",
+        (_MANUAL_POSITION_ID,),
+    ).fetchone() == (0,)
+
+    # The production endpoint intentionally filters to current manifest
+    # versions. Admit only this synthetic fixture version at that boundary;
+    # this is plumbing proof, never production strategy registration.
+    #
+    # ⚠ SCAN basis, not the result basis (#2814). ``_FIRED_SIGNALS_SQL`` reads
+    # ``strategy_signals``, written only by ``signal_ledger`` under
+    # ``SCAN_UNIVERSE``, and the two bases are disjoint — patching
+    # ``_current_versions`` here binds an identity this SQL never matches, so
+    # the page comes back empty and the assertion below dies on StopIteration
+    # rather than on anything the fixture did.
+    monkeypatch.setattr("app.api.strategies._current_scan_versions", lambda: {"S-ALLOC": "v1"})
+    signals = get_fired_signals(cursor=None, limit=50, strategy_id="S-ALLOC", conn=conn)
+    visible = next(item for item in signals.items if item.signal_id == signal_id)
+    assert visible.funding_status == "funded"
+    assert visible.funded_amount == amount
+    assert visible.strategy_trade_id == trade_id
+    assert visible.trade_lifecycle is not None
+    assert visible.trade_lifecycle.trade_status == "open"
+    assert visible.trade_lifecycle.ownership_count == 1
+    assert visible.trade_lifecycle.broker_position_id == _POSITION_ID
+    assert visible.trade_lifecycle.latest_reconciliation_state == "resolved"
+
+    conn.execute(
+        """
+        UPDATE strategy_order_reconciliation_state
+        SET state='ambiguous',reconciled_at=NULL,last_error_code='multiple_position_executions'
+        WHERE order_id=%s
+        """,
+        (order_id,),
+    )
+    ambiguous_signals = get_fired_signals(cursor=None, limit=50, strategy_id="S-ALLOC", conn=conn)
+    ambiguous = next(item for item in ambiguous_signals.items if item.signal_id == signal_id)
+    assert ambiguous.trade_lifecycle is not None
+    assert ambiguous.trade_lifecycle.incomplete_reasons == ["entry_order_reconciliation_ambiguous"]
+    conn.execute(
+        """
+        UPDATE strategy_order_reconciliation_state
+        SET state='resolved',reconciled_at=now(),last_error_code=NULL
+        WHERE order_id=%s
+        """,
+        (order_id,),
+    )
+
+    positions = get_strategy_owned_positions(conn)
+    owned = next(item for item in positions.positions if item.strategy_trade_id == trade_id)
+    assert owned.broker_position_id == _POSITION_ID
+    assert owned.strategy_id == "S-ALLOC"
+    assert owned.trade_status == "open"
+    # The operator can see the owned identity immediately; valuation stays
+    # explicitly unavailable until the independent portfolio sync persists it.
+    assert not owned.valuation_available
+    assert positions.live_quote_instrument_ids == [2449001]
+    conn.commit()
+
+    # A third replay is read-only for this signal/order and remains one owned
+    # lifecycle. It may manage the already-open position again, but cannot mint
+    # another funding decision, trade, order or broker submission.
+    replay = run_strategy_paper_cycle(
+        conn,
+        broker=broker,
+        now=_NOW + timedelta(minutes=10),
+        strategy_versions=["v1"],
+    )
+    assert replay.reconciled_orders == 0
+    assert replay.evaluated_signals == 0
+    broker.place_demo_strategy_order.assert_called_once()
+    assert conn.execute(
+        """
+        SELECT
+          (SELECT count(*) FROM strategy_funding_decisions WHERE signal_id=%s),
+          (SELECT count(*) FROM strategy_trades WHERE strategy_trade_id=%s),
+          (SELECT count(*) FROM strategy_trade_orders WHERE order_id=%s),
+          (SELECT count(*) FROM strategy_position_ownership WHERE strategy_trade_id=%s)
+        """,
+        (signal_id, trade_id, order_id, trade_id),
+    ).fetchone() == (1, 1, 1, 1)
 
 
 def test_runtime_ranks_the_complete_set_before_applying_its_execution_limit(


### PR DESCRIPTION
Closes #2768
Refs #2697, #2766, #2767, #2846

## Problem

Every paper-trading component had strong isolated coverage, and nothing crossed their
boundaries. The runtime happy-path test stopped at the funding verdict; reconciliation tests
started from a separately seeded order; position-manager tests started from a separately
opened trade; Strategies-page tests used mocked API payloads. A wiring regression could leave
all of them green while the operator could not observe one generated demo trade end to end.

## Change

### 1. The acceptance test

`test_generated_demo_trade_is_auditable_through_reconciliation_and_operator_reads` drives the
real paper cycle against a bounded fake broker:

- seeds the full historical / prospective / promotion / allocation authority the executor
  requires, from an explicitly registered **synthetic** capital candidate (`S-ALLOC`)
- cycle 1 → ranking, funding, broker preflight, demo submission
- cycle 2 → order reconciliation, exact position ownership, position management
- reads back through the **real** Strategies API service functions and asserts the signal
  lifecycle, order, owned position, allocation and audit identities all agree
- asserts exactly one demo submission and idempotent replay
- asserts a same-instrument **manual** position is never claimed

### 2. A real defect the test found

`_FIRED_SIGNALS_SQL` joined `strategy_order_reconciliation_state` on the position
operation's `order_id` only:

```sql
LEFT JOIN strategy_order_reconciliation_state reconciliation
  ON reconciliation.order_id = operation.order_id
```

A trade whose only order is the **entry** order — i.e. every freshly opened position, before
any position operation exists — therefore reported no reconciliation state at all. Fixed
with `COALESCE(operation.order_id, eo.order_id)`.

The refusal reasons were mislabelled for the same reason: a failure on the entry order was
reported as `position_operation_reconciliation_*`. They are now scoped by which order they
actually describe (`entry_order_*` vs `position_operation_*`), with matching labels rendered
on StrategiesPage.

## Security model

No control is weakened. `S-ALLOC` is a synthetic fixture and this is execution-plumbing
evidence only — it neither creates, promotes, nor implies a profitable production strategy.
Live/real activation stays fail-closed, no external broker is mutated, and the fake broker is
bounded. The SQL change is read-path only.

## Verification

At `6e45880c` in `~/Dev/.ebull-2768`:

| gate | result |
| --- | --- |
| `uv run ruff check .` | pass |
| `uv run ruff format --check .` | pass (1549 files) |
| `uv run pyright` | 0 errors, 0 warnings |
| `uv run pytest -m "not db"` | pass |
| `uv run pytest tests/smoke` | pass |
| `uv run pytest -m db tests/test_strategy_paper_runtime.py` | **10 passed** |
| `pnpm --dir frontend typecheck` | pass |
| `pnpm --dir frontend test:unit` | 136 files, 1540 tests pass |
| `codex exec review --base origin/main` | no actionable correctness regressions |

## One fix made during the rebase, worth a reviewer's eye

This branch was written 2026-08-15 and never pushed (surfaced by the #2846 worktree audit).
Rebased onto `103675ac` it compiled and linted clean but the acceptance test failed with a
bare `StopIteration` — the endpoint returned an empty page.

Cause: **#2814 moved `get_fired_signals` onto the scan version basis.** `_FIRED_SIGNALS_SQL`
reads `strategy_signals`, whose only writer is `signal_ledger` under `SCAN_UNIVERSE`, and per
#2803 the scan and result bases are **disjoint** — so the endpoint now binds
`_current_scan_versions()`. The test was still monkeypatching `_current_versions`, an identity
this SQL can never match. Repointed to `_current_scan_versions`, with the reason recorded at
the patch site so the next rebase does not have to rediscover it.

Worth noting the failure mode: patching the wrong version seam does not raise anything
diagnostic — it silently returns zero rows, and the test dies several lines later on
`next(...)`. Same shape as the defect above, from the opposite direction.

No schema migration, no parser or ETL change, so Definition-of-Done clauses 8-12 do not apply.
