### PR TITLE
feature(#2840): S-H arm 1 — S-4's breakout gated to the two volatile regimes

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -160,6 +160,7 @@ _TITLES = {
     "s8-range-mean-reversion": "Range mean reversion",
     "s9-squeeze-expansion": "Squeeze expansion",
     "s10-relative-strength-leader": "Relative-strength leader",
+    "s11-volatile-regime-gated-breakout": "Volatility breakout (volatile markets only)",
 }
 
 _PRESENTATION = {
@@ -202,6 +203,11 @@ _PRESENTATION = {
     "s10-relative-strength-leader": (
         "Holds top-decile 63-day leaders above their 50-day average in quiet bull markets.",
         "Reviewed at each monthly rebalance",
+    ),
+    "s11-volatile-regime-gated-breakout": (
+        "The same volatility-compression breakout, but it only trades while the wider "
+        "market is volatile — the conditions where the rule has historically paid.",
+        "Up to 40 market days",
     ),
 }
 

--- a/app/services/strategies/s11_volatile_regime_gated_breakout.py
+++ b/app/services/strategies/s11_volatile_regime_gated_breakout.py
@@ -1,0 +1,259 @@
+"""S-11 — S-4's compression breakout, gated to the two volatile regimes.
+
+The R5 sweep calls this candidate **S-H**; the manifest numbers its strategies
+``s{N}-`` and the id has to live in the manifest, so the sequence continues at 11
+and the mapping is recorded here. Spec:
+``docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md``.
+Refs #2840, #2832, #2437.
+
+THE RULE
+--------
+    entry(t) := s4_entry(t)  and  regime(t) in {bear_volatile, bull_volatile}
+
+S-4's rule is IMPORTED, never restated — ``compression_rank_series``,
+``prior_high_close_series`` and every constant come from
+``s4_volatility_compression_breakout``. The bracket, the two ATR multiples and
+the 40-bar hold cap are S-4's, unchanged: the gate conditions ENTRY, not the exit.
+
+⚠⚠ S-4 IS LEFT BYTE-IDENTICAL, AND THAT IS THE WHOLE REASON THIS IS A NEW
+STRATEGY ID RATHER THAN A NEW S-4 VERSION.
+#2840 step 1 asks for "a NEW strategy_version". Editing
+``s4_volatility_compression_breakout.py`` would move its ``_source_hash()`` and
+therefore the S-4 identity, so every stored S-4 result — the CONTROL this
+candidate is measured against — would stop being interpretable against the rule
+it ran under, for a change S-4's own rule did not undergo.
+
+⚠⚠ ``s4_source_hash`` IS IN ``S11_PARAMS`` AND IS LOAD-BEARING.
+This module imports S-4's rule rather than copying it, so an edit to S-4 changes
+what S-11 DOES. Without S-4's hash in these params, S-11's own ``_source_hash()``
+would not move and the changed rule would silently inherit this one's track
+record. Same construction, and the same reason, as S-5 hashing
+``LEVEL_RULE_VERSION`` and ``REGIME_RULE_VERSION`` rather than trusting its own
+file hash.
+
+⚠ THE HASH IS RECOMPUTED FROM S-4's MODULE PATH RATHER THAN IMPORTED.
+``s4_volatility_compression_breakout._source_hash`` is private and absent from
+that module's ``__all__``. Adding it there would change S-4's file bytes — i.e.
+bump the S-4 version, which is precisely the orphaning described above. So the
+one-line construction is repeated here and
+``test_s11_hash_tracks_s4`` asserts the two agree, which is what stops the copy
+drifting.
+
+⚠⚠ THE REGIME IS A DECLARED INPUT, NOT A CHECK IN THE BODY, AND THIS MODULE
+CANNOT BE A POST-FILTER OVER ``s4_signals``.
+Filtering S-4's returned signal list would collapse "the regime says no"
+(``not_fired``) and "there is no regime at all" (``not_evaluable /
+missing_market_context``) into the same non-firing bar — criterion 8's
+distinction destroyed at the last step, and the bug S-6 shipped. So the four S-4
+inputs are rebuilt here and the ``RegimeSeries`` is declared alongside them,
+LAST, exactly as ``s5_signals`` declares it.
+
+⚠ DECLARED LAST ON PURPOSE. ``evaluate`` refuses on the first unevaluable input,
+so S-4's own OHLC and warm-up refusals take precedence over the regime's. That is
+the honest order: a bar S-4 cannot evaluate is not a bar whose regime matters.
+
+⚠ THE PERMITTED SET IS THE HYPOTHESIS, NOT A TUNABLE.
+It is the two cohorts #2840 named. It is frozen in ``S11_PARAMS`` and hashed into
+the identity, so moving it mints a different strategy rather than re-reading this
+one's evidence. The measured premise behind it — including the 4x cohort
+double-count the ticket's headline figures contained, and the fact that
+``bull_volatile`` flips sign in the ``admitted`` quarantine arm — is in the spec's
+"Measured premise, corrected" section. It is NOT narrowed to ``bear_volatile``
+here: doing that would fit the hypothesis to the hold-out cohort that suggested it.
+
+⚠ ``WARMUP_BARS`` IS RE-EXPORTED FROM S-4 (113) AND IS NOT S-11's EFFECTIVE
+WARM-UP. The regime has its own — a 200-bar SMA and a 126-bar BandWidth window —
+so no S-11 bar is judgeable before the BENCHMARK has warmed up, which is a
+property of a different series and has no fixed offset into this one. Re-exporting
+S-4's is honest only because nothing enforces it as a length check: the series
+emit ``None`` until their windows fill and ``evaluate`` turns that into
+``insufficient_warmup`` structurally, exactly as S-4's own docstring describes. A
+caller that treats this constant as "the first judgeable index" would be wrong for
+S-11 in a way it is not wrong for S-4.
+
+⚠ REGIME BOUNDARY CONVENTIONS ARE INHERITED FROM ``market_regime``, NOT DECIDED
+HERE. ``close > SMA`` classifies equality as bearish and a tied Bulge counts as
+volatile. Both are frozen in ``REGIME_RULE_VERSION``, which this identity hashes,
+so a change to either is a new S-11 rather than a silent re-reading of this one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+
+from app.services.indicator_series import BarSeries, IndicatorSeries, Universe, atr_series
+from app.services.market_regime import REGIME_RULE_VERSION, Regime, RegimeSeries
+from app.services.strategies import s4_volatility_compression_breakout as s4
+from app.services.strategies.s4_volatility_compression_breakout import (
+    ATR_PERIOD,
+    ATR_STOP_MULTIPLE,
+    ATR_TARGET_MULTIPLE,
+    BREAKOUT_LOOKBACK,
+    COMPRESSION_QUANTILE,
+    COMPRESSION_WINDOW,
+    MAX_HOLD_BARS,
+    WARMUP_BARS,
+    compression_rank_series,
+    prior_high_close_series,
+    s4_exit_bracket,
+)
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+
+S11_STRATEGY_ID = "s11-volatile-regime-gated-breakout"
+
+#: The hypothesis under test. ⚠ BOTH volatile regimes — see the module docstring.
+PERMITTED_REGIMES = frozenset({Regime.BEAR_VOLATILE, Regime.BULL_VOLATILE})
+
+
+def _s4_source_hash() -> str:
+    """S-4's file hash, recomputed rather than imported — see the module docstring."""
+    return hashlib.sha256(Path(s4.__file__).read_bytes()).hexdigest()[:12]
+
+
+#: ⚠ WRITTEN OUT KEY BY KEY rather than merged from ``S4_PARAMS``. A merge has a
+#: collision direction to get wrong and hides which keys this strategy actually
+#: declares; there are seven of them and they are cheap to name.
+#:
+#: ⚠ ``permitted_regimes`` is a sorted tuple of enum VALUES, not the frozenset —
+#: ``s5_support_bounce``'s serialisation, because a set has no canonical JSON
+#: form and the identity digest needs one.
+S11_PARAMS: Mapping[str, object] = {
+    "atr_period": ATR_PERIOD,
+    "compression_window": COMPRESSION_WINDOW,
+    "compression_quantile": COMPRESSION_QUANTILE,
+    "breakout_lookback": BREAKOUT_LOOKBACK,
+    "atr_stop_multiple": ATR_STOP_MULTIPLE,
+    "atr_target_multiple": ATR_TARGET_MULTIPLE,
+    "max_hold_bars": MAX_HOLD_BARS,
+    "permitted_regimes": tuple(sorted(r.value for r in PERMITTED_REGIMES)),
+    "regime_rule_version": REGIME_RULE_VERSION,
+    "s4_source_hash": _s4_source_hash(),
+}
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s11_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-11 on one universe under one cost model."""
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "pass app.services.cost_model.COST_MODEL_ID rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S11_STRATEGY_ID,
+        params=S11_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, in the shape the runner checks for evaluability.
+
+    ⚠ A LOCAL COPY, matching what S-1, S-3, S-4 and S-5 each already carry — the
+    package's convention is one per module. S-4's is private and this module must
+    not edit S-4's file to export it (that would bump S-4's version, per the
+    module docstring). ``test_s11_close_input_matches_s4`` compares the two.
+    """
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
+def s11_exit_bracket(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> tuple[Decimal, Decimal, int]:
+    """S-4's bracket, unchanged. The gate conditions entry, never the exit.
+
+    Delegated rather than reimplemented so the two can never disagree — and so
+    the ATR-at-signal-bar rule S-4's docstring calls out as the trap is enforced
+    in exactly one place.
+    """
+    return s4_exit_bracket(series, signal_index=signal_index, entry_price=entry_price, universe=universe)
+
+
+def s11_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    """S-11's entry verdict for every bar. ENTRIES ONLY, as S-4.
+
+    The four S-4 inputs are rebuilt here rather than obtained by calling
+    ``s4_signals`` — see the module docstring on why a post-filter is wrong.
+    """
+    if masked_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {masked_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+    if len(regime) != len(series):
+        raise ValueError(f"regime series has {len(regime)} bars against {len(series)} price bars; they must align")
+
+    closes = series.float_closes
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    compression = compression_rank_series(atr, universe=universe)
+    prior_high = prior_high_close_series(series, universe=universe)
+
+    inputs = (
+        StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
+        StrategyInput(series=atr, reason=masked_reason),
+        StrategyInput(series=compression, reason=masked_reason),
+        StrategyInput(series=prior_high, reason=masked_reason),
+        # ⚠⚠ LAST, and with its own reason code. See the module docstring: a
+        # benchmark hole is `missing_market_context`, while a benchmark bar that
+        # exists but is not yet classifiable stays `insufficient_warmup`, which
+        # `evaluate` derives structurally from the bare `None`.
+        StrategyInput(series=regime, reason="missing_market_context"),
+    )
+
+    def entry(index: int) -> bool:
+        close = closes[index]
+        rank = compression.values[index]
+        highest_prior_close = prior_high.values[index]
+        # Not reachable through `evaluate`, which refuses the bar first.
+        assert close is not None and rank is not None and highest_prior_close is not None
+        if not regime.permits(index, PERMITTED_REGIMES):
+            return False
+        return rank < COMPRESSION_QUANTILE and close > highest_prior_close
+
+    return evaluate(entry, inputs=inputs, n_bars=len(series), kind="entry")
+
+
+__all__ = [
+    "ATR_PERIOD",
+    "ATR_STOP_MULTIPLE",
+    "ATR_TARGET_MULTIPLE",
+    "BREAKOUT_LOOKBACK",
+    "COMPRESSION_QUANTILE",
+    "COMPRESSION_WINDOW",
+    "MAX_HOLD_BARS",
+    "PERMITTED_REGIMES",
+    "S11_PARAMS",
+    "S11_STRATEGY_ID",
+    "WARMUP_BARS",
+    "s11_exit_bracket",
+    "s11_identity",
+    "s11_signals",
+]

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -152,6 +152,12 @@ from app.services.strategies.s10_relative_strength_leader import (
     s10_identity,
     s10_rebalance_dates,
 )
+from app.services.strategies.s11_volatile_regime_gated_breakout import (
+    S11_STRATEGY_ID,
+    s11_exit_bracket,
+    s11_identity,
+    s11_signals,
+)
 from app.services.strategy_exit_levels_batch import (
     s4_exit_levels_batch,
     s5_exit_levels_batch,
@@ -618,6 +624,61 @@ def _s4_exit_levels(
     return scalar
 
 
+def _s11_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    regime: RegimeSeries,
+) -> list[StrategySignal]:
+    """⚠ PASSES THE REGIME THROUGH. Copying ``_s4_signals`` — which drops it with
+    a ``noqa: ARG001`` because S-4 does not gate — would silently un-gate S-11 and
+    leave every test of the strategy module itself still passing.
+    ``test_2840_manifest_adapter_gates`` asserts this directly.
+    """
+    return s11_signals(series, universe=universe, masked_reason=masked_reason, regime=regime)
+
+
+def _s11_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-11's exits are S-4's — the gate conditions entry only."""
+    _reject_decision_dates(S11_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=False, level_based=True, max_hold_bars=S4_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s11_exit_levels(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    entry_price: Decimal,
+    universe: Universe,
+) -> ExitLevels | UnresolvedReason:
+    """S-11's bracket is S-4's, so the S-4 batch factory is its oracle too.
+
+    ⚠ ``s11_exit_bracket`` is called rather than ``s4_exit_bracket`` even though
+    it delegates: the comparison has to be against the factory the MANIFEST
+    registered for this strategy, or a future divergence in S-11's bracket would
+    pass a check that only ever looked at S-4's.
+    """
+    (batched,) = s4_exit_levels_batch(
+        series,
+        requests=((signal_index, entry_price),),
+        universe=universe,
+    )
+    if batched == "unorderable_exit_levels":
+        return batched
+
+    target, stop, max_hold = s11_exit_bracket(
+        series,
+        signal_index=signal_index,
+        entry_price=entry_price,
+        universe=universe,
+    )
+    scalar = ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+    if scalar != batched:
+        raise RuntimeError("S-11 scalar and batch exit-level factories disagree")
+    return scalar
+
+
 def _s9_signals(
     series: BarSeries,
     *,
@@ -1040,6 +1101,28 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
                 min_participants=S10_MIN_CROSS_SECTION,
             ),
             retired_reason=_RETIRED_NOT_A_COST_PROBLEM,
+        ),
+        #: #2840 (R5 candidate S-H). S-4's rule gated to the two volatile
+        #: regimes — a research seat, NOT one of the ten. ⚠ Not retired: it
+        #: exists precisely to produce new evidence, which is what retirement
+        #: forbids. Its bracket is S-4's, hence the shared batch factory.
+        S11_STRATEGY_ID: StrategyEntry(
+            strategy_id=S11_STRATEGY_ID,
+            #: ⚠ ``harness_validation`` like every other entry, and NOT
+            #: ``capital_candidate``. It runs on the survivor-only,
+            #: carry-unmodelled corpus, whose stamps make any result
+            #: structurally unpromotable — the matching preregistration is
+            #: ``falsification_only`` for the same reason
+            #: (``prereg_contract.declaration_refusals``).
+            purpose="harness_validation",
+            identity=s11_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s11_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s11_signals,
+            exit_levels=_s11_exit_levels,
+            exit_levels_batch=s4_exit_levels_batch,
         ),
     }
 )

--- a/docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md
+++ b/docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md
@@ -1,0 +1,267 @@
+# S-H arm 1 — the volatile-regime-gated compression breakout (#2840)
+
+Refs #2840, #2832, #2437. Depends on #2829 (the declaration freezes after this lands).
+
+Contract version: `sh-volatile-regime-gate-2026-08-22`. ⚠ That string is what the frozen
+declaration will carry in `PreregDeclaration.contract_version`, and it is how the readout
+rule in §"Readout and abort bar" below becomes part of the declaration. The digest hashes
+the STRING, not this file's bytes (`prereg_contract.digest_payload`), so once the freeze
+runs this document is append-only: a correction is a new contract version and a new trial.
+
+## What this ships
+
+One new manifest strategy, `s11-volatile-regime-gated-breakout` — S-4's entry rule
+conjoined with `regime ∈ {bear_volatile, bull_volatile}`. Nothing else. The declaration
+freeze, the exploration run and arms 2/3 are separate acts, sequenced in §Sequencing.
+
+**Name.** The R5 sweep calls this candidate S-H; the manifest numbers its strategies
+`s{N}-`, and the id has to live in the manifest. `s11-` continues that sequence and the
+S-H mapping is recorded here and in the module docstring. No other R5 candidate has taken
+a manifest id, so there is nothing to collide with.
+
+## Why a new strategy id and not a new version of S-4
+
+#2840 step 1 says *"as a NEW strategy_version"*. A version bump is the wrong shape:
+
+1. **S-4's stored evidence is the control, and a bump orphans it.** Editing
+   `s4_volatility_compression_breakout.py` moves `_source_hash()` and therefore the S-4
+   identity, so results 501-504 and every other stored S-4 row stop being interpretable
+   against the rule they were measured under — for a change S-4's rule did not undergo.
+   This is the decisive one.
+2. Keeping both rules live in the manifest also lets the gated and ungated arms be run
+   from one invocation over one corpus load, which the stored control alone would not give
+   for any window not already measured.
+
+So S-4 is left **byte-identical** and the gate is a new module that imports it.
+
+## The rule
+
+    entry(t) := s4_entry(t)  ∧  regime(t) ∈ {bear_volatile, bull_volatile}
+
+`s4_entry` is not restated — the module imports `compression_rank_series`,
+`prior_high_close_series` and every S-4 constant. The bracket, the stop/target multiples
+and the 40-bar hold cap are S-4's, unchanged: the gate conditions ENTRY, not the exit.
+
+### Source rule
+
+Neither half is invented here.
+
+- The compression + breakout legs are S-4's, whose construction (and its explicit
+  "no published formulation, fixed by construction" note) is in its module docstring;
+  parent spec `strategy-catalogue-and-backtest-validity.md` §4.
+- The regime is `app/services/market_regime.py`: close vs the 200-day SMA for trend, and
+  Bollinger BandWidth at its 126-trading-day extreme for volatility — the published
+  Squeeze/Bulge rule (*Bollinger on Bollinger Bands*, ch. 21), the one #2279 caught being
+  replaced by an invented percentile cut. ⚠ Its boundary conventions are **inherited, not
+  re-decided here**: `close > SMA` classifies equality as bearish and `>= max(window)`
+  classifies a tied Bulge as volatile. Both are frozen in `REGIME_RULE_VERSION`, which
+  S-11's identity hashes, so a future change to either is a new S-11 and not a silent
+  re-reading of this one. Re-opening them is `market_regime`'s ticket, not this one.
+- The permitted-regime SET is the hypothesis under test and is not a free parameter: it is
+  the two cohorts #2840 named, frozen in `S11_PARAMS` and hashed into the identity.
+  Moving it mints a different strategy.
+
+## Identity — the one thing that has to be right
+
+`S11_PARAMS` is written out key by key (no dict merge, so there is no collision to
+resolve): S-4's seven parameters, `permitted_regimes` as a sorted tuple of enum VALUES
+(`s5_support_bounce.py`'s serialisation, because a `frozenset` has no canonical JSON
+form), `regime_rule_version`, and `s4_source_hash`.
+
+⚠⚠ **`s4_source_hash` is the load-bearing member.** This module imports S-4's rule rather
+than copying it, so an edit to `s4_volatility_compression_breakout.py` changes what S-11
+DOES. Without S-4's hash in S-11's params, S-11's own `_source_hash()` would not move and
+the changed rule would silently inherit the old track record. Same reason S-5 hashes
+`LEVEL_RULE_VERSION` and `REGIME_RULE_VERSION` instead of relying on its own file hash.
+
+⚠ **S-11 computes that hash itself from S-4's module path; it does NOT import
+`s4._source_hash`.** That function is private and absent from S-4's `__all__`, and adding
+it there would change S-4's file bytes — i.e. bump the S-4 version, which is exactly the
+orphaning this design exists to avoid. A test asserts the two agree, so the duplicated
+one-line construction cannot drift silently.
+
+## The regime is a declared INPUT, not a body check
+
+`s11_signals` declares the `RegimeSeries` as a `StrategyInput` with
+`reason="missing_market_context"`, last, exactly as `s5_signals` does — and for the reason
+S-6 shipped a bug over: a bar with no benchmark observation must be recorded
+`not_evaluable / missing_market_context`, not silently "did not fire".
+
+⚠ This is why the gate CANNOT be a post-filter over `s4_signals`' output. Filtering the
+returned signal list would collapse "the regime says no" (`not_fired`) and "there is no
+regime" (`not_evaluable`) into the same bar, destroying criterion 8's distinction at the
+last step. Declaring the regime LAST keeps S-4's own OHLC/warm-up refusals taking
+precedence, which is the honest order: a bar S-4 cannot evaluate is not a bar whose regime
+matters.
+
+## Measured premise, corrected
+
+The ticket's headline cohorts are a 4× double-count. Query:
+
+```sql
+SELECT r.ambiguity_arm, r.quarantine_arm, c.regime, c.trade_count, c.expectancy_pct,
+       c.profit_factor, c.expectancy_ci_low_pct, c.expectancy_ci_high_pct
+FROM strategy_result_regime_cohorts c
+JOIN strategy_results_store r ON r.result_id = c.result_id
+WHERE r.strategy_id = 's4-volatility-compression-breakout'
+  AND r.evidence_window_id = 'primary-2022-plus'
+  AND r.result_scope = 'hold_out';
+```
+
+Each `(strategy, evidence_window, result_scope)` carries **four** rows —
+`ambiguity_arm ∈ {best_case, worst_case}` × `quarantine_arm ∈ {masked, admitted}` — which
+are four MEASUREMENTS over one window (`strategy_result.py:488`). They are not four
+disjoint trade sets: `admitted` refuses fewer bars than `masked` and is a SUPERSET of it
+(`research_price_structure_store.py:86-88` — *"`masked` is what every strategy reads and
+is the default everywhere; `admitted` is the sensitivity arm — the same bars with the
+quarantined fields left at their STORED values"*). Summing the four `trade_count`s counts
+every trade up to four times.
+
+`trade_count` in that table is **realised trades** — resolved entries, one row per fill,
+regime attributed at the entry SIGNAL date (`strategy_regime_evidence.py` module
+docstring: *"that is the information the strategy consumed when it decided to fire"*).
+The CI is that module's clustered block bootstrap, clustered by decision date, with the
+block length, resample count and seed stored per cohort row.
+
+`worst_case` ambiguity, both quarantine arms:
+
+| quarantine arm | regime | trades | exp %/trade | PF | 95% CI |
+| --- | --- | ---: | ---: | ---: | --- |
+| masked (default) | bear_volatile | 429 | +2.092 | 1.332 | [−0.668, +4.801] |
+| admitted (sensitivity) | bear_volatile | 508 | +1.261 | 1.196 | [−0.867, +3.540] |
+| masked (default) | bull_volatile | 555 | +0.585 | 1.103 | [−2.489, +3.267] |
+| admitted (sensitivity) | bull_volatile | 811 | **−0.172** | **0.969** | [−2.734, +2.091] |
+
+429 + 508 + 429 + 508 = 1,874 and 555 + 811 + 555 + 811 = 2,732 — the ticket's two counts
+reproduce exactly, which is what identifies the pooling as their source.
+
+Three consequences, all carried into the declaration rather than into this diff:
+
+- the largest independent cohort behind the bear_volatile lead is **508 trades**, not
+  1,874;
+- **bull_volatile flips sign in the sensitivity arm**, so that half of the lead is a claim
+  about the quarantine masking as much as about the regime;
+- both volatile CIs span zero on the default arm, not just the bear one the ticket flags.
+
+The gate is still declared on BOTH volatile regimes. Narrowing it to bear_volatile now
+would be fitting the hypothesis to the hold-out cohort that suggested it.
+
+## ⚠⚠ There is no clean confirmatory corpus window for this hypothesis
+
+#2840's step 4 asks for *"one confirmatory shot on a window the exploration never
+touched"*. Applied honestly, **no stored window qualifies.**
+
+The hypothesis was formed by reading the `primary-2022-plus` hold-out cohorts. Every
+pinned window in the store — `primary-2022-plus` (2022-01-01→2024-09-27), `rolling-36m`
+(2021-09-28→), `rolling-24m` (2022-09-28→), `year-2022`, `year-2023`, `year-2024` — lies
+inside or across that span, so all of them contain the trades that produced the lead. A
+"confirmatory" run on any of them re-reads the data that generated the hypothesis, which
+is the hold-out-becomes-training-data trap #2840 was written to avoid and which the ticket
+records as having already killed the flip idea.
+
+So the design splits differently from the one filed:
+
+- **Exploration** — in-sample pre-2022, using the purged K-fold machinery (#2240/#2823).
+  Never looked at for this hypothesis, so it is legal exploration and it answers the only
+  question worth asking cheaply: does the volatile-regime edge exist at all outside the
+  span that suggested it? A null here kills the candidate for the cost of one run.
+- **Confirmation** — **forward shadow**, not a corpus replay. It is the only instrument
+  whose data did not exist when the hypothesis was formed. This is the same conclusion
+  #2840's own addendum reaches for arms 2/3 (*"the clean instrument is forward paper
+  trading"*); it applies to arm 1 for a different reason (adaptivity rather than cost
+  bands), and the two agree.
+
+This is a correction to the ticket's step 4, stated here rather than quietly implemented.
+It costs nothing today: step 4 was always conditional on step 3 passing.
+
+## Readout and abort bar
+
+Frozen under this contract version, before any look:
+
+- **Report the four cells separately** — {bear_volatile, bull_volatile} ×
+  {masked, admitted} — never a pooled volatile number. A pooled figure is what produced
+  the 4× count above.
+- **A pass needs bear_volatile positive in BOTH quarantine arms.** A result carried by
+  bull_volatile-on-masked alone is a FAIL, because that cell is the one already known to
+  flip sign under the sensitivity arm.
+- **Abort bar on cohort n: 508.** ⚠ This is the largest independent cohort the lead itself
+  rests on, i.e. an upper bound on the evidence available, NOT a power calculation — there
+  is no published floor to cite and inventing one would be the made-up constant the
+  instruction set forbids. It is fixed by construction: an exploration cohort smaller than
+  the cohort that generated the hypothesis cannot be more informative than the hypothesis,
+  so it is reported and NOT read as a verdict either way.
+- **Decision metrics: `expectancy_per_trade_pct`, `profit_factor`, deflated Sharpe.**
+  CAGR, Sharpe, Sortino and win rate are banned as decision metrics
+  (`.claude/skills/quant/cost-aware-viability.md`).
+- **Turnover after gating is measured, not assumed** (#2840 step 5). The gate should cut
+  trade count; if it does not, that is reported as a fail of the stated mechanism even if
+  expectancy improves.
+
+## Sequencing — why the declaration is NOT in this PR
+
+`PreregDeclaration.digest_payload` includes `strategy_version`, and for a MANIFEST
+strategy that string is the identity hash (`result_ledger.py:574` writes
+`identity.strategy_version` on every access row, and declarations are looked up by
+`(strategy_id, strategy_version)`). A declaration frozen on the branch would be
+invalidated by any review comment that touches the module, and `sql/333` bars UPDATE and
+DELETE — recovery would mean a new strategy version and a second charge on the shared
+trial register. Order:
+
+1. **this PR** — the strategy exists, is registered, is tested;
+2. add the `DeclaredTrial` register entry, then freeze the declaration against the merged
+   `strategy_version` (`falsification_only`, under the survivor-only + carry-unmodelled
+   stamps it will run on, which make it structurally unpromotable and therefore a
+   declaration `capital_candidate` would be refused for);
+3. explore on in-sample pre-2022;
+4. forward-shadow confirmation, only if 3 passes.
+
+Steps 2-4 follow `scripts/freeze_2837_se_overlay_declaration.py`'s pattern, including its
+rule that the freeze script is never the script that opens the outcomes.
+
+## Arms 2 and 3
+
+Out of scope here, and not by omission: #2840's addendum states the corpus cannot assign a
+cost band because its prices are split-adjusted, so the nominal-price ≥ $100 gate is a
+bounded sensitivity in backtest and its clean instrument is forward paper. Arm 2 is a
+forward-shadow declaration in its own right and does not need this module to exist first.
+
+## Tests
+
+Pure tier, no DB.
+
+*The rule*
+- S-4 fires + quiet regime → does NOT fire; the same bar + volatile regime → fires.
+- Every one of the four regime values is exercised, so an asymmetric permitted set cannot
+  pass.
+- S-11's fired set is a SUBSET of S-4's over a generated series (the gate can only remove).
+
+*The refusal distinction — the bug this design exists to prevent*
+- `None` regime on a bar S-4 would fire → `not_evaluable / missing_market_context`.
+- `None` regime on a bar S-4 would NOT fire → still `not_evaluable`, never `not_fired`
+  (a short-circuiting implementation gets this wrong).
+- A permitted-but-not-volatile regime → `not_fired`, distinct from the above.
+- Masked OHLC on a permitted volatile bar → S-4's `masked_reason` wins, not the regime's.
+
+*Identity*
+- `S11_PARAMS["s4_source_hash"]` equals S-4's live `_source_hash()` — the drift guard.
+- Changing the S-4 hash changes `s11_identity(...).version` (monkeypatched, so the
+  dependency is proven rather than assumed).
+- Changing the permitted set changes the version.
+- Blank `cost_model_id` is rejected, as on S-4.
+
+*Manifest wiring*
+- The entry is present, non-retired, `per_series`, entry-only, with the S-4 exit regime
+  (40-bar cap, level-based) and BOTH `exit_levels` and `exit_levels_batch` registered.
+- The manifest's signals adapter passes the regime through (a copy of `_s4_signals`, which
+  discards it, would silently un-gate the strategy — asserted directly).
+- Scalar and batch exit levels agree, and equal S-4's for the same request.
+
+*Housekeeping*
+- The #2845 `KEPT` set grows to include `s11-…`, so "the manifest minus the retired eight"
+  stays an exact assertion rather than becoming a stale one.
+
+## What this is not
+
+Not a new TA idea. The standing order forbids another daily-bar variant, and this is not
+one: it is a declared conditioning of an EXISTING measured rule, which is #2840 as filed
+and phase 2 of the R5b queue.

--- a/tests/test_2780_s5_exit_levels_batch.py
+++ b/tests/test_2780_s5_exit_levels_batch.py
@@ -55,6 +55,11 @@ BATCHED = (
     ("s7-trend-pullback", s7_exit_levels_batch, 40),
     ("s8-range-mean-reversion", s8_exit_levels_batch, 40),
     ("s9-squeeze-expansion", s9_exit_levels_batch, 40),
+    #: #2840's S-11 SHARES S-4's factory — its bracket is S-4's, unchanged. It is
+    #: listed separately anyway: the equivalence below runs against the MANIFEST's
+    #: registered adapter, so this row proves S-11's own `_s11_exit_levels` agrees
+    #: with the batch, which S-4's row cannot speak for.
+    ("s11-volatile-regime-gated-breakout", s4_exit_levels_batch, 40),
 )
 
 

--- a/tests/test_2840_volatile_regime_gated_breakout.py
+++ b/tests/test_2840_volatile_regime_gated_breakout.py
@@ -1,0 +1,325 @@
+"""S-11 — S-4 gated to the two volatile regimes (#2840, R5 candidate S-H).
+
+Spec: ``docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md``.
+
+⚠ WHAT IS ACTUALLY AT RISK HERE, AND WHY THE NEGATIVE TESTS DOMINATE.
+Conjoining a gate onto an existing rule is three lines; the things that go wrong
+are all invisible to a test that only asks "did it fire":
+
+* the gate collapsing ``not_evaluable`` into ``not_fired`` — the S-6 bug, and the
+  reason a post-filter over ``s4_signals`` is forbidden;
+* the manifest adapter dropping the regime (``_s4_signals`` does exactly that,
+  deliberately, and copying it would silently un-gate S-11 while every test of
+  the strategy module still passed);
+* S-11's identity not moving when S-4's source moves, since S-11 IMPORTS S-4's
+  rule rather than copying it.
+
+One test each, below, and they are the point of the file.
+
+Pure tier: no database, no fixtures, no IO.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+import app.services.strategies.s4_volatility_compression_breakout as s4_module
+import app.services.strategies.s11_volatile_regime_gated_breakout as s11_module
+from app.services.cost_model import COST_MODEL_ID
+from app.services.indicator_series import BarSeries
+from app.services.market_regime import Regime, RegimeSeries
+from app.services.outcome_resolver import ExitLevels
+from app.services.strategies.s4_volatility_compression_breakout import s4_exit_bracket, s4_signals
+from app.services.strategies.s11_volatile_regime_gated_breakout import (
+    PERMITTED_REGIMES,
+    S11_PARAMS,
+    S11_STRATEGY_ID,
+    s11_exit_bracket,
+    s11_identity,
+    s11_signals,
+)
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_registry import StrategySignal
+from app.services.technical_analysis import OHLCVRow
+
+UNIVERSE = "survivor_only"
+REASON = "quarantined_bar"
+
+#: The bar S-4 fires on in ``_firing_series`` below. Written out rather than
+#: computed, so a fixture that stops firing fails loudly instead of vacuously
+#: passing every "does not fire" assertion in the file.
+FIRING_INDEX = 170
+
+#: ⚠ TRANSCRIBED, not imported. #2840's declared hypothesis is the two volatile
+#: regimes; importing ``PERMITTED_REGIMES`` for the expected value would make the
+#: assertion agree with whatever the module happens to say, including a set
+#: somebody narrowed to ``bear_volatile`` after seeing a result.
+SPEC_PERMITTED = {"bear_volatile", "bull_volatile"}
+
+
+def _bars(closes: Sequence[float | None], half_ranges: Sequence[float]) -> BarSeries:
+    """One bar per close, ``high = close + h``, ``low = close - h``.
+
+    ``None`` is a MASKED bar — every field present and empty, as
+    ``load_masked_series`` produces. Same helper shape as ``test_strategy_s4``'s.
+    """
+    assert len(half_ranges) == len(closes), "half_ranges must align with closes"
+    rows: list[OHLCVRow] = [
+        {
+            "open": None if c is None else Decimal(str(c)),
+            "high": None if c is None else Decimal(str(c + h)),
+            "low": None if c is None else Decimal(str(c - h)),
+            "close": None if c is None else Decimal(str(c)),
+            "volume": 1_000,
+        }  # type: ignore[typeddict-item]
+        for c, h in zip(closes, half_ranges, strict=True)
+    ]
+    start = date(2020, 1, 1)
+    return BarSeries(dates=tuple(start + timedelta(days=i) for i in range(len(closes))), rows=tuple(rows))
+
+
+def _firing_closes() -> tuple[list[float | None], list[float]]:
+    """130 wide-range bars, then 40 compressed flat ones, then a small breakout.
+
+    ⚠ THE BREAKOUT IS DELIBERATELY TINY (100.0 -> 100.2). A large gap would blow
+    up the breakout bar's own true range, and S-4 reads compression at ``t``
+    INCLUDING that bar — so a dramatic-looking fixture never fires and the
+    reason is easy to misread as a broken gate.
+    """
+    closes: list[float | None] = [*(100.0 + (i % 7) for i in range(130)), *([100.0] * 40), *([100.2] * 5)]
+    spans: list[float] = [3.0] * 130 + [0.05] * 45
+    return closes, spans
+
+
+def _firing_series() -> BarSeries:
+    closes, spans = _firing_closes()
+    return _bars(closes, spans)
+
+
+def _regime(n: int, regime: Regime | None, *, holes: tuple[int, ...] = ()) -> RegimeSeries:
+    values: tuple[Regime | None, ...] = tuple(None if i in holes else regime for i in range(n))
+    return RegimeSeries(values=values, not_evaluable_indices=holes)
+
+
+def _verdict_at(signals: Sequence[StrategySignal], index: int) -> tuple[str, str | None]:
+    signal = signals[index]
+    return signal.verdict, signal.reason
+
+
+# --------------------------------------------------------------------- the rule
+
+
+def test_the_fixture_fires_s4_ungated() -> None:
+    """The sentinel. Every negative assertion below is vacuous without it."""
+    series = _firing_series()
+    fired = [
+        s.signal_index for s in s4_signals(series, universe=UNIVERSE, masked_reason=REASON) if s.verdict == "fired"
+    ]
+    assert fired == [FIRING_INDEX]
+
+
+@pytest.mark.parametrize("regime", [Regime.BEAR_VOLATILE, Regime.BULL_VOLATILE])
+def test_a_permitted_regime_lets_the_s4_signal_through(regime: Regime) -> None:
+    series = _firing_series()
+    signals = s11_signals(series, universe=UNIVERSE, masked_reason=REASON, regime=_regime(len(series), regime))
+    assert [s.signal_index for s in signals if s.verdict == "fired"] == [FIRING_INDEX]
+
+
+@pytest.mark.parametrize("regime", [Regime.BEAR_QUIET, Regime.BULL_QUIET])
+def test_a_quiet_regime_suppresses_the_same_bar_as_not_fired(regime: Regime) -> None:
+    """⚠ ``not_fired``, NOT ``not_evaluable``. The bar WAS judged — the regime is
+    known and simply is not one the strategy permits (``RegimeSeries`` docstring:
+    *"spec §0 rule 2 makes firing outside a declared domain the defect"*)."""
+    series = _firing_series()
+    signals = s11_signals(series, universe=UNIVERSE, masked_reason=REASON, regime=_regime(len(series), regime))
+    assert not [s for s in signals if s.verdict == "fired"]
+    assert _verdict_at(signals, FIRING_INDEX) == ("not_fired", None)
+
+
+def test_all_four_regimes_are_exercised_by_the_two_tests_above() -> None:
+    """Guards against an asymmetric permitted set slipping through.
+
+    Without this, a module that permitted only ``bear_volatile`` would still pass
+    one half of each parametrised pair and the file would look green.
+    """
+    assert {r.value for r in Regime} == SPEC_PERMITTED | {"bear_quiet", "bull_quiet"}
+    assert {r.value for r in PERMITTED_REGIMES} == SPEC_PERMITTED
+
+
+def test_s11_fires_on_a_subset_of_s4s_bars() -> None:
+    """The gate can only remove. Checked across all four regimes at once."""
+    series = _firing_series()
+    s4_fired = {
+        s.signal_index for s in s4_signals(series, universe=UNIVERSE, masked_reason=REASON) if s.verdict == "fired"
+    }
+    for regime in Regime:
+        s11_fired = {
+            s.signal_index
+            for s in s11_signals(series, universe=UNIVERSE, masked_reason=REASON, regime=_regime(len(series), regime))
+            if s.verdict == "fired"
+        }
+        assert s11_fired <= s4_fired, f"{regime} produced a signal S-4 did not"
+
+
+# ------------------------------------------------- the refusal distinction (S-6)
+
+
+def test_a_benchmark_hole_on_a_firing_bar_is_missing_market_context() -> None:
+    """The bug this design exists to prevent, stated on the bar that matters."""
+    series = _firing_series()
+    regime = _regime(len(series), Regime.BULL_VOLATILE, holes=(FIRING_INDEX,))
+    signals = s11_signals(series, universe=UNIVERSE, masked_reason=REASON, regime=regime)
+    assert _verdict_at(signals, FIRING_INDEX) == ("not_evaluable", "missing_market_context")
+
+
+def test_a_benchmark_hole_refuses_even_where_s4_would_not_fire() -> None:
+    """⚠ THE ONE A SHORT-CIRCUITING IMPLEMENTATION GETS WRONG.
+
+    A post-filter over ``s4_signals`` — or a body that checks the S-4 predicate
+    before the regime — reports ``not_fired`` here, because S-4's rule already
+    said no. The bar is still one we could not judge.
+    """
+    series = _firing_series()
+    quiet_bar = FIRING_INDEX - 1
+    assert [s for s in s4_signals(series, universe=UNIVERSE, masked_reason=REASON)][quiet_bar].verdict == "not_fired"
+    regime = _regime(len(series), Regime.BULL_VOLATILE, holes=(quiet_bar,))
+    signals = s11_signals(series, universe=UNIVERSE, masked_reason=REASON, regime=regime)
+    assert _verdict_at(signals, quiet_bar) == ("not_evaluable", "missing_market_context")
+
+
+def test_a_masked_ohlc_bar_reports_s4s_reason_not_the_regimes() -> None:
+    """Input ORDER is load-bearing: the regime is declared last, so a bar S-4
+    cannot evaluate is refused for S-4's reason rather than the benchmark's."""
+    closes, spans = _firing_closes()
+    closes[FIRING_INDEX] = None
+    series = _bars(closes, spans)
+    regime = _regime(len(series), Regime.BULL_VOLATILE, holes=(FIRING_INDEX,))
+    signals = s11_signals(series, universe=UNIVERSE, masked_reason=REASON, regime=regime)
+    assert _verdict_at(signals, FIRING_INDEX) == ("not_evaluable", REASON)
+
+
+def test_a_misaligned_regime_series_is_rejected() -> None:
+    series = _firing_series()
+    with pytest.raises(ValueError, match="must align"):
+        s11_signals(
+            series, universe=UNIVERSE, masked_reason=REASON, regime=_regime(len(series) - 1, Regime.BULL_VOLATILE)
+        )
+
+
+def test_an_unknown_masked_reason_is_rejected() -> None:
+    series = _firing_series()
+    with pytest.raises(ValueError, match="unknown reason code"):
+        s11_signals(
+            series,
+            universe=UNIVERSE,
+            masked_reason="not_a_reason",  # type: ignore[arg-type]
+            regime=_regime(len(series), Regime.BULL_VOLATILE),
+        )
+
+
+# ------------------------------------------------------------------- the identity
+
+
+def test_s11_params_carry_s4s_live_source_hash() -> None:
+    """⚠⚠ THE DRIFT GUARD. S-11 imports S-4's rule, so S-4's bytes are part of
+    what S-11 does. Recomputed here by a third construction rather than by
+    calling either module's private helper."""
+    expected = hashlib.sha256(Path(s4_module.__file__).read_bytes()).hexdigest()[:12]
+    assert S11_PARAMS["s4_source_hash"] == expected
+
+
+def test_the_local_close_input_matches_s4s() -> None:
+    """The one helper copied rather than imported — see the module docstring."""
+    series = _firing_series()
+    assert s11_module._close_input(series, universe=UNIVERSE) == s4_module._close_input(series, universe=UNIVERSE)
+
+
+def test_moving_s4s_source_moves_s11s_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Proved, not assumed: without this the params key could be inert."""
+    before = s11_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID).version
+    moved = dict(S11_PARAMS) | {"s4_source_hash": "deadbeefcafe"}
+    monkeypatch.setattr(s11_module, "S11_PARAMS", moved)
+    assert s11_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID).version != before
+
+
+def test_moving_the_permitted_set_moves_the_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    before = s11_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID).version
+    narrowed = dict(S11_PARAMS) | {"permitted_regimes": ("bear_volatile",)}
+    monkeypatch.setattr(s11_module, "S11_PARAMS", narrowed)
+    assert s11_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID).version != before
+
+
+def test_the_permitted_set_is_serialised_canonically() -> None:
+    """A ``frozenset`` has no canonical JSON form; the params must carry a sorted
+    tuple of values, as S-5's do."""
+    assert S11_PARAMS["permitted_regimes"] == ("bear_volatile", "bull_volatile")
+
+
+def test_a_blank_cost_model_id_is_rejected() -> None:
+    with pytest.raises(ValueError, match="cost_model_id"):
+        s11_identity(universe=UNIVERSE, cost_model_id="  ")
+
+
+def test_s11_and_s4_are_distinct_identities() -> None:
+    s11 = s11_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+    s4 = s4_module.s4_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+    assert s11.strategy_id != s4.strategy_id
+    assert s11.version != s4.version
+
+
+# ------------------------------------------------------------------ the manifest
+
+
+def test_the_manifest_entry_is_wired_and_not_retired() -> None:
+    entry = STRATEGY_MANIFEST[S11_STRATEGY_ID]
+    assert entry.strategy_id == S11_STRATEGY_ID
+    assert entry.retired_reason is None, "S-11 exists to produce evidence; retirement forbids that"
+    assert entry.purpose == "harness_validation"
+    assert entry.strategy_class == "per_series"
+    assert entry.signal_kinds == frozenset({"entry"})
+    assert entry.decision_calendar is not None and entry.decision_calendar([]) is None
+    regime = entry.exit_regime(None)
+    assert (regime.signal_pair, regime.level_based, regime.max_hold_bars) == (False, True, 40)
+
+
+def test_the_manifest_adapter_passes_the_regime_through() -> None:
+    """⚠⚠ The un-gating bug. ``_s4_signals`` discards its ``regime`` argument by
+    design; a copy-paste of it here would leave S-11 firing in quiet regimes with
+    every test in the sections above still green, because they call
+    ``s11_signals`` directly."""
+    series = _firing_series()
+    entry = STRATEGY_MANIFEST[S11_STRATEGY_ID]
+    assert entry.signals is not None
+    quiet = entry.signals(
+        series, universe=UNIVERSE, masked_reason=REASON, regime=_regime(len(series), Regime.BULL_QUIET)
+    )
+    volatile = entry.signals(
+        series, universe=UNIVERSE, masked_reason=REASON, regime=_regime(len(series), Regime.BULL_VOLATILE)
+    )
+    assert not [s for s in quiet if s.verdict == "fired"]
+    assert [s.signal_index for s in volatile if s.verdict == "fired"] == [FIRING_INDEX]
+
+
+def test_the_scalar_and_batch_exit_levels_agree_and_equal_s4s() -> None:
+    series = _firing_series()
+    entry_price = Decimal("100.20")
+    entry = STRATEGY_MANIFEST[S11_STRATEGY_ID]
+    assert entry.exit_levels is not None
+    # The manifest adapter raises if scalar and batch disagree, so a clean return
+    # IS the parity assertion; the equality below is the S-4 half.
+    levels = entry.exit_levels(series, signal_index=FIRING_INDEX, entry_price=entry_price, universe=UNIVERSE)
+    target, stop, max_hold = s4_exit_bracket(
+        series, signal_index=FIRING_INDEX, entry_price=entry_price, universe=UNIVERSE
+    )
+    assert levels == ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+    assert s11_exit_bracket(series, signal_index=FIRING_INDEX, entry_price=entry_price, universe=UNIVERSE) == (
+        target,
+        stop,
+        max_hold,
+    )

--- a/tests/test_2845_retired_strategies.py
+++ b/tests/test_2845_retired_strategies.py
@@ -38,7 +38,18 @@ RETIRED = frozenset(
         "s10-relative-strength-leader",
     }
 )
-KEPT = frozenset({"s4-volatility-compression-breakout", "s8-range-mean-reversion"})
+#: ⚠ THREE, not two. s4 and s8 are the survivors of the measured ten (#2827);
+#: s11 is #2840's research seat — S-4's rule gated to the two volatile regimes —
+#: which landed AFTER this retirement and is not one of the ten. It is listed
+#: here rather than excused by loosening the assertion below, so "the manifest
+#: minus the retired eight" stays an exact statement.
+KEPT = frozenset(
+    {
+        "s4-volatility-compression-breakout",
+        "s8-range-mean-reversion",
+        "s11-volatile-regime-gated-breakout",
+    }
+)
 
 
 def _retired_ids() -> frozenset[str]:
@@ -83,7 +94,10 @@ def test_all_ten_stay_in_the_manifest_and_keep_resolving() -> None:
     resolving it, and `/strategies` loses it entirely — the "vanished" outcome the
     acceptance criteria forbid.
     """
-    assert len(STRATEGY_MANIFEST) == 10
+    # ⚠ ELEVEN. The ten stay; #2840's S-11 research seat was added afterwards.
+    # Derived from RETIRED | KEPT rather than restated, so the next addition
+    # updates one place.
+    assert len(STRATEGY_MANIFEST) == len(RETIRED | KEPT) == 11
     assert RETIRED | KEPT == set(STRATEGY_MANIFEST)
     assert set(current_result_versions()) == set(STRATEGY_MANIFEST)
 

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -837,4 +837,6 @@ def test_overview_declares_exactly_the_manifest_strategies_with_exit_adapters_as
         "s8-range-mean-reversion": True,
         "s9-squeeze-expansion": True,
         "s10-relative-strength-leader": False,
+        # #2840's S-11 carries S-4's bracket, so it resolves forward like S-4.
+        "s11-volatile-regime-gated-breakout": True,
     }

--- a/tests/test_audit_2697_metric_axis_ab.py
+++ b/tests/test_audit_2697_metric_axis_ab.py
@@ -66,7 +66,11 @@ def _complete() -> list[dict[str, Any]]:
 def test_complete_exact_head_population_passes_without_reporting_values() -> None:
     report = audit_records(_complete(), candidate_head=_HEAD)
     assert report.failures == ()
-    assert report.comparison_count == 40
+    # ⚠ DERIVED, not the literal 40 it used to be. That figure was
+    # |manifest| x |ambiguity arms| x |quarantine arms| and went stale the moment
+    # #2840 added an eleventh strategy — a hand-written product of three sizes is
+    # exactly the derived statistic the instruction set says to compute or omit.
+    assert report.comparison_count == len(STRATEGY_MANIFEST) * len(AMBIGUITY_ARM_ORDER) * len(QUARANTINE_ARM_ORDER)
     assert report.as_dict()["performance_values_reported"] is False
 
 

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -223,7 +223,13 @@ class TestRunnableStrategies:
         builder regressed and retirement happened to hide it.
         """
         runnable, excluded = runnable_strategies()
-        assert list(runnable) == ["s4-volatility-compression-breakout", "s8-range-mean-reversion"]
+        # ⚠ THREE. #2840's S-11 research seat is deliberately NOT retired — it
+        # exists to produce new evidence, which is what retirement forbids.
+        assert list(runnable) == [
+            "s11-volatile-regime-gated-breakout",
+            "s4-volatility-compression-breakout",
+            "s8-range-mean-reversion",
+        ]
         assert [item.strategy_id for item in excluded] == [
             "s1-time-series-momentum",
             "s10-relative-strength-leader",

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -54,6 +54,11 @@ SPEC_S7 = "s7-trend-pullback"
 SPEC_S8 = "s8-range-mean-reversion"
 SPEC_S9 = "s9-squeeze-expansion"
 SPEC_S10 = "s10-relative-strength-leader"
+#: #2840's research seat (R5 candidate S-H): S-4's rule gated to the two volatile
+#: regimes. ⚠ NOT one of the ten — it landed after the #2845 retirement and is the
+#: reason every "ten" below reads eleven. Written out for the same reason as the
+#: rest: the bridge to the source is ``test_the_spec_ids_are_the_modules_ids``.
+SPEC_S11 = "s11-volatile-regime-gated-breakout"
 
 #: Spec §3's table, verbatim, as ``(signal_pair, level_based, max_hold_bars,
 #: has_rebalance_dates)``. ⚠ Written out for the reason in the module docstring:
@@ -76,6 +81,9 @@ SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
     #: close is entry-set retention — declaring both would close
     #: band-surviving positions a month early (module docstring).
     SPEC_S10: (True, False, None, False),
+    #: S-11's exits ARE S-4's — the gate conditions entry only — so this row is a
+    #: deliberate duplicate of SPEC_S4's, not a copy-paste slip.
+    SPEC_S11: (False, True, 40, False),
 }
 
 #: The legs each strategy emits — §4: S-1 and S-3 have an exit rule, S-2 closes
@@ -91,6 +99,7 @@ SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
     SPEC_S8: frozenset({"entry"}),
     SPEC_S9: frozenset({"entry"}),
     SPEC_S10: frozenset({"entry", "exit"}),
+    SPEC_S11: frozenset({"entry"}),
 }
 
 SPEC_CLASSES: dict[str, str] = {
@@ -104,11 +113,24 @@ SPEC_CLASSES: dict[str, str] = {
     SPEC_S8: "per_series",
     SPEC_S9: "per_series",
     SPEC_S10: "cross_sectional",
+    SPEC_S11: "per_series",
 }
 
 SPEC_PURPOSES = {
     strategy_id: "harness_validation"
-    for strategy_id in (SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4, SPEC_S5, SPEC_S6, SPEC_S7, SPEC_S8, SPEC_S9, SPEC_S10)
+    for strategy_id in (
+        SPEC_S1,
+        SPEC_S2,
+        SPEC_S3,
+        SPEC_S4,
+        SPEC_S5,
+        SPEC_S6,
+        SPEC_S7,
+        SPEC_S8,
+        SPEC_S9,
+        SPEC_S10,
+        SPEC_S11,
+    )
 }
 
 
@@ -183,7 +205,7 @@ class TestManifestIsComplete:
         forever. Pin that it is actually reading the modules it claims to — the
         prevention-log lesson from a probe that matched nothing."""
         declared = self._declared_strategy_ids()
-        assert len(declared) == 10, f"expected the ten catalogue modules, walked {sorted(declared)}"
+        assert len(declared) == 11, f"expected the ten catalogue modules plus #2840's S-11, walked {sorted(declared)}"
         assert declared["s1_time_series_momentum.py"] == SPEC_S1
 
     def test_every_strategy_module_is_registered(self) -> None:
@@ -220,6 +242,7 @@ class TestManifestIsComplete:
             SPEC_S8,
             SPEC_S9,
             SPEC_S10,
+            SPEC_S11,
         }
 
 


### PR DESCRIPTION
## What this is

Phase 2 of the R5b queue (#2437). One new manifest strategy,
`s11-volatile-regime-gated-breakout` — S-4's entry rule conjoined with
`regime ∈ {bear_volatile, bull_volatile}`. That is the whole behavioural change.

Spec: `docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md`.

## The premise was re-measured first, and it moved

#2840's opening paragraph is an inherited conclusion, so per working-order 3b/3c it was
re-run on the full stored population before any code. Query:

```sql
SELECT r.ambiguity_arm, r.quarantine_arm, c.regime, c.trade_count, c.expectancy_pct,
       c.profit_factor, c.expectancy_ci_low_pct, c.expectancy_ci_high_pct
FROM strategy_result_regime_cohorts c
JOIN strategy_results_store r ON r.result_id = c.result_id
WHERE r.strategy_id = 's4-volatility-compression-breakout'
  AND r.evidence_window_id = 'primary-2022-plus'
  AND r.result_scope = 'hold_out';
```

Each `(strategy, evidence_window, result_scope)` carries **four** result rows —
`ambiguity_arm × quarantine_arm` — which `app/services/strategy_result.py:488` defines as
four *measurements* of one window. `admitted` refuses fewer bars than `masked` and is a
superset of it (`research_price_structure_store.py:86-88`), so summing the four
`trade_count`s counts every trade up to 4×.

`worst_case` ambiguity, both quarantine arms:

| quarantine arm | regime | trades | exp %/trade | PF | 95% CI |
| --- | --- | ---: | ---: | ---: | --- |
| masked (default) | bear_volatile | 429 | +2.092 | 1.332 | [−0.668, +4.801] |
| admitted (sensitivity) | bear_volatile | 508 | +1.261 | 1.196 | [−0.867, +3.540] |
| masked (default) | bull_volatile | 555 | +0.585 | 1.103 | [−2.489, +3.267] |
| admitted (sensitivity) | bull_volatile | 811 | **−0.172** | **0.969** | [−2.734, +2.091] |

429+508+429+508 = 1,874 and 555+811+555+811 = 2,732 — the ticket's two counts reproduce
exactly, which identifies the pooling as their source.

**Three corrections, all posted on #2840 and carried into the spec's frozen readout rule,
not into this diff:** the independent cohort behind the lead is 508 trades and not 1,874;
bull_volatile flips sign in the sensitivity arm, so that half of the lead is a claim about
the quarantine masking as much as about the regime; and both volatile CIs span zero on the
default arm, not just the bear one the ticket flags.

The gate is still declared on **both** volatile regimes. Narrowing it to bear_volatile now
would be fitting the hypothesis to the hold-out cohort that suggested it.

## Also corrects #2840's step 4 — there is no clean confirmatory corpus window

The ticket asks for *"one confirmatory shot on a window the exploration never touched"*.
The hypothesis was formed by reading `primary-2022-plus`'s hold-out cohorts, and every
pinned window in the store (`primary-2022-plus`, `rolling-36m`, `rolling-24m`, `year-2022`,
`year-2023`, `year-2024`) lies inside or across that span. None of them qualifies.

So: exploration on in-sample pre-2022 (never looked at for this hypothesis), and
confirmation by **forward shadow** — the only instrument whose data did not exist when the
hypothesis was formed. #2840's own addendum reaches the same conclusion for arms 2/3 on a
different ground (cost bands), and the two agree. Stated rather than quietly implemented;
it costs nothing today because step 4 was always conditional on step 3 passing.

## Why a new strategy id rather than a new S-4 version

#2840 step 1 says "a NEW strategy_version". Editing `s4_volatility_compression_breakout.py`
moves its `_source_hash()` and therefore the S-4 identity, so every stored S-4 row — the
CONTROL — stops being interpretable against the rule it ran under, for a change S-4's own
rule did not undergo. S-4 is left byte-identical.

⚠ That constraint has a consequence worth flagging for review: S-11 needs S-4's file hash
in its own params (it imports S-4's rule, so an S-4 edit changes what S-11 *does*), but
`_source_hash` is private and unexported — and adding it to S-4's `__all__` would itself
change S-4's bytes. S-11 therefore recomputes the one-line construction from S-4's module
path, with `test_s11_params_carry_s4s_live_source_hash` comparing the two by a third
independent construction.

## Why the gate is a declared input, not a body check

`s11_signals` declares the `RegimeSeries` as a `StrategyInput` with
`reason="missing_market_context"`, last, as `s5_signals` does. A post-filter over
`s4_signals`' output would collapse "the regime says no" (`not_fired`) and "there is no
regime" (`not_evaluable`) into one non-firing bar — the distinction criterion 8 exists for,
and the bug S-6 shipped.

Both guards were mutation-checked rather than assumed:

- replacing `_s11_signals` with a copy of `_s4_signals` (which drops its `regime` argument
  by design) → `test_the_manifest_adapter_passes_the_regime_through` FAILS;
- moving the regime out of the declared inputs and into a short-circuited `and` →
  `test_a_benchmark_hole_on_a_firing_bar_is_missing_market_context` and
  `test_a_benchmark_hole_refuses_even_where_s4_would_not_fire` both FAIL.

## What is NOT in this PR, deliberately

**The frozen declaration.** `PreregDeclaration.digest_payload` includes `strategy_version`,
and for a manifest strategy that is the identity hash (`result_ledger.py:574` writes
`identity.strategy_version` on every access row; declarations are looked up by
`(strategy_id, strategy_version)`). A declaration frozen on this branch would be
invalidated by any review comment that touches the module, and `sql/333` bars UPDATE and
DELETE — recovery would mean a new strategy version and a second charge on the shared trial
register. Order is: merge → register entry + freeze (`falsification_only`, following
`scripts/freeze_2837_se_overlay_declaration.py`) → explore → forward-shadow confirmation.

**Arms 2 and 3** (nominal-price band gate). #2840's addendum already states their clean
instrument is forward paper, not a corpus replay, so they do not need this module first.

## Blast radius

`s11` is registered non-retired, so `runnable_strategies()` now returns three ids rather
than two. That is the point — a retired entry produces no new evidence, which is what this
one exists to do. Everything else is the manifest's own completeness machinery reporting
an eleventh member:

| file | why it changed |
| --- | --- |
| `tests/test_strategy_manifest.py` | spec tables (exit regime, signal kinds, class, purpose) + the walk's cardinality. Values transcribed, not imported, per the file's own docstring. |
| `tests/test_2845_retired_strategies.py` | `KEPT` grows to three; the count assertion is now derived from `RETIRED \| KEPT` instead of the literal 10. |
| `tests/test_backtest_run.py` | the runnable list. |
| `tests/test_2780_s5_exit_levels_batch.py` | S-11 added to `BATCHED` — it shares S-4's factory, but the equivalence runs against the MANIFEST's registered adapter, so this row proves `_s11_exit_levels` agrees with the batch, which S-4's row cannot speak for. |
| `tests/test_audit_2697_metric_axis_ab.py` | a hardcoded `40` was `\|manifest\| × \|ambiguity arms\| × \|quarantine arms\|`; now computed. A hand-written product of three sizes is the derived statistic the instruction set says to compute or omit. |
| `app/api/strategies.py` | `_TITLES` + `_PRESENTATION` entries — without them `/strategies/overview` renders the raw id, which `test_every_manifest_strategy_has_operator_readable_presentation` refuses. |

## Security model

Not applicable, and stated rather than left silent: no auth surface, no user input, no SQL,
no broker path. `s11` is a pure per-bar predicate module plus manifest registration; the
only endpoint touched gains two display strings behind the existing
`require_session_or_service_token` dependency.

## Verification

- `uv run ruff check .` / `ruff format --check .` / `uv run pyright` — clean.
- Fast tier `-m "not db"` — clean. `tests/smoke` — clean.
- Full `-m db` tier in 40-file batches — clean except 7 pre-existing failures in
  `test_strategy_monitoring.py` (5) and `test_strategy_control_plane.py` (2), all
  `etoro_instrument_types.description = 'Stocks' resolved to 0 rows`. **Confirmed identical
  on clean `main`** by stashing this branch and re-running the two files: same 7, same
  errors. Not introduced here; noted rather than ticketed per the standing order.
- Mutation checks on the two load-bearing guards, above.
- Codex checkpoint 1 (spec) — 60 findings, of which the two load-bearing ones (the
  confirmatory-window adaptivity and the private `_source_hash` dependency) are fixed in
  the spec and the implementation. Checkpoint 2 (`codex exec review --base origin/main`,
  with the new files staged) — no actionable correctness regressions.

Definition-of-Done clauses 8-12 do not apply: no parser, ETL, schema migration or
ownership/observations data path is touched.

Refs #2840, #2832, #2437
