### PR TITLE
feature(#2840): S-H arm 1's register entry + declaration freeze script

### DIFF
--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -143,7 +143,13 @@ from typing import Final
 #: `harness_validation_only` on all of them, and the bump added a second refusal
 #: code to rows that could not promote anyway. Four earlier versions appear in
 #: the same output, which is what a register that is doing its job looks like.
-TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-22-r8"
+#:
+#: r9 (2026-08-22, #2840) adds S-H arm 1 and was measured the same way. The
+#: command above returned the SAME five (version, purpose) groups — 488 rows,
+#: every one `harness_validation`, and r8 itself carrying none, because nothing
+#: has been backtested since it landed. So r9 strands nothing that could have
+#: promoted either.
+TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-22-r9"
 
 #: #2600 Gate D-0.1. Every search this register counts happened at or before this
 #: instant; the two durable clocks (``strategy_results_store.created_at`` and
@@ -753,6 +759,28 @@ TRIAL_REGISTER: Final = TrialRegister(
             ),
             exactness=TrialExactness.EXACT,
             declared_for=("se-ma-overlay-drawdown-insurance", "se-ma-overlay-drawdown-insurance-v1"),
+        ),
+        DeclaredTrial(
+            trial_id="sh-volatile-regime-gate-2026-08-22",
+            description=(
+                "S-H arm 1: S-4's compression breakout with entry gated to regime in {bear_volatile, "
+                "bull_volatile}. ONE frozen rule read across four cells ({bear,bull} x {masked,admitted}). "
+                "⚠ searches=1 and not 4 — the cells are a fragility screen the pass bar requires jointly "
+                "(bear_volatile positive in BOTH quarantine arms), so no favourable cell is selectable. "
+                "⚠ Narrowing permitted_regimes to bear_volatile after the look would be a DIFFERENT rule: "
+                "the set is hashed into S11_PARAMS, so it mints a new strategy_version and charges this "
+                "register a second time rather than re-reading this entry."
+            ),
+            evidence=(
+                "docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md §'The rule', "
+                "§'Readout and abort bar' and §'Sequencing'; issue #2840"
+            ),
+            exactness=TrialExactness.EXACT,
+            # ⚠ The `survivorship_free` identity, NOT the `survivor_only` one
+            # (`strategy-registry-v1+65274a70a40b`). They are two different
+            # trials: `BACKTEST_UNIVERSE` is `survivorship_free` and that is what
+            # the exploration measures; `survivor_only` is `SCAN_UNIVERSE`.
+            declared_for=("s11-volatile-regime-gated-breakout", "strategy-registry-v1+d5f25fd08376"),
         ),
     ),
 )

--- a/docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md
+++ b/docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md
@@ -184,12 +184,35 @@ Frozen under this contract version, before any look:
 - **A pass needs bear_volatile positive in BOTH quarantine arms.** A result carried by
   bull_volatile-on-masked alone is a FAIL, because that cell is the one already known to
   flip sign under the sensitivity arm.
-- **Abort bar on cohort n: 508.** ⚠ This is the largest independent cohort the lead itself
-  rests on, i.e. an upper bound on the evidence available, NOT a power calculation — there
-  is no published floor to cite and inventing one would be the made-up constant the
-  instruction set forbids. It is fixed by construction: an exploration cohort smaller than
-  the cohort that generated the hypothesis cannot be more informative than the hypothesis,
-  so it is reported and NOT read as a verdict either way.
+- **Abort bar on cohort n: 508 trades — which are 14 DECISION DATES, and the dates are the
+  unit that binds.** ⚠⚠ Corrected before the freeze, from the cohort table's own
+  `decision_date_count` column, which the premise re-measurement above quoted `trade_count`
+  without reading:
+
+  | arm | regime | trade_count | decision_date_count | instrument_count |
+  | --- | --- | ---: | ---: | ---: |
+  | worst_case / masked | bear_volatile | 429 | **14** | 408 |
+  | worst_case / admitted | bear_volatile | 508 | **14** | 485 |
+  | worst_case / masked | bull_volatile | 555 | **18** | 509 |
+  | worst_case / admitted | bull_volatile | 811 | **18** | 739 |
+
+  The regime is a market-wide series, so one regime date fans out across hundreds of
+  instruments and `trade_count` counts the fan-out. `ForwardShadowFloor`'s own docstring
+  names this failure — *"DECISION DATES, NOT SIGNALS … cannot tell twenty signals on one
+  day from twenty days of evidence"*. It is the same defect class as the 4× arm-pooling
+  above, one level down.
+
+  ⚠ The 14 is NOT a property of the outcome: the benchmark chain carries exactly 14
+  `bear_volatile` and 18 `bull_volatile` days inside `primary-2022-plus`
+  (`MarketRegimeProvider.load_research`), so S-4 fired on every volatile date there was
+  and the cohort's date count is the REGIME's date supply, read without opening a result.
+
+  Neither number is a power calculation — there is no published floor to cite for a
+  per-trade expectancy claim and inventing one would be the made-up constant the
+  instruction set forbids. Both are fixed by construction as an upper bound on the
+  evidence available: an exploration cohort thinner than the one that generated the
+  hypothesis cannot be more informative than the hypothesis. They are reported, and NOT
+  read as a verdict either way.
 - **Decision metrics: `expectancy_per_trade_pct`, `profit_factor`, deflated Sharpe.**
   CAGR, Sharpe, Sortino and win rate are banned as decision metrics
   (`.claude/skills/quant/cost-aware-viability.md`).

--- a/scripts/freeze_2840_sh_regime_gate_declaration.py
+++ b/scripts/freeze_2840_sh_regime_gate_declaration.py
@@ -1,0 +1,239 @@
+"""Freeze S-H arm 1's #2599 preregistration declaration. Run ONCE, before outcomes open.
+
+Contract: ``docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md``.
+Refs #2840, #2832. Follows ``scripts/freeze_2837_se_overlay_declaration.py``, whose
+four preamble warnings apply here verbatim and are not restated:
+
+- a declaration frozen by the thing that opens the outcomes declares nothing, so this
+  is a SEPARATE script from the measurement;
+- the freeze is coupled to ``STRUCTURAL_REFUSAL_POLICY_VERSION`` and ``sql/333`` bars
+  UPDATE and DELETE, so ``--dry-run`` first and freeze only when no policy change is
+  in flight;
+- it cannot run before ``sh-volatile-regime-gate-2026-08-22`` is on ``main``, because
+  ``freeze_preregistration`` refuses a declaration no ``DeclaredTrial`` claims;
+- no number below is chosen here.
+
+⚠⚠ THE STRATEGY VERSION IS THE ``survivorship_free`` IDENTITY, AND THAT IS A CHOICE
+BETWEEN TWO REAL TRIALS RATHER THAN A LOOKUP. ``S11.identity(universe=...)`` returns
+``strategy-registry-v1+d5f25fd08376`` for ``survivorship_free`` and
+``strategy-registry-v1+65274a70a40b`` for ``survivor_only``, and declarations key on
+``(strategy_id, strategy_version)`` — so the two universes are two declarations and
+two charges on the shared register. The exploration this declaration authorises runs
+on the research corpus, i.e. ``strategy_result_identity.BACKTEST_UNIVERSE``, which IS
+``survivorship_free``; ``survivor_only`` is ``strategy_signal_scan.SCAN_UNIVERSE`` and
+is not what step 3 measures. Asserted below rather than pasted, so a future change to
+either constant fails loudly instead of freezing the wrong trial.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from typing import Final
+
+import psycopg
+
+from app.config import settings
+from app.services.prereg_contract import ForwardShadowFloor, PreregDeclaration
+from app.services.result_ledger import PreregDeclarationRefused, freeze_preregistration, load_preregistration
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_result import STRUCTURAL_REFUSAL_POLICY_VERSION, structural_promotion_refusals
+from app.services.strategy_result_identity import BACKTEST_UNIVERSE, COST_MODEL_ID
+from scripts._prereg_freeze_guard import assert_policy_version_merged, policy_version_report
+
+STRATEGY_ID: Final = "s11-volatile-regime-gated-breakout"
+CONTRACT_VERSION: Final = "sh-volatile-regime-gate-2026-08-22"
+DECLARED_BY: Final = "scripts/freeze_2840_sh_regime_gate_declaration.py (#2840)"
+
+#: ⚠ COMPUTED from the merged manifest, never pasted. A hand-typed hash that
+#: stopped matching the module would freeze a declaration for a strategy version
+#: that does not exist, and nothing downstream would ever load it.
+STRATEGY_VERSION: Final = (
+    STRATEGY_MANIFEST[STRATEGY_ID].identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+)
+
+# --- The forward-shadow floor's priors. All four are REGIME-SERIES facts. ---
+#
+# ⚠⚠ NONE OF THESE READS AN OUTCOME, WHICH IS THE ONLY REASON THE DERIVATION IS
+# NOT CIRCULAR. They are counts of benchmark days by regime on ``spy_chain_v1``,
+# so they were fixed before any strategy ran on it. Reproduce all four with:
+#
+#   PYTHONPATH=. uv run python -c "
+#   import psycopg, collections; from datetime import date
+#   from app.config import settings
+#   from app.services.market_regime_provider import MarketRegimeProvider
+#   with psycopg.connect(settings.database_url) as c:
+#       c.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+#       m = MarketRegimeProvider.load_research(c)._by_date; c.rollback()
+#   print(min(m), max(m), collections.Counter(v.value if v else None for v in m.values()))
+#   print(collections.Counter(v.value if v else None for d, v in m.items()
+#         if date(2022,1,1) <= d <= date(2024,9,27)))"
+
+#: ``bear_volatile`` benchmark days inside ``primary-2022-plus`` — the entire date
+#: supply behind the pass leg. The cohort table's ``decision_date_count`` for that
+#: cohort is also 14, i.e. S-4 fired on every one of them, which is what lets this
+#: be read off the regime series instead of off the result.
+_WINDOW_BEAR_VOLATILE_DATES: Final = 14
+
+#: The chain's long-run volatile mix, 1993-01-29 → 2026-07-08 (8,391 benchmark days).
+_CHAIN_BEAR_VOLATILE_DAYS: Final = 155
+_CHAIN_BULL_VOLATILE_DAYS: Final = 150
+#: Calendar days spanned by those 8,391 benchmark days — the trading-day → calendar
+#: conversion, taken from the chain itself rather than from a 252-day convention.
+_CHAIN_CALENDAR_DAYS: Final = 12213
+
+_CHAIN_VOLATILE_DAYS: Final = _CHAIN_BEAR_VOLATILE_DAYS + _CHAIN_BULL_VOLATILE_DAYS
+
+#: S-11 fires ONLY in the two volatile regimes, so its decision dates ARE volatile
+#: benchmark days. Supplying ``_WINDOW_BEAR_VOLATILE_DATES`` bear_volatile dates
+#: therefore costs the bull_volatile dates that arrive alongside them at the chain's
+#: own mix — which is why the floor is larger than 14 without any number being picked.
+MIN_FORWARD_DECISION_DATES: Final = math.ceil(
+    _WINDOW_BEAR_VOLATILE_DATES * _CHAIN_VOLATILE_DAYS / _CHAIN_BEAR_VOLATILE_DAYS
+)
+MIN_FORWARD_CALENDAR_WEEKS: Final = math.ceil(
+    MIN_FORWARD_DECISION_DATES * _CHAIN_CALENDAR_DAYS / _CHAIN_VOLATILE_DAYS / 7
+)
+
+#: ⚠ sql/333 caps this column at 1000 characters. The longer reading is the
+#: contract's "Readout and abort bar"; this is the arithmetic plus the limits that
+#: keep it from being read as a power calculation.
+_FORWARD_SHADOW_DERIVATION: Final = (
+    "NOT a power calculation — none is published for a per-trade expectancy claim and none is invented. Fixed BY "
+    "CONSTRUCTION from spy_chain_v1's REGIME series only (no outcome read): primary-2022-plus holds "
+    f"{_WINDOW_BEAR_VOLATILE_DATES} bear_volatile benchmark days, the whole date supply behind the pass leg, and "
+    f"the chain's long-run mix is {_CHAIN_BEAR_VOLATILE_DAYS} bear / {_CHAIN_BULL_VOLATILE_DAYS} bull volatile "
+    f"days over {_CHAIN_CALENDAR_DAYS} calendar days. S-11 fires only in volatile regimes, so dates = ceil("
+    f"{_WINDOW_BEAR_VOLATILE_DATES}x{_CHAIN_VOLATILE_DAYS}/{_CHAIN_BEAR_VOLATILE_DAYS}) = "
+    f"{MIN_FORWARD_DECISION_DATES}; weeks = ceil({MIN_FORWARD_DECISION_DATES}x{_CHAIN_CALENDAR_DAYS}/"
+    f"{_CHAIN_VOLATILE_DAYS}/7) = {MIN_FORWARD_CALENDAR_WEEKS} (~3.1y). Three limits, stated: (1) the bear dates "
+    "are EXPECTED in that span, not assured — volatile regimes CLUSTER (2008, 2020), so arrivals are bursty and "
+    "a quiet 3 years supplies none; (2) the dates are NOT independent (200-SMA and 126-day BandWidth windows "
+    "overlap, and volatile days arrive in runs), so the mix is a long-run average and not an exchangeable "
+    "arrival rate; (3) clearing this floor is necessary and nowhere near sufficient. falsification_only "
+    "regardless, so it gates nothing already ungated."
+)
+
+
+def build_declaration() -> PreregDeclaration:
+    """S-H arm 1's declaration. Every stamp is the run's actual state, read not chosen.
+
+    ⚠ ``survivorship_free`` is the honest basis and is nonetheless UNPROMOTABLE
+    here: ``carry_unmodelled`` because the cost model is
+    ``carry-fx-structural-zero-long-x1-real-usd`` — carry is stamped structurally
+    zero, not modelled — and ``fx_unmodelled`` because the corpus is USD against a
+    GBP account. Both are stamps the run will actually produce, not pessimistic
+    labels.
+
+    ⚠ ``falsification_only`` FOLLOWS from those stamps rather than being chosen: a
+    ``capital_candidate`` purpose over a non-empty recomputed refusal list is
+    exactly what ``ineligible_trial_not_declared_falsification`` refuses.
+    """
+    universe_basis = BACKTEST_UNIVERSE
+    carry_unmodelled = True
+    fx_unmodelled = True
+    return PreregDeclaration(
+        strategy_id=STRATEGY_ID,
+        strategy_version=STRATEGY_VERSION,
+        contract_version=CONTRACT_VERSION,
+        prereg_purpose="falsification_only",
+        structural_refusal_policy_version=STRUCTURAL_REFUSAL_POLICY_VERSION,
+        declared_universe_basis=universe_basis,
+        declared_carry_unmodelled=carry_unmodelled,
+        declared_fx_unmodelled=fx_unmodelled,
+        # ⚠ COMPUTED, never written out. A hand-typed list is a second copy of the
+        # refusal policy that drifts the first time the policy moves.
+        expected_structural_refusals=structural_promotion_refusals(
+            universe_basis=universe_basis, carry_unmodelled=carry_unmodelled, fx_unmodelled=fx_unmodelled
+        ),
+        forward_shadow=ForwardShadowFloor(
+            min_independent_decision_dates=MIN_FORWARD_DECISION_DATES,
+            min_calendar_weeks=MIN_FORWARD_CALENDAR_WEEKS,
+            derivation=_FORWARD_SHADOW_DERIVATION,
+        ),
+        declared_by=DECLARED_BY,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="build and print the declaration and its digest without writing it",
+    )
+    parser.add_argument(
+        "--allow-policy-divergence",
+        action="store_true",
+        help=(
+            "freeze even though this tree's STRUCTURAL_REFUSAL_POLICY_VERSION is not the one on origin/main, "
+            "or that ref could not be refreshed. The override is recorded in the output."
+        ),
+    )
+    args = parser.parse_args(argv)
+    declaration = build_declaration()
+    summary: dict[str, object] = {**declaration.digest_payload, "declaration_sha256": declaration.sha256}
+    if args.dry_run:
+        sys.stdout.write(json.dumps({**summary, **policy_version_report(), "outcome": "dry_run"}, sort_keys=True))
+        sys.stdout.write("\n")
+        return 0
+
+    summary.update(assert_policy_version_merged(allow_divergence=args.allow_policy_divergence))
+    with psycopg.connect(settings.database_url) as conn:
+        try:
+            declaration_id = freeze_preregistration(conn, declaration)
+        except psycopg.errors.UniqueViolation:
+            # ⚠ A bare UniqueViolation is two situations wearing one error, and
+            # they want opposite operator actions — see the #2837 script.
+            conn.rollback()
+            stored = load_preregistration(conn, declaration.strategy_id, declaration.strategy_version)
+            if stored is not None and stored.declaration_sha256 == declaration.sha256:
+                sys.stdout.write(
+                    json.dumps(
+                        {**summary, "outcome": "already_frozen_identical", "declaration_id": stored.declaration_id},
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+                return 0
+            sys.stderr.write(
+                json.dumps(
+                    {
+                        "outcome": "conflicting_declaration_already_frozen",
+                        "stored_declaration_sha256": None if stored is None else stored.declaration_sha256,
+                        "would_have_frozen_sha256": declaration.sha256,
+                        "note": "declarations are immutable; different terms mean a new strategy_version",
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+            return 1
+        except PreregDeclarationRefused as refused:
+            conn.rollback()
+            sys.stderr.write(
+                json.dumps({"outcome": "refused", "refusals": list(refused.refusals)}, sort_keys=True) + "\n"
+            )
+            return 1
+        conn.commit()
+    sys.stdout.write(json.dumps({**summary, "outcome": "frozen", "declaration_id": declaration_id}, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "DECLARED_BY",
+    "MIN_FORWARD_CALENDAR_WEEKS",
+    "MIN_FORWARD_DECISION_DATES",
+    "STRATEGY_ID",
+    "STRATEGY_VERSION",
+    "build_declaration",
+    "main",
+]

--- a/tests/test_2631_freeze_policy_guard.py
+++ b/tests/test_2631_freeze_policy_guard.py
@@ -293,9 +293,10 @@ def test_every_freeze_script_calls_the_guard() -> None:
     scripts = sorted((_REPO_ROOT / "scripts").glob("freeze_*.py"))
     # ⚠ The pin is the point: it fires on a NEW freeze script and makes its
     # author confirm the convention rather than discover it later. It did that
-    # for #2837's S-E declaration (the fourth), which calls the guard and
-    # freezes through the ledger like the other three.
-    assert len(scripts) == 4, f"a new freeze script appeared: {[p.name for p in scripts]}"
+    # for #2837's S-E declaration (the fourth) and again for #2840's S-H arm 1
+    # (the fifth); both call the guard and freeze through the ledger like the
+    # other three.
+    assert len(scripts) == 5, f"a new freeze script appeared: {[p.name for p in scripts]}"
     for path in scripts:
         source = path.read_text()
         # ⚠ THE CALL, NOT THE NAME. A bare substring check is satisfied by the

--- a/tests/test_2829_declaration_trial_binding.py
+++ b/tests/test_2829_declaration_trial_binding.py
@@ -256,9 +256,14 @@ class TestWhatThisChangeDeliberatelyDoesNotMove:
         ``purpose_promotion_refusals`` already returned a terminal
         ``harness_validation_only`` on all of them; the bump added a second
         refusal code to rows that could not promote regardless.
+
+        r9 (2026-08-22, #2840) added S-H arm 1 and had the same conversation on
+        the same command: the five stored ``(version, purpose)`` groups were
+        unchanged at 488 rows, all ``harness_validation``, and r8 itself carried
+        none because nothing has been backtested since it landed.
         """
-        assert TRIAL_REGISTER.declared_count == 275
-        assert len(TRIAL_REGISTER.trials) == 31
+        assert TRIAL_REGISTER.declared_count == 276
+        assert len(TRIAL_REGISTER.trials) == 32
 
     def test_the_declaration_refusal_vocabulary_is_untouched(self) -> None:
         """⚠ The first draft added ``trial_not_in_register`` here. Codex ckpt-1

--- a/tests/test_2840_sh_declaration.py
+++ b/tests/test_2840_sh_declaration.py
@@ -1,0 +1,125 @@
+"""S-H arm 1's register entry and preregistration declaration (#2840 step 2).
+
+Contract: ``docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md``.
+
+Pure tier, no DB. Everything asserted here is a property of the declaration the
+freeze script WOULD write, checked before it writes it — ``sql/333`` bars UPDATE
+and DELETE, so a wrong row is only recoverable by minting a new strategy version
+and charging the shared trial register twice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.prereg_contract import PREREG_PURPOSES
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_result import structural_promotion_refusals
+from app.services.strategy_result_identity import BACKTEST_UNIVERSE, COST_MODEL_ID
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
+from app.services.trial_register import TRIAL_REGISTER, TrialExactness
+from scripts.freeze_2840_sh_regime_gate_declaration import (
+    CONTRACT_VERSION,
+    MIN_FORWARD_CALENDAR_WEEKS,
+    MIN_FORWARD_DECISION_DATES,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    build_declaration,
+)
+
+TRIAL_ID = "sh-volatile-regime-gate-2026-08-22"
+
+#: The regime-series priors the floor is built from, restated here so the test
+#: fails if the script's arithmetic is edited without the derivation moving.
+WINDOW_BEAR_VOLATILE_DATES = 14
+CHAIN_BEAR_VOLATILE_DAYS = 155
+CHAIN_VOLATILE_DAYS = CHAIN_BEAR_VOLATILE_DAYS + 150
+
+
+class TestTheRegisterEntry:
+    def test_the_trial_is_declared_before_any_outcome_is_opened(self) -> None:
+        trial = next(trial for trial in TRIAL_REGISTER.trials if trial.trial_id == TRIAL_ID)
+        assert trial.exactness is TrialExactness.EXACT
+        # ⚠ 1, not 4. The four readout cells are a fragility screen the pass bar
+        # requires jointly, so no favourable cell can be selected between.
+        assert trial.searches == 1
+        assert "2026-08-22-sh-volatile-regime-gated-breakout.md" in trial.evidence
+
+    def test_the_trial_claims_the_declaration_the_freeze_script_writes(self) -> None:
+        """``freeze_preregistration`` refuses a declaration no trial claims."""
+        trial = next(trial for trial in TRIAL_REGISTER.trials if trial.trial_id == TRIAL_ID)
+        assert trial.declared_for == (STRATEGY_ID, STRATEGY_VERSION)
+
+    def test_the_declared_identity_is_the_research_corpus_one(self) -> None:
+        """⚠⚠ The two universes are two trials, and only one is being declared.
+
+        Pasting the wrong hash would freeze a declaration for the scan universe,
+        which is not what the exploration measures — and nothing downstream would
+        report the mismatch, because the row would simply never be loaded.
+        """
+        assert BACKTEST_UNIVERSE == "survivorship_free"
+        assert SCAN_UNIVERSE == "survivor_only"
+        entry = STRATEGY_MANIFEST[STRATEGY_ID]
+        scan_version = entry.identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        assert STRATEGY_VERSION != scan_version
+        assert STRATEGY_VERSION == entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+
+
+class TestTheDeclaration:
+    def test_the_purpose_follows_from_the_stamps_rather_than_being_chosen(self) -> None:
+        declaration = build_declaration()
+        assert declaration.prereg_purpose in PREREG_PURPOSES
+        # A non-empty refusal list is exactly what
+        # `ineligible_trial_not_declared_falsification` refuses a
+        # `capital_candidate` for, so the purpose is forced, not picked.
+        assert declaration.expected_structural_refusals
+        assert declaration.prereg_purpose == "falsification_only"
+
+    def test_the_expected_refusals_are_recomputed_not_transcribed(self) -> None:
+        declaration = build_declaration()
+        assert declaration.expected_structural_refusals == structural_promotion_refusals(
+            universe_basis=declaration.declared_universe_basis,
+            carry_unmodelled=declaration.declared_carry_unmodelled,
+            fx_unmodelled=declaration.declared_fx_unmodelled,
+        )
+
+    def test_the_contract_version_names_a_spec_that_exists(self) -> None:
+        """The contract version names the doc, and the doc is the frozen readout."""
+        assert CONTRACT_VERSION == "sh-volatile-regime-gate-2026-08-22"
+        spec = Path("docs/proposals/ta/2026-08-22-sh-volatile-regime-gated-breakout.md")
+        assert spec.is_file()
+        assert "Readout and abort bar" in spec.read_text(encoding="utf-8")
+
+    def test_the_digest_is_stable_across_builds(self) -> None:
+        assert build_declaration().sha256 == build_declaration().sha256
+
+
+class TestTheForwardShadowFloor:
+    def test_the_floor_supplies_at_least_the_window_s_own_bear_volatile_dates(self) -> None:
+        """⚠ The pass leg is bear_volatile, so THAT is what has to accumulate.
+
+        S-11 fires in both volatile regimes, so a total-date floor only clears the
+        bear leg if the chain's mix carries it there.
+        """
+        expected_bear = MIN_FORWARD_DECISION_DATES * CHAIN_BEAR_VOLATILE_DAYS / CHAIN_VOLATILE_DAYS
+        assert expected_bear >= WINDOW_BEAR_VOLATILE_DATES
+
+    def test_the_floor_is_denominated_in_dates_not_trades(self) -> None:
+        """⚠⚠ 508 trades were 14 decision dates across 485 instruments.
+
+        A floor set from the trade count would be inflated by same-day fan-out —
+        the failure ``ForwardShadowFloor``'s own docstring names.
+        """
+        assert MIN_FORWARD_DECISION_DATES == 28
+        assert MIN_FORWARD_DECISION_DATES < 508
+
+    def test_the_calendar_leg_is_derived_from_the_chain_s_own_span(self) -> None:
+        assert MIN_FORWARD_CALENDAR_WEEKS == 161
+
+    def test_the_derivation_fits_the_column_and_states_its_limits(self) -> None:
+        floor = build_declaration().forward_shadow
+        # sql/333 caps the column at 1000 characters.
+        assert len(floor.derivation) <= 1000
+        assert "NOT a power calculation" in floor.derivation
+        assert str(MIN_FORWARD_DECISION_DATES) in floor.derivation
+        assert str(MIN_FORWARD_CALENDAR_WEEKS) in floor.derivation

--- a/tests/test_trial_register.py
+++ b/tests/test_trial_register.py
@@ -23,7 +23,7 @@ def _trial(trial_id: str, exactness: TrialExactness = TrialExactness.EXACT) -> D
 
 class TestTheShippedDeclaration:
     def test_the_register_is_stamped_with_its_version(self) -> None:
-        assert TRIAL_REGISTER.version == TRIAL_REGISTER_VERSION == "trial-register-2026-08-22-r8"
+        assert TRIAL_REGISTER.version == TRIAL_REGISTER_VERSION == "trial-register-2026-08-22-r9"
 
     def test_every_declared_trial_carries_its_evidence(self) -> None:
         """⚠ An entry nobody can trace is indistinguishable from one invented."""
@@ -70,10 +70,11 @@ class TestTheShippedDeclaration:
         """
         # ⚠ 259 (#2600's Gate D-0.1 reconstruction) + 7 (#2614's C-4 entry) +
         # 6 S-5..S-10 declarations + 2 MT-1 controlled pairs + 1 S-E overlay
-        # (#2837, r8). Moved deliberately, not loosened: the pin exists to catch
-        # a DROPPED entry, and an addition that raises M is the conservative
-        # direction — a larger M lowers the DSR.
-        assert TRIAL_REGISTER.declared_count == 275
+        # (#2837, r8) + 1 S-H arm 1 (#2840, r9). Moved deliberately, not
+        # loosened: the pin exists to catch a DROPPED entry, and an addition
+        # that raises M is the conservative direction — a larger M lowers the
+        # DSR.
+        assert TRIAL_REGISTER.declared_count == 276
         assert TRIAL_REGISTER.declared_count == sum(trial.searches for trial in TRIAL_REGISTER.trials)
 
     def test_the_two_mt1_controlled_pairs_are_charged_before_outcomes(self) -> None:


### PR DESCRIPTION
Step 2 of #2840 — the declaration substrate. Step 1 (`s11-volatile-regime-gated-breakout`) merged as `91db5daa`.

## What changed

1. **`sh-volatile-regime-gate-2026-08-22` joins the trial register** (`searches=1`, `EXACT`, `TRIAL_REGISTER_VERSION` → `r9`). `freeze_preregistration` refuses a declaration no `DeclaredTrial` claims, so this has to be on `main` before the freeze runs.
2. **`scripts/freeze_2840_sh_regime_gate_declaration.py`** — a separate script from the measurement, per `freeze_2837_se_overlay_declaration.py`'s rule that a declaration frozen by the thing that opens the outcomes declares nothing.
3. **The spec's frozen abort bar is corrected before it freezes** (see below).
4. Two deliberate count pins moved (`test_2829`: 275/31 → 276/32; `test_2631`: 4 → 5 freeze scripts). Both are tripwires designed to force this conversation; neither was loosened.

## The correction: 508 trades are 14 decision dates

The premise re-measurement on the issue quoted `strategy_result_regime_cohorts.trade_count` and never read the `decision_date_count` column sitting beside it. Measured:

| arm | regime | trade_count | decision_date_count | instrument_count |
| --- | --- | ---: | ---: | ---: |
| worst_case / masked | bear_volatile | 429 | **14** | 408 |
| worst_case / admitted | bear_volatile | 508 | **14** | 485 |
| worst_case / masked | bull_volatile | 555 | **18** | 509 |
| worst_case / admitted | bull_volatile | 811 | **18** | 739 |

The regime is a market-wide series, so one regime date fans out across hundreds of instruments. This is the same defect class as the 4× `ambiguity_arm × quarantine_arm` pooling step 1 caught, one level down — and `ForwardShadowFloor`'s own docstring names it: *"DECISION DATES, NOT SIGNALS … cannot tell twenty signals on one day from twenty days of evidence."*

The spec is append-only **from the moment the freeze runs**, and it has not run, so this correction lands now or never.

## The forward-shadow floor, and why it is not circular

Derived from the **regime series only** — no outcome is read:

- `primary-2022-plus` holds exactly **14 `bear_volatile`** and **18 `bull_volatile`** benchmark days (`MarketRegimeProvider.load_research`). Those match the cohorts' `decision_date_count` exactly, i.e. S-4 fired on every volatile date there was — which is what lets the date supply be read off the benchmark rather than off the result.
- `spy_chain_v1`'s long-run mix: 155 bear / 150 bull volatile days over 8,391 benchmark days spanning 12,213 calendar days (1993-01-29 → 2026-07-08).
- S-11 fires **only** in volatile regimes, so its decision dates *are* volatile benchmark days. `dates = ceil(14 × 305/155) = 28`; `weeks = ceil(28 × 12213/305/7) = 161` (~3.1y).

Not a power calculation, and the derivation string says so plus its three limits (volatile regimes cluster, so arrivals are bursty; the dates are not independent; clearing the floor is necessary and nowhere near sufficient).

## Identity — the choice that had to be made

`S11.identity(universe=…)` gives two different versions, and declarations key on `(strategy_id, strategy_version)`, so they are **two trials**:

| universe | version |
| --- | --- |
| `survivorship_free` (`BACKTEST_UNIVERSE`) | `strategy-registry-v1+d5f25fd08376` ← declared |
| `survivor_only` (`SCAN_UNIVERSE`) | `strategy-registry-v1+65274a70a40b` |

The exploration runs on the research corpus, so `survivorship_free` is the one declared. ⚠ The spec's sequencing section said "survivor-only"; that was wrong and the handoff comment on #2840 already corrected it. The script **computes** the hash from the merged manifest rather than pasting it, and a test asserts it differs from the scan-universe one.

`prereg_purpose` is `falsification_only` and is not a choice: `structural_promotion_refusals('survivorship_free', carry=True, fx=True)` returns `('carry_unmodelled', 'fx_unmodelled')`, and a `capital_candidate` over a non-empty refusal list is what `ineligible_trial_not_declared_falsification` refuses.

## The r9 bump, measured not argued

The command in `TRIAL_REGISTER_VERSION`'s own note returned the same five `(version, purpose)` groups — 488 DSR rows, every one `harness_validation` (already terminally refused by `purpose_promotion_refusals`), and r8 itself carrying none because nothing has been backtested since it landed. So r9 strands nothing that could have promoted.

## Verification

- `uv run ruff check .` / `ruff format --check` / `uv run pyright` — clean.
- Pre-push gate (fast tier + smoke + chokepoint lints) green on `fe30a386`.
- `codex exec review --base origin/main` (staged, so the new files were visible) — no findings.
- `--dry-run` output verified: `policy_version_matches_main: true`, `strategy_version: strategy-registry-v1+d5f25fd08376`, `expected_structural_refusals: [carry_unmodelled, fx_unmodelled]`, `min_independent_decision_dates: 28`, `min_calendar_weeks: 161`. **Nothing was frozen** — the register entry is not on `main` yet, which is exactly what would refuse it.

## Security model

Not applicable: no auth surface, no user input, no SQL built from anything user-controlled. The one DB write this adds is an append-only INSERT through `freeze_preregistration`, gated by `sql/333`, and it is not executed by this PR.

## Follow-up (not in this PR)

After merge: run `PYTHONPATH=. uv run python -m scripts.freeze_2840_sh_regime_gate_declaration --dry-run`, confirm `policy_version_matches_main`, then freeze. Steps 3 (explore, in-sample pre-2022) and 4 (forward shadow) follow.

Refs #2840
