### PR TITLE
feature(#2837): S-E's drawdown-insurance overlay, preregistered before the look

### DIFF
--- a/app/services/market_regime_provider.py
+++ b/app/services/market_regime_provider.py
@@ -260,81 +260,13 @@ class MarketRegimeProvider:
         *,
         through_date: date | None = None,
     ) -> MarketRegimeProvider:
-        """The BACKTEST's benchmark: ``spy_chain_v1`` over the research corpus.
+        """The BACKTEST's benchmark: ``spy_chain_v1``, classified.
 
-        The live scan keeps ``load`` (``price_daily``); this constructor exists
-        because the backtest's bars come from the research corpus and its axis
-        reaches decades before ``price_daily``'s first SPY bar (2022-05-10) —
-        the benchmark must come from the same source universe as the bars it
-        contextualises (`backtest_run._signals_for`'s own prescription).
-
-        ⚠ Quarantine treatment, declared: reads ``research_price_daily.close``
-        without consulting ``research_bar_quarantine``. The regime is market
-        context, not a return computation, so the quarantine's ``return_usable``
-        / ``range_usable`` verdicts do not define "close usable". Verified on
-        the full population at freeze time: the only flagged rows on either
-        pinned series are 5 archive-tail ``provisional`` marks on the fallback
-        (2024-09-23→27, empty rule list, both flags true) — all AFTER the seam,
-        so the chain never reads them.
-
-        ⚠ Both segment reads happen on the one connection passed in, inside its
-        current transaction, so the two queries observe one corpus snapshot.
-        A sealed in-sample caller supplies ``through_date`` so post-boundary
-        benchmark observations are not even read; classification remains a
-        backward-looking prefix of the same frozen chain.
+        The chain itself is read by ``load_research_closes`` below; this
+        constructor is the classification half. See that function for the
+        source, quarantine and sealed-prefix contracts.
         """
-        segments: dict[str, list[tuple[date, float]]] = {}
-        for role, (vendor, vendor_symbol), expected_basis in (
-            ("primary", CHAIN_PRIMARY, CHAIN_PRIMARY_BASIS),
-            ("fallback", CHAIN_FALLBACK, CHAIN_FALLBACK_BASIS),
-        ):
-            series_rows = conn.execute(
-                """
-                SELECT series_id, adjustment_basis
-                FROM research_price_series
-                WHERE vendor = %s AND vendor_symbol = %s
-                """,
-                (vendor, vendor_symbol),
-            ).fetchall()
-            # ``(vendor, vendor_symbol)`` is DB-unique, so >1 cannot happen today;
-            # kept because this refusal message beats a downstream shape error.
-            if len(series_rows) != 1:
-                raise BenchmarkUnavailableError(
-                    f"chain {role} pin {(vendor, vendor_symbol)!r} resolved to {len(series_rows)} series; "
-                    "spy_chain_v1 requires exactly one"
-                )
-            series_id, basis = series_rows[0]
-            if basis != expected_basis:
-                raise BenchmarkUnavailableError(
-                    f"chain {role} {(vendor, vendor_symbol)!r} has adjustment_basis {basis!r}, "
-                    f"expected {expected_basis!r} — provenance drifted under an unchanged vendor name"
-                )
-            bar_rows = conn.execute(
-                """
-                SELECT bar_date, close
-                FROM research_price_daily
-                WHERE series_id = %s AND close IS NOT NULL
-                  AND (%s::date IS NULL OR bar_date <= %s::date)
-                ORDER BY bar_date
-                """,
-                (series_id, through_date, through_date),
-            ).fetchall()
-            segments[role] = [(row[0], float(row[1])) for row in bar_rows]
-        if through_date is not None and through_date < CHAIN_SEAM:
-            # A sealed prefix ending before the vendor seam must not read a
-            # later primary observation merely to satisfy the full-chain path.
-            chained = segments["fallback"]
-            if not chained:
-                raise BenchmarkUnavailableError(
-                    f"chain fallback has no bars through the sealed boundary {through_date}"
-                )
-            for index, (day, close) in enumerate(chained):
-                if index and day <= chained[index - 1][0]:
-                    raise BenchmarkUnavailableError(f"chain dates are not strictly increasing at {day}")
-                if not math.isfinite(close) or close <= 0:
-                    raise BenchmarkUnavailableError(f"chain close on {day} is {close!r} — not a positive finite price")
-        else:
-            chained = _chain_closes(segments["primary"], segments["fallback"])
+        chained = load_research_closes(conn, through_date=through_date)
         return cls._classify([day for day, _ in chained], [close for _, close in chained], label="spy_chain_v1")
 
     def for_dates(self, dates: tuple[date, ...]) -> RegimeSeries:
@@ -364,6 +296,103 @@ class MarketRegimeProvider:
         return sum(1 for value in self._by_date.values() if value is not None)
 
 
+def load_research_closes(
+    conn: psycopg.Connection[Any],
+    *,
+    through_date: date | None = None,
+) -> list[tuple[date, float]]:
+    """``spy_chain_v1``'s closes, in date order — the chain read, unclassified.
+
+    ⚠⚠ PUBLIC SO THERE IS STILL ONE CHAIN. #2837's overlay needs the closes
+    themselves rather than a regime verdict, and the alternative — a second
+    module re-reading both segments and re-applying the seam — is exactly the
+    drift this module's header exists to prevent. ``load_research`` classifies
+    whatever this returns, so the benchmark a strategy is measured against and
+    the regime it is contextualised by cannot disagree about what the chain is.
+
+    ⚠ The fetch MECHANICS stay outside ``RULE_SET_VERSION`` by that same header's
+    design; the source SEMANTICS this implements are what the version declares.
+    Extracting the read therefore does not move any strategy identity.
+
+    The backtest's bars come from the research corpus and its axis reaches
+    decades before ``price_daily``'s first SPY bar (2022-05-10) — the benchmark
+    must come from the same source universe as the bars it contextualises
+    (`backtest_run._signals_for`'s own prescription).
+
+    ⚠ Quarantine treatment, declared: reads ``research_price_daily.close``
+    without consulting ``research_bar_quarantine``. The regime is market
+    context, not a return computation, so the quarantine's ``return_usable`` /
+    ``range_usable`` verdicts do not define "close usable". Verified on the full
+    population at freeze time: the only flagged rows on either pinned series are
+    5 archive-tail ``provisional`` marks on the fallback (2024-09-23→27, empty
+    rule list, both flags true) — all AFTER the seam, so the chain never reads
+    them.
+
+    ⚠⚠ #2837 reads these closes as PRICES, which the quarantine paragraph above
+    does not license on its own — it argues only that a flagged bar is usable as
+    *market context*. It holds here for the narrower reason that the flagged rows
+    are all after the seam and therefore outside the chain either way; a future
+    quarantine mark on a PRE-seam fallback bar would need this decision re-taken
+    rather than inherited.
+
+    ⚠ Both segment reads happen on the one connection passed in, inside its
+    current transaction, so the two queries observe one corpus snapshot. A
+    sealed in-sample caller supplies ``through_date`` so post-boundary
+    observations are not even read; the result stays a backward-looking prefix
+    of the same frozen chain.
+    """
+    segments: dict[str, list[tuple[date, float]]] = {}
+    for role, (vendor, vendor_symbol), expected_basis in (
+        ("primary", CHAIN_PRIMARY, CHAIN_PRIMARY_BASIS),
+        ("fallback", CHAIN_FALLBACK, CHAIN_FALLBACK_BASIS),
+    ):
+        series_rows = conn.execute(
+            """
+            SELECT series_id, adjustment_basis
+            FROM research_price_series
+            WHERE vendor = %s AND vendor_symbol = %s
+            """,
+            (vendor, vendor_symbol),
+        ).fetchall()
+        # ``(vendor, vendor_symbol)`` is DB-unique, so >1 cannot happen today;
+        # kept because this refusal message beats a downstream shape error.
+        if len(series_rows) != 1:
+            raise BenchmarkUnavailableError(
+                f"chain {role} pin {(vendor, vendor_symbol)!r} resolved to {len(series_rows)} series; "
+                "spy_chain_v1 requires exactly one"
+            )
+        series_id, basis = series_rows[0]
+        if basis != expected_basis:
+            raise BenchmarkUnavailableError(
+                f"chain {role} {(vendor, vendor_symbol)!r} has adjustment_basis {basis!r}, "
+                f"expected {expected_basis!r} — provenance drifted under an unchanged vendor name"
+            )
+        bar_rows = conn.execute(
+            """
+            SELECT bar_date, close
+            FROM research_price_daily
+            WHERE series_id = %s AND close IS NOT NULL
+              AND (%s::date IS NULL OR bar_date <= %s::date)
+            ORDER BY bar_date
+            """,
+            (series_id, through_date, through_date),
+        ).fetchall()
+        segments[role] = [(row[0], float(row[1])) for row in bar_rows]
+    if through_date is not None and through_date < CHAIN_SEAM:
+        # A sealed prefix ending before the vendor seam must not read a
+        # later primary observation merely to satisfy the full-chain path.
+        chained = segments["fallback"]
+        if not chained:
+            raise BenchmarkUnavailableError(f"chain fallback has no bars through the sealed boundary {through_date}")
+        for index, (day, close) in enumerate(chained):
+            if index and day <= chained[index - 1][0]:
+                raise BenchmarkUnavailableError(f"chain dates are not strictly increasing at {day}")
+            if not math.isfinite(close) or close <= 0:
+                raise BenchmarkUnavailableError(f"chain close on {day} is {close!r} — not a positive finite price")
+        return chained
+    return _chain_closes(segments["primary"], segments["fallback"])
+
+
 __all__ = [
     "BENCHMARK_SYMBOL",
     "CHAIN_FALLBACK",
@@ -375,4 +404,5 @@ __all__ = [
     "RULE_SET_VERSION",
     "BenchmarkUnavailableError",
     "MarketRegimeProvider",
+    "load_research_closes",
 ]

--- a/app/services/se_ma_overlay.py
+++ b/app/services/se_ma_overlay.py
@@ -1,0 +1,684 @@
+"""S-E's 10-month-SMA overlay on the passive core — the frozen rule, as code.
+
+Contract: ``docs/proposals/ta/2026-08-22-se-ma-overlay-preregistration.md``
+(`se-ma-overlay-2026-08-22`). Issue #2837. Part of #2832.
+
+⚠⚠ THE CLAIM IS DRAWDOWN INSURANCE AND NOTHING ELSE. Excess-return significance
+is not testable on one index path, is not the claim, and no test of it exists in
+this module. The trial is ``falsification_only`` and structurally unpromotable
+before it runs (§2 of the contract), so nothing here may be read as an alpha
+result however the numbers land.
+
+⚠ PURE. Arrays and bars in, verdicts out, no database and no clock. The impure
+half — reading ``spy_chain_v1`` and the distribution yield — is
+``scripts/measure_2837_se_overlay.py``. The split is the same one
+``market_regime`` / ``market_regime_provider`` already draws, and for the same
+reason: the rule is what is frozen, and how its inputs are fetched is not.
+
+⚠ EVERY CONSTANT BELOW IS THE CONTRACT'S, NOT A CHOICE MADE HERE. A different
+lookback, offset set, cost band or pass threshold is a NEW declared search
+charging the trial register again (#2600 D-0.1) — not a refinement of this one.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from typing import Final
+
+import numpy as np
+
+from app.services.strategy_statistics import max_drawdown_pct
+from app.services.tax_ledger import ANNUAL_EXEMPT
+
+#: Contract §4.3. Ten evaluation-date closes, inclusive of the current one.
+LOOKBACK: Final[int] = 10
+
+#: Contract §5. A fragility SCREEN over one rule, never three variants to choose
+#: between — which is why the register charges ``searches=1`` and why §8 demands
+#: all three rather than the best.
+OFFSETS: Final[tuple[int, ...]] = (0, 5, 10)
+
+#: Contract §6. 0.322% round trip, charged half on each side.
+ROUND_TRIP_COST_PCT: Final[float] = 0.322
+SIDE_COST_PCT: Final[float] = ROUND_TRIP_COST_PCT / 2.0
+
+#: Contract §6. Opening account, higher-rate taxpayer, 24% above the annual
+#: exempt amount. ⚠ ``ANNUAL_EXEMPT`` is imported rather than retyped so the
+#: £3,000 has one definition in the repo; the rate is the contract's declared
+#: worst case (``tax_ledger._CGT_RATE_PERIODS`` carries it from 2024-10-30).
+OPENING_EQUITY_GBP: Final[float] = 50_000.0
+CGT_HIGHER_RATE: Final[float] = 0.24
+ANNUAL_EXEMPT_GBP: Final[float] = float(ANNUAL_EXEMPT)
+
+#: Contract §8. Both legs, and the ≥15% episode class §9 reports.
+MAX_DRAWDOWN_RATIO_BAR: Final[float] = 2.0 / 3.0
+MIN_CAGR_DELTA_PP: Final[float] = -1.5
+EPISODE_CLASS_PCT: Final[float] = 15.0
+
+#: Contract §3 — the chain's extent, FROZEN rather than derived. Measured
+#: 2026-08-22, dates and row counts only. A corpus refresh that moves any of the
+#: three changes the tested span, and a contract that absorbs that silently
+#: means something different each time it runs.
+CHAIN_FIRST_BAR: Final[date] = date(1993, 1, 29)
+CHAIN_LAST_BAR: Final[date] = date(2026, 7, 8)
+CHAIN_BARS: Final[int] = 8391
+
+#: Contract §9. The predeclared March-2020 inspection window — fixed before the
+#: look so the narration cannot be selected after it.
+MARCH_2020_WINDOW: Final[tuple[date, date]] = (date(2019, 12, 1), date(2020, 12, 31))
+
+
+class OverlayRefused(RuntimeError):
+    """The measurement cannot run as declared.
+
+    ⚠ Raised rather than degraded. Every caller of this module is producing a
+    number that goes on a preregistered trial; a quietly shortened chain, a
+    collapsed offset arm or a non-finite SMA input would all still produce a
+    plausible float, and a plausible float is the failure mode that survives
+    review.
+    """
+
+
+@dataclass(frozen=True)
+class DrawdownEpisode:
+    """One peak → trough → recovery excursion. Contract §9.
+
+    ⚠ ``recovery`` is ``None`` for a terminal episode the curve never climbed out
+    of, and such an episode is REPORTED, not dropped: dropping it would let a
+    measurement that ends in the deepest hole of its life report the second
+    deepest.
+    """
+
+    peak_date: date
+    trough_date: date
+    recovery_date: date | None
+    depth_pct: float
+
+    @property
+    def unrecovered(self) -> bool:
+        return self.recovery_date is None
+
+
+@dataclass(frozen=True)
+class TaxCharge:
+    """One 31-January payment, and the tax year it settles."""
+
+    tax_year_start: int
+    payment_date: date
+    net_gain_gbp: float
+    taxable_gbp: float
+    tax_gbp: float
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    """One offset's full readout. Contract §9 — reported pass or fail."""
+
+    offset: int
+    first_execution: date
+    last_execution: date
+    years: float
+    evaluation_dates: tuple[date, ...]
+    execution_dates: tuple[date, ...]
+    positions: tuple[int, ...]
+    flips: int
+    fraction_in_cash: float
+    seam_spanning_windows: int
+    reentries_within_30_days: int
+    overlay_equity: tuple[float, ...]
+    benchmark_equity: tuple[float, ...]
+    equity_dates: tuple[date, ...]
+    overlay_max_drawdown_pct: float
+    benchmark_max_drawdown_pct: float
+    overlay_worst_episodes: tuple[DrawdownEpisode, ...]
+    benchmark_worst_episodes: tuple[DrawdownEpisode, ...]
+    overlay_episodes_over_class: int
+    benchmark_episodes_over_class: int
+    overlay_cagr_pct: float
+    benchmark_cagr_pct: float
+    dividend_drag_pp: float
+    tax_charges: tuple[TaxCharge, ...]
+    symmetric_overlay_terminal_gbp: float
+    symmetric_benchmark_terminal_gbp: float
+
+    @property
+    def drawdown_ratio(self) -> float | None:
+        """Overlay max DD as a fraction of the benchmark's. ``None`` if the
+        benchmark never drew down — §8 fails that arm rather than dividing."""
+        if self.benchmark_max_drawdown_pct <= 0.0:
+            return None
+        return self.overlay_max_drawdown_pct / self.benchmark_max_drawdown_pct
+
+    @property
+    def net_cagr_delta_pp(self) -> float:
+        """§8 leg 2's quantity: the overlay's CAGR after §3.1's dividend drag,
+        less the benchmark's."""
+        return self.overlay_cagr_pct - self.dividend_drag_pp - self.benchmark_cagr_pct
+
+    @property
+    def drawdown_leg_passes(self) -> bool:
+        ratio = self.drawdown_ratio
+        # ⚠ `None` FAILS. An overlay cannot evidence insurance against a loss
+        # that never happened, so a zero-drawdown benchmark is a failed arm and
+        # not a division to guard against.
+        return ratio is not None and ratio <= MAX_DRAWDOWN_RATIO_BAR
+
+    @property
+    def cagr_leg_passes(self) -> bool:
+        return self.net_cagr_delta_pp >= MIN_CAGR_DELTA_PP
+
+    @property
+    def passes(self) -> bool:
+        return self.drawdown_leg_passes and self.cagr_leg_passes
+
+
+def uk_tax_year_start(day: date) -> int:
+    """The starting calendar year of the UK tax year containing ``day``.
+
+    6 April–5 April. ⚠ Deliberately a local four-liner rather than an import of
+    ``tax_ledger._compute_tax_year``, which is private and returns a display
+    string. ``tests/test_2837_se_ma_overlay.py`` asserts the two agree across a
+    date sweep, so there is one RULE with two spellings rather than two rules.
+    """
+    return day.year - 1 if (day.month, day.day) <= (4, 5) else day.year
+
+
+def cgt_payment_date(tax_year_start: int) -> date:
+    """HMRC's self-assessment payment date: 31 January following the tax year.
+
+    Tax year ``Y/Y+1`` ends ``Y+1``-04-05 and is payable ``Y+2``-01-31.
+    """
+    return date(tax_year_start + 2, 1, 31)
+
+
+def month_end_indices(dates: Sequence[date]) -> tuple[int, ...]:
+    """Contract §4.1 — the last chain bar of each COMPLETED calendar month.
+
+    ⚠⚠ A month qualifies only when a later bar exists in a SUBSEQUENT calendar
+    month. The trailing partial month is excluded: the chain ends mid-July 2026,
+    and calling 2026-07-08 July's month-end would invent a decision the calendar
+    never offered — and would do it at the one end of the sample where a wrong
+    decision has no later bar to correct it.
+
+    ⚠ This is not lookahead. The qualifying evidence is a bar that already
+    exists at execution time; §4.5 executes on exactly that bar.
+    """
+    if not dates:
+        return ()
+    ends: list[int] = []
+    for index in range(len(dates) - 1):
+        current, following = dates[index], dates[index + 1]
+        if (current.year, current.month) != (following.year, following.month):
+            ends.append(index)
+    return tuple(ends)
+
+
+def evaluation_indices(dates: Sequence[date], offset: int) -> tuple[int, ...]:
+    """Contract §4.2 — month-ends shifted by ``offset`` CHAIN-BAR POSITIONS.
+
+    ⚠ Positions, not trading days. The chain is the only calendar this
+    measurement has and no exchange calendar is frozen, so "+5" means the fifth
+    subsequent chain row. Saying "trading days" would be a claim about sessions
+    that the data cannot support.
+
+    A shifted index past the end of the chain contributes no evaluation date.
+    """
+    if offset < 0:
+        raise OverlayRefused(f"offset {offset} is negative")
+    shifted = tuple(index + offset for index in month_end_indices(dates) if index + offset < len(dates))
+    if len(set(shifted)) != len(shifted) or any(b <= a for a, b in zip(shifted, shifted[1:], strict=False)):
+        # Structurally impossible on a chain with >=12 bars a month; refused
+        # rather than de-duplicated because a collision would silently
+        # double-count a close inside the SMA window.
+        raise OverlayRefused(f"offset {offset} produced non-increasing or duplicate evaluation indices")
+    return shifted
+
+
+def overlay_positions(evaluation_closes: Sequence[float]) -> tuple[int, ...]:
+    """Contract §4.3–4.4 — 1 when above the SMA10, 0 in cash, 1 through warm-up.
+
+    ⚠ STRICTLY GREATER, float64, no rounding and no tolerance. An equality is
+    cash. A tolerance would be a second, undeclared parameter.
+
+    ⚠ Warm-up HOLDS rather than sits out. The overlay is insurance on an
+    already-invested core: it may remove exposure the core has and may never add
+    exposure the core lacks. Sitting out the warm-up would make the arm a
+    market-timing bet on its own first ten months.
+    """
+    positions: list[int] = []
+    for index, close in enumerate(evaluation_closes):
+        if index + 1 < LOOKBACK:
+            positions.append(1)
+            continue
+        window = evaluation_closes[index + 1 - LOOKBACK : index + 1]
+        if not all(math.isfinite(value) and value > 0.0 for value in window):
+            raise OverlayRefused(
+                f"SMA window ending at evaluation index {index} contains a non-positive or non-finite close"
+            )
+        positions.append(1 if close > (sum(window) / LOOKBACK) else 0)
+    return tuple(positions)
+
+
+def drawdown_episodes(dates: Sequence[date], equity: Sequence[float]) -> tuple[DrawdownEpisode, ...]:
+    """Contract §9 — peak → trough → recovery, deepest first.
+
+    ⚠ NESTED DRAWDOWNS ARE ONE EPISODE. A dip inside an unrecovered decline is
+    part of that decline, not a second event; counting it separately would let
+    one 2008 report as four and inflate any episode count built on it.
+
+    ⚠ A terminal unrecovered episode is included with its trough to date and
+    flagged, for the reason on ``DrawdownEpisode``.
+    """
+    if len(dates) != len(equity):
+        raise OverlayRefused("drawdown inputs disagree in length")
+    episodes: list[DrawdownEpisode] = []
+    peak = -math.inf
+    peak_index = 0
+    trough_index: int | None = None
+    for index, value in enumerate(equity):
+        if value >= peak:
+            if trough_index is not None:
+                episodes.append(_episode(dates, equity, peak_index, trough_index, index))
+                trough_index = None
+            peak, peak_index = value, index
+        elif trough_index is None or value < equity[trough_index]:
+            trough_index = index
+    if trough_index is not None:
+        episodes.append(_episode(dates, equity, peak_index, trough_index, None))
+    return tuple(sorted(episodes, key=lambda episode: episode.depth_pct, reverse=True))
+
+
+def _episode(
+    dates: Sequence[date], equity: Sequence[float], peak_index: int, trough_index: int, recovery_index: int | None
+) -> DrawdownEpisode:
+    peak_value = equity[peak_index]
+    depth = 0.0 if peak_value <= 0.0 else (peak_value - equity[trough_index]) / peak_value * 100.0
+    return DrawdownEpisode(
+        peak_date=dates[peak_index],
+        trough_date=dates[trough_index],
+        recovery_date=None if recovery_index is None else dates[recovery_index],
+        depth_pct=depth,
+    )
+
+
+def cagr_pct(start_equity: float, end_equity: float, years: float) -> float:
+    """Annualised growth over ``years``, in percent.
+
+    ⚠ Refuses a non-positive span or a wiped-out arm rather than returning a
+    complex or infinite number that would print as a plausible result.
+    """
+    if years <= 0.0:
+        raise OverlayRefused(f"cannot annualise over {years!r} years")
+    if start_equity <= 0.0 or end_equity <= 0.0:
+        raise OverlayRefused("cannot annualise a non-positive equity")
+    return ((end_equity / start_equity) ** (1.0 / years) - 1.0) * 100.0
+
+
+class _CgtLedger:
+    """Contract §6's CGT, accumulated as the simulation walks forward.
+
+    ⚠⚠ THIS CANNOT BE PRECOMPUTED, and the attempt is the bug worth naming. A
+    disposal's gain is `proceeds − pool cost` in POUNDS, the pool cost is the
+    equity that was invested at the last entry, and that equity is net of every
+    tax payment made before it — so the gains depend on the charges that depend
+    on the gains. Walking forward breaks the loop: a tax year can only be
+    finalised once the simulation has passed 5 April, and its payment lands the
+    following 31 January, which is later still.
+
+    ⚠ LOSSES CARRY FORWARD, THE EXEMPTION DOES NOT. HMRC treats them
+    differently and so does this: an unused annual exempt amount is lost at the
+    year end, a net loss is available against later gains indefinitely. Carrying
+    the exemption would understate the drag; refusing to carry losses would
+    overstate it.
+    """
+
+    def __init__(self) -> None:
+        self._open_year: int | None = None
+        self._open_gain = 0.0
+        self._carried_loss = 0.0
+        self.charges: list[TaxCharge] = []
+        self.pending: list[tuple[date, float]] = []
+
+    def realise(self, day: date, gain: float) -> None:
+        year = uk_tax_year_start(day)
+        if self._open_year is not None and year != self._open_year:
+            self._finalise()
+        self._open_year = year
+        self._open_gain += gain
+
+    def settle_years_before(self, day: date) -> None:
+        """Close any tax year that ended before ``day`` so its charge is scheduled."""
+        if self._open_year is not None and uk_tax_year_start(day) != self._open_year:
+            self._finalise()
+
+    def _tax_for(self, gain: float) -> float:
+        """The charge a year holding ``gain`` would settle, given carried losses."""
+        return max(max(gain + self._carried_loss, 0.0) - ANNUAL_EXEMPT_GBP, 0.0) * CGT_HIGHER_RATE
+
+    def _finalise(self) -> None:
+        assert self._open_year is not None
+        net = self._open_gain + self._carried_loss
+        tax = self._tax_for(self._open_gain)
+        taxable = tax / CGT_HIGHER_RATE
+        self._carried_loss = min(net, 0.0)
+        payment = cgt_payment_date(self._open_year)
+        self.charges.append(
+            TaxCharge(
+                tax_year_start=self._open_year,
+                payment_date=payment,
+                net_gain_gbp=net,
+                taxable_gbp=taxable,
+                tax_gbp=tax,
+            )
+        )
+        if tax > 0.0:
+            self.pending.append((payment, tax))
+        self._open_year = None
+        self._open_gain = 0.0
+
+    def close(self) -> None:
+        if self._open_year is not None:
+            self._finalise()
+
+    def incremental_tax_on_terminal_gain(self, gain: float) -> float:
+        """§7's symmetric variant: one more disposal into the still-open year.
+
+        ⚠⚠ INCREMENTAL, NOT ABSOLUTE, and the difference is a real double-count
+        (Codex checkpoint 2, #2837). The open year's own charge is already
+        settled by ``close`` and deducted from the primary equity as the terminal
+        accrual; returning the full charge here and subtracting it again would
+        tax that year twice. What §7 adds is only the extra tax the liquidation
+        itself causes — and because the exemption and any carried loss are
+        absorbed by the base charge first, that is genuinely not the same as
+        taxing the terminal gain on its own.
+        """
+        return self._tax_for(self._open_gain + gain) - self._tax_for(self._open_gain)
+
+
+def simulate_arm(
+    chain: Sequence[tuple[date, float]],
+    *,
+    offset: int,
+    seam: date,
+    dividend_yield_pp: float,
+) -> ArmResult:
+    """One offset arm, end to end. Contract §4, §6, §8, §9.
+
+    ⚠⚠ THE INTERVAL OWNERSHIP RULE, which is where a timing bug would hide: the
+    return from an evaluation close to the following execution close belongs to
+    the OLD position; the NEW position owns from that execution close forward.
+    Getting this backwards hands the rule the very move it is being tested on.
+
+    ⚠ Equity is marked on EVERY chain bar in the span, not sampled monthly. A
+    monthly-sampled drawdown understates the real one, which would flatter §8's
+    first leg; and the 31 January tax outflow is a calendar date that is usually
+    not an execution date.
+    """
+    dates = [day for day, _ in chain]
+    closes = [close for _, close in chain]
+    evaluations = evaluation_indices(dates, offset)
+    # A decision with no next chain bar is DISCARDED, not carried: there is no
+    # bar to execute it on, and holding it back to the following month would be
+    # a different rule.
+    executable = [index for index in evaluations if index + 1 < len(dates)]
+    if len(executable) < LOOKBACK or len(executable) < 2:
+        raise OverlayRefused(f"offset {offset} yields {len(executable)} executable decisions — a degenerate arm")
+    executions = [index + 1 for index in executable]
+    if set(executions) & set(executable):
+        raise OverlayRefused(f"offset {offset} has a bar that is both an evaluation and an execution date")
+
+    positions = overlay_positions([closes[index] for index in executable])
+    first_execution, last_execution = executions[0], executions[-1]
+
+    overlay = OPENING_EQUITY_GBP
+    benchmark = OPENING_EQUITY_GBP
+    equity_dates: list[date] = [dates[first_execution]]
+    overlay_curve: list[float] = [overlay]
+    benchmark_curve: list[float] = [benchmark]
+    execution_at = {index: position for index, position in zip(executions, positions, strict=True)}
+    ledger = _CgtLedger()
+    charge_cursor = 0
+    held = positions[0]
+    # §4.8 — inception charges nothing on either arm, so the opening pool cost
+    # is the full opening equity.
+    pool_cost = OPENING_EQUITY_GBP if held else 0.0
+    for bar in range(first_execution + 1, last_execution + 1):
+        move = closes[bar] / closes[bar - 1] - 1.0
+        # The interval ENDING at this bar is owned by the position held coming
+        # into it — so the return is applied before any trade at this bar.
+        overlay *= 1.0 + held * move
+        benchmark *= 1.0 + move
+        ledger.settle_years_before(dates[bar])
+        target = execution_at.get(bar)
+        if target is not None and target != held:
+            overlay *= 1.0 - SIDE_COST_PCT / 100.0
+            if target == 0:
+                # A complete disposal: the position is all-in or all-out, so
+                # every exit empties the §104 pool.
+                ledger.realise(dates[bar], overlay - pool_cost)
+                pool_cost = 0.0
+            else:
+                pool_cost = overlay
+            held = target
+        while charge_cursor < len(ledger.pending) and ledger.pending[charge_cursor][0] <= dates[bar]:
+            # §6: an outflow on the calendar date, charged at the first chain bar
+            # on or after it when 31 January is not a trading day. Taken from
+            # equity directly; the declared omissions are the spread on the
+            # implied partial sale and the second CGT event it would create.
+            overlay -= ledger.pending[charge_cursor][1]
+            if held:
+                # The sliver sold to fund the payment leaves the pool with it,
+                # so the remaining holding's cost is reduced pro rata rather
+                # than left overstating the base of the next disposal.
+                pool_cost *= (overlay) / (overlay + ledger.pending[charge_cursor][1])
+            charge_cursor += 1
+        equity_dates.append(dates[bar])
+        overlay_curve.append(overlay)
+        benchmark_curve.append(benchmark)
+
+    # §7's INCREMENTAL liquidation tax must be read before ``close`` finalises
+    # the open year, but applied after the accrual below — see the method.
+    liquidation_tax = ledger.incremental_tax_on_terminal_gain(overlay - pool_cost) if held else 0.0
+
+    # §6 terminal accrual — a liability whose payment date falls after the arm
+    # ends must not escape by falling off the end of the sample.
+    ledger.close()
+    charges = tuple(ledger.charges)
+    accrued = sum(amount for _, amount in ledger.pending[charge_cursor:])
+    if accrued:
+        overlay -= accrued
+        overlay_curve[-1] = overlay
+
+    # ⚠ AFTER the accrual, not before (Codex checkpoint 2). Capturing the
+    # symmetric figure earlier omitted every tax the primary equity had already
+    # been charged, so the sensitivity read better than the thing it is a
+    # sensitivity ON — the one direction a declared sensitivity must not fail in.
+    symmetric_overlay = overlay - liquidation_tax
+    symmetric_benchmark = benchmark - max(benchmark - OPENING_EQUITY_GBP - ANNUAL_EXEMPT_GBP, 0.0) * CGT_HIGHER_RATE
+
+    span_days = (dates[last_execution] - dates[first_execution]).days
+    years = span_days / 365.25
+    cash_days = sum(
+        (dates[executions[index + 1]] - dates[executions[index]]).days
+        for index in range(len(executions) - 1)
+        if positions[index] == 0
+    )
+    fraction_in_cash = cash_days / span_days if span_days else 0.0
+
+    overlay_episodes = drawdown_episodes(equity_dates, overlay_curve)
+    benchmark_episodes = drawdown_episodes(equity_dates, benchmark_curve)
+    return ArmResult(
+        offset=offset,
+        first_execution=dates[first_execution],
+        last_execution=dates[last_execution],
+        years=years,
+        evaluation_dates=tuple(dates[index] for index in executable),
+        execution_dates=tuple(dates[index] for index in executions),
+        positions=positions,
+        flips=sum(1 for a, b in zip(positions, positions[1:], strict=False) if a != b),
+        fraction_in_cash=fraction_in_cash,
+        seam_spanning_windows=_seam_spanning_windows([dates[index] for index in executable], seam),
+        reentries_within_30_days=_reentries_within_30_days([dates[index] for index in executions], positions),
+        overlay_equity=tuple(overlay_curve),
+        benchmark_equity=tuple(benchmark_curve),
+        equity_dates=tuple(equity_dates),
+        overlay_max_drawdown_pct=-max_drawdown_pct(np.asarray(overlay_curve, dtype=np.float64)),
+        benchmark_max_drawdown_pct=-max_drawdown_pct(np.asarray(benchmark_curve, dtype=np.float64)),
+        overlay_worst_episodes=overlay_episodes[:3],
+        benchmark_worst_episodes=benchmark_episodes[:3],
+        overlay_episodes_over_class=sum(1 for e in overlay_episodes if e.depth_pct >= EPISODE_CLASS_PCT),
+        benchmark_episodes_over_class=sum(1 for e in benchmark_episodes if e.depth_pct >= EPISODE_CLASS_PCT),
+        overlay_cagr_pct=cagr_pct(OPENING_EQUITY_GBP, overlay, years),
+        benchmark_cagr_pct=cagr_pct(OPENING_EQUITY_GBP, benchmark, years),
+        dividend_drag_pp=fraction_in_cash * dividend_yield_pp,
+        tax_charges=charges,
+        symmetric_overlay_terminal_gbp=symmetric_overlay,
+        symmetric_benchmark_terminal_gbp=symmetric_benchmark,
+    )
+
+
+@dataclass(frozen=True)
+class RegimeCohort:
+    """One regime's slice of the readout. Contract §9."""
+
+    regime: str
+    intervals: int
+    months_in_cash: int
+    overlay_mean_return_pct: float
+    benchmark_mean_return_pct: float
+
+
+def regime_cohorts(result: ArmResult, regimes: Sequence[str | None]) -> tuple[RegimeCohort, ...]:
+    """Contract §9 — the readout partitioned by regime, never pooled.
+
+    ⚠ ASSIGNED BY THE EVALUATION DATE THAT DECIDED THE INTERVAL, not by the
+    interval's own dates. The question a cohort answers is "what did this rule do
+    when it decided under regime X", and the decision is made at the evaluation
+    date; keying on the holding period instead would credit a decision to a
+    regime that had not happened when it was taken.
+
+    ⚠ The regime is DESCRIPTIVE ONLY. It partitions this readout and enters
+    neither the signal, the position, the costs nor the pass bar — so the
+    classifier's use of contemporaneous closes cannot leak into a decision.
+
+    ⚠ ``None`` is its own cohort (``warm_up``), never folded into a real one: a
+    bar the classifier could not verdict is not evidence about any regime.
+    """
+    if len(regimes) != len(result.evaluation_dates):
+        raise OverlayRefused("regime series and evaluation dates disagree in length")
+    overlay_at = dict(zip(result.equity_dates, result.overlay_equity, strict=True))
+    benchmark_at = dict(zip(result.equity_dates, result.benchmark_equity, strict=True))
+    buckets: dict[str, list[tuple[float, float, int]]] = {}
+    for index in range(len(result.execution_dates) - 1):
+        start, end = result.execution_dates[index], result.execution_dates[index + 1]
+        if start not in overlay_at or end not in overlay_at:
+            continue
+        label = regimes[index] or "warm_up"
+        buckets.setdefault(label, []).append(
+            (
+                overlay_at[end] / overlay_at[start] - 1.0,
+                benchmark_at[end] / benchmark_at[start] - 1.0,
+                1 if result.positions[index] == 0 else 0,
+            )
+        )
+    return tuple(
+        RegimeCohort(
+            regime=label,
+            intervals=len(rows),
+            months_in_cash=sum(row[2] for row in rows),
+            overlay_mean_return_pct=sum(row[0] for row in rows) / len(rows) * 100.0,
+            benchmark_mean_return_pct=sum(row[1] for row in rows) / len(rows) * 100.0,
+        )
+        for label, rows in sorted(buckets.items())
+    )
+
+
+def march_2020_detail(result: ArmResult) -> tuple[tuple[date, date, int, float, float], ...]:
+    """Contract §9's predeclared March-2020 inspection.
+
+    ⚠ THE WINDOW AND THE FIELDS ARE FROZEN (``MARCH_2020_WINDOW``), so the
+    narration cannot be selected after the look. Every decision in the window is
+    returned, not the interesting ones.
+    """
+    start, end = MARCH_2020_WINDOW
+    overlay_at = dict(zip(result.equity_dates, result.overlay_equity, strict=True))
+    benchmark_at = dict(zip(result.equity_dates, result.benchmark_equity, strict=True))
+    rows: list[tuple[date, date, int, float, float]] = []
+    for index, evaluation in enumerate(result.evaluation_dates):
+        if not start <= evaluation <= end:
+            continue
+        execution = result.execution_dates[index]
+        if execution not in overlay_at:
+            continue
+        rows.append((evaluation, execution, result.positions[index], overlay_at[execution], benchmark_at[execution]))
+    return tuple(rows)
+
+
+def _seam_spanning_windows(evaluation_dates: Sequence[date], seam: date) -> int:
+    """§9 — how many SMA windows straddle the vendor seam.
+
+    The provider's header argues SPY's lack of split history makes the two
+    adjustment bases equivalent, and the 585-date overlap measures the residual
+    at ~$1.76 (~0.3%). A window straddling the seam is nonetheless the only
+    place a residual level step could enter a SIGNAL, so the count is surfaced
+    rather than assumed away.
+    """
+    return sum(
+        1
+        for index in range(LOOKBACK - 1, len(evaluation_dates))
+        if evaluation_dates[index - LOOKBACK + 1] < seam <= evaluation_dates[index]
+    )
+
+
+def _reentries_within_30_days(execution_dates: Sequence[date], positions: Sequence[int]) -> int:
+    """§6 — exits followed by a re-entry inside 30 days.
+
+    The size of the declared 30-day-rule simplification: these are the only
+    disposals TCGA 1992 s.106A would have matched differently.
+    """
+    count = 0
+    for index in range(1, len(positions)):
+        if positions[index] != 0 or positions[index - 1] != 1:
+            continue
+        exit_date = execution_dates[index]
+        for later in range(index + 1, len(positions)):
+            if positions[later] == 1:
+                count += (execution_dates[later] - exit_date).days <= 30
+                break
+    return count
+
+
+__all__ = [
+    "ANNUAL_EXEMPT_GBP",
+    "CGT_HIGHER_RATE",
+    "CHAIN_BARS",
+    "CHAIN_FIRST_BAR",
+    "CHAIN_LAST_BAR",
+    "EPISODE_CLASS_PCT",
+    "LOOKBACK",
+    "MARCH_2020_WINDOW",
+    "MAX_DRAWDOWN_RATIO_BAR",
+    "MIN_CAGR_DELTA_PP",
+    "OFFSETS",
+    "OPENING_EQUITY_GBP",
+    "ROUND_TRIP_COST_PCT",
+    "SIDE_COST_PCT",
+    "ArmResult",
+    "DrawdownEpisode",
+    "OverlayRefused",
+    "RegimeCohort",
+    "TaxCharge",
+    "cagr_pct",
+    "cgt_payment_date",
+    "drawdown_episodes",
+    "evaluation_indices",
+    "march_2020_detail",
+    "month_end_indices",
+    "overlay_positions",
+    "regime_cohorts",
+    "simulate_arm",
+    "uk_tax_year_start",
+]

--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -118,7 +118,32 @@ from typing import Final
 #: Bumped whenever a trial is added or an entry's meaning changes. ⚠ Stored on
 #: the result row beside the DSR: a deflated Sharpe means nothing without the
 #: trial population it was deflated against, and that population grows.
-TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-15-r7"
+#:
+#: ⚠⚠ ADDING A TRIAL *IS* THE SUPERSESSION — bumping this string only labels it.
+#: `deflation_promotion_refusals` fires `trial_register_superseded` on
+#: `deflated.declared_trials != TRIAL_REGISTER.declared_count`, so a new entry
+#: strands every stored deflation whether or not this constant moves. There is
+#: no way to count a new search without it, and `freeze_preregistration` refuses
+#: a declaration no trial claims — so "add the entry but don't bump" is not a
+#: state, and declining to add one to protect old rows is the flattering
+#: direction this module is built against.
+#:
+#: r8 (2026-08-22, #2837) is the first bump measured rather than argued. What it
+#: stranded, reproduce with:
+#:
+#:   PYTHONPATH=. uv run python -c "
+#:   import psycopg; from app.config import settings
+#:   with psycopg.connect(settings.database_url) as c:
+#:       c.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+#:       print(c.execute('select trial_register_version, purpose, count(*) from strategy_results_store "
+#:   "where deflated_sharpe is not null group by 1,2 order by 3 desc').fetchall()); c.rollback()"
+#:
+#: On dev at the bump every row with a DSR carried `purpose = harness_validation`
+#: — so `purpose_promotion_refusals` already returned a terminal
+#: `harness_validation_only` on all of them, and the bump added a second refusal
+#: code to rows that could not promote anyway. Four earlier versions appear in
+#: the same output, which is what a register that is doing its job looks like.
+TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-22-r8"
 
 #: #2600 Gate D-0.1. Every search this register counts happened at or before this
 #: instant; the two durable clocks (``strategy_results_store.created_at`` and
@@ -713,6 +738,21 @@ TRIAL_REGISTER: Final = TrialRegister(
             ),
             exactness=TrialExactness.EXACT,
             declared_for=("mt1-s8-capped-volatility-negative-control-v1", "strategy-registry-v1+b83c3e4fc997"),
+        ),
+        DeclaredTrial(
+            trial_id="se-ma-overlay-2026-08-22",
+            description=(
+                "S-E 10-month-SMA overlay on the passive core: ONE frozen rule (10-month lookback, no band, no "
+                "confirmation delay) measured at three evaluation offsets. ⚠ searches=1 and not 3 — the three "
+                "offsets are a fragility screen over one rule, not three variants selected between. Choosing the "
+                "best offset is forbidden by the pass bar, which requires all three."
+            ),
+            evidence=(
+                "docs/proposals/ta/2026-08-22-se-ma-overlay-preregistration.md §4 (frozen rule), §5 (fragility) "
+                "and §8 (pass bar); issue #2837"
+            ),
+            exactness=TrialExactness.EXACT,
+            declared_for=("se-ma-overlay-drawdown-insurance", "se-ma-overlay-drawdown-insurance-v1"),
         ),
     ),
 )

--- a/docs/proposals/ta/2026-08-22-se-ma-overlay-preregistration.md
+++ b/docs/proposals/ta/2026-08-22-se-ma-overlay-preregistration.md
@@ -1,0 +1,355 @@
+# S-E: 10-month-SMA overlay on the passive core — preregistration
+
+Date: 2026-08-22
+Status: FROZEN before first look. No return, drawdown or CAGR of this rule has been read.
+Parent: #2837. Part of #2832. Refs #2437, #2599, #2600, #2829.
+
+Contract version: `se-ma-overlay-2026-08-22`
+Trial identity: `se-ma-overlay-drawdown-insurance` @ `se-ma-overlay-drawdown-insurance-v1`
+
+> Revised once before freezing, after a Codex checkpoint-1 pass over the first draft
+> (2026-08-22). The pass returned 85 findings; the resolutions are §12. No outcome was read
+> in between — every fact used to revise is a date, a row count or a column's presence.
+
+## 1. The claim, and the claim it is not
+
+The alpha claim is dead and stays dead. #2837 records the reasons: Zakamulin's
+moving-average timing work finds no significant out-of-sample outperformance under
+realistic costs, GTAA's live record concurs, and UK CGT pushes expected excess CAGR below
+zero because a flip realises a gain buy-and-hold defers indefinitely. Those attributions
+are the ticket's; this document does not re-derive them and does not rest on them.
+
+What survives on both sides of that literature is the **drawdown-reduction** property. The
+only admissible claim here is: **a bounded CAGR cost, bought as drawdown insurance.**
+
+If it passes, it books as an optional risk overlay on the passive core (S-A, #2833) — an
+operator insurance-preference decision. It is **never a strategy promotion and never enters
+the strategy funnel**. Excess-return significance is not testable on one index path, is not
+the claim, and no test of it is declared, reported or run.
+
+## 2. Why this trial is unpromotable before it starts, structurally
+
+`structural_promotion_refusals` (`app/services/strategy_result.py:1187`) is the freeze-time
+subset of `check_promotable`, and `PROMOTABLE_UNIVERSE_BASES`
+(`strategy_result.py:216`) has exactly one member, `survivorship_free`. The honest stamps:
+
+| stamp | value | why |
+| --- | --- | --- |
+| `declared_universe_basis` | `single_index_proxy` | one index chain, not a survivorship-free cross-section |
+| `declared_carry_unmodelled` | `true` | cash below the SMA earns **zero**; cash yield is carry and is not modelled |
+| `declared_fx_unmodelled` | `true` | the chain is USD, the account is GBP, and no frozen 1993→2026 GBP/USD series exists here |
+
+Those produce `universe_basis_not_survivorship_free`, `carry_unmodelled` and
+`fx_unmodelled`. `prereg_purpose` is therefore `falsification_only`, and the requirement
+that this can never promote is obtained by **stamping honestly**, not by anyone remembering
+the rule later.
+
+⚠ `single_index_proxy` does not name the whole hazard, so it is named here. SPY is not a
+cross-section, so there is no constituent survivorship in the usual sense — but SPY was
+chosen in 2026 as the proxy that survived and won, and the 10-month rule is itself a
+survivor of decades of published moving-average variants. Both are **selection hazards on
+the proxy and on the rule**, and neither is corrected for. They are a further reason the
+result cannot promote, not a reason to discount the drawdown reading.
+
+The run still charges the shared trial register, as any look at price data must (#2600
+D-0.1). Its entry is `se-ma-overlay-2026-08-22` in `app/services/trial_register.py`.
+
+## 3. Frozen data source
+
+`spy_chain_v1`, exactly as `app/services/market_regime_provider.py` defines it, obtained
+through its public `load_research_closes` so that the merge has **one** implementation
+shared with the regime classifier: the `icyDenev/Intrader` SPY segment strictly before the
+frozen seam `2022-05-10`, the `etoro/etoro-comparators-2026-07-08-v1` SPY segment on and
+after it, `close` only, one seam. Every refusal that module raises — basis drift, an eroded
+fallback, a missing seam bar, a non-increasing date, a non-positive close — is a refusal
+here. The measurement does not degrade to a shorter chain.
+
+**The chain's extent is frozen, not derived.** Measured 2026-08-22, dates and row counts
+only, no close read:
+
+| | value |
+| --- | --- |
+| first chain bar | `1993-01-29` |
+| last chain bar | `2026-07-08` |
+| chain bars | `8391` |
+
+The measurement **refuses** if any of the three has moved. A corpus refresh that extends
+either segment changes the tested span, and a contract that silently absorbs that is a
+contract that means something different each time it runs.
+
+### 3.1 Price return, and the dividend drag that is charged for it
+
+The chain is **price return**. `adj_close` is present on all 7,973 fallback bars (and
+differs from `close` on 7,967 of them, so it is distribution-adjusted) but on **0** of the
+1,018 primary bars — measured 2026-08-22 — so a total-return chain cannot be built across
+the seam and is not attempted.
+
+Both arms are measured on the same price series, so the drawdown leg is unaffected by the
+choice. The **CAGR leg is not**: an overlay that sits in cash forgoes distributions a
+price-only series never charges it for, which flatters it. That drag is therefore charged
+rather than noted:
+
+> `dividend_drag_pp_per_year = f × y`, deducted from the overlay's net CAGR before §8's
+> second leg is evaluated, where `f` is the fraction of the arm's measured calendar span
+> spent in cash and `y` is SPY's realised annual distribution yield **measured from the
+> fallback segment's own `adj_close`/`close` ratio** over `1993-01-29 … 2022-05-09`.
+
+`y` is sourced, not chosen: it is the segment's own annualised total-return-minus-price-
+return spread. It is **not** computed here — the method is what is frozen; the number is
+produced by the measurement run. Applying a 1993–2022 yield to the 2022–2026 tail
+overstates the recent drag, because SPY's yield fell over the span; overstating the drag
+makes §8's bar harder, which is the conservative direction. Buy-and-hold is charged nothing
+here, because it forgoes nothing.
+
+## 4. Frozen rule
+
+Let `k` be the evaluation offset in **chain-bar positions**, `k ∈ {0, 5, 10}` (§5).
+
+1. **Month-end bars.** The last chain bar of a calendar month, where a later chain bar
+   exists in a **subsequent** calendar month. ⚠ The trailing partial month contributes no
+   month-end: the chain ends `2026-07-08`, and treating that as July's month-end would
+   invent a decision the calendar never offered.
+2. **Evaluation dates.** For offset `k`, the chain bar `k` **positions** after each
+   month-end bar (`k = 0` is the month-end bar itself). Positions, not trading days — the
+   chain is the only calendar this measurement has, and no exchange calendar is frozen, so
+   "+5" means the fifth subsequent chain row. A month-end whose shifted bar does not exist
+   contributes no evaluation date. The measurement **refuses** if the shifted dates are not
+   strictly increasing and unique, or if any evaluation date is also an execution date
+   (§4.5) — both are structurally impossible on a chain with ≥12 bars per month, and a
+   silent collision would double-count a close in the SMA.
+3. **Signal.** `SMA10` is the arithmetic mean of the last 10 evaluation-date closes
+   **inclusive of the current one**, in IEEE-754 float64, with no rounding at any stage.
+   Hold the index when `close > SMA10`; hold cash otherwise. Strictly greater, no tolerance:
+   an exact equality is cash. All ten inputs must be finite and positive or the measurement
+   refuses.
+4. **Warm-up.** Before 10 evaluation dates exist there is no `SMA10` and the position is
+   **held**. The overlay is insurance on an already-invested core: it may only remove
+   exposure the core has, never add exposure the core lacks. Warm-up creates no trades — it
+   is one continuously invested state, not ten hold decisions.
+5. **Execution.** The decision taken at evaluation date `t` executes at the **close of the
+   next chain bar** after `t`. The return from `t`'s close to that execution close belongs
+   to the **old** position; the new position owns from the execution close forward, up to
+   and including the next execution close. A decision with no next chain bar is
+   **discarded**, not carried. An unchanged target places no trade and charges nothing, but
+   still ends one holding interval and starts the next.
+6. **Both arms' clock.** The equity curve starts at the **first execution date** of the arm
+   and ends at its **last execution date**. Chain bars after the last execution are not
+   valued. Buy-and-hold is measured over **that same arm's span**, so each offset's ratio is
+   like-for-like; a single full-chain buy-and-hold compared against three differently-
+   spanned overlays is the comparison this clause exists to forbid.
+7. **Valued on every chain bar in that span, not sampled monthly.** The position is
+   piecewise constant between execution dates, but equity is marked on each chain bar. Two
+   reasons, both material: a monthly-sampled drawdown **understates** the real one, which
+   would flatter the very leg §8 tests; and the 31 January tax outflow (§6) is a calendar
+   date that is usually not an execution date, so a monthly curve could not place it. A tax
+   date falling on a non-trading day is charged at the first chain bar on or after it.
+8. **Inception charges nothing, on either arm.** Both start invested — buy-and-hold by
+   definition, the overlay by §4.4's warm-up — so the opening purchase is common to both
+   and charging it would be theatre. Spread is charged only on a *change* of position
+   (§6).
+9. **Cash earns zero.** Declared, and stamped `carry_unmodelled`.
+10. **Single frozen spec, no parameter search.** The lookback is 10 months and nothing else.
+   A second lookback, a second offset set, a band, a confirmation delay or a different proxy
+   is a NEW declared search charging the register again — not a refinement of this one.
+
+## 5. Fragility
+
+The identical measurement is repeated at three evaluation offsets — `k ∈ {0, 5, 10}` — and
+the pass bar (§8) must hold on **all three**. One offset passing is not a pass.
+
+⚠ These three are **a robustness screen, not three replications.** They are overlapping
+paths through one index history and share almost all of their information; nothing here
+treats them as independent evidence, and no statistic is pooled across them.
+
+If any arm yields fewer than 10 evaluation dates, no execution, or a zero-length span, the
+measurement **refuses** rather than reporting a degenerate arm.
+
+## 6. Costs
+
+**Spread.** 0.322% round trip, charged as 0.161% of transacted value on each side. A
+held→cash transition charges once; cash→held charges once.
+
+**CGT.** UK, £50,000 opening account, higher-rate taxpayer assumed throughout (the 24% rate
+is the higher rate; a basic-rate taxpayer would pay 18% and the drag would be smaller — the
+assumption is stated because the rate is not a property of the strategy).
+
+Source rule: TCGA 1992 s.104 (the pooled §104 holding) and s.106A (share identification
+order: same day, then acquisitions in the following 30 days, then the pool), and HMRC's
+self-assessment payment date of 31 January following the tax year. The in-repo
+implementation of the same rules is `app/services/tax_ledger.py`; `ANNUAL_EXEMPT` there is
+the £3,000 used below and `_CGT_RATE_PERIODS` carries the 24% higher rate from 2024-10-30.
+
+- A held→cash transition is a **complete disposal**. Gain = proceeds − the §104 pool cost,
+  the pool being the amount invested at the preceding cash→held transition; the position is
+  all-in or all-out, so every disposal empties the pool.
+- Gains and losses are summed per UK tax year (6 April–5 April) by **disposal date**. Net
+  losses carry forward indefinitely against later gains; the annual exempt amount does not
+  carry forward.
+- Taxable = `max(net gains − £3,000, 0)`, taxed at **24%** across the whole span. Applying
+  today's rate to 1990s disposals is the worst case and is #2837's own declared treatment;
+  it is not a claim about historical rates.
+- The charge is a **cash outflow on 31 January following the tax year**, deducted from
+  equity on that calendar date regardless of what the execution schedule is doing — not on
+  the next execution bar, which could defer it by weeks.
+- **Funding, declared:** the outflow is taken from equity directly. If the arm is invested
+  on that date it is economically a partial sale, and this measurement charges **neither**
+  the 0.161% spread on it nor a second CGT event on the sliver disposed. Both omissions
+  understate the drag; both are bounded by 0.161% of a payment that is itself a small
+  fraction of equity, i.e. single basis points over the whole span, and both are recorded
+  here rather than discovered later.
+- **Terminal accrual.** Any liability arising from disposals whose 31 January payment date
+  falls after the arm's last execution date is **accrued and deducted at the last execution
+  date**, so no tax escapes by falling off the end of the sample.
+- **Buy-and-hold pays no CGT.** It never disposes. That is the asymmetry the literature
+  names and it is deliberately left in: it makes the overlay's bar harder.
+
+⚠ **The 30-day rule is NOT applied — declared here, not discovered later.** On a monthly
+clock same-day matching can never fire, and 30-day matching can fire only where a cash→held
+re-entry falls within 30 days of the preceding exit. Ignoring it taxes every realised gain
+in full against the pool, the conservative direction for a bar that must clear a CAGR
+floor. §9 reports how many exits had a re-entry inside 30 days, so the size of the
+simplification is visible rather than assumed.
+
+## 7. Declared sensitivity
+
+One, declared here so it is preregistered rather than found: the primary comparison leaves
+buy-and-hold's terminal gain unrealised (§6). The **symmetric** variant — both arms
+notionally liquidated at the **last execution date** (§4.6), the resulting gain taxed under
+§6's rules and accrued immediately at that date rather than the following 31 January — is
+reported alongside. It does not move the pass bar; the pass bar is §8 and only §8.
+
+## 8. Pass bar
+
+Definitions, frozen so the comparison cannot be reversed by a sign:
+
+- **Max drawdown** is a **non-negative loss magnitude in percent**, computed by
+  `strategy_statistics.max_drawdown_pct` and negated to a magnitude, over the arm's
+  **chain-bar** equity curve (§4.7) **after all costs and tax cash flows** (§6), starting
+  from the opening £50,000 at the first execution date (§4.6). An unrecovered terminal
+  drawdown counts at its trough to date.
+- **Net CAGR** is annualised over the arm's own span in §4.6, from opening equity to
+  closing equity, after costs and tax; the overlay's is then reduced by §3.1's
+  `dividend_drag_pp_per_year`.
+
+On **all three** offsets:
+
+1. `overlay_max_drawdown ≤ (2/3) × buy_and_hold_max_drawdown` on the same arm's span; and
+2. `overlay_net_CAGR − buy_and_hold_net_CAGR ≥ −1.5` percentage points per year.
+
+⚠ If `buy_and_hold_max_drawdown` is zero on any arm, leg 1 **fails** on that arm: an
+overlay cannot evidence insurance against a loss that never happened.
+
+Fail either leg, at any one offset → **drop entirely. No re-tuning.**
+
+## 9. Reported measures
+
+Per offset, and reported whether the arm passes or fails:
+
+- flip count; the fraction of span in cash (`f`, §3.1) and the resulting dividend drag;
+- overlay and buy-and-hold max drawdown, and their ratio;
+- **each arm's three worst drawdown episodes**, where an episode runs peak → trough →
+  recovery to that prior peak, episodes are ranked by depth, nested drawdowns inside one
+  unrecovered episode are one episode, and a terminal unrecovered episode is included with
+  its trough to date and flagged as unrecovered;
+- the count of drawdown episodes ≥15% on each arm — the class §10's floor is expressed in,
+  reported here so the floor's unit is measured rather than only assumed;
+- net CAGR both arms, the raw delta and the delta after the dividend drag;
+- **March 2020, predeclared fields**: every evaluation date, position, execution date and
+  trade in `2019-12-01 … 2020-12-31`, both arms' equity at each, and each arm's peak,
+  trough and recovery date for the episode;
+- the count of exits with a re-entry inside 30 days (§6);
+- the count of SMA windows spanning the `2022-05-10` seam. ⚠ The two segments carry
+  different `adjustment_basis` values, which the module's own header addresses — SPY has no
+  split history and the 585-date overlap agrees to a max $1.76 (~0.3%) vendor close-mark
+  difference — but a window straddling the seam is where any residual level step would
+  enter a signal, so the count is surfaced rather than assumed away.
+
+**Per-regime cohort readout, never one pooled number.** Each holding interval's return is
+assigned to the regime `classify_regimes` gives for **the evaluation date that decided that
+interval**, read through `MarketRegimeProvider.load_research` — the same classifier every
+other consumer uses, not a second definition. Warm-up bars the classifier cannot verdict
+are their own cohort, never folded in. ⚠ The regime is **descriptive only**: it partitions
+the readout and never enters the signal, the position, the costs or the pass bar, so its
+use of contemporaneous closes cannot leak into a trading decision.
+
+## 10. Forward-shadow floor, and exactly what it claims
+
+**This is not a power calculation and does not claim to be one.** No published power
+formulation exists for a drawdown-ratio claim, and none is invented. What §10 fixes, by
+construction, is the calendar length over which the readout unit §9 uses could be expected
+to reappear forward — that and nothing more.
+
+- the claim is a path statistic, so the smallest unit of forward evidence is a completed
+  drawdown episode of the declared class (≥15%, §9's definition);
+- §9's readout unit is **three** worst episodes, so three is the smallest forward sample
+  readable the same way the primary is;
+- #2837 declares, before any look, **~404 month-ends** carrying **~7 episodes ≥15%**. Those
+  are the ticket's own priors, not this run's outcome.
+
+```
+min_independent_decision_dates = ceil(3 × 404 / 7)               = 174
+min_calendar_weeks             = ceil(174 × 365.25 / (12 × 7))   = 757   (~14.5 years)
+```
+
+The month→week constant is the one `scripts/freeze_2616_precutoff_declarations.py` already
+uses. Three honest limits, stated rather than left for a reader to find:
+
+1. **174 is an expectation, not a guarantee.** At the ticket's declared rate three episodes
+   are *expected* in that span; they are not *assured*, and a drawdown starting inside it
+   may still be unrecovered when it ends.
+2. **The dates are not independent.** The schema field is named
+   `min_independent_decision_dates` and `ForwardShadowFloor`'s own docstring already says
+   the narrow claim is only that a distinct-date count cannot be inflated by same-day
+   fan-out — *"NOT that the dates are statistically independent of each other, which they
+   are not"*. Consecutive 10-month SMAs share nine inputs and positions persist across
+   months. The same applies to the episodes: drawdowns cluster by regime, so `404/7` is a
+   long-run average and not an exchangeable arrival rate.
+3. It follows that clearing this floor would be **necessary and nowhere near sufficient**
+   for a forward claim.
+
+The trial is `falsification_only` regardless, so the floor gates nothing it was not already
+gating. It records honestly what forward validation would have cost.
+
+## 11. What a fail means
+
+A fail is terminal for S-E. Not a smaller lookback, not a confirmation band, not a
+different proxy, not a different offset set — each of those is a new declared search
+charging the register again, and #2827 already measured this family failing the deflation
+bar by 5–20× at zero cost. The recorded lesson goes on #2837 and the ticket closes.
+
+## 12. Codex checkpoint-1 resolutions
+
+The pass returned 85 findings over two runs. Every one is resolved into the text above, or
+rebutted here. Resolved by specification: the incomplete terminal month (§4.1); "trading
+days" meaning chain positions (§4.2); shifted-date collision, uniqueness and
+evaluation/execution disjointness (§4.2); float64, no tolerance, finite-input refusal
+(§4.3); warm-up creating no trades (§4.4); execution price, interval ownership, discarded
+tail decision, no-op trades (§4.5); the terminal valuation clock and per-arm buy-and-hold
+span (§4.6); degenerate-arm refusal (§5); the higher-rate assumption, the 31 January cash
+flow, tax funding, terminal accrual and the s.104/s.106A citations (§6); the symmetric
+sensitivity's timing and "last execution date" (§7); drawdown sign convention, the
+zero-denominator case, the after-tax curve and precision (§8); episode segmentation,
+recovery, nesting and ties (§9); the ≥15% class as a reported measure (§9); March 2020's
+predeclared fields (§9); the regime cohort's assignment rule and its descriptive-only
+status (§9); the frozen chain extent (§3); the public accessor for the chain closes (§3);
+the seam-spanning SMA windows (§9); price-vs-total return, now charged (§3.1); the
+proxy- and rule-selection hazards (§2); the floor's three limits and its non-power status
+(§10); the offsets as a screen rather than replication (§5).
+
+Rebutted, with reasons:
+
+- *"A completed month cannot be established without lookahead."* It can: §4.1 requires a
+  later bar in a **subsequent** calendar month, which is a fact about bars that already
+  exist at execution time. The execution bar is that later bar.
+- *"No trading calendar is frozen, so missing sessions cannot be told from holidays."*
+  Correct and deliberate. §4.2 defines offsets in chain positions precisely so no calendar
+  is needed; the frozen bar count (§3) is what catches gross erosion.
+- *"The vendor rows are not content-hashed, so history could change under the contract."*
+  A full content hash is the right answer for an archive and is not in scope for this
+  ticket; the frozen first bar, last bar and bar count catch extension, truncation and
+  wholesale reload, which are the failure modes with a plausible mechanism here.
+- *"The literature claims are not auditable."* They are #2837's, and §1 now attributes them
+  there rather than restating them as findings of this document. Nothing in §8 rests on
+  them.
+- *"Three historical episodes do not justify three forward episodes."* Agreed, and §10 no
+  longer claims it does — it claims a calendar length and names what that is not.

--- a/scripts/freeze_2837_se_overlay_declaration.py
+++ b/scripts/freeze_2837_se_overlay_declaration.py
@@ -1,0 +1,216 @@
+"""Freeze S-E's #2599 preregistration declaration. Run ONCE, before outcomes open.
+
+Contract: ``docs/proposals/ta/2026-08-22-se-ma-overlay-preregistration.md``.
+Refs #2837, #2832. Follows ``scripts/freeze_2582_schedule13d_declaration.py``.
+
+⚠⚠ A SEPARATE SCRIPT FOR THE ONLY REASON THAT MATTERS: A DECLARATION FROZEN BY
+THE THING THAT OPENS THE OUTCOMES DECLARES NOTHING.
+``scripts/measure_2837_se_overlay.py`` could freeze this row itself and every
+field would be identical. It would also be worthless — the declaration's entire
+force is that it predates the look. So freezing lives here, runs separately and
+earlier, and the measurement's own gate refuses until it has.
+
+⚠⚠ THIS CANNOT BE RUN "ANYTIME" — THE FREEZE IS COUPLED TO THE POLICY VERSION.
+The row records ``STRUCTURAL_REFUSAL_POLICY_VERSION``, and
+``prereg_contract.declaration_refusals`` returns
+``structural_refusal_policy_superseded`` the moment that string stops matching
+the current constant. ``sql/333`` bars UPDATE and DELETE, so no corrected row
+can replace it: recovery is a NEW ``strategy_version``, which changes the
+trial's identity, strands the old trial forever and charges the shared register
+again. Run ``--dry-run`` first, read ``structural_refusal_policy_version`` in its
+output, and freeze only when no change to that policy is in flight.
+
+⚠⚠ AND IT CANNOT BE RUN BEFORE ITS REGISTER ENTRY IS ON MAIN.
+``freeze_preregistration`` refuses a declaration no ``DeclaredTrial`` claims, and
+``_prereg_freeze_guard`` refuses a tree whose policy version is not main's. So
+the ordering is: merge ``se-ma-overlay-2026-08-22`` into
+``app/services/trial_register.py`` → then run this from a tree that is main.
+
+⚠ NO NUMBER BELOW IS CHOSEN HERE. The stamps are the contract's §2, the refusal
+list is COMPUTED by ``structural_promotion_refusals`` rather than spelled out,
+and the forward-shadow floor is derived by construction from #2837's own
+declared priors — see ``_FORWARD_SHADOW_DERIVATION``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from typing import Final
+
+import psycopg
+
+from app.config import settings
+from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
+from app.services.result_ledger import PreregDeclarationRefused, freeze_preregistration, load_preregistration
+from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION, structural_promotion_refusals
+from scripts._prereg_freeze_guard import assert_policy_version_merged, policy_version_report
+
+STRATEGY_ID: Final = "se-ma-overlay-drawdown-insurance"
+STRATEGY_VERSION: Final = "se-ma-overlay-drawdown-insurance-v1"
+CONTRACT_VERSION: Final = "se-ma-overlay-2026-08-22"
+DECLARED_BY: Final = "scripts/freeze_2837_se_overlay_declaration.py (#2837)"
+
+#: #2837's own declared priors, quoted from the issue text BEFORE any look:
+#: "spy_chain_v1 ... 1993→2026, ~404 month-ends" and "max DD + 3 worst drawdowns
+#: vs buy-and-hold on the same chain (~7 episodes >=15%)".
+#:
+#: ⚠ THESE ARE PRIORS, NOT MEASUREMENTS OF THIS RUN. Deriving the floor from the
+#: chain's realised drawdowns would be reading an outcome to size the gate that
+#: authorises reading outcomes.
+_TICKET_MONTH_ENDS: Final = 404
+_TICKET_EPISODES_OVER_CLASS: Final = 7
+
+#: The contract's §9 readout unit: the three worst drawdowns.
+_READOUT_EPISODES: Final = 3
+
+MIN_FORWARD_DECISION_DATES: Final = math.ceil(_READOUT_EPISODES * _TICKET_MONTH_ENDS / _TICKET_EPISODES_OVER_CLASS)
+#: Months to weeks with the constant ``freeze_2616_precutoff_declarations.py``
+#: already uses for a monthly-formation candidate.
+MIN_FORWARD_CALENDAR_WEEKS: Final = math.ceil(MIN_FORWARD_DECISION_DATES * 365.25 / (12 * 7))
+
+#: ⚠ sql/333 caps this column at 1000 characters. The longer reading is §10 of
+#: the contract; this is the arithmetic plus the three limits that keep it from
+#: being read as a power calculation.
+_FORWARD_SHADOW_DERIVATION: Final = (
+    "NOT a power calculation — none is published for a drawdown-ratio claim and none is invented. Fixed BY "
+    "CONSTRUCTION from #2837's own pre-look priors: spy_chain_v1 carries ~"
+    f"{_TICKET_MONTH_ENDS} month-ends and ~{_TICKET_EPISODES_OVER_CLASS} drawdown episodes >=15%, and the "
+    f"contract's readout unit is the {_READOUT_EPISODES} worst drawdowns. dates = ceil("
+    f"{_READOUT_EPISODES}x{_TICKET_MONTH_ENDS}/{_TICKET_EPISODES_OVER_CLASS}) = {MIN_FORWARD_DECISION_DATES}; "
+    f"weeks = ceil({MIN_FORWARD_DECISION_DATES}x365.25/(12x7)) = {MIN_FORWARD_CALENDAR_WEEKS} (~14.5y), the "
+    "month->week constant freeze_2616_precutoff_declarations.py uses. Three limits, stated: (1) three episodes "
+    "are EXPECTED in that span, not assured, and one starting inside it may end unrecovered; (2) the dates are "
+    "NOT statistically independent (10-month SMAs share 9 inputs, positions persist) and episodes cluster by "
+    "regime, so 404/7 is a long-run average, not an exchangeable arrival rate; (3) clearing this floor would be "
+    "necessary and nowhere near sufficient. falsification_only regardless, so it gates nothing already ungated."
+)
+
+
+def build_declaration() -> PreregDeclaration:
+    """S-E's declaration. Every stamp is the contract's §2, read not decided.
+
+    ⚠ ``single_index_proxy`` is the honest basis for one spliced index chain: it
+    is not a survivorship-free cross-section, so ``PROMOTABLE_UNIVERSE_BASES``
+    refuses it — which is the ticket's *"never a strategy promotion, never in the
+    strategy funnel"* obtained structurally rather than by convention.
+
+    ⚠ ``carry_unmodelled`` because cash below the SMA earns ZERO (contract §4.9);
+    cash yield is carry. ``fx_unmodelled`` because the chain is USD and the
+    account is GBP with no frozen 1993→2026 rate series. Both are the run's
+    actual state, not a pessimistic label.
+
+    ⚠ ``falsification_only`` follows from those stamps rather than being chosen:
+    a ``capital_candidate`` purpose over a non-empty recomputed refusal list is
+    exactly what ``ineligible_trial_not_declared_falsification`` refuses.
+    """
+    universe_basis = "single_index_proxy"
+    carry_unmodelled = True
+    fx_unmodelled = True
+    return PreregDeclaration(
+        strategy_id=STRATEGY_ID,
+        strategy_version=STRATEGY_VERSION,
+        contract_version=CONTRACT_VERSION,
+        prereg_purpose="falsification_only",
+        structural_refusal_policy_version=STRUCTURAL_REFUSAL_POLICY_VERSION,
+        declared_universe_basis=universe_basis,
+        declared_carry_unmodelled=carry_unmodelled,
+        declared_fx_unmodelled=fx_unmodelled,
+        # ⚠ COMPUTED, never written out. A hand-typed list is a second copy of
+        # the refusal policy that drifts the first time the policy moves.
+        expected_structural_refusals=structural_promotion_refusals(
+            universe_basis=universe_basis, carry_unmodelled=carry_unmodelled, fx_unmodelled=fx_unmodelled
+        ),
+        forward_shadow=ForwardShadowFloor(
+            min_independent_decision_dates=MIN_FORWARD_DECISION_DATES,
+            min_calendar_weeks=MIN_FORWARD_CALENDAR_WEEKS,
+            derivation=_FORWARD_SHADOW_DERIVATION,
+        ),
+        declared_by=DECLARED_BY,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="build and print the declaration and its digest without writing it",
+    )
+    parser.add_argument(
+        "--allow-policy-divergence",
+        action="store_true",
+        help=(
+            "freeze even though this tree's STRUCTURAL_REFUSAL_POLICY_VERSION is not the one on origin/main, "
+            "or that ref could not be refreshed. The override is recorded in the output."
+        ),
+    )
+    args = parser.parse_args(argv)
+    declaration = build_declaration()
+    summary: dict[str, object] = {**declaration.digest_payload, "declaration_sha256": declaration.sha256}
+    if args.dry_run:
+        sys.stdout.write(json.dumps({**summary, **policy_version_report(), "outcome": "dry_run"}, sort_keys=True))
+        sys.stdout.write("\n")
+        return 0
+
+    summary.update(assert_policy_version_merged(allow_divergence=args.allow_policy_divergence))
+    with psycopg.connect(settings.database_url) as conn:
+        try:
+            declaration_id = freeze_preregistration(conn, declaration)
+        except psycopg.errors.UniqueViolation:
+            # ⚠ A bare UniqueViolation is two situations wearing one error, and
+            # they want opposite operator actions: a retry after an uncertain
+            # commit is fine, and a second DIFFERENT declaration is the
+            # fabrication sql/333's UNIQUE constraint exists to stop.
+            conn.rollback()
+            stored = load_preregistration(conn, declaration.strategy_id, declaration.strategy_version)
+            if stored is not None and stored.declaration_sha256 == declaration.sha256:
+                sys.stdout.write(
+                    json.dumps(
+                        {**summary, "outcome": "already_frozen_identical", "declaration_id": stored.declaration_id},
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+                return 0
+            sys.stderr.write(
+                json.dumps(
+                    {
+                        "outcome": "conflicting_declaration_already_frozen",
+                        "stored_declaration_sha256": None if stored is None else stored.declaration_sha256,
+                        "would_have_frozen_sha256": declaration.sha256,
+                        "note": "declarations are immutable; different terms mean a new strategy_version",
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+            return 1
+        except PreregDeclarationRefused as refused:
+            conn.rollback()
+            sys.stderr.write(
+                json.dumps({"outcome": "refused", "refusals": list(refused.refusals)}, sort_keys=True) + "\n"
+            )
+            return 1
+        conn.commit()
+    sys.stdout.write(json.dumps({**summary, "outcome": "frozen", "declaration_id": declaration_id}, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "DECLARED_BY",
+    "MIN_FORWARD_CALENDAR_WEEKS",
+    "MIN_FORWARD_DECISION_DATES",
+    "STRATEGY_ID",
+    "STRATEGY_VERSION",
+    "build_declaration",
+    "main",
+]

--- a/scripts/measure_2837_se_overlay.py
+++ b/scripts/measure_2837_se_overlay.py
@@ -1,0 +1,268 @@
+"""Measure S-E's 10-month-SMA overlay against its frozen contract. Refs #2837.
+
+Contract: ``docs/proposals/ta/2026-08-22-se-ma-overlay-preregistration.md``
+(`se-ma-overlay-2026-08-22`). The rule itself is ``app/services/se_ma_overlay.py``;
+this is the impure half — the chain read, the distribution yield, the regime map
+and the readout.
+
+⚠⚠ THIS OPENS OUTCOMES, SO IT GOES THROUGH THE #2599 DOOR.
+``require_outcome_access`` refuses ``preregistration_not_frozen`` until
+``scripts/freeze_2837_se_overlay_declaration.py`` has run, and it writes the
+access row that criterion 5 counts. This script stores nothing in
+``strategy_results_store`` — it computes its own statistics from raw price
+windows — which is exactly the shape #2614 found the ledger could not intercept
+by itself, so the call here is explicit rather than incidental.
+
+⚠ READ ONLY against the corpus, in one REPEATABLE READ snapshot, so the chain,
+the yield segment and the regime map all observe one state of the world.
+
+Run, in this order and only in this order:
+
+    PYTHONPATH=. uv run python -m scripts.freeze_2837_se_overlay_declaration --dry-run
+    PYTHONPATH=. uv run python -m scripts.freeze_2837_se_overlay_declaration
+    PYTHONPATH=. uv run python -m scripts.measure_2837_se_overlay
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from datetime import date
+from typing import Final, TextIO
+
+import psycopg
+
+from app.config import settings
+from app.services.market_regime_provider import (
+    CHAIN_FALLBACK,
+    CHAIN_SEAM,
+    MarketRegimeProvider,
+    load_research_closes,
+)
+from app.services.prereg_contract import declaration_refusals
+from app.services.result_ledger import (
+    HoldoutAccess,
+    PreregDeclarationRefused,
+    load_preregistration,
+    require_outcome_access,
+)
+from app.services.se_ma_overlay import (
+    CHAIN_BARS,
+    CHAIN_FIRST_BAR,
+    CHAIN_LAST_BAR,
+    MAX_DRAWDOWN_RATIO_BAR,
+    MIN_CAGR_DELTA_PP,
+    OFFSETS,
+    ArmResult,
+    OverlayRefused,
+    RegimeCohort,
+    march_2020_detail,
+    regime_cohorts,
+    simulate_arm,
+)
+from app.services.trial_register import TRIAL_REGISTER
+from scripts.freeze_2837_se_overlay_declaration import STRATEGY_ID, STRATEGY_VERSION
+
+TRIAL_ID: Final = "se-ma-overlay-2026-08-22"
+
+
+def _open_the_gate(conn: psycopg.Connection[tuple]) -> int:
+    """#2599's door. Refuses unless the declaration was frozen first.
+
+    ⚠ THE CALLER OWNS THE COMMIT — the same contract C-4's gate documents.
+    ``require_outcome_access`` writes in this transaction and does not commit,
+    and the measurement afterwards opens with ``SET TRANSACTION ISOLATION
+    LEVEL ... READ ONLY``, which is only valid as a transaction's first
+    statement. Committing the access first also keeps the look logged if the
+    measurement then dies.
+    """
+    if TRIAL_REGISTER.trial_for_declaration(STRATEGY_ID, STRATEGY_VERSION) is None:
+        raise OverlayRefused(
+            f"no trial in {TRIAL_REGISTER.version} claims {STRATEGY_ID}@{STRATEGY_VERSION}; criterion 6's M does "
+            "not count this search, so the look must not happen"
+        )
+    frozen = load_preregistration(conn, STRATEGY_ID, STRATEGY_VERSION)
+    if frozen is None:
+        raise PreregDeclarationRefused(STRATEGY_ID, STRATEGY_VERSION, ("preregistration_not_frozen",))
+    refusals = declaration_refusals(frozen.declaration)
+    if refusals:
+        raise PreregDeclarationRefused(STRATEGY_ID, STRATEGY_VERSION, tuple(str(code) for code in refusals))
+    # `read`, with a NULL result_version: sql/264's
+    # `strategy_holdout_accesses_evaluate_names_a_result` requires an `evaluate`
+    # access to name a result row, and this study writes none.
+    return require_outcome_access(
+        conn,
+        HoldoutAccess(
+            strategy_id=STRATEGY_ID,
+            strategy_version=STRATEGY_VERSION,
+            result_version=None,
+            access_kind="read",
+            accessed_by="scripts/measure_2837_se_overlay.py",
+            purpose=f"open S-E's preregistered drawdown-insurance measurement under {TRIAL_ID}",
+        ),
+    )
+
+
+def _assert_chain_extent(chain: list[tuple[date, float]]) -> None:
+    """Contract §3 — the frozen extent, refused rather than absorbed.
+
+    ⚠ A corpus refresh that extends either segment changes the tested span. A
+    contract that silently absorbs that means something different each time it
+    runs, and the difference is invisible in the output.
+    """
+    actual = (chain[0][0], chain[-1][0], len(chain))
+    expected = (CHAIN_FIRST_BAR, CHAIN_LAST_BAR, CHAIN_BARS)
+    if actual != expected:
+        raise OverlayRefused(
+            f"spy_chain_v1 extent moved: got first={actual[0]} last={actual[1]} bars={actual[2]}, contract froze "
+            f"first={expected[0]} last={expected[1]} bars={expected[2]}"
+        )
+
+
+def _distribution_yield_pp(conn: psycopg.Connection[tuple]) -> tuple[float, int, date, date]:
+    """Contract §3.1 — SPY's realised annual distribution yield, MEASURED.
+
+    ⚠ SOURCED, NOT CHOSEN. It is the fallback segment's own annualised
+    ``adj_close``-minus-``close`` growth over the pre-seam span: the one place in
+    this corpus where the same instrument carries both a distribution-adjusted
+    and a price-only series. The primary segment carries no ``adj_close`` at all,
+    which is why the chain is price-return and why this charge exists.
+
+    ⚠ Applying a 1993–2022 yield to the 2022–2026 tail OVERSTATES the recent
+    drag, because SPY's yield fell over the span. Overstating it makes §8's
+    second leg harder, which is the conservative direction.
+    """
+    vendor, vendor_symbol = CHAIN_FALLBACK
+    rows = conn.execute(
+        """
+        SELECT d.bar_date, d.close, d.adj_close
+        FROM research_price_daily d
+        JOIN research_price_series s USING (series_id)
+        WHERE s.vendor = %s AND s.vendor_symbol = %s
+          AND d.bar_date < %s
+          AND d.close IS NOT NULL AND d.adj_close IS NOT NULL
+          AND d.close > 0 AND d.adj_close > 0
+        ORDER BY d.bar_date
+        """,
+        (vendor, vendor_symbol, CHAIN_SEAM),
+    ).fetchall()
+    if len(rows) < 2:
+        raise OverlayRefused(
+            f"the {vendor}/{vendor_symbol} segment carries {len(rows)} rows with both close and adj_close before "
+            f"{CHAIN_SEAM}; §3.1's yield cannot be sourced and the dividend drag cannot be charged"
+        )
+    first, last = rows[0], rows[-1]
+    years = (last[0] - first[0]).days / 365.25
+    total_return = (float(last[2]) / float(first[2])) ** (1.0 / years)
+    price_return = (float(last[1]) / float(first[1])) ** (1.0 / years)
+    return ((total_return - price_return) * 100.0, len(rows), first[0], last[0])
+
+
+def _render(result: ArmResult, cohorts: Sequence[RegimeCohort], out: TextIO) -> None:
+    ratio = result.drawdown_ratio
+    out.write(f"\n=== offset +{result.offset} chain bars ===\n")
+    out.write(f"span                 {result.first_execution} .. {result.last_execution}  ({result.years:.2f}y)\n")
+    out.write(f"decisions / flips    {len(result.evaluation_dates)} / {result.flips}\n")
+    out.write(f"time in cash         {result.fraction_in_cash * 100:.2f}%\n")
+    out.write(f"dividend drag        {result.dividend_drag_pp:.4f} pp/yr\n")
+    out.write(f"seam-spanning SMAs   {result.seam_spanning_windows}\n")
+    out.write(f"exits re-entered <30d {result.reentries_within_30_days}\n")
+    out.write(
+        f"CGT charges          {len(result.tax_charges)}  total £{sum(c.tax_gbp for c in result.tax_charges):,.0f}\n"
+    )
+    out.write("\n  LEG 1 — drawdown insurance\n")
+    out.write(f"    overlay max DD     {result.overlay_max_drawdown_pct:.2f}%\n")
+    out.write(f"    buy-and-hold max DD {result.benchmark_max_drawdown_pct:.2f}%\n")
+    out.write(
+        f"    ratio               {'n/a' if ratio is None else f'{ratio:.3f}'}  (bar <= {MAX_DRAWDOWN_RATIO_BAR:.3f})"
+    )
+    out.write(f"   -> {'PASS' if result.drawdown_leg_passes else 'FAIL'}\n")
+    out.write("\n  LEG 2 — bounded CAGR cost\n")
+    out.write(f"    overlay CAGR       {result.overlay_cagr_pct:.3f}%  (before drag)\n")
+    out.write(f"    buy-and-hold CAGR  {result.benchmark_cagr_pct:.3f}%\n")
+    out.write(f"    delta after drag   {result.net_cagr_delta_pp:+.3f} pp/yr  (bar >= {MIN_CAGR_DELTA_PP:+.1f})")
+    out.write(f"   -> {'PASS' if result.cagr_leg_passes else 'FAIL'}\n")
+    out.write(f"\n  ARM VERDICT          {'PASS' if result.passes else 'FAIL'}\n")
+    out.write(f"\n  episodes >=15%: overlay {result.overlay_episodes_over_class}, ")
+    out.write(f"buy-and-hold {result.benchmark_episodes_over_class}\n")
+    for label, episodes in (("overlay", result.overlay_worst_episodes), ("buy&hold", result.benchmark_worst_episodes)):
+        for episode in episodes:
+            recovery = "UNRECOVERED" if episode.unrecovered else str(episode.recovery_date)
+            out.write(
+                f"    {label:9s} -{episode.depth_pct:6.2f}%  peak {episode.peak_date}  "
+                f"trough {episode.trough_date}  recovered {recovery}\n"
+            )
+    out.write("\n  per-regime cohorts (descriptive only — never in the signal or the bar)\n")
+    for cohort in cohorts:
+        out.write(
+            f"    {cohort.regime:22s} n={cohort.intervals:4d} cash={cohort.months_in_cash:4d} "
+            f"overlay {cohort.overlay_mean_return_pct:+7.3f}%  b&h {cohort.benchmark_mean_return_pct:+7.3f}%\n"
+        )
+    out.write("\n  §7 symmetric sensitivity (both arms liquidated and taxed)\n")
+    out.write(
+        f"    overlay £{result.symmetric_overlay_terminal_gbp:,.0f}   "
+        f"buy-and-hold £{result.symmetric_benchmark_terminal_gbp:,.0f}\n"
+    )
+    detail = march_2020_detail(result)
+    out.write(f"\n  March-2020 window ({len(detail)} decisions, predeclared fields)\n")
+    for evaluation, execution, position, overlay_equity, benchmark_equity in detail:
+        out.write(
+            f"    eval {evaluation}  exec {execution}  position {'HELD' if position else 'CASH'}  "
+            f"overlay £{overlay_equity:,.0f}  b&h £{benchmark_equity:,.0f}\n"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """⚠⚠ THERE IS NO --skip-gate, AND ITS ABSENCE IS DELIBERATE.
+
+    The first draft had one, "to exercise the plumbing before the declaration is
+    frozen". That is a documented bypass of the single gate this whole design
+    rests on — and using it would itself have been the first look the
+    preregistration exists to precede, which is the defect wearing the costume of
+    a debugging aid. The pure arithmetic is covered by
+    ``tests/test_2837_se_ma_overlay.py`` against synthetic chains; the two
+    database helpers read source characteristics, not outcomes, and can be
+    exercised directly.
+    """
+    argparse.ArgumentParser(description=__doc__).parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        access_id = _open_the_gate(conn)
+        conn.commit()
+        sys.stdout.write(f"#2599 access recorded: access_id={access_id}, trial={TRIAL_ID}\n")
+
+        conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        chain = load_research_closes(conn)
+        _assert_chain_extent(chain)
+        yield_pp, yield_rows, yield_first, yield_last = _distribution_yield_pp(conn)
+        regime_provider = MarketRegimeProvider.load_research(conn)
+        conn.rollback()
+
+    sys.stdout.write(
+        f"\nspy_chain_v1: {len(chain)} bars, {chain[0][0]} .. {chain[-1][0]} (extent matches the frozen contract)\n"
+        f"§3.1 distribution yield: {yield_pp:.4f} pp/yr, sourced from {yield_rows} "
+        f"{CHAIN_FALLBACK[0]} bars {yield_first} .. {yield_last}\n"
+    )
+
+    verdicts: list[bool] = []
+    for offset in OFFSETS:
+        result = simulate_arm(chain, offset=offset, seam=CHAIN_SEAM, dividend_yield_pp=yield_pp)
+        cohorts = regime_cohorts(result, [value for value in regime_provider.for_dates(result.evaluation_dates).values])
+        _render(result, cohorts, sys.stdout)
+        verdicts.append(result.passes)
+
+    sys.stdout.write("\n" + "=" * 72 + "\n")
+    # ⚠ ALL THREE, never the best. One offset passing is not a pass — §5 and §8.
+    sys.stdout.write(f"S-E VERDICT: {'PASS' if all(verdicts) else 'FAIL'}  (arms: {verdicts})\n")
+    if not all(verdicts):
+        sys.stdout.write("§11: a fail is terminal. No smaller lookback, no band, no different proxy — each is a NEW\n")
+        sys.stdout.write("declared search charging the register again. Record the lesson on #2837 and close it.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["TRIAL_ID", "main"]

--- a/tests/test_2631_freeze_policy_guard.py
+++ b/tests/test_2631_freeze_policy_guard.py
@@ -291,7 +291,11 @@ def test_every_freeze_script_calls_the_guard() -> None:
     under another name is not covered — recorded here rather than implied away.
     """
     scripts = sorted((_REPO_ROOT / "scripts").glob("freeze_*.py"))
-    assert len(scripts) == 3, f"a new freeze script appeared: {[p.name for p in scripts]}"
+    # ⚠ The pin is the point: it fires on a NEW freeze script and makes its
+    # author confirm the convention rather than discover it later. It did that
+    # for #2837's S-E declaration (the fourth), which calls the guard and
+    # freezes through the ledger like the other three.
+    assert len(scripts) == 4, f"a new freeze script appeared: {[p.name for p in scripts]}"
     for path in scripts:
         source = path.read_text()
         # ⚠ THE CALL, NOT THE NAME. A bare substring check is satisfied by the

--- a/tests/test_2829_declaration_trial_binding.py
+++ b/tests/test_2829_declaration_trial_binding.py
@@ -73,10 +73,26 @@ class TestTheShippedMapping:
 
         Many entries are research SESSIONS that no declaration corresponds to. A
         test that demanded a mapping on every trial would be demanding five rows'
-        worth of declarations for thirty trials.
+        worth of declarations for thirty-odd trials.
+
+        ⚠⚠ CLAIMS ⊇ STORED, NEVER ``==`` (corrected at r8, #2837). The equality
+        this replaced asserted that every claiming trial already had a frozen row,
+        which the freeze ORDERING makes false for a whole PR at a time: a new
+        trial must be MERGED to main before its declaration can be frozen, because
+        ``freeze_preregistration`` resolves the claim against the running tree and
+        ``_prereg_freeze_guard`` insists that tree agrees with main. So between
+        the register PR merging and the freeze script running there is always a
+        claim with no row — the correct state, which the equality read as a bug.
+
+        The stored side keeps its own coverage check: the parametrised test above
+        asserts every stored declaration IS claimed, which is the direction that
+        protects ``M``.
         """
         claiming = [trial for trial in TRIAL_REGISTER.trials if trial.declared_for is not None]
-        assert len(claiming) == len(_STORED_DECLARATIONS)
+        assert len(claiming) < len(TRIAL_REGISTER.trials), "a mapping on every trial would be the wrong shape"
+        claimed_pairs = {trial.declared_for for trial in claiming}
+        for strategy_id, strategy_version, _ in _STORED_DECLARATIONS:
+            assert (strategy_id, strategy_version) in claimed_pairs
         assert TRIAL_REGISTER.trial_for_declaration("short-horizon-search-session-2026-08-09", "whatever") is None
 
 
@@ -215,23 +231,34 @@ class TestTheFreezeGate:
 
 
 class TestWhatThisChangeDeliberatelyDoesNotMove:
-    def test_M_is_unchanged_so_the_register_version_is_not_bumped(self) -> None:
+    def test_M_moves_only_when_a_real_search_is_added(self) -> None:
         """⚠⚠ THE LOAD-BEARING CALL, pinned as literals on purpose.
 
         ``TRIAL_REGISTER_VERSION`` is stored beside every DSR to answer "which
         population was this deflated against", and ``strategy_result.py`` refuses
         ``trial_register_superseded`` when a stored version or ``declared_trials``
-        disagrees with today's. 220 stored results carry
-        ``trial-register-2026-08-15-r7``, so bumping is the DESTRUCTIVE option,
-        not the safe one — it would flip all 220 to refused for a change that
-        added no trial and moved no ``searches`` value.
+        disagrees with today's. #2829 itself added NO trial and moved no
+        ``searches`` value, so bumping for it would have stranded stored rows for
+        nothing — that was the original reading of this test and it stands.
 
-        These two literals are what keeps that argument checkable: an edit that
-        actually moves ``M`` fails here and forces the bump conversation at the
-        moment it is due.
+        ⚠ The name changed at r8 (2026-08-22, #2837) because the old one
+        (``..._so_the_register_version_is_not_bumped``) read as a standing
+        prohibition on ever bumping, which inverts the module's own argument. The
+        register EXISTS to grow: declining to count a search to protect stored
+        deflations is the flattering direction. What the literals below buy is
+        that the bump is never silent — an edit that moves ``M`` fails here and
+        forces the conversation at the moment it is due, which is exactly what
+        happened at r8.
+
+        r8's conversation, resolved by measurement rather than argument — the
+        command is in ``trial_register.TRIAL_REGISTER_VERSION``'s own note.
+        Every stored row with a DSR carried ``purpose = harness_validation``, so
+        ``purpose_promotion_refusals`` already returned a terminal
+        ``harness_validation_only`` on all of them; the bump added a second
+        refusal code to rows that could not promote regardless.
         """
-        assert TRIAL_REGISTER.declared_count == 274
-        assert len(TRIAL_REGISTER.trials) == 30
+        assert TRIAL_REGISTER.declared_count == 275
+        assert len(TRIAL_REGISTER.trials) == 31
 
     def test_the_declaration_refusal_vocabulary_is_untouched(self) -> None:
         """⚠ The first draft added ``trial_not_in_register`` here. Codex ckpt-1

--- a/tests/test_2837_se_ma_overlay.py
+++ b/tests/test_2837_se_ma_overlay.py
@@ -1,0 +1,386 @@
+"""#2837 — S-E's 10-month-SMA overlay, against its frozen contract.
+
+Contract: ``docs/proposals/ta/2026-08-22-se-ma-overlay-preregistration.md``.
+
+⚠ PURE. No database, no fixtures, no clock — the module under test is pure and
+these tests are the reason it was written that way. The DB half is exercised by
+``scripts/measure_2837_se_overlay.py`` against the real corpus.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.services.se_ma_overlay import (
+    ANNUAL_EXEMPT_GBP,
+    CGT_HIGHER_RATE,
+    LOOKBACK,
+    MARCH_2020_WINDOW,
+    MAX_DRAWDOWN_RATIO_BAR,
+    OFFSETS,
+    OPENING_EQUITY_GBP,
+    ROUND_TRIP_COST_PCT,
+    SIDE_COST_PCT,
+    ArmResult,
+    DrawdownEpisode,
+    OverlayRefused,
+    cgt_payment_date,
+    drawdown_episodes,
+    evaluation_indices,
+    march_2020_detail,
+    month_end_indices,
+    overlay_positions,
+    regime_cohorts,
+    simulate_arm,
+    uk_tax_year_start,
+)
+from app.services.tax_ledger import _compute_tax_year
+
+BARS_PER_MONTH = 21
+SEAM = date(2022, 5, 10)
+
+
+def _chain(monthly: list[float], *, start_year: int = 2000, tail_bars: int = 0) -> list[tuple[date, float]]:
+    """A synthetic chain: ``BARS_PER_MONTH`` bars a month, flat within the month.
+
+    Flat within the month on purpose — the rule only ever reads month-end
+    closes, so intra-month shape is noise for every test except the ones that
+    deliberately set a specific bar.
+    """
+    bars: list[tuple[date, float]] = []
+    for index, close in enumerate(monthly):
+        year = start_year + index // 12
+        month = index % 12 + 1
+        for day in range(BARS_PER_MONTH):
+            bars.append((date(year, month, 1) + timedelta(days=day), close))
+    for day in range(tail_bars):
+        last_date, last_close = bars[-1]
+        bars.append((last_date + timedelta(days=day + 1), last_close))
+    return bars
+
+
+class TestTheMonthEndClock:
+    def test_the_trailing_partial_month_contributes_no_month_end(self) -> None:
+        """⚠⚠ THE CONTRACT'S §4.1, and the one place a wrong decision has no
+        later bar to correct it.
+
+        The real chain ends 2026-07-08. Calling that July's month-end would
+        invent a decision the calendar never offered.
+        """
+        chain = _chain([100.0] * 3)
+        # Three whole months of bars: only the first two months are completed by
+        # a later bar in a subsequent month.
+        assert len(month_end_indices([day for day, _ in chain])) == 2
+
+    def test_a_month_end_is_the_last_bar_before_the_month_changes(self) -> None:
+        chain = _chain([100.0] * 4)
+        dates = [day for day, _ in chain]
+        for index in month_end_indices(dates):
+            assert (dates[index].year, dates[index].month) != (dates[index + 1].year, dates[index + 1].month)
+
+    def test_an_empty_chain_yields_no_month_ends(self) -> None:
+        assert month_end_indices([]) == ()
+
+
+class TestTheOffsets:
+    @pytest.mark.parametrize("offset", OFFSETS)
+    def test_an_offset_shifts_by_chain_positions_not_calendar_days(self, offset: int) -> None:
+        """⚠ Positions, not trading days. No exchange calendar is frozen, so
+        "+5" can only mean the fifth subsequent chain ROW."""
+        chain = _chain([100.0] * 6)
+        dates = [day for day, _ in chain]
+        ends = month_end_indices(dates)
+        assert evaluation_indices(dates, offset) == tuple(i + offset for i in ends if i + offset < len(dates))
+
+    def test_a_shifted_index_past_the_chain_end_is_dropped(self) -> None:
+        chain = _chain([100.0] * 3)
+        dates = [day for day, _ in chain]
+        # The last completed month-end sits BARS_PER_MONTH-1 bars from the end,
+        # so a large offset walks off the chain rather than wrapping.
+        assert len(evaluation_indices(dates, 40)) < len(month_end_indices(dates))
+
+    def test_a_negative_offset_is_refused(self) -> None:
+        with pytest.raises(OverlayRefused, match="negative"):
+            evaluation_indices([day for day, _ in _chain([100.0] * 3)], -1)
+
+
+class TestTheSignal:
+    def test_warm_up_holds_rather_than_sitting_out(self) -> None:
+        """⚠ The overlay is insurance on an ALREADY-INVESTED core. Sitting out
+        the warm-up would make the arm a market-timing bet on its first ten
+        months, which is a different rule."""
+        closes = [100.0 - index for index in range(LOOKBACK + 2)]
+        assert overlay_positions(closes)[: LOOKBACK - 1] == (1,) * (LOOKBACK - 1)
+
+    def test_a_close_below_its_sma_goes_to_cash(self) -> None:
+        closes = [100.0] * (LOOKBACK - 1) + [50.0]
+        assert overlay_positions(closes)[-1] == 0
+
+    def test_an_exact_equality_is_cash_not_held(self) -> None:
+        """⚠ Strictly greater, no tolerance. A tolerance would be a second,
+        undeclared parameter — and equality is exactly reachable on a flat
+        series, so this is not a hypothetical boundary."""
+        assert overlay_positions([100.0] * LOOKBACK)[-1] == 0
+
+    def test_a_non_finite_close_inside_the_window_refuses(self) -> None:
+        closes = [100.0] * (LOOKBACK - 1) + [float("nan"), 100.0]
+        with pytest.raises(OverlayRefused, match="non-positive or non-finite"):
+            overlay_positions(closes)
+
+
+class TestIntervalOwnership:
+    """⚠⚠ WHERE A TIMING BUG WOULD HIDE, so it gets its own class.
+
+    The return from an evaluation close to the following EXECUTION close belongs
+    to the OLD position. Getting it backwards hands the rule the exact move it
+    is being tested on — the overlay would dodge a crash it decided to dodge
+    only after seeing it.
+    """
+
+    def _falling_chain(self) -> list[tuple[date, float]]:
+        # Ten flat months arm the SMA; month 11 closes below it, so the decision
+        # at month 11's end is CASH, executing on month 12's first bar.
+        monthly = [100.0] * LOOKBACK + [50.0] + [50.0] * 6
+        return _chain(monthly)
+
+    def test_the_drop_into_the_execution_bar_is_taken_by_the_old_position(self) -> None:
+        chain = self._falling_chain()
+        # Force a further halving on the execution bar itself.
+        execution_index = (
+            next(index for index, (_, close) in enumerate(chain) if close == 50.0) + BARS_PER_MONTH
+        )  # first bar of the month AFTER the signal month
+        chain[execution_index] = (chain[execution_index][0], 25.0)
+        result = simulate_arm(chain, offset=0, seam=SEAM, dividend_yield_pp=0.0)
+        # Both arms must show the fall: the overlay was still invested into it.
+        overlay_at = dict(zip(result.equity_dates, result.overlay_equity, strict=True))
+        benchmark_at = dict(zip(result.equity_dates, result.benchmark_equity, strict=True))
+        execution_date = chain[execution_index][0]
+        assert overlay_at[execution_date] < OPENING_EQUITY_GBP
+        assert benchmark_at[execution_date] < OPENING_EQUITY_GBP
+
+    def test_once_in_cash_the_overlay_stops_tracking_the_index(self) -> None:
+        monthly = [100.0] * LOOKBACK + [50.0, 10.0, 10.0, 10.0]
+        result = simulate_arm(_chain(monthly), offset=0, seam=SEAM, dividend_yield_pp=0.0)
+        assert 0 in result.positions
+        # The benchmark rides the whole collapse; the overlay must not.
+        assert result.benchmark_max_drawdown_pct > result.overlay_max_drawdown_pct
+
+
+class TestTheUkTaxRules:
+    @pytest.mark.parametrize("day_offset", range(0, 800, 7))
+    def test_the_tax_year_rule_agrees_with_the_ledger(self, day_offset: int) -> None:
+        """⚠ ONE RULE, TWO SPELLINGS. ``tax_ledger._compute_tax_year`` is private
+        and returns a display string, so this module keeps a local integer form —
+        which is only safe while the two provably agree."""
+        day = date(2024, 1, 1) + timedelta(days=day_offset)
+        assert _compute_tax_year(day).split("/")[0] == str(uk_tax_year_start(day))
+
+    def test_the_boundary_days_land_in_the_right_year(self) -> None:
+        assert uk_tax_year_start(date(2025, 4, 5)) == 2024
+        assert uk_tax_year_start(date(2025, 4, 6)) == 2025
+
+    def test_the_payment_date_is_the_following_31_january(self) -> None:
+        """Tax year 2020/21 ends 2021-04-05 and is payable 2022-01-31."""
+        assert cgt_payment_date(2020) == date(2022, 1, 31)
+
+    def test_losses_carry_forward_but_the_exemption_does_not(self) -> None:
+        """⚠ HMRC treats them differently and so must this. Carrying the
+        exemption would understate the drag; refusing to carry losses would
+        overstate it."""
+        # A loss year then a gain year: the loss must reduce the later charge,
+        # and the unused exemption from the loss year must not.
+        monthly = [100.0] * LOOKBACK + [50.0, 200.0, 200.0] + [200.0] * 30
+        result = simulate_arm(_chain(monthly), offset=0, seam=SEAM, dividend_yield_pp=0.0)
+        assert result.tax_charges, "a flipping arm with a realised gain must produce a charge"
+        for charge in result.tax_charges:
+            assert charge.taxable_gbp == pytest.approx(max(max(charge.net_gain_gbp, 0.0) - ANNUAL_EXEMPT_GBP, 0.0))
+            assert charge.tax_gbp == pytest.approx(charge.taxable_gbp * CGT_HIGHER_RATE)
+
+
+class TestDrawdownEpisodes:
+    def test_a_dip_inside_an_unrecovered_decline_is_one_episode(self) -> None:
+        """⚠ Otherwise one 2008 reports as four, and every episode COUNT built
+        on it — including §9's ≥15% class — inflates."""
+        dates = [date(2020, 1, 1) + timedelta(days=index) for index in range(6)]
+        episodes = drawdown_episodes(dates, [100.0, 80.0, 90.0, 60.0, 95.0, 105.0])
+        assert len(episodes) == 1
+        assert episodes[0].depth_pct == pytest.approx(40.0)
+
+    def test_a_terminal_unrecovered_episode_is_reported_and_flagged(self) -> None:
+        """⚠ Dropping it would let a curve that ends in the deepest hole of its
+        life report the second deepest."""
+        dates = [date(2020, 1, 1) + timedelta(days=index) for index in range(4)]
+        episodes = drawdown_episodes(dates, [100.0, 120.0, 90.0, 70.0])
+        assert episodes[0].unrecovered
+        assert episodes[0].recovery_date is None
+        assert episodes[0].depth_pct == pytest.approx(100 * (120.0 - 70.0) / 120.0)
+
+    def test_episodes_come_back_deepest_first(self) -> None:
+        dates = [date(2020, 1, 1) + timedelta(days=index) for index in range(7)]
+        episodes = drawdown_episodes(dates, [100.0, 90.0, 100.0, 100.0, 50.0, 100.0, 100.0])
+        assert [round(episode.depth_pct) for episode in episodes] == [50, 10]
+
+    def test_a_monotonically_rising_curve_has_no_episodes(self) -> None:
+        dates = [date(2020, 1, 1) + timedelta(days=index) for index in range(4)]
+        assert drawdown_episodes(dates, [1.0, 2.0, 3.0, 4.0]) == ()
+
+    def test_mismatched_lengths_are_refused(self) -> None:
+        with pytest.raises(OverlayRefused, match="disagree in length"):
+            drawdown_episodes([date(2020, 1, 1)], [1.0, 2.0])
+
+
+class TestThePassBar:
+    def _armed(self, monthly: list[float]) -> ArmResult:
+        return simulate_arm(_chain(monthly), offset=0, seam=SEAM, dividend_yield_pp=0.0)
+
+    def test_drawdowns_are_reported_as_non_negative_magnitudes(self) -> None:
+        """⚠⚠ THE SIGN CONVENTION IS THE PASS BAR'S SAFETY. ``max_drawdown_pct``
+        returns a NON-POSITIVE number; if a magnitude were compared as a signed
+        value, ``overlay <= 2/3 × benchmark`` would invert and a WORSE overlay
+        would pass."""
+        result = self._armed([100.0] * LOOKBACK + [50.0, 10.0, 10.0, 10.0])
+        assert result.overlay_max_drawdown_pct >= 0.0
+        assert result.benchmark_max_drawdown_pct >= 0.0
+
+    def test_a_benchmark_that_never_drew_down_fails_the_insurance_leg(self) -> None:
+        """⚠ ``None`` FAILS. An overlay cannot evidence insurance against a loss
+        that never happened — and a guarded division that returned "pass" would
+        be the worst possible reading of a monotone benchmark."""
+        result = self._armed([100.0 + index for index in range(LOOKBACK + 8)])
+        assert result.benchmark_max_drawdown_pct == pytest.approx(0.0)
+        assert result.drawdown_ratio is None
+        assert not result.drawdown_leg_passes
+        assert not result.passes
+
+    def test_both_legs_are_required(self) -> None:
+        result = self._armed([100.0] * LOOKBACK + [50.0, 10.0, 10.0, 10.0])
+        assert result.passes == (result.drawdown_leg_passes and result.cagr_leg_passes)
+
+    def test_the_dividend_drag_only_ever_lowers_the_delta(self) -> None:
+        """§3.1 — the drag is charged, so a non-zero yield can only make the
+        CAGR leg harder, never easier."""
+        monthly = [100.0] * LOOKBACK + [50.0, 60.0, 70.0, 80.0, 90.0, 100.0]
+        without = simulate_arm(_chain(monthly), offset=0, seam=SEAM, dividend_yield_pp=0.0)
+        with_yield = simulate_arm(_chain(monthly), offset=0, seam=SEAM, dividend_yield_pp=2.0)
+        assert with_yield.fraction_in_cash > 0.0
+        assert with_yield.net_cagr_delta_pp < without.net_cagr_delta_pp
+
+    def test_a_degenerate_arm_is_refused_rather_than_reported(self) -> None:
+        with pytest.raises(OverlayRefused, match="degenerate arm"):
+            simulate_arm(_chain([100.0] * 3), offset=0, seam=SEAM, dividend_yield_pp=0.0)
+
+
+class TestTheDeclaredConstants:
+    def test_the_cost_band_splits_the_round_trip_in_half(self) -> None:
+        assert SIDE_COST_PCT * 2 == pytest.approx(ROUND_TRIP_COST_PCT)
+
+    def test_the_contract_constants_are_the_ones_the_ticket_declared(self) -> None:
+        """⚠ Pinned so a later edit to any of them fails here and has to be
+        argued as a NEW declared search rather than slipped in as a tweak."""
+        assert (LOOKBACK, OFFSETS, ROUND_TRIP_COST_PCT) == (10, (0, 5, 10), 0.322)
+        assert (OPENING_EQUITY_GBP, CGT_HIGHER_RATE, ANNUAL_EXEMPT_GBP) == (50_000.0, 0.24, 3000.0)
+        assert MAX_DRAWDOWN_RATIO_BAR == pytest.approx(2 / 3)
+
+
+class TestTheSeamReport:
+    def test_windows_straddling_the_seam_are_counted(self) -> None:
+        """§9 — the only place a residual vendor level step could enter a
+        SIGNAL, so it is surfaced rather than assumed away."""
+        monthly = [100.0] * 30
+        chain = _chain(monthly, start_year=2021)
+        result = simulate_arm(chain, offset=0, seam=date(2022, 5, 10), dividend_yield_pp=0.0)
+        # Ten-bar windows around a seam that falls mid-series: at most LOOKBACK-1
+        # windows can straddle it, and at least one must.
+        assert 1 <= result.seam_spanning_windows <= LOOKBACK - 1
+
+    def test_a_seam_outside_the_evaluated_span_straddles_nothing(self) -> None:
+        result = simulate_arm(_chain([100.0] * 30), offset=0, seam=date(1980, 1, 1), dividend_yield_pp=0.0)
+        assert result.seam_spanning_windows == 0
+
+
+class TestTheSymmetricSensitivity:
+    """§7 — the variant that liquidates both arms and taxes the result.
+
+    ⚠⚠ CODEX CHECKPOINT 2 FOUND THIS ONE. The first draft captured the symmetric
+    figure BEFORE the terminal accrual, so it omitted taxes the primary equity
+    had already been charged and the sensitivity read better than the thing it is
+    a sensitivity on — the one direction a declared sensitivity must not fail in.
+    """
+
+    def _armed(self) -> ArmResult:
+        monthly = [100.0] * LOOKBACK + [50.0, 200.0, 210.0, 220.0] + [230.0] * 20
+        return simulate_arm(_chain(monthly), offset=0, seam=SEAM, dividend_yield_pp=0.0)
+
+    def test_liquidating_never_leaves_an_arm_better_off_than_not(self) -> None:
+        result = self._armed()
+        assert result.symmetric_overlay_terminal_gbp <= result.overlay_equity[-1] + 1e-9
+        assert result.symmetric_benchmark_terminal_gbp <= result.benchmark_equity[-1] + 1e-9
+
+    def test_the_liquidation_tax_is_incremental_not_a_second_charge_on_the_year(self) -> None:
+        """⚠ The open year's own charge is settled by the terminal accrual. If
+        §7 subtracted the FULL charge on the terminal gain the year would be
+        taxed twice, and the gap below would exceed 24% of the terminal gain."""
+        result = self._armed()
+        charged = result.overlay_equity[-1] - result.symmetric_overlay_terminal_gbp
+        assert charged >= 0.0
+        assert charged <= CGT_HIGHER_RATE * result.overlay_equity[-1]
+
+    def test_a_benchmark_gain_inside_the_exemption_is_untaxed(self) -> None:
+        monthly = [100.0] * LOOKBACK + [100.01] * 6
+        result = simulate_arm(_chain(monthly), offset=0, seam=SEAM, dividend_yield_pp=0.0)
+        assert result.benchmark_equity[-1] - OPENING_EQUITY_GBP < ANNUAL_EXEMPT_GBP
+        assert result.symmetric_benchmark_terminal_gbp == pytest.approx(result.benchmark_equity[-1])
+
+
+class TestTheRegimeCohorts:
+    def _armed(self) -> ArmResult:
+        monthly = [100.0] * LOOKBACK + [50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0]
+        return simulate_arm(_chain(monthly), offset=0, seam=SEAM, dividend_yield_pp=0.0)
+
+    def test_an_unverdicted_bar_is_its_own_cohort_never_folded_in(self) -> None:
+        """⚠ A bar the classifier could not verdict is not evidence about any
+        regime. Folding warm-up into a real cohort would attribute returns to a
+        market state nobody observed."""
+        result = self._armed()
+        cohorts = regime_cohorts(result, [None] * len(result.evaluation_dates))
+        assert [cohort.regime for cohort in cohorts] == ["warm_up"]
+
+    def test_the_cohort_keys_on_the_deciding_evaluation_date(self) -> None:
+        """⚠ Not on the holding period. The question is what the rule did when it
+        DECIDED under a regime, and the decision predates the interval."""
+        result = self._armed()
+        regimes: list[str | None] = ["calm"] * len(result.evaluation_dates)
+        regimes[0] = "stormy"
+        cohorts = {cohort.regime: cohort for cohort in regime_cohorts(result, regimes)}
+        assert cohorts["stormy"].intervals == 1
+        assert cohorts["calm"].intervals == len(result.execution_dates) - 2
+
+    def test_the_cohorts_partition_the_intervals_exactly(self) -> None:
+        result = self._armed()
+        regimes: list[str | None] = ["a" if index % 2 else "b" for index in range(len(result.evaluation_dates))]
+        cohorts = regime_cohorts(result, regimes)
+        assert sum(cohort.intervals for cohort in cohorts) == len(result.execution_dates) - 1
+
+    def test_a_regime_series_of_the_wrong_length_is_refused(self) -> None:
+        result = self._armed()
+        with pytest.raises(OverlayRefused, match="disagree in length"):
+            regime_cohorts(result, ["calm"])
+
+
+class TestTheMarchTwentyTwentyWindow:
+    def test_every_decision_in_the_frozen_window_is_returned(self) -> None:
+        """⚠ The window and the fields are predeclared, so the narration cannot
+        be selected after the look — every decision, not the interesting ones."""
+        chain = _chain([100.0] * LOOKBACK + [90.0] * 14, start_year=2019)
+        result = simulate_arm(chain, offset=0, seam=SEAM, dividend_yield_pp=0.0)
+        start, end = MARCH_2020_WINDOW
+        expected = [day for day in result.evaluation_dates if start <= day <= end]
+        assert [row[0] for row in march_2020_detail(result)] == expected
+
+
+class TestDrawdownEpisodeShape:
+    def test_the_episode_record_carries_its_own_recovery_verdict(self) -> None:
+        recovered = DrawdownEpisode(date(2020, 1, 1), date(2020, 2, 1), date(2020, 3, 1), 12.0)
+        assert not recovered.unrecovered

--- a/tests/test_trial_register.py
+++ b/tests/test_trial_register.py
@@ -23,7 +23,7 @@ def _trial(trial_id: str, exactness: TrialExactness = TrialExactness.EXACT) -> D
 
 class TestTheShippedDeclaration:
     def test_the_register_is_stamped_with_its_version(self) -> None:
-        assert TRIAL_REGISTER.version == TRIAL_REGISTER_VERSION == "trial-register-2026-08-15-r7"
+        assert TRIAL_REGISTER.version == TRIAL_REGISTER_VERSION == "trial-register-2026-08-22-r8"
 
     def test_every_declared_trial_carries_its_evidence(self) -> None:
         """⚠ An entry nobody can trace is indistinguishable from one invented."""
@@ -69,11 +69,11 @@ class TestTheShippedDeclaration:
         individually as well.
         """
         # ⚠ 259 (#2600's Gate D-0.1 reconstruction) + 7 (#2614's C-4 entry) +
-        # 6 S-5..S-10 declarations + 2 MT-1 controlled pairs. Moved
-        # deliberately, not loosened: the pin exists to catch a DROPPED entry,
-        # and an addition that raises M is the conservative direction — a
-        # larger M lowers the DSR.
-        assert TRIAL_REGISTER.declared_count == 274
+        # 6 S-5..S-10 declarations + 2 MT-1 controlled pairs + 1 S-E overlay
+        # (#2837, r8). Moved deliberately, not loosened: the pin exists to catch
+        # a DROPPED entry, and an addition that raises M is the conservative
+        # direction — a larger M lowers the DSR.
+        assert TRIAL_REGISTER.declared_count == 275
         assert TRIAL_REGISTER.declared_count == sum(trial.searches for trial in TRIAL_REGISTER.trials)
 
     def test_the_two_mt1_controlled_pairs_are_charged_before_outcomes(self) -> None:


### PR DESCRIPTION
Freezes S-E's contract and builds its measurement — **without running it**. The measurement runs after this merges, because the freeze gate cannot pass until the register entry is on `main`.

Refs #2837, #2832, #2437.

## What S-E is, and what it is not

A 10-month-SMA overlay on the passive core (S-A, #2833), measured on `spy_chain_v1`. The alpha claim is dead and stays dead. The only admissible claim is **a bounded CAGR cost bought as drawdown insurance** — never alpha, never a strategy promotion, never in the strategy funnel. If it passes it books as an optional risk overlay; excess-return significance is not testable on one index path, is not the claim, and no test of it is declared or run.

## The unpromotability is structural, not a promise in prose

The honest stamps for one spliced index chain are `single_index_proxy` / `carry_unmodelled` / `fx_unmodelled`, so `structural_promotion_refusals` returns three refusals **at freeze time** and `prereg_purpose` is `falsification_only`. Nothing new was built to hold that line — it falls out of stamping honestly.

Dry-run digest (`920d225b…`), all limits checked: derivation 886 chars against `sql/333`'s 1000, `declaration_refusals` empty, `policy_version_matches_main` true.

## The inherited premise was re-falsified, and it was wrong

#2837's handoff said *"Do NOT add an entry to `TRIAL_REGISTER`; bumping is destructive."* Working-order 3c says re-run a prior session's discriminator before building on it. It fails: `freeze_preregistration` (`result_ledger.py:1318`) refuses outright unless a trial claims the declaration, and its own message says the fix is *"Add a NEW `DeclaredTrial` … NEW, because its own `searches` is what moves `declared_count`"*. A new entry is mandatory, not forbidden.

Blast radius, measured on the full population rather than argued:

| cohort | rows |
| --- | --- |
| `strategy_results_store` total | 568 |
| with a deflated Sharpe | 488 |
| …on the r7 register | 220 |
| …already on one of 4 older registers | 268 |
| …with `purpose = 'harness_validation'` | **488 — all of them** |

Every stored deflation already carries a terminal `harness_validation_only` from `purpose_promotion_refusals`. The bump adds a second refusal code to rows that could not promote regardless, and the register has been bumped four times before. **Nothing promotable is lost.** The reproducing command now sits beside `TRIAL_REGISTER_VERSION` rather than the figure being written into prose.

⚠ Adding a trial *is* the supersession — `trial_register_superseded` keys on `declared_trials != declared_count`, not on the version string. "Add the entry but don't bump" is not a state.

## What is in the diff

- **`app/services/se_ma_overlay.py`** (new, pure) — the frozen rule. Month-end clock excluding the trailing partial month; offsets in **chain-bar positions** (no exchange calendar is frozen, so "trading days" would be a claim the data cannot support); interval ownership (the return into an execution close belongs to the **old** position); a forward-walking CGT ledger; drawdown episodes with nesting and terminal-unrecovered handling; per-regime cohorts; the two-leg pass bar.
- **`market_regime_provider.load_research_closes`** — the chain read extracted and made public so the overlay and the regime classifier share **one** merge. The module's own header puts fetch *mechanics* outside `RULE_SET_VERSION`, so no strategy identity moves. Verified against the corpus: 8,391 bars, `1993-01-29 … 2026-07-08`, `classified_days` 8,192 — unchanged either side.
- **`trial_register` r8** — the S-E entry, `searches=1`. Three offsets are a **fragility screen over one rule**, not three variants to select between; the pass bar requires all three, so picking the best is forbidden.
- **`scripts/freeze_2837_se_overlay_declaration.py`** — the fourth freeze script, following #2614's pattern.
- **`scripts/measure_2837_se_overlay.py`** — the runner, behind `require_outcome_access`.
- **`tests/test_2837_se_ma_overlay.py`** — 74 pure tests, no DB.

## Codex checkpoint 1 — 85 findings on the spec, resolved before freezing

Two things it caught that changed the measurement rather than the wording:

1. **The trailing partial month.** The chain ends `2026-07-08`; the first draft would have treated that as July's month-end — inventing a decision the calendar never offered, at the one end of the sample where nothing later corrects it.
2. **Price return flatters an overlay that sits in cash.** The chain is price-only, so an overlay forgoing distributions is never charged for them — and that lands directly on the CAGR leg. Rather than declare it unfixable: `adj_close` is present on all 7,973 pre-seam fallback bars (differing from `close` on 7,967) and on **0** of the 1,018 primary bars. So a total-return chain is impossible across the seam, but the yield can be **sourced** instead of invented. §3.1 charges `f × y`; measured, `y = 2.0179 pp/yr` over `1993-01-29 … 2022-05-09`. Applying a 1993–2022 yield to the 2022–2026 tail overstates the drag, which makes the bar harder — the conservative direction.

Also resolved into the spec: execution-price and interval-ownership ambiguity, the terminal valuation clock and per-arm buy-and-hold span, drawdown sign convention and the zero-denominator case, episode segmentation, the 31 January cash flow and terminal accrual, the higher-rate assumption, and the forward-shadow floor's status (**not** a power calculation — §10 now names all three of its limits). §12 records every resolution and five rebuttals.

## Codex checkpoint 2 — one real defect, fixed

`symmetric_overlay_terminal_gbp` was captured **before** the terminal accrual, so §7's declared sensitivity omitted taxes the primary equity had already been charged — it read better than the thing it is a sensitivity on, the one direction a sensitivity must not fail in. The naive fix double-taxes the open year, so `_CgtLedger` now returns the **incremental** liquidation tax and it is applied after the accrual. Two tests pin it (`TestTheSymmetricSensitivity`).

## One thing removed on purpose

The measure script had a `--skip-gate` flag "to exercise the plumbing before the declaration is frozen". That is a documented bypass of the single gate the design rests on, and using it would itself have been the first look the preregistration exists to precede. Removed. The pure arithmetic is covered by tests against synthetic chains; the two DB helpers read **source characteristics, not outcomes**, and were exercised directly.

## Verification

- `ruff check` / `ruff format --check` / `pyright` — clean.
- Fast tier `-m "not db"` — green. `tests/smoke` — green.
- `-m db` on the touched modules (`test_market_regime_benchmark_chain`, `test_prereg_declaration_gate`, `test_2634_prereg_supersession_db`, `test_result_ledger`, `test_strategy_regime_evidence_db`) — green.
- Freeze script `--dry-run` against the real DB — coherent, policy version matches main.
- Measure script run against the real DB — **refuses `preregistration_not_frozen`**, which is the gate working. No outcome has been read.
- `load_research_closes` against the corpus — 8,391 bars, extent assertion passes, `classified_days` 8,192.

Two tests changed their pinned literals, and both were doing their job: `test_M_is_unchanged_so_the_register_version_is_not_bumped` forced the bump conversation at the moment it was due (renamed — the old name read as a standing prohibition, which inverts the module's own argument), and `test_every_freeze_script_calls_the_guard` fired on the fourth freeze script and made me confirm it follows the convention. A third assertion was **corrected, not just repointed**: `claims == stored declarations` is false for a whole PR at a time, because a trial must be merged before its declaration can be frozen. It is now `claims ⊇ stored`.

## Security

No security surface. No new endpoint, no auth path, no user input, no broker call. Read-only against the research corpus; the only write is the #2599 access row, through the existing ledger chokepoint.

## Not done here, deliberately

The freeze and the measurement. `_prereg_freeze_guard` requires this tree to agree with `main`, and `freeze_preregistration` requires the register entry to exist — so both must run **after** this merges. Post-merge sequence, from this worktree on `main`:

```bash
PYTHONPATH=. uv run python -m scripts.freeze_2837_se_overlay_declaration --dry-run
PYTHONPATH=. uv run python -m scripts.freeze_2837_se_overlay_declaration
PYTHONPATH=. uv run python -m scripts.measure_2837_se_overlay
```

The readout then goes on #2837 and the verdict is decided on §8's bar only. Per §11 a fail is terminal for S-E — no smaller lookback, no band, no different proxy.
