### PR TITLE
feature(#2845): retire the dead eight, by name, without hiding them

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -460,17 +460,29 @@ _EXISTING_RESULT_VERSIONS = """
 # ---------------------------------------------------------------------------
 
 
+#: Why an entry is excluded. ``capability`` = the builder cannot produce a result
+#: for it; ``retired`` = it could, and policy says it must not (#2845). A consumer
+#: that needs to tell them apart must not have to parse prose.
+ExclusionKind = Literal["capability", "retired"]
+
+
 @dataclass(frozen=True)
 class ExcludedStrategy:
-    """A manifest entry that cannot produce a result row, and the reason.
+    """A manifest entry that will not produce a result row, and the reason.
 
-    ⚠ The reason is the message ``build_positions`` RAISED, not a paraphrase of
-    it. §3: the entire exclusion of S-4 rests on that refusal, and a paraphrase
-    goes stale the day the builder's rule changes.
+    ⚠ For ``kind="capability"`` the reason is the message ``build_positions``
+    RAISED, not a paraphrase of it. §3: the entire exclusion of S-4 rests on that
+    refusal, and a paraphrase goes stale the day the builder's rule changes.
+
+    ⚠ For ``kind="retired"`` (#2845) the reason is the manifest's declared
+    ``retired_reason``. That is a POLICY statement rather than a builder refusal,
+    which is why the two carry a discriminator instead of one overloaded string —
+    the sentence above stays true of the arm it was written about.
     """
 
     strategy_id: str
     reason: str
+    kind: ExclusionKind = "capability"
 
 
 @dataclass(frozen=True)
@@ -719,31 +731,45 @@ def runnable_strategies(
     one state this function must not paper over: the exclusion is derived from
     the refusal, so a missing refusal means the derivation no longer holds and
     the honest answer is to stop rather than to guess which way it went.
+
+    ⚠⚠ CAPABILITY IS VALIDATED FOR EVERY ENTRY, INCLUDING RETIRED ONES (#2845),
+    AND THE RETIREMENT TEST COMES AFTER (Codex ckpt-1). Short-circuiting on
+    ``retired_reason`` first would make retirement **a way to conceal a malformed
+    declaration** — the two raises below are manifest-schema assertions, not
+    merely the derivation behind one exclusion, and eight of ten entries would
+    stop being checked in one change. The probe runs against a synthetic
+    ``_PROBE_CALENDAR``, so there is no cost argument for skipping it either.
+
+    ⚠ A capability exclusion OUTRANKS a retirement one in the reported reason:
+    "the builder cannot produce a result for this at all" is the stronger
+    statement, and a retired entry that is also broken should say so.
     """
     runnable: list[str] = []
     excluded: list[ExcludedStrategy] = []
     for strategy_id in sorted(manifest):
         entry = manifest[strategy_id]
         regime = _regime_for(entry, calendar)
+        capability_refusal: str | None = None
         if not regime.level_based:
             if entry.exit_levels is not None or entry.exit_levels_batch is not None:
                 raise RuntimeError(
                     f"{strategy_id} supplies scalar or batch exit levels for a non-level regime — the declared "
                     "close source and its consumer disagree"
                 )
+        elif entry.exit_levels is None:
+            capability_refusal = _demonstrate_level_refusal(entry, regime)
+            if capability_refusal is None:
+                raise RuntimeError(
+                    f"{strategy_id} is level_based but build_positions did NOT refuse an entry with no outcome — "
+                    "§3.2 excludes it BECAUSE of that refusal, so the exclusion can no longer be derived and the "
+                    "spec has to be re-measured rather than trusted"
+                )
+        if capability_refusal is not None:
+            excluded.append(ExcludedStrategy(strategy_id=strategy_id, reason=capability_refusal, kind="capability"))
+        elif entry.retired_reason is not None:
+            excluded.append(ExcludedStrategy(strategy_id=strategy_id, reason=entry.retired_reason, kind="retired"))
+        else:
             runnable.append(strategy_id)
-            continue
-        if entry.exit_levels is not None:
-            runnable.append(strategy_id)
-            continue
-        refusal = _demonstrate_level_refusal(entry, regime)
-        if refusal is None:
-            raise RuntimeError(
-                f"{strategy_id} is level_based but build_positions did NOT refuse an entry with no outcome — "
-                "§3.2 excludes it BECAUSE of that refusal, so the exclusion can no longer be derived and the "
-                "spec has to be re-measured rather than trusted"
-            )
-        excluded.append(ExcludedStrategy(strategy_id=strategy_id, reason=refusal))
     return tuple(runnable), tuple(excluded)
 
 
@@ -4269,5 +4295,6 @@ __all__ = [
     "load_corpus",
     "log_report",
     "run_backtest",
+    "ExclusionKind",
     "runnable_strategies",
 ]

--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -4284,6 +4284,7 @@ __all__ = [
     "ArmMeasurement",
     "BacktestRunReport",
     "ExcludedStrategy",
+    "ExclusionKind",
     "NamespaceMeasurement",
     "WrittenRow",
     "assert_no_existing_results",
@@ -4295,6 +4296,5 @@ __all__ = [
     "load_corpus",
     "log_report",
     "run_backtest",
-    "ExclusionKind",
     "runnable_strategies",
 ]

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -527,6 +527,27 @@ def promote_strategy(
     if to_stage == "live_enabled":
         raise StrategyControlError("live_enabled requires the dedicated measured live-promotion gate")
     purpose = registered_strategy_purpose(strategy_id)
+    # #2845. A retired strategy produces no new evidence, so it must not advance on
+    # old evidence either. This is the chokepoint every promotion path passes: the
+    # API's `/advance`, #2770's `advance_strategy`, and #2843's autonomous approver.
+    # `strategy_paper_runtime` selects `capital_candidate` entries directly rather
+    # than through `runnable_strategies`, so a retired capital candidate would
+    # otherwise be paper-executable the day one exists.
+    #
+    # ⚠ FIRST, ahead of the two purpose checks, and that is deliberate rather than
+    # arbitrary. Placed after them it would be UNREACHABLE — every manifest entry is
+    # `harness_validation` today, so the first check always wins — and an
+    # unreachable guard cannot be proven to work, which is how a guard rots. It is
+    # also the strongest statement available about a strategy: "this is dead" says
+    # more than "this is not a capital candidate".
+    #
+    # ⚠ SCOPED TO THE EVIDENCE STAGES, like the two checks below. `paused` and
+    # `retired` must stay reachable for a retired entry, or the retired eight become
+    # unmanageable — a lifecycle that cannot be wound down is worse than one that
+    # can still move forward.
+    manifest_entry = STRATEGY_MANIFEST.get(strategy_id)
+    if to_stage in _EXTERNAL_EVIDENCE_STAGES and manifest_entry is not None and manifest_entry.retired_reason:
+        raise StrategyControlError(f"{strategy_id} is retired and cannot advance: {manifest_entry.retired_reason}")
     if to_stage in _EXTERNAL_EVIDENCE_STAGES and purpose == "harness_validation":
         raise StrategyControlError("harness-validation strategies are permanent controls and cannot be promoted")
     if to_stage in _EXTERNAL_EVIDENCE_STAGES and purpose != "capital_candidate":

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -365,10 +365,30 @@ class StrategyEntry:
     #: Optional result-equivalent batch form. It may share immutable indicator
     #: work, never entry-specific prices or signal indices.
     exit_levels_batch: ExitLevelsBatchFactory | None = None
+    #: #2845. Set iff this strategy is retired: it produces NO new evidence, and
+    #: this string is the named reason every surface reports instead of a silent
+    #: skip. ``None`` is the live state.
+    #:
+    #: ⚠⚠ A retired entry STAYS IN THE MANIFEST. Membership is what keeps its
+    #: stored results resolvable -- ``registered_strategy_purpose``,
+    #: ``current_result_versions`` and the ``/strategies`` card all key on it, and
+    #: deleting the entry would strand immutable result rows at a version the code
+    #: no longer produces. Only RUNNABILITY changes.
+    #:
+    #: ⚠ Deliberately NOT part of the identity hash, which comes from the
+    #: ``identity`` factory rather than from this dataclass. If it ever entered,
+    #: retiring a strategy would rotate its version and falsify exactly the claim
+    #: above. Pinned by a test rather than left as a reading.
+    retired_reason: str | None = None
 
     def __post_init__(self) -> None:
         if not self.strategy_id.strip():
             raise ValueError("strategy_id must be a non-empty declaration")
+        if self.retired_reason is not None and not self.retired_reason.strip():
+            # Blank and whitespace-only are the same defect: both render an empty
+            # exclusion in the UI and in a job note, which reads as "retired for no
+            # reason" -- the silent skip this field exists to prevent.
+            raise ValueError(f"{self.strategy_id} declares a blank retired_reason; retirement must name its reason")
         if self.purpose not in STRATEGY_PURPOSES:
             raise ValueError(f"unknown strategy purpose {self.purpose!r}; must be one of {sorted(STRATEGY_PURPOSES)}")
         if self.strategy_class not in STRATEGY_CLASSES:
@@ -847,6 +867,40 @@ def _s10_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
     return ExitRegime(signal_pair=True, level_based=False, max_hold_bars=None, rebalance_dates=None)
 
 
+# ---------------------------------------------------------------------------
+# Retirement reasons (#2845)
+# ---------------------------------------------------------------------------
+#
+# The operator's cut-and-reset (2026-08-22) retires eight of the ten on #2827's
+# measurement.  Three verdict classes, because #2827 measured three and a single
+# uniform string would throw that away.
+#
+# ⚠⚠ NO FIGURE FROM #2827 IS COPIED HERE.  A derived statistic written by hand
+# goes stale silently in the place a reader trusts most, so these name the
+# verdict CLASS and the ticket that holds the reproducible numbers.  Read them
+# there: `gh issue view 2827 --comments`.
+#
+# ⚠ Retirement stops NEW evidence.  It deletes nothing, and it does not stop
+# `run_outcome_resolution` draining already-fired signals -- see its own note.
+
+_RETIRED_GROSS_NEGATIVE = (
+    "retired 2026-08-22: measured gross-negative per trade at ZERO cost, so no cost "
+    "reduction can reach the deflation bar (#2827, #2832)"
+)
+
+_RETIRED_NOT_A_COST_PROBLEM = (
+    "retired 2026-08-22: measured gross-negative per trade at ZERO cost, and cost accounts "
+    "for a minority of the loss -- the band sensitivity is far narrower than the loss "
+    "itself, so this is not a cost problem in any arm (#2827, #2832)"
+)
+
+_RETIRED_SHORT_OF_THE_BAR = (
+    "retired 2026-08-22: gross-POSITIVE but its gross trade Sharpe is an order below the "
+    "deflation bar, and it is not one of the two candidates -- break-even at a realistic "
+    "cost band, or an edge that is mostly an ambiguity-arm assumption (#2827, #2832)"
+)
+
+
 #: Every strategy in the catalogue, keyed by ``strategy_id``.
 #:
 #: ⚠⚠ COMPLETENESS IS A TEST, NOT A CONVENTION.
@@ -867,6 +921,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             exit_regime=_s1_exit_regime,
             decision_calendar=_no_decision_calendar,
             signals=_s1_signals,
+            retired_reason=_RETIRED_GROSS_NEGATIVE,
         ),
         S2_STRATEGY_ID: StrategyEntry(
             strategy_id=S2_STRATEGY_ID,
@@ -879,6 +934,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             member=_s2_member,
             select=s2_select,
             min_participants=MIN_CROSS_SECTION,
+            retired_reason=_RETIRED_NOT_A_COST_PROBLEM,
         ),
         S3_STRATEGY_ID: StrategyEntry(
             strategy_id=S3_STRATEGY_ID,
@@ -889,6 +945,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             exit_regime=_s3_exit_regime,
             decision_calendar=_no_decision_calendar,
             signals=_s3_signals,
+            retired_reason=_RETIRED_SHORT_OF_THE_BAR,
         ),
         S4_STRATEGY_ID: StrategyEntry(
             strategy_id=S4_STRATEGY_ID,
@@ -913,6 +970,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             signals=_s5_signals,
             exit_levels=_s5_exit_levels,
             exit_levels_batch=s5_exit_levels_batch,
+            retired_reason=_RETIRED_SHORT_OF_THE_BAR,
         ),
         S6_STRATEGY_ID: StrategyEntry(
             strategy_id=S6_STRATEGY_ID,
@@ -925,6 +983,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             signals=_s6_signals,
             exit_levels=_s6_exit_levels,
             exit_levels_batch=s6_exit_levels_batch,
+            retired_reason=_RETIRED_GROSS_NEGATIVE,
         ),
         S7_STRATEGY_ID: StrategyEntry(
             strategy_id=S7_STRATEGY_ID,
@@ -937,6 +996,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             signals=_s7_signals,
             exit_levels=_s7_exit_levels,
             exit_levels_batch=s7_exit_levels_batch,
+            retired_reason=_RETIRED_GROSS_NEGATIVE,
         ),
         S8_STRATEGY_ID: StrategyEntry(
             strategy_id=S8_STRATEGY_ID,
@@ -961,6 +1021,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             signals=_s9_signals,
             exit_levels=_s9_exit_levels,
             exit_levels_batch=s9_exit_levels_batch,
+            retired_reason=_RETIRED_GROSS_NEGATIVE,
         ),
         S10_STRATEGY_ID: StrategyEntry(
             strategy_id=S10_STRATEGY_ID,
@@ -978,6 +1039,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
                 select=s10_exit_select,
                 min_participants=S10_MIN_CROSS_SECTION,
             ),
+            retired_reason=_RETIRED_NOT_A_COST_PROBLEM,
         ),
     }
 )

--- a/app/services/strategy_outcome_resolution.py
+++ b/app/services/strategy_outcome_resolution.py
@@ -252,6 +252,15 @@ def run_outcome_resolution(
     if batch_limit < 1:
         raise ValueError(f"batch_limit must be positive, got {batch_limit}")
 
+    # ⚠⚠ RETIRED STRATEGIES ARE **NOT** FILTERED OUT HERE (#2845), and that is the
+    # decision rather than an oversight — an unexamined omission and a deliberate
+    # one look identical in a diff, so it is written down.
+    #
+    # Retirement stops a strategy producing NEW evidence; it never stops the drain
+    # of old. s5/s6/s7/s9 are retired and level-based, and they hold already-fired
+    # signals whose outcomes are unresolved. Filtering them would strand those
+    # permanently — corrupting the very evidence record retirement exists to
+    # preserve, and doing it silently, because an unresolved fill has no alarm.
     level_entries = [(strategy_id, entry) for strategy_id, entry in sorted(manifest.items()) if entry.exit_levels]
     if len(level_entries) > batch_limit:
         raise ValueError(

--- a/app/services/strategy_scan_freshness.py
+++ b/app/services/strategy_scan_freshness.py
@@ -33,7 +33,7 @@ Spec: ``docs/proposals/ops/2026-08-13-strategy-scan-freshness.md``
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, Sequence, Set
 from dataclasses import dataclass
 from datetime import date
 from typing import Any, Literal
@@ -44,6 +44,14 @@ logger = logging.getLogger(__name__)
 
 ScanFreshnessStatus = Literal[
     "ok",
+    #: #2845 — the manifest declares this strategy retired, so it is EXPECTED not
+    #: to scan. ⚠⚠ Non-alerting, and that is the whole point of the status. A
+    #: retired strategy's watermark freezes the day it retires, so without this
+    #: every poll of /system/status would report it `stale` for ever — the
+    #: prevention-log defect of an alarm with a documented "ignore this" attached,
+    #: which is strictly worse than no alarm because it still costs attention and
+    #: occupies the slot a working detector would have.
+    "retired",
     "stale",
     "rotated_awaiting_scan",
     "rotated_scan_overdue",
@@ -154,6 +162,7 @@ def assess_scan_freshness(
     current_versions: Mapping[str, str],
     watermarks: Mapping[tuple[str, str], date],
     trading_dates: Sequence[date],
+    retired_ids: Set[str] = frozenset(),
 ) -> list[StrategyScanFreshness]:
     """Pure verdict for every strategy in ``current_versions``.
 
@@ -161,7 +170,8 @@ def assess_scan_freshness(
     ``watermarks`` is ``read_watermarks``' shape, keyed ``(strategy_id, version)``.
 
     Returns one entry per strategy, always — a strategy with no verdict is a
-    strategy nothing reports on.
+    strategy nothing reports on. That includes retired ones (#2845): they get a
+    `retired` verdict rather than disappearing, for the same reason.
     """
     corpus_date = trading_dates[-1] if trading_dates else None
     newest_by_strategy: dict[str, date] = {}
@@ -200,6 +210,13 @@ def assess_scan_freshness(
                 detail=detail,
             )
 
+        if strategy_id in retired_ids:
+            # #2845. FIRST, ahead of every measurement: a retired strategy is
+            # expected not to scan, so its lag is not a defect and reporting one
+            # would be a permanent false alarm. The verdict still carries the
+            # watermark it froze at, so "when did it stop" stays answerable.
+            results.append(_verdict("retired", detail="retired in the strategy manifest"))
+            continue
         if basis_date is None:
             # No watermark under ANY version. One state, one meaning -- "no track
             # record at all" -- which also absorbs a renamed strategy_id and a
@@ -238,8 +255,13 @@ def assess_scan_freshness(
 
 def read_scan_freshness_inputs(
     conn: psycopg.Connection[Any],
-) -> tuple[dict[str, str], dict[tuple[str, str], date], list[date]]:
-    """The three measured inputs, so the verdict itself stays pure and testable."""
+) -> tuple[dict[str, str], dict[tuple[str, str], date], list[date], frozenset[str]]:
+    """The measured inputs, so the verdict itself stays pure and testable.
+
+    ``retired_ids`` is read from the manifest here rather than in the pure verdict,
+    for the same reason as the other three: the verdict must be table-testable
+    without importing the live catalogue (#2845).
+    """
     from app.services.cost_model import COST_MODEL_ID
     from app.services.strategy_manifest import STRATEGY_MANIFEST
     from app.services.strategy_signal_scan import SCAN_UNIVERSE, read_watermarks
@@ -248,9 +270,12 @@ def read_scan_freshness_inputs(
         strategy_id: entry.identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID).version
         for strategy_id, entry in STRATEGY_MANIFEST.items()
     }
+    retired_ids = frozenset(
+        strategy_id for strategy_id, entry in STRATEGY_MANIFEST.items() if entry.retired_reason is not None
+    )
     watermarks = read_watermarks(conn)
     trading_dates = [row[0] for row in conn.execute(_RECENT_TRADING_DATES, {"window": _TRADING_DATE_WINDOW}).fetchall()]
-    return current_versions, watermarks, trading_dates
+    return current_versions, watermarks, trading_dates, retired_ids
 
 
 def check_scan_freshness(conn: psycopg.Connection[Any]) -> list[StrategyScanFreshness]:
@@ -271,7 +296,7 @@ def check_scan_freshness(conn: psycopg.Connection[Any]) -> list[StrategyScanFres
     """
     try:
         with conn.transaction():
-            current_versions, watermarks, trading_dates = read_scan_freshness_inputs(conn)
+            current_versions, watermarks, trading_dates, retired_ids = read_scan_freshness_inputs(conn)
     except Exception:
         logger.exception("check_scan_freshness: failed to read inputs")
         return [
@@ -288,7 +313,12 @@ def check_scan_freshness(conn: psycopg.Connection[Any]) -> list[StrategyScanFres
                 detail="scan freshness query failed (see server logs)",
             )
         ]
-    return assess_scan_freshness(current_versions=current_versions, watermarks=watermarks, trading_dates=trading_dates)
+    return assess_scan_freshness(
+        current_versions=current_versions,
+        watermarks=watermarks,
+        trading_dates=trading_dates,
+        retired_ids=retired_ids,
+    )
 
 
 __all__ = [

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -116,11 +116,31 @@ StrategyScanStatus = Literal[
     "written",
     "up_to_date",
     "refused_frontier_regressed",
+    #: #2845 — the manifest declares this strategy retired, so it produces no new
+    #: evidence. ⚠ A RECORDED result, never an absent one: a run reporting "2
+    #: strategies evaluated" with eight silently missing is the narrowing
+    #: criterion 9 forbids, and it is the whole reason retirement carries a named
+    #: reason rather than being a deletion.
+    "refused_retired",
     "failed",
 ]
 
 #: (signal_kind, verdict, not_evaluable_reason or "") -> count.
 CensusKey = tuple[SignalKind, Verdict, str]
+
+
+def retired_scan_ids(manifest: Mapping[str, StrategyEntry] = STRATEGY_MANIFEST) -> frozenset[str]:
+    """Which manifest entries produce NO new scan evidence (#2845).
+
+    ⚠ ONE predicate for BOTH call sites — the per-strategy loop and the
+    decision-calendar publication. Written twice they would drift, and the drift is
+    silent in the worse direction: a strategy skipped by the scan but still having
+    its calendar published looks healthy on the card while producing nothing.
+
+    Pure and manifest-derived, so it is table-testable without a database and
+    without the universe/bar fixture ``run_signal_scan`` needs.
+    """
+    return frozenset(strategy_id for strategy_id, entry in manifest.items() if entry.retired_reason is not None)
 
 
 @dataclass(frozen=True)
@@ -514,8 +534,17 @@ def _publish_decision_calendars(
     withdraw another's, which is `_commit_strategy`'s isolation contract applied to
     a second relation.
     """
+    # ⚠ RETIRED ENTRIES EXCLUDED (#2845). A decision calendar is an input to
+    # evidence production, and a retired strategy produces none — publishing one
+    # would keep paying the write while the card correctly shows the strategy as
+    # retired. NOT the #2811 mistake in reverse: that was gating publication on a
+    # fact about THIS RUN's coverage, which made never-measured zeros read as
+    # measured. Retirement is a declared property of the entry.
+    retired = retired_scan_ids(manifest)
     cross_sectional = [
-        strategy_id for strategy_id in sorted(manifest) if manifest[strategy_id].strategy_class == "cross_sectional"
+        strategy_id
+        for strategy_id in sorted(manifest)
+        if manifest[strategy_id].strategy_class == "cross_sectional" and strategy_id not in retired
     ]
     if not cross_sectional:
         return {}
@@ -653,6 +682,7 @@ def run_signal_scan(
     at_frontier = sum(1 for span in spans.values() if span.last_bar == frontier.bar_date)
 
     watermarks = read_watermarks(conn)
+    retired = retired_scan_ids(manifest)
     plans: list[_Plan] = []
     results: list[StrategyScanResult] = []
     current_versions: dict[str, str] = {}
@@ -660,7 +690,22 @@ def run_signal_scan(
         entry = manifest[strategy_id]
         identity = entry.identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID)
         version = identity.version
+        # ⚠ Recorded BEFORE the retirement test, deliberately. `current_versions`
+        # is what `_publish_decision_calendars` and the census key on, and a
+        # retired strategy's stored rows must stay resolvable at its current
+        # version — retirement stops new evidence, it does not hide old.
         current_versions[strategy_id] = version
+        if strategy_id in retired:
+            # #2845. Not `continue` into silence: the result row is the record.
+            results.append(
+                StrategyScanResult(
+                    strategy_id=strategy_id,
+                    strategy_version=version,
+                    status="refused_retired",
+                    resumed_from=watermarks.get((strategy_id, version)),
+                )
+            )
+            continue
         watermark = watermarks.get((strategy_id, version))
         if watermark is not None and watermark >= frontier.bar_date:
             regressed = watermark > frontier.bar_date
@@ -1193,6 +1238,7 @@ __all__ = [
     "Frontier",
     "ScanReport",
     "ScanStatus",
+    "retired_scan_ids",
     "StrategyScanResult",
     "advance_watermark",
     "assert_census_complete",

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -702,7 +702,13 @@ def run_signal_scan(
                     strategy_id=strategy_id,
                     strategy_version=version,
                     status="refused_retired",
-                    resumed_from=watermarks.get((strategy_id, version)),
+                    # ⚠ None, not the frozen watermark (review nitpick on PR #2861).
+                    # `resumed_from` means "this run picked up from here"; a retired
+                    # strategy will never resume, so reporting a value there reads as
+                    # a resumption that is not going to happen. Where it froze is
+                    # answerable from `assess_scan_freshness`'s `retired` verdict,
+                    # which carries `frontier_date` for exactly that question.
+                    resumed_from=None,
                 )
             )
             continue

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5255,6 +5255,14 @@ def strategy_signal_scan() -> None:
         with connect_job(autocommit=True) as conn:
             report = run_signal_scan(conn)
             tracker.row_count = report.rows_written
+            # #2845 — say how many of the manifest actually ran. A row count alone
+            # cannot distinguish "ten strategies, quiet day" from "eight retired",
+            # and after the retirement that difference is most of the number.
+            retired = sum(1 for result in report.per_strategy if result.status == "refused_retired")
+            tracker.note = (
+                f"status={report.status} rows={report.rows_written} "
+                f"evaluated={len(report.per_strategy) - retired}/{len(report.per_strategy)} retired={retired}"
+            )
             failed = sorted(result.strategy_id for result in report.per_strategy if result.status == "failed")
         # ⚠ INSIDE the tracker, so a per-strategy failure fails the JOB — while
         # every healthy strategy's batch stays committed, which is the isolation

--- a/docs/proposals/ta/2026-08-22-retire-the-dead-eight.md
+++ b/docs/proposals/ta/2026-08-22-retire-the-dead-eight.md
@@ -1,0 +1,200 @@
+# Retire the dead eight from the manifest (#2845)
+
+Status: proposed, 2026-08-22. Phase-0 item 6 of the R5b queue, after #2843 (`ceffc769`).
+Revised after Codex ckpt-1, which corrected a factual claim and found four real gaps.
+
+## Source rule
+
+Not a market-data or SEC decision. The governing rule is the operator's cut-and-reset
+(2026-08-22) plus #2827's measurement, read off the issue rather than recalled:
+
+| class | strategies | what #2827 measured |
+| --- | --- | --- |
+| gross-negative at zero cost | s1, s6, s7, s9 | negative gross expectancy per trade, PF < 1 |
+| gross-negative, and **not a cost problem** | s2, s10 | same, plus cost accounts for under a fifth of the loss — the band sensitivity is far narrower than the loss itself |
+| gross-positive but short of the deflation bar | s3, s5 | positive gross expectancy, gross trade Sharpe an order below the bar; s5 break-even at a realistic band, s3's edge 8× wider between ambiguity arms than the others' |
+| **KEPT** | s4, s8 | the only two clearing a plausible cost band, barely; substrate of #2840 |
+
+⚠ **No figure from that table is copied into the code.** Reason strings name the verdict
+class and the ticket; the numbers live in #2827 where they are reproducible. Hardcoding a
+derived statistic into a comment is the thing that goes stale in the place a reader trusts
+most.
+
+## Premise check — "the pattern already exists"
+
+It does, one layer up from where the issue implies. `runnable_strategies`
+(`app/services/backtest_run.py:702`) already returns
+`tuple[runnable, tuple[ExcludedStrategy, ...]]` and `/strategies` already renders
+`exclusion_reason` from it (`app/api/strategies.py:2030,2261`). Its exclusions are
+**derived from capability**; retirement is a **policy** axis with no representation today.
+
+## Measured, not assumed
+
+```
+PYTHONPATH=. uv run python -c "... _regime_for(entry, _PROBE_CALENDAR) ..."
+```
+
+| | |
+| --- | --- |
+| `level_based` | s4, s5, s6, s7, s8, s9 — **six**, not one |
+| all six declare `exit_levels` | so `excluded` is empty today, matching `assert excluded == ()` |
+
+⚠ A first draft of this spec said *"s4 is the only `level_based` entry"*. That was wrong,
+caught at ckpt-1, and it mattered: it was the load-bearing premise of a "skip the probe for
+retired entries" design that is now abandoned (below).
+
+## Full-population state (dev, 2026-08-22)
+
+```sql
+select strategy_id, count(*) from strategy_results_store group by 1;   -- 568 rows over all 10
+select strategy_id, count(*) from strategy_signals     group by 1;
+```
+
+All ten carry stored results, so retirement must not make any unresolvable. Durable signal
+rows for the retired eight total **55,309** against **1,526** for s4+s8 (s2 and s10 hold
+none — cross-sectional, they publish calendars). That is the recurring cost retirement
+stops.
+
+⚠ Mid-flight rule checked: no `running` row in `job_runs`, and no `strategy_backtest_runs`
+relation exists — nothing is in flight.
+
+## Design
+
+### 1. Retirement is a manifest FIELD, not a removal
+
+`StrategyEntry.retired_reason: str | None = None`, refused when **blank after `.strip()`**
+— `""` and `" "` are the same defect and would render a blank exclusion in the UI.
+
+⚠⚠ **The entries STAY in `STRATEGY_MANIFEST`.** Deleting them would take
+`registered_strategy_purpose` to `None` (so `promote_strategy` refuses),
+`current_result_versions()` would stop resolving their stored rows, and `/strategies` would
+lose them — the "vanished" outcome the acceptance forbids, stranding 568 immutable result
+rows at versions the code no longer produces. Membership is what makes stored evidence
+readable; only *runnability* changes.
+
+⚠ `retired_reason` must never reach the identity hash, or retirement would rotate every
+version and falsify the whole "stored rows stay resolvable" claim. It cannot today —
+identity comes from the `entry.identity(...)` factory, not from the dataclass — but that is
+a property worth an assertion rather than a reading, so a test pins each strategy's current
+version across the change.
+
+### 2. `runnable_strategies` — validate EVERY entry, then exclude on policy
+
+⚠⚠ **The capability probe runs for retired entries too.** The first draft checked
+retirement first and skipped it. That is wrong: the probe asserts more than exclusion
+honesty — for a non-level entry it refuses a stray `exit_levels`, and for a level entry it
+refuses a builder that has stopped refusing. Short-circuiting on retirement would make
+retirement **a way to conceal a malformed declaration**, and eight of ten entries would
+stop being schema-checked at once. The probe runs on a tiny synthetic `_PROBE_CALENDAR`,
+so there is no cost argument for skipping it either.
+
+Order: derive the capability verdict for every entry → then classify. A capability
+exclusion still wins over a retirement one for the *reason* text, because "this cannot
+produce a result at all" is the stronger statement.
+
+`ExcludedStrategy` gains `kind: Literal["capability", "retired"]`, so a consumer can tell a
+policy exclusion from a builder refusal without parsing prose. Its docstring says the
+reason *"is the message `build_positions` RAISED, not a paraphrase"* — amended rather than
+quietly falsified: that stays true of `kind="capability"`.
+
+### 3. The signal scan skips them, by name
+
+New `StrategyScanStatus` member `refused_retired`, emitted from `run_signal_scan`'s
+per-strategy loop; retired entries filtered from `_publish_decision_calendars`; the job
+note reports the retired count so a 2-of-10 population is visible rather than inferred.
+
+⚠ A skip must be a RECORDED result, not an absent one — §9's observability contract. A
+scan reporting "2 strategies evaluated" with eight simply missing is the silent narrowing
+criterion 9 forbids.
+
+⚠ Not gated on anything corpus-shaped. #2811's lesson was that gating decision-calendar
+publication on "has bars to write" made never-measured zeros read as measured; retirement
+is a declared property of the entry, not a fact about this run.
+
+### 4. Scan freshness must say `retired`, not `stale`
+
+`assess_scan_freshness` gains `retired_ids` and a `retired` status, **outside**
+`_ALERTING_STATUSES`.
+
+⚠⚠ **Without this the change ships a permanent false alarm.** The eight stop scanning, so
+their watermarks freeze, so every `/system/status` poll reports eight `stale` strategies
+for ever. That is precisely the prevention-log defect about an alarm with a documented
+"ignore this" attached — strictly worse than no alarm, because it still costs attention and
+occupies the slot a working detector would have. Found by Codex ckpt-1.
+
+### 5. A retired strategy cannot advance a lifecycle stage
+
+`promote_strategy` refuses a retired entry into `_EXTERNAL_EVIDENCE_STAGES`, one condition
+beside the two existing `purpose` checks it already makes there.
+
+⚠ Scoped to the evidence stages deliberately: `paused` and `retired` must stay reachable
+for a retired strategy, or the eight become unmanageable. This is the chokepoint every
+promotion path passes, which closes the hole Codex named in `strategy_paper_runtime` (it
+selects `capital_candidate` entries directly rather than through `runnable_strategies`) and
+in #2843's autonomous approver.
+
+⚠⚠ **Placed FIRST, ahead of the two purpose checks, and that ordering is load-bearing.** A
+draft put it after them, and writing the test exposed why that is wrong: every manifest
+entry is `harness_validation` today, so the purpose check always wins and the new guard
+would be UNREACHABLE. An unreachable guard cannot be proven to work, which is how a guard
+rots — and I had written a test *documenting* the unreachability, which is the tell. It is
+also the strongest statement available about a strategy: "this is dead" says more than
+"this is not a capital candidate".
+
+### 6. Outcome resolution keeps processing retired strategies — deliberately
+
+`run_outcome_resolution` iterates entries with `exit_levels`, which includes retired
+s5/s6/s7/s9. **It is not filtered, and that is the decision, not an oversight.** Those
+strategies have already-fired signals whose outcomes are unresolved; filtering would strand
+them permanently and corrupt the evidence record that retirement exists to preserve.
+Retirement stops NEW evidence, never the drain of old. Stated here and asserted by a test,
+because an unexamined omission and a deliberate one look identical in a diff.
+
+### 7. Nothing is deleted, and no migration
+
+`strategy_results_store`, the ledgers, the trial register, declarations and the registry
+modules are untouched.
+
+## Tests
+
+- `runnable_strategies()` returns exactly `("s4-...", "s8-...")`; the other eight are in
+  `excluded` with `kind="retired"` and a non-empty reason naming #2827.
+- The existing `runnable | excluded == STRATEGY_MANIFEST` test keeps passing, plus
+  **disjointness** — membership alone does not prove exactly-one classification.
+- **At least one strategy is runnable.** A general invariant, not this ticket's set: a
+  manifest that retires everything is a system that cannot produce evidence at all.
+- All ten remain in `STRATEGY_MANIFEST` and `current_result_versions()`, and **each
+  strategy's current version is unchanged by the field**, pinning §1's identity claim.
+- A retired entry with a malformed capability declaration STILL raises — the assertion that
+  retirement did not become a concealment channel (§2).
+- `StrategyEntry` refuses a blank or whitespace-only `retired_reason`.
+- `assess_scan_freshness` returns `retired` (and `is_alerting is False`) for a retired
+  strategy whose watermark is old enough to be `stale`, i.e. the arm that would have
+  alarmed.
+- `promote_strategy` refuses a retired strategy into an evidence stage and still permits
+  `paused`.
+- Outcome resolution still selects a retired strategy's entry (§6).
+- The scan's two call sites share ONE retirement predicate (`retired_scan_ids`), asserted
+  from the module source — written twice they drift, and silently in the worse direction: a
+  strategy skipped by the scan but still publishing a calendar looks healthy on the card
+  while producing nothing.
+
+⚠ **No new DB test for `run_signal_scan`, and the reason is stated rather than the gap left
+open.** No `run_signal_scan` DB harness exists in the tree — every current test of that
+module is pure — so covering a `continue` would mean building a universe + bars + watermark
+fixture from scratch. Instead the decision was EXTRACTED (`retired_scan_ids`) and
+table-tested, which is this repo's stated preference, and the consequential properties
+follow structurally: the retired branch `continue`s before `plans.append`, so no `_Plan`
+exists, so no writer is reached. A reviewer who wants the integration test anyway should
+say so — this is a judgement about proportion, not an oversight.
+
+## Out of scope (named, not forgotten)
+
+- **A structured retirement date/source beyond `kind` + reason.** `kind` covers the
+  machine-readable need; a date field with no consumer is a declared-but-unwired symbol.
+- **A UI "retired at" cutoff** distinguishing retained evidence from live production.
+  Raised by ckpt-1; no consumer asks for it, and the card already shows the reason.
+- **`strategy_monitoring._panel_floor`** — a defensive per-id lookup that returns 1 for an
+  unknown strategy. Retirement does not change what it returns.
+- **Un-retiring.** A later ticket clears the field; there is no workflow because there is
+  no candidate.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,12 +74,18 @@ def registered_strategy_test_candidates(monkeypatch: pytest.MonkeyPatch) -> None
     Production has no capital candidates today.  Tests that exercise the
     post-admission lifecycle need explicit test-only candidates; treating an
     unknown ID as one would hide the fail-closed boundary those tests protect.
+
+    ⚠ This stands in for a ``StrategyEntry``, so it must carry EVERY field the
+    control plane reads off one.  ``retired_reason`` was added by #2845 and its
+    absence raised ``AttributeError`` from ``promote_strategy`` — a stub missing a
+    field the production type has fails in a way that looks like a code bug rather
+    than a fixture gap.  Add new fields here when the entry gains them.
     """
     from app.services import strategy_control_plane
 
     manifest = dict(strategy_control_plane.STRATEGY_MANIFEST)
     for strategy_id in ("S-ALLOC", "S-GOV", "S-LIVE-GATE", "S-OWN", "S-REC"):
-        manifest[strategy_id] = cast(Any, SimpleNamespace(purpose="capital_candidate"))
+        manifest[strategy_id] = cast(Any, SimpleNamespace(purpose="capital_candidate", retired_reason=None))
     monkeypatch.setattr(strategy_control_plane, "STRATEGY_MANIFEST", manifest)
 
 

--- a/tests/test_2845_retired_strategies.py
+++ b/tests/test_2845_retired_strategies.py
@@ -1,0 +1,335 @@
+"""#2845 — retiring eight of the ten, and the things retirement must NOT change.
+
+The interesting assertions here are the negative ones. Retiring a strategy is easy;
+retiring it without silently breaking its stored evidence, without concealing a
+malformed declaration, and without leaving a permanent false alarm on
+`/system/status` is the actual work, and each of those is a test below.
+
+Pure only — no `ebull_test_conn`, so the `db` marker does not evict this module from
+the fast pre-push gate. The scan's behaviour is exercised in
+`tests/test_2845_retired_strategies_db.py`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+
+import pytest
+
+from app.services import backtest_run
+from app.services.backtest_run import runnable_strategies
+from app.services.cost_model import COST_MODEL_ID
+from app.services.strategy_control_plane import StrategyControlError, promote_strategy
+from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry
+from app.services.strategy_result_identity import current_result_versions
+from app.services.strategy_scan_freshness import assess_scan_freshness
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
+
+RETIRED = frozenset(
+    {
+        "s1-time-series-momentum",
+        "s2-cross-sectional-momentum",
+        "s3-mean-reversion-in-trend",
+        "s5-support-bounce",
+        "s6-resistance-breakout",
+        "s7-trend-pullback",
+        "s9-squeeze-expansion",
+        "s10-relative-strength-leader",
+    }
+)
+KEPT = frozenset({"s4-volatility-compression-breakout", "s8-range-mean-reversion"})
+
+
+def _retired_ids() -> frozenset[str]:
+    return frozenset(sid for sid, entry in STRATEGY_MANIFEST.items() if entry.retired_reason is not None)
+
+
+# --------------------------------------------------------------- the declaration
+
+
+def test_the_retirement_set_is_exactly_the_measured_dead_eight() -> None:
+    assert _retired_ids() == RETIRED
+    assert frozenset(STRATEGY_MANIFEST) - _retired_ids() == KEPT
+
+
+def test_every_retirement_names_a_reason_and_its_evidence() -> None:
+    for strategy_id in sorted(RETIRED):
+        reason = STRATEGY_MANIFEST[strategy_id].retired_reason
+        assert reason is not None and reason.strip()
+        # The ticket, not the numbers: a derived statistic written by hand goes
+        # stale in the place a reader trusts most.
+        assert "#2827" in reason
+        assert "2026-08-22" in reason
+
+
+@pytest.mark.parametrize("blank", ["", " ", "\t\n"])
+def test_a_blank_retirement_reason_is_refused(blank: str) -> None:
+    """A blank reason renders an empty exclusion in the UI and in a job note — the
+    silent skip this field exists to prevent, wearing the field's name."""
+    live = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
+    with pytest.raises(ValueError, match="blank retired_reason"):
+        replace(live, retired_reason=blank)
+
+
+# ------------------------------------------- what retirement must NOT change
+
+
+def test_all_ten_stay_in_the_manifest_and_keep_resolving() -> None:
+    """⚠ The assertion that catches a future "tidy-up" deleting the entries.
+
+    Membership is what keeps 568 stored result rows readable: drop an entry and
+    `registered_strategy_purpose` goes None, `current_result_versions` stops
+    resolving it, and `/strategies` loses it entirely — the "vanished" outcome the
+    acceptance criteria forbid.
+    """
+    assert len(STRATEGY_MANIFEST) == 10
+    assert RETIRED | KEPT == set(STRATEGY_MANIFEST)
+    assert set(current_result_versions()) == set(STRATEGY_MANIFEST)
+
+
+def test_retirement_does_not_move_any_identity_version() -> None:
+    """⚠ The load-bearing claim of "stored rows stay resolvable", pinned.
+
+    `retired_reason` must never reach the identity hash — it comes from the
+    `identity` factory rather than from the dataclass. If it ever entered, retiring
+    a strategy would rotate its version and strand every row written under the old
+    one. Asserted by construction: an entry with and without the field must produce
+    the same version.
+    """
+    for strategy_id, entry in sorted(STRATEGY_MANIFEST.items()):
+        with_field = entry.identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        without_field = (
+            replace(entry, retired_reason=None).identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        )
+        assert with_field == without_field, strategy_id
+
+
+def test_retirement_cannot_conceal_a_malformed_declaration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """⚠⚠ Codex ckpt-1's finding, as a test.
+
+    A first draft checked `retired_reason` BEFORE the capability probe, which would
+    have made retirement a way to hide a broken entry — and eight of ten would have
+    stopped being schema-checked in one change. A retired, level-based entry whose
+    builder has stopped refusing must still raise.
+    """
+    s5 = STRATEGY_MANIFEST["s5-support-bounce"]
+    assert s5.retired_reason is not None
+    manifest = {**STRATEGY_MANIFEST, s5.strategy_id: replace(s5, exit_levels=None, exit_levels_batch=None)}
+    monkeypatch.setattr(backtest_run, "_demonstrate_level_refusal", lambda entry, regime: None)
+    with pytest.raises(RuntimeError, match="did NOT refuse"):
+        runnable_strategies(manifest)
+
+
+def test_a_capability_refusal_outranks_a_retirement(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ "The builder cannot produce a result for this at all" is the stronger
+    statement, so a retired-and-broken entry reports the refusal, not the policy."""
+    s5 = STRATEGY_MANIFEST["s5-support-bounce"]
+    manifest = {**STRATEGY_MANIFEST, s5.strategy_id: replace(s5, exit_levels=None, exit_levels_batch=None)}
+    monkeypatch.setattr(backtest_run, "_demonstrate_level_refusal", lambda entry, regime: "builder refused")
+    _runnable, excluded = runnable_strategies(manifest)
+    by_id = {item.strategy_id: item for item in excluded}
+    assert by_id["s5-support-bounce"].kind == "capability"
+    assert by_id["s5-support-bounce"].reason == "builder refused"
+    assert by_id["s1-time-series-momentum"].kind == "retired"
+
+
+def test_the_outcome_drain_still_covers_retired_strategies() -> None:
+    """⚠ Retirement stops NEW evidence, never the drain of old.
+
+    `run_outcome_resolution` selects every entry with `exit_levels`, which includes
+    retired s5/s6/s7/s9. Filtering them would strand their already-fired signals
+    permanently — and silently, because an unresolved fill has no alarm. This
+    asserts the omission is the deliberate one.
+    """
+    level_ids = {sid for sid, entry in STRATEGY_MANIFEST.items() if entry.exit_levels}
+    assert level_ids & RETIRED == {
+        "s5-support-bounce",
+        "s6-resistance-breakout",
+        "s7-trend-pullback",
+        "s9-squeeze-expansion",
+    }
+
+
+# ------------------------------------------------------- the false alarm, averted
+
+
+def _freshness(strategy_id: str, *, retired: bool) -> object:
+    """One verdict for a strategy whose watermark is old enough to be `stale`."""
+    trading_dates = [date(2026, 8, d) for d in range(1, 21)]
+    results = assess_scan_freshness(
+        current_versions={strategy_id: "v1"},
+        watermarks={(strategy_id, "v1"): date(2026, 8, 1)},
+        trading_dates=trading_dates,
+        retired_ids=frozenset({strategy_id}) if retired else frozenset(),
+    )
+    assert len(results) == 1
+    return results[0]
+
+
+def test_a_retired_strategy_reads_retired_and_does_not_alert() -> None:
+    """⚠⚠ Without this the change ships a PERMANENT false alarm.
+
+    A retired strategy stops scanning, so its watermark freezes and every poll of
+    `/system/status` would report it `stale` for ever. The control arm is the same
+    inputs with `retired_ids` empty — which must still be `stale`, or this test
+    would pass for the wrong reason.
+    """
+    control = _freshness("s1-time-series-momentum", retired=True)
+    assert control.status == "retired"  # type: ignore[attr-defined]
+    assert control.is_alerting is False  # type: ignore[attr-defined]
+    # ⚠ The watermark it froze at is still reported, so "when did it stop" stays
+    # answerable from the verdict rather than needing a second query.
+    assert control.frontier_date == date(2026, 8, 1)  # type: ignore[attr-defined]
+
+    not_retired = _freshness("s1-time-series-momentum", retired=False)
+    assert not_retired.status == "stale"  # type: ignore[attr-defined]
+    assert not_retired.is_alerting is True  # type: ignore[attr-defined]
+
+
+def test_every_manifest_strategy_still_gets_a_freshness_verdict() -> None:
+    """A strategy with no verdict is a strategy nothing reports on — retirement
+    changes the verdict, never whether there is one."""
+    results = assess_scan_freshness(
+        current_versions=dict.fromkeys(STRATEGY_MANIFEST, "v1"),
+        watermarks={},
+        trading_dates=[date(2026, 8, 20)],
+        retired_ids=_retired_ids(),
+    )
+    assert {item.strategy_id for item in results} == set(STRATEGY_MANIFEST)
+
+
+# --------------------------------------------------- a retired stage cannot advance
+
+
+def test_promote_strategy_refuses_a_retired_strategy_into_an_evidence_stage() -> None:
+    """Bound at the chokepoint every promotion path passes: the API's `/advance`,
+    #2770's `advance_strategy`, and #2843's autonomous approver.
+
+    ⚠ No connection is needed — the refusal is raised from the argument checks,
+    before `_lock_strategy` touches the database. `None` reaching a query would be
+    an AttributeError, so this passing IS the proof it refuses early.
+    """
+    with pytest.raises(StrategyControlError, match="is retired and cannot advance"):
+        promote_strategy(
+            None,  # type: ignore[arg-type]
+            strategy_id="s1-time-series-momentum",
+            strategy_version="v1",
+            to_stage="historical_validated",
+            promoted_by="operator",
+            reason="should refuse",
+            evidence_ref="ref",
+        )
+
+
+def test_the_retirement_guard_fires_ahead_of_the_purpose_guard() -> None:
+    """⚠ Ordering is the point, not an accident.
+
+    Every manifest entry is `harness_validation` today, so placing the retirement
+    check after the purpose checks would make it UNREACHABLE — and an unreachable
+    guard cannot be proven to work. The test above only passes because retirement
+    is checked first; this records why that ordering is load-bearing.
+    """
+    assert all(entry.purpose == "harness_validation" for entry in STRATEGY_MANIFEST.values())
+    with pytest.raises(StrategyControlError) as caught:
+        promote_strategy(
+            None,  # type: ignore[arg-type]
+            strategy_id="s4-volatility-compression-breakout",
+            strategy_version="v1",
+            to_stage="historical_validated",
+            promoted_by="operator",
+            reason="a KEPT strategy still hits the purpose guard",
+            evidence_ref="ref",
+        )
+    assert "permanent controls" in str(caught.value)
+
+
+def test_a_retired_strategy_may_still_be_paused() -> None:
+    """⚠ The guard is scoped to the evidence stages deliberately. A lifecycle that
+    cannot be wound down is worse than one that can still move forward, so `paused`
+    must stay reachable — asserted by the refusal NOT being the retirement one."""
+    with pytest.raises(Exception) as caught:  # noqa: PT011 - the type is not the point
+        promote_strategy(
+            None,  # type: ignore[arg-type]
+            strategy_id="s1-time-series-momentum",
+            strategy_version="v1",
+            to_stage="paused",
+            promoted_by="operator",
+            reason="wind it down",
+        )
+    assert "is retired and cannot advance" not in str(caught.value)
+
+
+def test_a_manifest_entry_is_constructible_without_the_field() -> None:
+    """`retired_reason` defaults to None, so every existing construction site — and
+    every future strategy — is live unless it says otherwise."""
+    live = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
+    assert isinstance(live, StrategyEntry)
+    assert live.retired_reason is None
+
+
+# ------------------------------------------------------- the scan stops paying for them
+
+
+def test_the_scan_excludes_exactly_the_retired_eight() -> None:
+    from app.services.strategy_signal_scan import retired_scan_ids
+
+    assert retired_scan_ids(STRATEGY_MANIFEST) == RETIRED
+
+
+def test_both_scan_call_sites_share_one_retirement_predicate() -> None:
+    """⚠ Written twice, the per-strategy skip and the decision-calendar filter would
+    drift — and silently in the worse direction: a strategy skipped by the scan but
+    still having its calendar published looks healthy on the card while producing
+    nothing. Asserted from the source because the two sites cannot be reached
+    together without a universe/bar fixture.
+    """
+    import inspect
+
+    from app.services import strategy_signal_scan
+
+    source = inspect.getsource(strategy_signal_scan)
+    # The predicate is used, and the raw field test appears ONLY inside its own body.
+    assert source.count("retired_scan_ids(manifest)") == 2
+    assert source.count("entry.retired_reason is not None") == 1
+
+
+def test_no_retired_cross_sectional_strategy_can_reach_calendar_publication() -> None:
+    """Both cross-sectional strategies are retired, so the publication list is empty
+    and `_publish_decision_calendars` returns before loading the union calendar."""
+    from app.services.strategy_signal_scan import retired_scan_ids
+
+    cross_sectional = {sid for sid, entry in STRATEGY_MANIFEST.items() if entry.strategy_class == "cross_sectional"}
+    assert cross_sectional == {"s2-cross-sectional-momentum", "s10-relative-strength-leader"}
+    assert cross_sectional <= retired_scan_ids(STRATEGY_MANIFEST)
+
+
+def test_a_retired_strategy_with_no_watermark_at_all_still_reads_retired() -> None:
+    """⚠ Codex ckpt-2 raised this as a P2 defect — "the `basis_date is None` branch
+    fires first, so a never-scanned retired strategy reports `never_scanned`".
+
+    It does not: the retirement check sits AHEAD of that branch. But nothing
+    asserted the case, so the rebuttal was unevidenced — a wrong finding pointing at
+    a real coverage hole. This is the evidence, and it also pins the ordering
+    against a future edit that moves the check down.
+
+    The state is reachable: a fresh deployment, or a purged watermark history.
+    """
+    results = assess_scan_freshness(
+        current_versions={"s1-time-series-momentum": "v1"},
+        watermarks={},
+        trading_dates=[date(2026, 8, 20)],
+        retired_ids=frozenset({"s1-time-series-momentum"}),
+    )
+    assert [item.status for item in results] == ["retired"]
+    assert results[0].frontier_date is None
+    assert results[0].is_alerting is False
+
+    # Control: the same inputs without the retirement say `never_scanned`, so the
+    # assertion above is about retirement and not about the empty watermark map.
+    control = assess_scan_freshness(
+        current_versions={"s1-time-series-momentum": "v1"},
+        watermarks={},
+        trading_dates=[date(2026, 8, 20)],
+    )
+    assert [item.status for item in control] == ["never_scanned"]

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -213,27 +213,53 @@ def _measurement(
 class TestRunnableStrategies:
     """§3 — every declared close source must have its outcome producer."""
 
-    def test_all_four_are_runnable_once_s4_declares_causal_exit_levels(self) -> None:
+    def test_only_the_two_kept_strategies_are_runnable(self) -> None:
+        """#2845 retired eight of the ten; s4 and s8 are what is left.
+
+        ⚠ Every capability exclusion is still empty — all six `level_based` entries
+        declare `exit_levels`, so nothing here is excluded for being broken. The
+        eight are excluded on POLICY, which is why `kind` is asserted rather than
+        just the count: a capability refusal appearing in this list would mean a
+        builder regressed and retirement happened to hide it.
+        """
         runnable, excluded = runnable_strategies()
-        assert list(runnable) == [
+        assert list(runnable) == ["s4-volatility-compression-breakout", "s8-range-mean-reversion"]
+        assert [item.strategy_id for item in excluded] == [
             "s1-time-series-momentum",
             "s10-relative-strength-leader",
             "s2-cross-sectional-momentum",
             "s3-mean-reversion-in-trend",
-            "s4-volatility-compression-breakout",
             "s5-support-bounce",
             "s6-resistance-breakout",
             "s7-trend-pullback",
-            "s8-range-mean-reversion",
             "s9-squeeze-expansion",
         ]
-        assert excluded == ()
+        assert {item.kind for item in excluded} == {"retired"}
+        assert all("#2827" in item.reason for item in excluded)
 
-    def test_every_manifest_entry_is_accounted_for(self) -> None:
+    def test_every_manifest_entry_is_accounted_for_exactly_once(self) -> None:
         from app.services.strategy_manifest import STRATEGY_MANIFEST
 
         runnable, excluded = runnable_strategies()
-        assert set(runnable) | {entry.strategy_id for entry in excluded} == set(STRATEGY_MANIFEST)
+        excluded_ids = [entry.strategy_id for entry in excluded]
+        assert set(runnable) | set(excluded_ids) == set(STRATEGY_MANIFEST)
+        # ⚠ Membership alone does not prove EXACTLY-ONE classification: a
+        # strategy in both lists satisfies the union and is a real bug.
+        assert not set(runnable) & set(excluded_ids)
+        assert (
+            len(runnable) + len(excluded_ids) == len(STRATEGY_MANIFEST) == len(set(excluded_ids)) + len(set(runnable))
+        )
+
+    def test_at_least_one_strategy_remains_runnable(self) -> None:
+        """A general invariant, not this ticket's set.
+
+        Retiring everything leaves a system that cannot produce evidence at all,
+        and every downstream "no results" would read as a data problem rather than
+        as the manifest saying no. Cheap to assert, and the failure it catches is
+        one nobody would look for.
+        """
+        runnable, _excluded = runnable_strategies()
+        assert runnable
 
     def test_a_level_based_entry_that_stops_refusing_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The exclusion is DERIVED from the refusal, so a missing refusal stops the run.

--- a/tests/test_backtest_run_lock_scope.py
+++ b/tests/test_backtest_run_lock_scope.py
@@ -99,7 +99,10 @@ def _run_until_evaluation(
     monkeypatch.setattr(backtest_run, "evaluate_arm", _evaluate)
     monkeypatch.setattr(backtest_run, "evaluate_level_arms", _evaluate)
 
-    strategy_id = next(iter(sorted(STRATEGY_MANIFEST)))
+    # ⚠ A LIVE strategy (#2845). `sorted(...)[0]` is s1, which is now retired, so a
+    # one-entry manifest built from it has NO runnable strategy and the run refuses
+    # before reaching anything this test is about.
+    strategy_id = next(sid for sid in sorted(STRATEGY_MANIFEST) if STRATEGY_MANIFEST[sid].retired_reason is None)
     with pytest.raises(_StopAfterEvaluation):
         run_backtest(
             conn,
@@ -148,7 +151,10 @@ def _run_to_the_write_phase(
     monkeypatch.setattr(backtest_run, "evaluate_arm", evaluate)
     monkeypatch.setattr(backtest_run, "evaluate_level_arms", lambda *args, **kwargs: (evaluate(*args, **kwargs),))
 
-    strategy_id = next(iter(sorted(STRATEGY_MANIFEST)))
+    # ⚠ A LIVE strategy (#2845). `sorted(...)[0]` is s1, which is now retired, so a
+    # one-entry manifest built from it has NO runnable strategy and the run refuses
+    # before reaching anything this test is about.
+    strategy_id = next(sid for sid in sorted(STRATEGY_MANIFEST) if STRATEGY_MANIFEST[sid].retired_reason is None)
     call = partial(
         run_backtest,
         conn,

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -981,7 +981,12 @@ def test_harness_control_cannot_be_promoted_or_funded(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:
     conn = ebull_test_conn
-    entry = next(iter(STRATEGY_MANIFEST.values()))
+    # ⚠ A LIVE control, not `next(iter(...))` (#2845). Eight of the ten are now
+    # retired, and the retirement guard fires ahead of the purpose guard — so the
+    # arbitrary first entry would refuse for the wrong reason and this test would
+    # pass while proving nothing about harness controls.
+    entry = next(item for item in STRATEGY_MANIFEST.values() if item.retired_reason is None)
+    assert entry.purpose == "harness_validation"
     version = entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID).version
     promote_strategy(
         conn,


### PR DESCRIPTION
`runnable_strategies()` now returns exactly `{s4, s8}`. The other eight are **named
exclusions** carrying #2827's verdict class — not deletions, not silent skips.

Closes #2845. Refs #2827, #2832, #2437, #2840.
Spec: `docs/proposals/ta/2026-08-22-retire-the-dead-eight.md`.

## Why these eight

Read off #2827 rather than recalled:

| class | strategies |
| --- | --- |
| gross-negative at zero cost | s1, s6, s7, s9 |
| gross-negative, and **not a cost problem** (cost is a minority of the loss) | s2, s10 |
| gross-positive but short of the deflation bar, and not a candidate | s3, s5 |
| **KEPT** — the only two clearing a plausible cost band, #2840's substrate | s4, s8 |

⚠ **No figure from #2827 is copied into the code.** The three reason strings name the
verdict class and the ticket; the numbers stay where they are reproducible. A derived
statistic written by hand goes stale in the place a reader trusts most.

## The central decision: they STAY in the manifest

`StrategyEntry.retired_reason: str | None`, not a deletion. Deleting the entries would
take `registered_strategy_purpose` to `None`, stop `current_result_versions()` resolving
their rows, and drop them from `/strategies` — the "vanished" outcome the acceptance
criteria forbid, stranding **568 immutable result rows** at versions the code no longer
produces. Membership is what keeps stored evidence readable; only *runnability* changes.

`ExcludedStrategy` gains `kind: "capability" | "retired"` so a consumer can tell a policy
exclusion from a builder refusal without parsing prose. `/strategies` already renders
`exclusion_reason`, so the card shows them retired-with-reason with no frontend change.

## Full-population state (dev)

```sql
select strategy_id, count(*) from strategy_results_store group by 1;  -- 568 over all 10
select strategy_id, count(*) from strategy_signals     group by 1;
```

Durable signal rows: **55,309** for the retired eight against **1,526** for s4+s8 (s2 and
s10 hold none — cross-sectional, they publish calendars). That is the recurring cost this
stops. Mid-flight rule checked: no `running` row in `job_runs`, no `strategy_backtest_runs`
relation — nothing in flight.

## Four things Codex ckpt-1 caught, all real

**1. My spec's premise was factually wrong.** It said *"s4 is the only `level_based`
entry"*. Measured: **six** are (s4–s9), and all six declare `exit_levels`, which is why
`excluded` is empty today. That wrong claim was the load-bearing premise of a
"skip the capability probe for retired entries" design — now abandoned.

**2. Skipping the probe would make retirement a way to conceal a malformed declaration.**
The probe asserts more than exclusion honesty: for a non-level entry it refuses a stray
`exit_levels`, for a level entry it refuses a builder that stopped refusing. Short-circuiting
would have unchecked eight of ten entries at once. **Every entry is now validated first,
then classified.** A capability refusal outranks a retirement in the reported reason.

**3. Without a `retired` freshness status this ships a permanent false alarm.** The eight
stop scanning, their watermarks freeze, and every `/system/status` poll would report eight
`stale` strategies for ever — the prevention-log defect of an alarm with a documented
"ignore this" attached. `assess_scan_freshness` now returns `retired`, outside
`_ALERTING_STATUSES`.

**4. Outcome resolution must NOT filter them.** `run_outcome_resolution` covers retired
s5/s6/s7/s9, and filtering would strand their already-fired signals permanently —
corrupting the evidence record retirement exists to preserve, silently, because an
unresolved fill has no alarm. **Retirement stops new evidence, never the drain of old.**
Written down and asserted, because an unexamined omission and a deliberate one look
identical in a diff.

## An ordering that writing the test exposed

`promote_strategy` refuses a retired strategy into `_EXTERNAL_EVIDENCE_STAGES` — the
chokepoint every promotion path passes (`/advance`, #2770's `advance_strategy`, #2843's
autonomous approver). It also closes the hole in `strategy_paper_runtime`, which selects
`capital_candidate` entries directly rather than through `runnable_strategies`.

⚠ It sits **first, ahead of the two purpose checks**. A draft put it after them, and the
test exposed why that is wrong: every manifest entry is `harness_validation` today, so the
purpose check always wins and the new guard would be **unreachable**. I had written a test
*documenting* the unreachability — that is the tell. An unreachable guard can't be proven
to work. Scoped to the evidence stages so `paused`/`retired` stay reachable; a lifecycle
that cannot be wound down is worse than one that can still move forward.

## Codex ckpt-2 — one P2, rebutted with a test rather than an assertion

Codex reported that a never-scanned retired strategy would fall through to
`never_scanned` because "the `basis_date is None` branch fires first". **It does not** —
the retirement check is at `strategy_scan_freshness.py:213`, the no-watermark branch at
220. But nothing asserted that case, so the rebuttal was unevidenced: a wrong finding
pointing at a real coverage hole. `test_a_retired_strategy_with_no_watermark_at_all_still_reads_retired`
now covers it, with a control arm proving the assertion is about retirement and not about
the empty watermark map.

## Tests

Pure (`tests/test_2845_retired_strategies.py`, 20): the retirement set; every reason names
its evidence; blank/whitespace reasons refused; **all ten still resolve**; **no identity
version moves** (pinning the "stored rows stay resolvable" claim by construction);
retirement cannot conceal a malformed declaration; capability outranks retirement; the
outcome drain still covers them; `retired` is non-alerting with a `stale` control arm; the
promote guard fires and `paused` still works; both scan call sites share one predicate.

Plus, in `test_backtest_run.py`: exactly-once classification (**disjointness**, not just
union — a strategy in both lists satisfies the union and is a real bug) and **at least one
strategy remains runnable**, a general invariant rather than this ticket's set.

Revert-probed: neutering the freshness check or the retirement branch fails 3 tests.

⚠ **No new DB test for `run_signal_scan`, stated rather than left as a gap.** No
`run_signal_scan` DB harness exists — every current test of that module is pure — so
covering a `continue` would mean building a universe + bars + watermark fixture from
scratch. Instead the decision was extracted (`retired_scan_ids`, now shared by both call
sites) and table-tested, and the consequential properties follow structurally: the retired
branch `continue`s before `plans.append`, so no `_Plan` exists and no writer is reached.
A judgement about proportion — say so if you want the integration test anyway.

## Test-suite fallout, and why it is the right kind

Three tests picked a strategy with `next(iter(STRATEGY_MANIFEST))` and now picked a dead
one. Each is fixed to ask for a **live** entry, which is the correct expression of intent:

- `test_harness_control_cannot_be_promoted_or_funded` — refused for the wrong reason, so it
  would have passed while proving nothing about harness controls.
- `test_backtest_run_lock_scope` (2 sites) — built a one-entry manifest from s1, giving
  `runnable today: []`.
- `tests/conftest.py::registered_strategy_test_candidates` — its `SimpleNamespace` stub was
  missing `retired_reason`, raising `AttributeError` from `promote_strategy`. A stub
  standing in for a production type must carry every field the code reads off it.

## Security model

Not applicable in the usual sense — no auth, no user input, no SQL. The one adjacent
property is that this only ever *narrows* what may run: the new `promote_strategy`
condition adds a refusal and removes none, and `runnable_strategies` moves strategies from
runnable to excluded, never the reverse.

## Gates

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` ·
`pytest tests/smoke` · `pnpm typecheck` — green. DB tier across every
`test_*strateg*` / `*backtest*` / `*signal*` / `*scan*` module: green except the same
**pre-existing** `test_the_deployment_currency_refusal...[2]` and
`test_strategy_monitoring[5]` failures, all `etoro_instrument_types.description = 'Stocks'
resolved to 0 rows` — a missing worker-DB seed, reproduced identically on `origin/main` in
a throwaway worktree. Not introduced here.

No migration, no backfill, no job restart needed beyond the scheduler already running
(the scan job note now reports `evaluated=N/10 retired=N`).
