### PR TITLE
feature(#2833): the cost lane names the instrument's own currency, not just the order's

### DIFF
--- a/app/services/cost_model.py
+++ b/app/services/cost_model.py
@@ -66,6 +66,20 @@ from typing import Literal, get_args
 #: are UNCHANGED from v2 — what changed is what the model claims about carry
 #: and FX, and the module rule (a change to what is charged is a new model)
 #: applies to a claim exactly as it does to a number.
+#:
+#: ⚠ #2833 DELIBERATELY DID NOT MOVE THIS, and the reasoning is recorded here
+#: because it is the obvious objection. That change added
+#: ``CostLane.instrument_denomination`` and an import guard, so a reviewer can
+#: fairly say "the same id now admits a narrower set of lanes". It does — but
+#: the set of PRICED POSITIONS is identical, because the docstring above
+#: already named the lane as a "USD-quoted universe" and ``FX_EVIDENCE`` leg 2
+#: already asserted it full-population. Nothing was charged differently, no
+#: stored result changes meaning, and the lane is a module constant no caller
+#: constructs, so the domain that narrowed is the space of future SOURCE EDITS
+#: rather than of runs. Moving the id would rehash every strategy version to
+#: announce a change that did not happen, which is its own false signal.
+#: The line: a claim moves the id (#2720); ENFORCING a claim already made does
+#: not.
 COST_MODEL_ID = "static-p75-insession-v3+split-adjusted-max+carry-fx-structural-zero-long-x1-real-usd"
 
 #: Whether a price can honestly select a nominal-price spread band.  The
@@ -132,7 +146,9 @@ CALIBRATION_LIMITS: tuple[str, ...] = (
     "carry is structurally zero for the declared lane ONLY (long x1 real-settlement USD); any other lane"
     " — short, leveraged, CFD-resolved, non-USD — is UNPRICED, not free",
     "FX is structurally zero for the same lane; the account currency is measured on the configured demo"
-    " account (account_equity_evidence), not proven for any other account",
+    " account (account_equity_evidence), not proven for any other account, and the lane's"
+    " instrument_denomination is USD — a non-USD-denominated instrument converts on unit sizing and is"
+    " outside this model however small the fee",
     "the backtest ASSUMES real-settlement fills: eToro resolves some non-leveraged buys as CFDs,"
     " historical resolution is unobservable, and the order path closes this only forward"
     " (settlementType is an assertion the platform rejects on mismatch)",
@@ -168,6 +184,14 @@ class CostLane:
     settlement: str
     order_currency: str
     account_currency: str
+    #: The currency the INSTRUMENT ITSELF is denominated in — a third currency,
+    #: not implied by the other two. #2833 is the case that needed it: an eToro
+    #: order for a GBP-denominated LSE UCITS ETF is still placed with
+    #: ``orderCurrency: usd`` from a USD account, so ``order_currency`` and
+    #: ``account_currency`` are both USD while a conversion event DOES occur.
+    #: Without this field the lane cannot state the difference and a non-USD
+    #: sleeve would inherit an FX closure measured on an all-USD path.
+    instrument_denomination: str
 
 
 #: Matches, field for field, what ``EtoroBrokerProvider.place_demo_strategy_order``
@@ -175,12 +199,20 @@ class CostLane:
 #: ``settlementType: real``, ``orderCurrency: usd``) and what
 #: ``BrokerStrategyOrder`` refuses at type level (``settlement_type`` is
 #: ``Literal["real"]``). Held together by test, not by import.
+#:
+#: ⚠ ``instrument_denomination`` is the one field with NO counterpart on the
+#: wire — the order payload never states it. It comes from the calibration
+#: population instead (``FX_EVIDENCE`` leg 2: the validated universe is
+#: uniformly USD-quoted), which is exactly why it has to be written down here:
+#: an unstated property of the population is the one a later consumer silently
+#: assumes still holds.
 STRUCTURAL_ZERO_LANE = CostLane(
     direction="long",
     leverage=1,
     settlement="real",
     order_currency="USD",
     account_currency="USD",
+    instrument_denomination="USD",
 )
 
 #: ⚠ The evidence a structural-zero claim stands on, DATED, one tuple per
@@ -269,7 +301,21 @@ def _check_closures() -> None:
     - the single lane is unleveraged and long: leverage above x1 is a CFD and a
       short accrues financing by construction (risk posture,
       ``.claude/CLAUDE.md``), so EITHER edit needs a new model, not this one
-      relabelled.
+      relabelled;
+    - an FX ``structural_zero`` names ONE currency in all three positions.
+      ``FX_CLOSURE`` says no conversion event OCCURS, which is a claim about
+      three currencies and not two: order, account AND the instrument's own
+      denomination. #2833's beta-sleeve candidates are the case that separates
+      them — CSPX.L / IUSA.L / IUMO.L / IUQA.L / R1VL.L are stored
+      ``instruments.currency = 'GBP'`` yet their eligibility proofs answer
+      ``response_currency = 'usd'`` from a USD account, so order and account
+      currency alone read exactly as an all-USD path does and cannot tell the
+      two apart. eToro's Cost & Charges worked examples size a non-USD
+      instrument through the GBP→USD rate, so on that lane a conversion is part
+      of the arithmetic; whether it carries a cost is a SEPARATE and open
+      question, and "structurally zero" is the one answer it cannot have. The
+      honest closure there is ``unmodelled`` — which this guard leaves
+      available and only refuses to let anyone skip.
 
     The guard is at IMPORT for the reason ``_check_bands_are_total`` is: these
     are edits somebody makes to the literals above, so the check belongs beside
@@ -298,6 +344,19 @@ def _check_closures() -> None:
             "and leverage above x1 is a CFD, both accrue financing by construction; that lane needs a NEW "
             "cost model, never this one relabelled."
         )
+    if FX_CLOSURE == "structural_zero":
+        currencies = {
+            "order_currency": STRUCTURAL_ZERO_LANE.order_currency,
+            "account_currency": STRUCTURAL_ZERO_LANE.account_currency,
+            "instrument_denomination": STRUCTURAL_ZERO_LANE.instrument_denomination,
+        }
+        if len(set(currencies.values())) != 1:
+            raise ValueError(
+                f"FX_CLOSURE is structural_zero but the lane names more than one currency ({currencies}) — "
+                "'no conversion event occurs' is a claim about all three, and a differing instrument "
+                "denomination means the event happens whatever it costs. That lane needs a NEW cost model "
+                "with a measured or documented FX component and a new COST_MODEL_ID, never this one relabelled."
+            )
 
 
 _check_closures()

--- a/tests/test_cost_model.py
+++ b/tests/test_cost_model.py
@@ -68,7 +68,7 @@ SPEC_COST_MODEL_ID = "static-p75-insession-v3+split-adjusted-max+carry-fx-struct
 #: ``test_the_order_payload_is_the_cost_model_lane`` captures that payload
 #: independently, so an executor change that leaves the lane fails there and a
 #: lane change that leaves the executor fails here.
-SPEC_LANE = ("long", 1, "real", "USD", "USD")
+SPEC_LANE = ("long", 1, "real", "USD", "USD", "USD")
 
 
 class TestTheFrozenTable:
@@ -293,6 +293,7 @@ class TestTheStructuralClosure:
             lane.settlement,
             lane.order_currency,
             lane.account_currency,
+            lane.instrument_denomination,
         ) == SPEC_LANE
 
     def test_the_lane_account_currency_matches_the_deployment_currency(self) -> None:
@@ -356,12 +357,40 @@ class TestTheStructuralClosure:
         needs a NEW cost model, never this one relabelled."""
         with pytest.raises(ValueError, match="must be long and unleveraged"):
             with mock.patch.object(
-                cost_model, "STRUCTURAL_ZERO_LANE", cost_model.CostLane("short", 1, "cfd", "USD", "USD")
+                cost_model, "STRUCTURAL_ZERO_LANE", cost_model.CostLane("short", 1, "cfd", "USD", "USD", "USD")
             ):
                 cost_model._check_closures()
         with pytest.raises(ValueError, match="must be long and unleveraged"):
             with mock.patch.object(
-                cost_model, "STRUCTURAL_ZERO_LANE", cost_model.CostLane("long", 2, "cfd", "USD", "USD")
+                cost_model, "STRUCTURAL_ZERO_LANE", cost_model.CostLane("long", 2, "cfd", "USD", "USD", "USD")
+            ):
+                cost_model._check_closures()
+
+    def test_the_closure_guard_refuses_a_non_usd_instrument_on_a_usd_path(self) -> None:
+        """⚠⚠ THE #2833 HOLE. The beta-sleeve candidates (CSPX.L, IUSA.L,
+        IUMO.L, IUQA.L, R1VL.L) are stored ``instruments.currency = 'GBP'`` and
+        their eligibility proofs answer ``response_currency = 'usd'`` from a USD
+        account — so order and account currency BOTH read USD while a
+        conversion event happens on unit sizing. Under the pre-#2833 lane
+        (order + account only) that sleeve inherits an FX ``structural_zero``
+        measured on an all-USD universe, silently and with every test green.
+
+        The discriminating case is the mixed one: same order and account
+        currency, different instrument denomination."""
+        with pytest.raises(ValueError, match="names more than one currency"):
+            with mock.patch.object(
+                cost_model, "STRUCTURAL_ZERO_LANE", cost_model.CostLane("long", 1, "real", "USD", "USD", "GBP")
+            ):
+                cost_model._check_closures()
+
+    def test_the_currency_guard_is_scoped_to_a_structural_zero_claim(self) -> None:
+        """An ``unmodelled`` FX closure claims nothing about conversion, so a
+        mixed-currency lane is not a contradiction there — it is the honest
+        state. Guarding it regardless would refuse the very lane a non-USD
+        sleeve has to declare on its way to measuring the fee."""
+        with mock.patch.object(cost_model, "FX_CLOSURE", "unmodelled"):
+            with mock.patch.object(
+                cost_model, "STRUCTURAL_ZERO_LANE", cost_model.CostLane("long", 1, "real", "USD", "USD", "GBP")
             ):
                 cost_model._check_closures()
 
@@ -456,6 +485,22 @@ class TestTheImportTimeGuardsActuallyRun:
 
         assert result.returncode != 0
         assert "must be long and unleveraged" in result.stderr
+
+    def test_a_non_usd_instrument_denomination_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
+        """⚠ #2833's half, and the reason it needs the subprocess arm too: the
+        edit this guards is somebody pointing the lane at a GBP-denominated
+        UCITS ETF because its eligibility proof answered ``usd``. Order and
+        account currency both still read USD, so nothing else in the module
+        objects — only the three-way comparison does, and only the module-level
+        call reaches it."""
+        result = self._run_with_substitution(
+            tmp_path,
+            '    instrument_denomination="USD",',
+            '    instrument_denomination="GBP",',
+        )
+
+        assert result.returncode != 0
+        assert "names more than one currency" in result.stderr
 
     def test_empty_carry_evidence_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
         """The evidence half, same reasoning: only the module-level call sees it."""


### PR DESCRIPTION
## What changed

`CostLane` gains a sixth field, `instrument_denomination`, set to `"USD"` on `STRUCTURAL_ZERO_LANE`; `_check_closures` refuses an FX `structural_zero` whose three currencies are not all the same. Two files, no schema, no migration, nothing charged differently.

## Why — #2833 step 3, and what researching it turned up

#2833's remaining step 3 is *"add the documented GBP→USD conversion fee for our tier"*. Researching it produced two results, and the second is the one that needed code.

**1. The documented fee's trigger does not fire on our path.** eToro's conversion-fee page scopes the charge to *"Trading assets using funds from your **local currency** account when the asset is denominated in a different currency"* ([source](https://www.etoro.com/trading/fees/conversion/)). Our account is USD (`account_currency_id = 1`, `account_equity_evidence`, #2698), not a local-currency eToro Money balance. And eToro's own Cost & Charges worked examples state, under the Single Stocks/ETFs notes, *"No FX mark up applies when converting non-USD denominated assets for unit amount purposes"* — its Barclays (GBX-quoted LSE) example sizes the position as `1,000 USD / ((135.50 GBX / 100) * 1.22219 [GBP to USD rate])` with only spread and commission cost rows, no conversion-fee row ([PDF](https://www.etoro.com/wp-content/uploads/2024/01/Cost-and-Charges-examples-table.pdf)).

⚠ **That is narrower than "FX is free", and the difference is the whole point of this PR.** "No FX mark up … for unit amount purposes" is scoped to sizing. It says nothing about a spread embedded in the applied rate, the close leg, dividends, or corporate actions. So the documented markup on the entry sizing is nil, and the lane's FX cost is still **unmeasured**.

**2. The model could not express that, because the lane named only two currencies.** Measured on `strategy_core_eligibility_proofs` (latest proof per instrument, dev DB):

| symbol | id | `instruments.currency` | proof verdict | `response_currency` |
| --- | ---: | --- | --- | --- |
| SPY.RTH | 3417 | USD | underlying / real / [1] | usd |
| QQQ.RTH | 3418 | USD | underlying / real / [1] | usd |
| CSPX.L | 3434 | GBP | underlying / real / [1] | usd |
| IUSA.L | 3075 | GBP | underlying / real / [1] | usd |
| IUMO.L | 15445 | GBP | underlying / real / [1] | usd |
| IUQA.L | 15446 | GBP | underlying / real / [1] | usd |
| R1VL.L | 14465 | GBP | underlying / real / [1] | usd |
| QDVA/QDVB/QDVI.DE | 2942/3/5 | EUR | underlying / real / [1] | usd |

Every proof answers `usd` — including the GBP- and EUR-denominated ones. So on a non-USD candidate, `order_currency` and `account_currency` both read USD and the lane is **bit-identical to an all-USD path**. `FX_CLOSURE = "structural_zero"` asserts that no conversion event *occurs*; that is a claim about three currencies, and `CostLane` carried two. A #2834 ARM A sleeve built on IUMO.L/IUQA.L/R1VL.L would have inherited an FX closure whose evidence reads *"validated universe uniformly USD-quoted"*, silently, with every test green.

This is the shape the prevention log already records at the executor's currency checks (*"widen the set to `{"USD","GBP"}` and a GBP-quoted response satisfies membership against a USD deployment"*) arriving one layer down, through a missing field instead of a widened set.

## The guard is scoped to the `structural_zero` claim only

`unmodelled` with a mixed-currency lane is not a contradiction — it is the honest state, and it is the lane a non-USD sleeve has to declare on its way to measuring the fee. Refusing it would block #2834 ARM A rather than protect it. `test_the_currency_guard_is_scoped_to_a_structural_zero_claim` pins that.

## COST_MODEL_ID deliberately unchanged

Raised by Codex at checkpoint 2 and worth stating, since the module's rule is deliberately strict (*"a change to what the model claims … applies to a claim exactly as it does to a number"*). The argument for moving it: the same id now admits a narrower set of lanes. The argument against, which is the one taken:

- the set of **priced positions** is identical — the module docstring already named the lane as a *"USD-quoted universe"* and `FX_EVIDENCE` leg 2 already asserted it full-population and re-asserts it per run at the stamping site;
- nothing is charged differently and no stored result changes meaning;
- `STRUCTURAL_ZERO_LANE` is a module constant no caller constructs, so what narrowed is the space of future **source edits**, not of runs;
- moving the id rehashes every strategy version to announce a change that did not happen.

The line: a claim moves the id; *enforcing* a claim already made does not. Recorded in the constant's own comment so it is not re-litigated.

## What this does NOT do

- Leaves #2833's pass bar open. Steps 1/2/4 remain on the five-trading-day quote clock; this touches none of them.
- Does not add a `no_fx_markup` closure member. #2720 deleted `FX_BPS` rather than zeroing it precisely so no dormant scalar exists to set; a third closure value ships **with** arithmetic that uses it, not before.

## Security

No security surface. No new input, no query, no credential path, no endpoint.

## Verification

| check | result |
| --- | --- |
| `uv run ruff check .` | exit 0 |
| `uv run ruff format --check .` | exit 0 (1561 files) |
| `uv run pyright` | 0 errors, 0 warnings |
| `uv run pytest tests/test_cost_model.py tests/test_position_costing.py tests/test_broker_provider.py` | exit 0 |
| pre-push hook (fast tier + smoke + chokepoint lints) | green at `4381502b` |
| Codex ckpt-2 (`review --base origin/main`, files staged) | no findings |

New tests, all at `4381502b`:
- `test_the_closure_guard_refuses_a_non_usd_instrument_on_a_usd_path` — the discriminating case: same order and account currency, different denomination. Fails under the pre-change five-field lane.
- `test_the_currency_guard_is_scoped_to_a_structural_zero_claim` — `unmodelled` + mixed currencies imports fine.
- `test_a_non_usd_instrument_denomination_fails_the_import_itself` — the subprocess arm, matching the existing guard tests: the module will not load, so the maintainer making that edit is stopped whether or not they run this file.

ETL/parser/schema clauses 8–12 do not apply — no ETL, parser, ingest or migration is touched.

## ⚠ One incidental, not investigated and not in scope

`CSPX.L` stores `instruments.currency = 'GBP'` with a latest quote of `827.40`, which is implausible as GBX (£8.27) and plausible as USD; `IUSA.L`'s `5613.75` is plausible as GBX. So `instruments.currency` on LSE lines may be venue-derived rather than per-instrument. It does not affect this PR — the guard compares the lane's declared denomination, and either reading puts these instruments outside the priced lane — but it is worth one query before the sleeve trusts a per-instrument denomination.

Refs #2833. Refs #2834. Part of #2832.

