### PR TITLE
docs(#2841): record the R5 kill table and re-measure the corpus figures

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -260,7 +260,7 @@ Reproduce: `curl -s "http://localhost:8000/_debug/etoro-candles-probe?instrument
 | --- | --- | --- |
 | REST intraday candles | OHLCV history, any instrument, on demand | 1000 bars, no date anchor; **120 market-data GET/min shared** |
 | WS rate stream | live bid/ask/last ticks, all instruments | no depth, no sizes; forward-only |
-| `research_price_daily` | 25.9M daily bars 1962-2026, survivorship-controlled | daily granularity only |
+| `research_price_daily` | 75.97M daily bars 1962-2026, survivorship-controlled | daily granularity only |
 
 ⚠ **Corpus arithmetic, because the rate limit binds hard.** The currently
 documented 120 market-data GET/min shared gives a full 6,700-instrument pull a

--- a/.claude/skills/data-sources/market-structure.md
+++ b/.claude/skills/data-sources/market-structure.md
@@ -286,7 +286,7 @@ Amihud illiquidity = mean( |return| / dollar volume )
 
 ⚠ Daily data only, no tape. Proxies price impact per unit of order flow (the
 empirical cousin of Kyle's λ). **Not implemented yet** — but computable on all
-25.9M bars with nothing new ingested, and it is also the quantity behind
+75.97M bars with nothing new ingested, and it is also the quantity behind
 Wyckoff's "effort versus result".
 
 ---

--- a/.claude/skills/data-sources/research-price-corpus.md
+++ b/.claude/skills/data-sources/research-price-corpus.md
@@ -12,6 +12,28 @@ This covers the **research corpus** (deep history, backtesting). It does not cov
 `.claude/skills/market-data/SKILL.md`. Keeping those two roles separate is the settled
 model; see `docs/proposals/ta/strategy-catalogue-and-backtest-validity.md` §0.
 
+## What we actually hold, and how to re-measure it
+
+```sql
+select count(*) from research_price_daily;    -- 75,972,649 bars   (2026-08-22)
+select count(*) from research_price_series;   -- 30,591 series
+select min(bar_date), max(bar_date) from research_price_daily;  -- 1962-01-02 .. 2026-08-21
+```
+
+⚠ **Run the queries; do not cite the numbers.** They are written down beside their own
+SQL precisely because they go stale — and they did: five skill files carried
+**25.9M bars / 7,727 series** until 2026-08-22, roughly a THIRD of the truth, and one of
+them had derived a percentage from the stale denominator (the pre-decimalisation share in
+`quant/strategy-evidence.md` §2.11a, which moved 20.3% → 16.2% when re-measured rather
+than re-denominated). A figure written by hand goes stale silently in the place a reader
+trusts most.
+
+⚠ #2841 named THIS file as the one holding the stale figure. It did not hold it at all —
+the copies were in `quant/strategy-evidence.md` (×3), `quant/data-capability.md` (×3),
+`data-sources/market-structure.md` and `data-sources/etoro-api.md`. When correcting a
+duplicated statistic, `grep` for the VALUE across the whole skill tree; the ticket telling
+you where it lives is a starting point, not the inventory.
+
 ## The one-line answer
 
 **Free FEEDS are Yahoo or downstream of it and have no delisting concept — but free

--- a/.claude/skills/quant/data-capability.md
+++ b/.claude/skills/quant/data-capability.md
@@ -22,7 +22,7 @@ cannot be tested, and the discovery usually happens after the spec is written.
 ## 1. What we actually hold
 
 ```text
-research_price_daily        25,939,169 bars   7,727 series, 1962-2026, daily OHLC + adj_close
+research_price_daily        75,972,649 bars  30,591 series, 1962-2026, daily OHLC + adj_close
 price_daily                  6,724,254        the eToro-fed operational series
 filing_documents             9,243,776   ⚠ a MANIFEST of URLs -- NO document bodies
 ownership_institutions_*        ~7M      13F, quarterly partitions
@@ -102,7 +102,7 @@ call. A cross-sectional intraday study is a scheduled harvest, not an ad-hoc que
 | --- | --- | --- |
 | REST intraday candles | OHLCV history on demand | 1000 bars, no date anchor, 60 GET/min |
 | WS rate stream | live bid/ask/last, all instruments | **no depth, no sizes** — the real gap |
-| `research_price_daily` | 25.9M daily bars 1962-2026 | daily granularity |
+| `research_price_daily` | 75.97M daily bars 1962-2026 | daily granularity |
 
 Source of truth: `.claude/skills/data-sources/etoro-api.md` § "WE HAVE INTRADAY
 HISTORY". Probe before asserting:
@@ -132,7 +132,7 @@ HISTORY". Probe before asserting:
 | **observed** bid/ask spread over time | footprint charts, volume-at-price |
 | quote-update frequency as an activity proxy | cumulative delta, absorption, exhaustion |
 | realised intraday volatility | trade-side classification, tape reading |
-| Amihud illiquidity (`\|return\| / dollar volume`) on 25.9M bars | true session VWAP |
+| Amihud illiquidity (`\|return\| / dollar volume`) on 75.97M bars | true session VWAP |
 
 ⚠⚠ **The impossible column is a DATA constraint, not a verdict on whether those
 methods work.** Cont/Kukanov/Stoikov show OFI predicts short-horizon returns with

--- a/.claude/skills/quant/strategy-evidence.md
+++ b/.claude/skills/quant/strategy-evidence.md
@@ -504,7 +504,8 @@ data, no order book.** It proxies price impact per unit of order flow (the
 empirical cousin of Kyle's λ) and is *"a relatively strong indicator of informed
 trading when trading is urgent."*
 
-Three uses, all available to us on 25.9M bars with nothing new ingested:
+Three uses, all available to us on the 75,972,649 bars / 30,591 series corpus with nothing new
+ingested (`select count(*), (select count(*) from research_price_series) from research_price_daily` → 75,972,649 / 30,591 (2026-08-22)):
 
 1. **A conditioner** — illiquid names are where limits to arbitrage bind, which
    is where §2.6's surviving anomalies survive.
@@ -720,7 +721,10 @@ once — not to root each and average.
 
 **Confound 2 — era mismatch.** `cost_model.BANDS` is calibrated on **modern**
 eToro spreads (p75, samples of 76-244). The research corpus runs 1962-2026, and
-**5,266,053 of 25,920,971 bars — 20.3% — predate decimalisation** (2001-04-09),
+**12,281,013 of 75,972,649 bars — 16.2% — predate decimalisation** (2001-04-09),
+⚠ re-measured 2026-08-22 after the corpus tripled;
+`select count(*) filter (where bar_date < date '2001-04-09'), count(*) from research_price_daily`.
+The share MOVED (was 20.3% on 25.9M bars), so this is not a denominator swap —
 when US equities traded in eighths and sixteenths. A 1/8 tick on a \$10 stock is
 **1.25%**, an order of magnitude above a modern spread. ⚠ So a large part of the
 "excess" may simply be that historical spreads were genuinely far wider than the
@@ -975,7 +979,7 @@ Wyckoff "ease of movement"   =  low volume, big move         ->  HIGH Amihud
 ```
 
 So the law Wyckoff rests on is a quantity that **does** have empirical support
-(§2.11) and is computable on our 25.9M bars with no new data. ⚠ Note what this
+(§2.11) and is computable on our 75.97M-bar corpus with no new data. ⚠ Note what this
 does NOT establish: that the *interpretation* (a composite operator accumulating)
 is correct. It establishes that the **observable** is real and measurable. Test
 the quantity, not the story attached to it.
@@ -1195,6 +1199,61 @@ insiders with >= 3 distinct PURCHASE years                  997 of 9,936 (10.0%)
 flag. Negligible as a share, material for this family specifically — a
 2,000-year gap wrecks the per-insider history the classification depends on.
 Filed as **#2441**.
+
+---
+
+## 3.2 ⚠⚠ THE R5 KILL TABLE — 32 candidates already examined and rejected (#2832, 2026-08-22)
+
+**Read this before proposing any strategy family.** After #2827 measured all ten TA
+strategies dead at ZERO cost, a 19-agent sweep asked the full-width question — *what can
+reliably make money programmatically for this account* — and examined **38 sub-strategies.
+Six survived as preregistered spikes; 32 were killed with reasons.** Those reasons are
+recorded here so no future session pays to re-derive them.
+
+Full per-verdict record: #2832 and its workflow journal `wf_f24998c8-93a`.
+
+| family | verdict | why |
+| --- | --- | --- |
+| **Flip the losers** (invert s2/s10) | KILLED | four independent reasons, any one sufficient — see below |
+| Intraday / overnight: overnight split, ORB, first-half-hour, gap plays, weekend | KILLED | die at our spreads. ORB was validated at **72–509× lower costs than ours** (§2.13) |
+| Crypto / FX systematic: momentum, carry, seasonality | KILLED | ~1%/side crypto spreads; weak or decayed OOS evidence |
+| Pairs / statistical arbitrage | KILLED | decayed post-2002; costs; borrow |
+| Options income (covered calls, put-writing) | KILLED | **no options on eToro UK** — 0 instruments, no API endpoints (VERIFIED-PORTAL). Packaged ETFs (QYLD, JEPI) demonstrably do not preserve the premium |
+| Index adds, spin-offs, buybacks, tenders, lockup expiries | KILLED | decayed post-publication and/or unexecutable at our order types |
+| PEAD, generic | KILLED as a family | decay. ⚠ **#2493's specific measured +2.676% long arm stands as its own evidence path** — reconciliation posted there |
+| Small/micro-cap "retail capacity" thesis | KILLED | the anomalies live in <\$5 names, where our own 1.45% cost band and the delisting tail eat them |
+| CEF discount capture | KILLED | **0 of 12 canonical CEF tickers in our universe** |
+| Convertible arbitrage | KILLED | no convertible instruments on the venue |
+| FINRA RegSHO daily | KILLED | it is short **VOLUME**, not short interest or borrow — it cannot price the published SI literature |
+| Spread-betting tax wrapper | KILLED | not offered on this venue |
+
+### Why "flip the losers" is dead, in full
+
+It is the most natural question to ask about a measured-negative strategy, so it gets the
+long answer once:
+
+1. **Inverting after observing the hold-out converts the hold-out into training data.** The
+   sign is a parameter like any other; choosing it on the evidence spends the confirmatory
+   shot.
+2. **Per-trade signal-to-noise is symmetric under a sign flip**, so it cannot close a 5–20×
+   deflation miss — the bar does not move when the sign does.
+3. **The short leg pays** 1.45% round trip + ~0.02%/day CFD financing over 60-day holds, and
+   a mandatory `stopLossRate` in exactly the gappiest names.
+4. **The magnitudes disagree with the literature by two orders.** Documented anti-momentum
+   is ~−0.4%/**month** (Cooper 2004); s2/s10 measured −3.8 to −6.0%/**trade**. That gap is a
+   regime artifact of a signal we ourselves measured as broken (#2797).
+
+**You cannot harvest the inverse of a bug.**
+
+### Deferred with a re-arm condition — NOT killed
+
+- **News / text strategies.** `news_events` is **forward-only from 2026-06-27**, and text
+  strategies additionally need filing BODIES — `filing_documents` holds 9.2M URLs and **no
+  bodies**. Re-arm condition: **≥24 months of accumulation** *and* a filing-body fetch
+  pipeline. Until both hold, any backtest here is measuring a corpus that did not exist.
+- **13F crowding / unwind.** `institutional_holdings` holds 8.46M rows over ~20 year-clusters
+  — the exact cluster depth the insider family is starved of, and §3 already rates the angle
+  viable-but-not-cloning. Deferred rather than killed; the deferral note is on #2832.
 
 ---
 


### PR DESCRIPTION
Docs only. Closes #2841. Refs #2832, #2827, #2493, #2797.

## 1. `strategy-evidence.md` gains §3.2 — the R5 kill table

The 32 candidates #2832's 19-agent sweep examined and rejected, each with its reason, so
no future session pays to re-derive them: intraday/overnight, crypto/FX systematic,
pairs/stat-arb, options income (**no options on eToro UK** — 0 instruments, no API
endpoints, VERIFIED-PORTAL), index adds / spin-offs / buybacks / tenders / lockups, the
small-cap capacity thesis, CEF discounts (**0 of 12** canonical tickers in universe),
convertible arb, FINRA RegSHO (short **volume**, not short interest), the spread-bet
wrapper, and generic PEAD — with #2493's specific measured +2.676% long arm preserved as
its own evidence path rather than swept in.

**"Flip the losers" gets the long answer**, because it is the most natural question to ask
about a measured-negative strategy: inverting after observing the hold-out spends the
confirmatory shot; per-trade S/N is symmetric under a sign flip so it cannot close a 5–20×
deflation miss; the short leg pays 1.45% RT + ~0.02%/day financing + a mandatory
`stopLossRate` in the gappiest names; and the magnitudes disagree with the literature by
two orders (−0.4%/**month** documented vs −3.8..−6.0%/**trade** measured), which makes it a
regime artifact of a signal we ourselves measured as broken. *You cannot harvest the
inverse of a bug.*

Two families are recorded as **deferred with a re-arm condition, not killed** — news/text
(`news_events` forward-only from 2026-06-27; `filing_documents` = 9.2M URLs and **no
bodies**; re-arm at ≥24 months + a body-fetch pipeline) and 13F crowding/unwind (8.46M
rows, ~20 year-clusters).

## 2. Corpus figures — re-measured, not copied

```sql
select count(*) from research_price_daily;    -- 75,972,649
select count(*) from research_price_series;   -- 30,591
select min(bar_date), max(bar_date) from research_price_daily;  -- 1962-01-02 .. 2026-08-21
```

Every figure lands beside the query that reproduces it, per the never-hardcode rule. The
ticket quoted the same numbers; I re-ran them rather than copying, which is what surfaced
both corrections below.

## ⚠ Two corrections to the ticket's own premise

**The stale figure was in FIVE skill files, not the one named** — `strategy-evidence.md`
(×3), `data-capability.md` (×3), `market-structure.md`, `etoro-api.md`. And
`research-price-corpus.md`, the file #2841 pointed at, **did not carry it at all**. When
correcting a duplicated statistic, grep for the VALUE across the tree; the ticket is a
starting point, not the inventory. That lesson is now written into
`research-price-corpus.md` beside the figures.

**One copy was a DERIVED statistic, so a denominator swap would have left it wrong.**
`strategy-evidence.md` §2.11a read *"5,266,053 of 25,920,971 bars — 20.3% — predate
decimalisation"*. Re-measured:

```sql
select count(*) filter (where bar_date < date '2001-04-09'), count(*) from research_price_daily;
-- 12,281,013 / 75,972,649 = 16.2%
```

The **share moved**, 20.3% → 16.2%. Swapping the denominator and keeping "20.3%" would have
produced a confidently wrong number in a confound analysis. The section now records that it
was re-measured and what it was before.

`research-price-corpus.md` also gains a "what we actually hold" block, since it is the
corpus skill and had no such figure.

## Security model

Not applicable — documentation only, no code, no schema, no endpoint.

## Verification

`grep -rn "25\.9M\|25,9[0-9][0-9]\|7,727" .claude/skills/` returns one hit: the deliberate
"was 20.3% on 25.9M bars" history note. `ruff check` and `pytest -m "not db"` green (no
code changed; run to confirm nothing in the tree asserts on these files).

⚠ Doc-only diff — the review bot is expected to post its doc-only skip notice, which is a
terminal state rather than a pending one.
