### PR TITLE
fix(#2833): the five-day spread sample needs a store that accumulates

### DIFF
--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -97,6 +97,10 @@ class EtoroMarketDataProvider(MarketDataProvider):
             bars = provider.get_daily_candles(12345, lookback_days=400)
     """
 
+    #: One upstream rates request per this many ids — see the base class.
+    #: Callers that need get_quotes to be all-or-nothing split by this.
+    quote_batch_size = _RATES_BATCH_SIZE
+
     def __init__(self, api_key: str, user_key: str, env: str = "demo") -> None:
         self._api_key = api_key
         self._user_key = user_key

--- a/app/providers/market_data.py
+++ b/app/providers/market_data.py
@@ -177,6 +177,21 @@ class MarketDataProvider(ABC):
     v1 implementation: EtoroMarketDataProvider
     """
 
+    #: Largest id list ``get_quotes`` sends in ONE upstream request.
+    #:
+    #: ⚠ This exists so a caller can make ``get_quotes`` all-or-nothing.
+    #: Implementations chunk internally and may return the chunks that
+    #: SUCCEEDED while dropping one that failed, so a missing id is
+    #: ambiguous — genuinely unquoted, or lost to a transport fault. A
+    #: caller that needs the difference (evidence lanes, where recording a
+    #: transport failure as "no quote" is a false observation) must split
+    #: its own ids by this value: one call is then exactly one upstream
+    #: request, which either returns or raises.
+    #:
+    #: Default 1 is the safe floor for any implementation that does not
+    #: document its batching — one id per request is trivially determinate.
+    quote_batch_size: int = 1
+
     @abstractmethod
     def get_tradable_instruments(self) -> list[InstrumentRecord]:
         """Return the full list of currently tradable instruments."""

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -11,13 +11,19 @@ import logging
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 import psycopg
 from psycopg.rows import dict_row
 
 from app.providers.market_data import MarketDataProvider, OHLCVBar, Quote
+from app.services.strategy_core_quote_observation import (
+    normalise_quote as normalise_core_quote,
+)
+from app.services.strategy_core_quote_observation import (
+    record_core_quote_observation,
+)
 from app.services.sync_orchestrator.exception_classifier import classify_exception
 from app.services.sync_orchestrator.layer_types import FailureCategory, UpstreamUnreachableError
 from app.services.sync_orchestrator.progress import report_progress
@@ -300,6 +306,11 @@ class QuoteRefreshSummary:
     # Swallowing it into a bare bool would force the job to either report
     # success or invent a category (#2271, Codex round 2).
     batch_error: Exception | None = None
+    # Rows written to ``strategy_core_quote_observations`` this tick (#2833
+    # step 2). Reported rather than left implicit so the lane cannot become a
+    # writer with no reader: a candidate cohort that silently stops accruing
+    # would otherwise look identical to one whose bar is still forming.
+    core_observations_written: int = 0
 
 
 def refresh_quotes(
@@ -308,6 +319,7 @@ def refresh_quotes(
     instruments: list[tuple[int, str]],
     *,
     max_spread_pct: Decimal = DEFAULT_MAX_SPREAD_PCT,
+    observe_instrument_ids: frozenset[int] | None = None,
 ) -> QuoteRefreshSummary:
     """Batch-fetch quotes for *instruments* and upsert each one.
 
@@ -326,6 +338,15 @@ def refresh_quotes(
     Per-instrument upsert failures are logged and skipped; a failure of the
     batch fetch itself aborts the whole set and is reported as
     ``batch_failed`` rather than silently reading as "no quotes available".
+
+    ``observe_instrument_ids`` additionally records each of those instruments
+    as an immutable hourly row in ``strategy_core_quote_observations`` (#2833
+    step 2).  The ``quotes`` table is one MUTABLE row per instrument, so it
+    can never accumulate the multi-day spread sample the core sleeve's pass
+    bar reads -- see sql/366.  The quotes are already in hand here, so the
+    lane costs no extra provider calls.  A missing quote is recorded too:
+    thinning the sample silently would bias the very percentile being
+    measured.
     """
     if not instruments:
         return QuoteRefreshSummary(0, 0, 0, 0)
@@ -349,8 +370,35 @@ def refresh_quotes(
         )
 
     quote_map: dict[int, Quote] = {q.instrument_id: q for q in quotes}
+    observed_ids = observe_instrument_ids or frozenset()
+    observed_at = datetime.now(tz=UTC)
+    core_observations_written = 0
     for instrument_id, symbol in instruments:
         quote = quote_map.get(instrument_id)
+        # Recorded BEFORE the missing-quote `continue` below: absence of a
+        # quote is itself coverage evidence, and dropping it would let a
+        # candidate's sample quietly shrink without the percentile moving.
+        if instrument_id in observed_ids:
+            try:
+                with conn.transaction():
+                    if record_core_quote_observation(
+                        conn,
+                        normalise_core_quote(
+                            instrument_id=instrument_id,
+                            quote=quote,
+                            observed_at=observed_at,
+                        ),
+                    ):
+                        core_observations_written += 1
+            except Exception:
+                # Never let the evidence lane break the quote refresh that
+                # eight headless services depend on (#2271).
+                logger.warning(
+                    "Failed to record core quote observation for %s (id=%d), skipping",
+                    symbol,
+                    instrument_id,
+                    exc_info=True,
+                )
         if quote is None:
             logger.debug("No quote returned for %s (id=%d), skipping quote upsert", symbol, instrument_id)
             quotes_skipped += 1
@@ -374,6 +422,7 @@ def refresh_quotes(
         quotes_updated=quotes_updated,
         quotes_skipped=quotes_skipped,
         spread_flags_set=spread_flags_set,
+        core_observations_written=core_observations_written,
     )
 
 

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -19,10 +19,11 @@ from psycopg.rows import dict_row
 
 from app.providers.market_data import MarketDataProvider, OHLCVBar, Quote
 from app.services.strategy_core_quote_observation import (
-    normalise_quote as normalise_core_quote,
+    CoreQuoteObservation,
+    record_core_quote_observations,
 )
 from app.services.strategy_core_quote_observation import (
-    record_core_quote_observation,
+    normalise_quote as normalise_core_quote,
 )
 from app.services.sync_orchestrator.exception_classifier import classify_exception
 from app.services.sync_orchestrator.layer_types import FailureCategory, UpstreamUnreachableError
@@ -379,40 +380,85 @@ def refresh_quotes(
     observed_at = datetime.now(tz=UTC)
     core_observations_written = 0
     core_observation_failures = 0
+    # Normalised in the same pass as the quote upserts but WRITTEN ONCE
+    # below.  ``quotes_refresh`` opens its connection with autocommit=True,
+    # so a ``conn.transaction()`` per candidate is a real BEGIN/COMMIT round
+    # trip each -- not a savepoint, which is what an earlier version of this
+    # comment claimed (Codex ckpt-3).  Batching removes that per-candidate
+    # cost without giving up per-instrument coverage: ``refusal_reason`` is
+    # ordinary row data and survives batching, and every row normalise_quote
+    # returns is shape-valid by construction, so a failure here is systemic
+    # (missing table, bad column) and would have failed each isolated insert
+    # anyway.
+    #
+    # ⚠ The candidate cohort is fetched SEPARATELY, and that is not
+    # redundancy.  ``get_quotes`` chunks internally and, on a partial chunk
+    # failure, logs it and returns only the chunks that SUCCEEDED -- so a
+    # candidate sitting in a failed chunk comes back as ``None``, exactly
+    # like an instrument eToro genuinely has no quote for.  Writing that as
+    # ``provider_omitted_quote`` would record a transport failure as broker
+    # evidence, which is the error `prove_2603_core_eligibility` names in its
+    # own docstring: "a transport failure records NOTHING" (Codex ckpt-3).
+    # The cohort is small (one chunk today), so its fetch either succeeds
+    # wholly -- making every remaining ``None`` a genuine omission -- or
+    # raises, and we record nothing at all for the tick.
+    candidate_ids = sorted(observed_ids)
+    pending_observations: list[CoreQuoteObservation] = []
+    if candidate_ids:
+        try:
+            # Split by the provider's own batch size so each call is exactly
+            # ONE upstream request: it then either returns or raises, and no
+            # id can go missing to a swallowed chunk. Fetching the cohort in
+            # one call would reintroduce the ambiguity as soon as it outgrew
+            # a single chunk (Codex ckpt-3, second round).
+            stride = max(provider.quote_batch_size, 1)
+            candidate_quotes: dict[int, Quote] = {}
+            for start in range(0, len(candidate_ids), stride):
+                chunk = candidate_ids[start : start + stride]
+                candidate_quotes.update({q.instrument_id: q for q in provider.get_quotes(chunk)})
+        except Exception:
+            core_observation_failures = len(candidate_ids)
+            logger.warning(
+                "Core candidate quote fetch FAILED for %d instrument(s); recording no observations "
+                "rather than storing a transport failure as absence of a quote",
+                len(candidate_ids),
+                exc_info=True,
+            )
+        else:
+            pending_observations = [
+                normalise_core_quote(
+                    instrument_id=instrument_id,
+                    quote=candidate_quotes.get(instrument_id),
+                    observed_at=observed_at,
+                )
+                # Includes candidates with NO quote: against a determinate
+                # fetch that absence is real coverage evidence, and dropping
+                # it would let the sample quietly shrink without the
+                # percentile moving.
+                for instrument_id in candidate_ids
+            ]
+    if pending_observations:
+        try:
+            with conn.transaction():
+                core_observations_written = record_core_quote_observations(conn, pending_observations)
+        except Exception:
+            # Never let the evidence lane break the quote refresh that eight
+            # headless services depend on (#2271) -- but do not let it fail
+            # SILENTLY either.  A bad column or bad SQL here would otherwise
+            # log once an hour forever while the candidate's sample never
+            # grows, which is this repo's "job that no-ops and reports
+            # success" class.  The counter is the detector: `quotes_refresh`
+            # logs it every tick, so a broken lane reads as written=0
+            # failures=N rather than being inferred from absence.
+            core_observation_failures = len(pending_observations)
+            logger.warning(
+                "Failed to record %d core quote observation(s); the candidate spread sample is not accruing this tick",
+                len(pending_observations),
+                exc_info=True,
+            )
+
     for instrument_id, symbol in instruments:
         quote = quote_map.get(instrument_id)
-        # Recorded BEFORE the missing-quote `continue` below: absence of a
-        # quote is itself coverage evidence, and dropping it would let a
-        # candidate's sample quietly shrink without the percentile moving.
-        if instrument_id in observed_ids:
-            try:
-                with conn.transaction():
-                    if record_core_quote_observation(
-                        conn,
-                        normalise_core_quote(
-                            instrument_id=instrument_id,
-                            quote=quote,
-                            observed_at=observed_at,
-                        ),
-                    ):
-                        core_observations_written += 1
-            except Exception:
-                # Never let the evidence lane break the quote refresh that
-                # eight headless services depend on (#2271) -- but do not let
-                # it fail SILENTLY either.  A bad column or bad SQL here is a
-                # programming error that would otherwise log once an hour
-                # forever while the candidate's sample never grows, which is
-                # this repo's "job that no-ops and reports success" class.
-                # The counter below is the detector: `quotes_refresh` logs it
-                # every tick, so a permanently broken lane is visible as
-                # written=0 failures=N rather than inferred from absence.
-                core_observation_failures += 1
-                logger.warning(
-                    "Failed to record core quote observation for %s (id=%d), skipping",
-                    symbol,
-                    instrument_id,
-                    exc_info=True,
-                )
         if quote is None:
             logger.debug("No quote returned for %s (id=%d), skipping quote upsert", symbol, instrument_id)
             quotes_skipped += 1

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -311,6 +311,11 @@ class QuoteRefreshSummary:
     # writer with no reader: a candidate cohort that silently stops accruing
     # would otherwise look identical to one whose bar is still forming.
     core_observations_written: int = 0
+    # Observation writes that raised. Isolated from the quote refresh (the
+    # lane must never break eight headless readers) but NOT swallowed: a
+    # persistent non-zero count is how a broken lane — bad SQL, missing
+    # column — surfaces instead of logging once an hour forever.
+    core_observation_failures: int = 0
 
 
 def refresh_quotes(
@@ -373,6 +378,7 @@ def refresh_quotes(
     observed_ids = observe_instrument_ids or frozenset()
     observed_at = datetime.now(tz=UTC)
     core_observations_written = 0
+    core_observation_failures = 0
     for instrument_id, symbol in instruments:
         quote = quote_map.get(instrument_id)
         # Recorded BEFORE the missing-quote `continue` below: absence of a
@@ -392,7 +398,15 @@ def refresh_quotes(
                         core_observations_written += 1
             except Exception:
                 # Never let the evidence lane break the quote refresh that
-                # eight headless services depend on (#2271).
+                # eight headless services depend on (#2271) -- but do not let
+                # it fail SILENTLY either.  A bad column or bad SQL here is a
+                # programming error that would otherwise log once an hour
+                # forever while the candidate's sample never grows, which is
+                # this repo's "job that no-ops and reports success" class.
+                # The counter below is the detector: `quotes_refresh` logs it
+                # every tick, so a permanently broken lane is visible as
+                # written=0 failures=N rather than inferred from absence.
+                core_observation_failures += 1
                 logger.warning(
                     "Failed to record core quote observation for %s (id=%d), skipping",
                     symbol,
@@ -423,6 +437,7 @@ def refresh_quotes(
         quotes_skipped=quotes_skipped,
         spread_flags_set=spread_flags_set,
         core_observations_written=core_observations_written,
+        core_observation_failures=core_observation_failures,
     )
 
 

--- a/app/services/strategy_core_quote_observation.py
+++ b/app/services/strategy_core_quote_observation.py
@@ -145,8 +145,8 @@ def normalise_quote(
     # ⚠ A non-positive rate is dropped to NULL rather than stored: it would
     # read as a denomination we cannot honour, and NULL already means "the
     # provider did not tell us" (never "USD" -- see sql/366).
-    rate = quote.conversion_rate
-    conversion_rate = Decimal(rate) if rate is not None and Decimal(rate) > 0 else None
+    rate = None if quote.conversion_rate is None else Decimal(quote.conversion_rate)
+    conversion_rate = rate if rate is not None and rate > 0 else None
     return CoreQuoteObservation(
         instrument_id=instrument_id,
         sample_bucket=bucket,

--- a/app/services/strategy_core_quote_observation.py
+++ b/app/services/strategy_core_quote_observation.py
@@ -22,6 +22,7 @@ without any new information arriving.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -176,35 +177,51 @@ _INSERT_OBSERVATION = """
 """
 
 
-def record_core_quote_observation(
-    conn: psycopg.Connection[Any],
-    observation: CoreQuoteObservation,
-) -> bool:
-    """Insert *observation*, keeping the first row already in its bucket.
+def _params(observation: CoreQuoteObservation) -> dict[str, Any]:
+    return {
+        "instrument_id": observation.instrument_id,
+        "sample_bucket": observation.sample_bucket,
+        "observed_at": observation.observed_at,
+        "quote_at": observation.quote_at,
+        "bid": observation.bid,
+        "ask": observation.ask,
+        "last": observation.last,
+        "spread_bps": observation.spread_bps,
+        "conversion_rate": observation.conversion_rate,
+        "observation_status": observation.observation_status,
+        "refusal_reason": observation.refusal_reason,
+        "source": observation.source,
+    }
 
-    Returns ``True`` when a row was written.  ``DO NOTHING`` rather than an
-    upsert because the first observation in a bucket is the evidence -- a
-    later manual dispatch must not replace it with a quote that knows more of
-    the bucket (sql/366's immutability trigger enforces the same rule).
+
+def record_core_quote_observations(
+    conn: psycopg.Connection[Any],
+    observations: Sequence[CoreQuoteObservation],
+) -> int:
+    """Insert *observations*, keeping any row already in its bucket.
+
+    Returns the number of rows written.  ``DO NOTHING`` rather than an upsert
+    because the first observation in a bucket is the evidence -- a later
+    manual dispatch must not replace it with a quote that knows more of the
+    bucket (sql/366's immutability trigger enforces the same rule).
+
+    One statement for the whole tick.  The caller owns the transaction: the
+    connection runs autocommit, so a per-observation transaction would be a
+    real BEGIN/COMMIT round trip each.  Every row is shape-valid by
+    construction (``normalise_quote`` guarantees the sql/366 CHECK is
+    satisfiable for observed AND refused rows alike), so the failure mode
+    that would lose a batch is systemic -- and a systemic failure would have
+    failed each isolated insert too.
     """
-    cursor = conn.execute(
-        _INSERT_OBSERVATION,
-        {
-            "instrument_id": observation.instrument_id,
-            "sample_bucket": observation.sample_bucket,
-            "observed_at": observation.observed_at,
-            "quote_at": observation.quote_at,
-            "bid": observation.bid,
-            "ask": observation.ask,
-            "last": observation.last,
-            "spread_bps": observation.spread_bps,
-            "conversion_rate": observation.conversion_rate,
-            "observation_status": observation.observation_status,
-            "refusal_reason": observation.refusal_reason,
-            "source": observation.source,
-        },
-    )
-    return cursor.rowcount > 0
+    if not observations:
+        return 0
+    with conn.cursor() as cursor:
+        cursor.executemany(_INSERT_OBSERVATION, [_params(o) for o in observations])
+        # psycopg3 accumulates affected rows across an executemany batch, so
+        # this is the count actually inserted -- bucket collisions (the
+        # idempotent re-run case) contribute zero rather than being counted
+        # as fresh evidence.
+        return max(cursor.rowcount, 0)
 
 
 __all__ = [
@@ -214,6 +231,6 @@ __all__ = [
     "CoreQuoteObservation",
     "ObservationStatus",
     "normalise_quote",
-    "record_core_quote_observation",
+    "record_core_quote_observations",
     "sample_bucket",
 ]

--- a/app/services/strategy_core_quote_observation.py
+++ b/app/services/strategy_core_quote_observation.py
@@ -1,0 +1,219 @@
+"""Prospective spread + denomination evidence for core sleeve candidates.
+
+#2833 step 2.  The application-wide ``quotes`` table is a mutable latest
+snapshot -- one row per instrument, enforced by its primary key -- so it can
+never supply "a spread percentile over ~5 trading days of stored quote
+snapshots", however long we wait.  ``sql/366`` carries the full reasoning.
+
+This module writes one immutable row per candidate per hourly bucket from the
+``Quote`` objects ``refresh_quotes`` has already fetched, so the lane costs no
+additional provider calls.
+
+It also persists ``conversion_rate`` -- eToro's documented "conversion rate
+from the instrument's currency to USD" -- which is the ONLY per-instrument
+denomination signal the API exposes.  ``instruments.currency`` is a venue
+lookup and reads GBP for every ``.L`` line regardless of actual denomination.
+
+A quote the provider re-serves from a shut market is refused as
+``quote_stale`` rather than recorded: the sample this lane exists to build is
+a spread PERCENTILE, and a duplicate is the one error that moves a percentile
+without any new information arriving.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any, Final, Literal
+
+import psycopg
+
+from app.providers.market_data import Quote
+
+SOURCE: Final = "etoro/core_candidate/best_bid_ask"
+#: ``quotes_refresh`` ticks hourly; one observation per candidate per tick.
+SAMPLE_INTERVAL_HOURS: Final = 1
+
+#: A quote further than ONE SAMPLING INTERVAL from the observation instant --
+#: in EITHER direction -- is not new evidence.  Too old and it is the same
+#: book the previous tick already recorded; too far ahead and the clock it
+#: came from is not ours, so it never ages out.  Either way counting it would
+#: inflate the percentile with duplicates of a single spread.
+#:
+#: ⚠ Not an invented threshold: it is the tick cadence itself.  At one sample
+#: per hour, anything older than an hour was already observable last tick, so
+#: this is the widest bound that cannot double-count.  A bucket-relative test
+#: would be wrong in the other direction -- a 14:59:58 quote recorded in the
+#: 15:00 bucket is five seconds old and is perfectly good evidence.
+#:
+#: This is a MEASURED hazard, not a hypothetical.  eToro returns the last
+#: quote when the market is shut (#2833: "markets shut; the provider returns
+#: the last quote"), and the data-sources/etoro-api skill records 18 of 20
+#: preflight timestamps arriving ~41 hours old.  Dev-verified 2026-08-23 (a
+#: Sunday): all ten candidates returned Friday quotes, which without this
+#: bound would have written ten `observed` rows per hour all weekend.
+MAX_QUOTE_AGE: Final = timedelta(hours=SAMPLE_INTERVAL_HOURS)
+
+ObservationStatus = Literal["observed", "missing", "invalid"]
+
+
+@dataclass(frozen=True)
+class CoreQuoteObservation:
+    instrument_id: int
+    sample_bucket: datetime
+    observed_at: datetime
+    quote_at: datetime | None
+    bid: Decimal | None
+    ask: Decimal | None
+    last: Decimal | None
+    spread_bps: Decimal | None
+    conversion_rate: Decimal | None
+    observation_status: ObservationStatus
+    refusal_reason: str | None
+    source: str = SOURCE
+
+
+def sample_bucket(observed_at: datetime) -> datetime:
+    """Truncate *observed_at* to its hourly bucket in UTC."""
+    if observed_at.tzinfo is None:
+        raise ValueError("observed_at must be timezone-aware")
+    return observed_at.astimezone(UTC).replace(minute=0, second=0, microsecond=0)
+
+
+def normalise_quote(
+    *,
+    instrument_id: int,
+    quote: Quote | None,
+    observed_at: datetime,
+) -> CoreQuoteObservation:
+    """Turn one provider response into a durable observation.
+
+    A missing or malformed quote is a row too: absence of evidence must stay
+    measurable rather than silently thinning the sample the pass bar reads.
+    """
+    bucket = sample_bucket(observed_at)
+    stamped = observed_at.astimezone(UTC)
+
+    def _refused(status: ObservationStatus, reason: str) -> CoreQuoteObservation:
+        return CoreQuoteObservation(
+            instrument_id=instrument_id,
+            sample_bucket=bucket,
+            observed_at=stamped,
+            quote_at=None,
+            bid=None,
+            ask=None,
+            last=None,
+            spread_bps=None,
+            conversion_rate=None,
+            observation_status=status,
+            refusal_reason=reason,
+        )
+
+    if quote is None:
+        return _refused("missing", "provider_omitted_quote")
+
+    if quote.timestamp.tzinfo is None:
+        return _refused("invalid", "quote_timestamp_naive")
+    if quote.bid <= 0 or quote.ask <= 0:
+        return _refused("invalid", "nonpositive_bid_or_ask")
+    if quote.ask < quote.bid:
+        return _refused("invalid", "crossed_market")
+    if quote.last is not None and quote.last <= 0:
+        return _refused("invalid", "nonpositive_last")
+    # Checked AFTER the shape guards so a malformed quote reports the reason
+    # an operator can act on, rather than being masked as merely stale.
+    #
+    # ⚠ The bound is SYMMETRIC, and deliberately so.  A one-sided staleness
+    # test leaves the mirror-image hole open: a future-dated quote has a
+    # NEGATIVE age, so it never expires and could populate every later bucket
+    # with the same response -- the identical duplicate-evidence failure this
+    # guard exists to prevent, arriving from the other direction.  Reusing
+    # MAX_QUOTE_AGE rather than minting a skew constant keeps the rule "the
+    # quote must belong to this tick's neighbourhood", with no second
+    # threshold to justify.  The two causes stay separate reasons because a
+    # future timestamp is a clock or provider fault, not a shut market.
+    age = stamped - quote.timestamp.astimezone(UTC)
+    if age > MAX_QUOTE_AGE:
+        return _refused("invalid", "quote_stale")
+    if age < -MAX_QUOTE_AGE:
+        return _refused("invalid", "quote_future")
+
+    bid = Decimal(quote.bid)
+    ask = Decimal(quote.ask)
+    midpoint = (bid + ask) / Decimal(2)
+    # ⚠ A non-positive rate is dropped to NULL rather than stored: it would
+    # read as a denomination we cannot honour, and NULL already means "the
+    # provider did not tell us" (never "USD" -- see sql/366).
+    rate = quote.conversion_rate
+    conversion_rate = Decimal(rate) if rate is not None and Decimal(rate) > 0 else None
+    return CoreQuoteObservation(
+        instrument_id=instrument_id,
+        sample_bucket=bucket,
+        observed_at=stamped,
+        quote_at=quote.timestamp.astimezone(UTC),
+        bid=bid,
+        ask=ask,
+        last=None if quote.last is None else Decimal(quote.last),
+        spread_bps=(ask - bid) / midpoint * Decimal(10_000),
+        conversion_rate=conversion_rate,
+        observation_status="observed",
+        refusal_reason=None,
+    )
+
+
+_INSERT_OBSERVATION = """
+    INSERT INTO strategy_core_quote_observations (
+        instrument_id, sample_bucket, observed_at, quote_at,
+        bid, ask, last, spread_bps, conversion_rate,
+        observation_status, refusal_reason, source
+    ) VALUES (
+        %(instrument_id)s, %(sample_bucket)s, %(observed_at)s, %(quote_at)s,
+        %(bid)s, %(ask)s, %(last)s, %(spread_bps)s, %(conversion_rate)s,
+        %(observation_status)s, %(refusal_reason)s, %(source)s
+    )
+    ON CONFLICT (instrument_id, sample_bucket) DO NOTHING
+"""
+
+
+def record_core_quote_observation(
+    conn: psycopg.Connection[Any],
+    observation: CoreQuoteObservation,
+) -> bool:
+    """Insert *observation*, keeping the first row already in its bucket.
+
+    Returns ``True`` when a row was written.  ``DO NOTHING`` rather than an
+    upsert because the first observation in a bucket is the evidence -- a
+    later manual dispatch must not replace it with a quote that knows more of
+    the bucket (sql/366's immutability trigger enforces the same rule).
+    """
+    cursor = conn.execute(
+        _INSERT_OBSERVATION,
+        {
+            "instrument_id": observation.instrument_id,
+            "sample_bucket": observation.sample_bucket,
+            "observed_at": observation.observed_at,
+            "quote_at": observation.quote_at,
+            "bid": observation.bid,
+            "ask": observation.ask,
+            "last": observation.last,
+            "spread_bps": observation.spread_bps,
+            "conversion_rate": observation.conversion_rate,
+            "observation_status": observation.observation_status,
+            "refusal_reason": observation.refusal_reason,
+            "source": observation.source,
+        },
+    )
+    return cursor.rowcount > 0
+
+
+__all__ = [
+    "MAX_QUOTE_AGE",
+    "SAMPLE_INTERVAL_HOURS",
+    "SOURCE",
+    "CoreQuoteObservation",
+    "ObservationStatus",
+    "normalise_quote",
+    "record_core_quote_observation",
+    "sample_bucket",
+]

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -3302,6 +3302,35 @@ WHERE p.instrument_id IS NOT NULL
 ORDER BY i.instrument_id, i.symbol
 """
 
+#: #2833 step 2 -- the arm-5 predicate on its own, naming just the core
+#: CANDIDATES so their spread sample can be accrued in
+#: ``strategy_core_quote_observations``.  Deliberately a separate statement
+#: rather than a flag column on ``QUOTES_REFRESH_SCOPE_SQL``: the arms there
+#: are OR'd and an instrument can qualify under several at once, so a
+#: per-arm marker would have to encode arm precedence to stay honest.  This
+#: lane wants exactly one question answered -- "is this a proved candidate?"
+#: -- and asks it directly.
+#:
+#: ⚠ The `quotes` table CANNOT serve this measurement: its primary key is
+#: UNIQUE on ``instrument_id``, so it holds one mutable row per instrument
+#: however many hourly ticks elapse (sql/366).
+CORE_CANDIDATE_QUOTE_SCOPE_SQL = """
+SELECT i.instrument_id
+FROM instruments i
+WHERE i.is_tradable = TRUE
+  AND EXISTS (
+      SELECT 1
+      FROM (
+          SELECT DISTINCT ON (e.environment) e.verdict
+          FROM strategy_core_eligibility_proofs e
+          WHERE e.instrument_id = i.instrument_id
+          ORDER BY e.environment, e.observed_at DESC, e.core_eligibility_proof_id DESC
+      ) latest
+      WHERE latest.verdict = %(pass_verdict)s
+  )
+ORDER BY i.instrument_id
+"""
+
 
 def quotes_refresh() -> None:
     """Refresh the ``quotes`` table for every instrument read headlessly.
@@ -3378,7 +3407,15 @@ def quotes_refresh() -> None:
                 tracker.row_count = 0
                 return
 
-            summary = refresh_quotes(provider, conn, instruments)
+            candidate_ids = frozenset(
+                int(r[0])
+                for r in conn.execute(
+                    CORE_CANDIDATE_QUOTE_SCOPE_SQL,
+                    {"pass_verdict": CORE_ELIGIBILITY_PASS_VERDICT},
+                ).fetchall()
+            )
+
+            summary = refresh_quotes(provider, conn, instruments, observe_instrument_ids=candidate_ids)
             if summary.batch_error is not None:
                 # #2218 shape — a total upstream failure must NOT report as a
                 # clean run that simply found no quotes. This has to raise
@@ -3404,11 +3441,12 @@ def quotes_refresh() -> None:
         # eToro returned with a wide spread, which is not the same as rows now
         # flagged in the table — a stale snapshot rejected by the monotonicity
         # guard still counts here (review NITPICK on #2275).
-        "quotes_refresh complete: requested=%d updated=%d no_quote=%d wide_spreads_fetched=%d",
+        "quotes_refresh complete: requested=%d updated=%d no_quote=%d wide_spreads_fetched=%d core_observations=%d",
         summary.instruments_requested,
         summary.quotes_updated,
         summary.quotes_skipped,
         summary.spread_flags_set,
+        summary.core_observations_written,
     )
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -3240,7 +3240,25 @@ def daily_candle_refresh() -> None:
 #: Params: ``benchmarks`` (``BENCHMARK_SYMBOLS``), ``pass_verdict``
 #: (``CORE_ELIGIBILITY_PASS_VERDICT``).
 QUOTES_REFRESH_SCOPE_SQL = """
-SELECT DISTINCT ON (i.instrument_id) i.instrument_id, i.symbol
+SELECT DISTINCT ON (i.instrument_id) i.instrument_id, i.symbol,
+       -- #2833 step 2: does this instrument ALSO satisfy the core-candidate
+       -- predicate (arm 5 below)?  Selected here rather than asked in a
+       -- second statement so scope and candidacy come from ONE snapshot --
+       -- two autocommit queries can disagree if a proof lands between them,
+       -- which would silently cost a newly proved candidate an hour of its
+       -- sample (Codex ckpt-3).  This is a plain boolean about ONE predicate,
+       -- not a claim about which OR'd arm admitted the row, so it needs no
+       -- arm precedence to stay honest.
+       (i.is_tradable = TRUE AND EXISTS (
+           SELECT 1
+           FROM (
+               SELECT DISTINCT ON (e.environment) e.verdict
+               FROM strategy_core_eligibility_proofs e
+               WHERE e.instrument_id = i.instrument_id
+               ORDER BY e.environment, e.observed_at DESC, e.core_eligibility_proof_id DESC
+           ) latest
+           WHERE latest.verdict = %(pass_verdict)s
+       )) AS is_core_candidate
 FROM instruments i
 LEFT JOIN coverage c ON c.instrument_id = i.instrument_id
 LEFT JOIN positions p ON p.instrument_id = i.instrument_id AND p.current_units > 0
@@ -3300,35 +3318,6 @@ WHERE p.instrument_id IS NOT NULL
           WHERE latest.verdict = %(pass_verdict)s
        ))
 ORDER BY i.instrument_id, i.symbol
-"""
-
-#: #2833 step 2 -- the arm-5 predicate on its own, naming just the core
-#: CANDIDATES so their spread sample can be accrued in
-#: ``strategy_core_quote_observations``.  Deliberately a separate statement
-#: rather than a flag column on ``QUOTES_REFRESH_SCOPE_SQL``: the arms there
-#: are OR'd and an instrument can qualify under several at once, so a
-#: per-arm marker would have to encode arm precedence to stay honest.  This
-#: lane wants exactly one question answered -- "is this a proved candidate?"
-#: -- and asks it directly.
-#:
-#: ⚠ The `quotes` table CANNOT serve this measurement: its primary key is
-#: UNIQUE on ``instrument_id``, so it holds one mutable row per instrument
-#: however many hourly ticks elapse (sql/366).
-CORE_CANDIDATE_QUOTE_SCOPE_SQL = """
-SELECT i.instrument_id
-FROM instruments i
-WHERE i.is_tradable = TRUE
-  AND EXISTS (
-      SELECT 1
-      FROM (
-          SELECT DISTINCT ON (e.environment) e.verdict
-          FROM strategy_core_eligibility_proofs e
-          WHERE e.instrument_id = i.instrument_id
-          ORDER BY e.environment, e.observed_at DESC, e.core_eligibility_proof_id DESC
-      ) latest
-      WHERE latest.verdict = %(pass_verdict)s
-  )
-ORDER BY i.instrument_id
 """
 
 
@@ -3395,6 +3384,9 @@ def quotes_refresh() -> None:
             ).fetchall()
 
             instruments = [(int(r[0]), str(r[1])) for r in rows]
+            # #2833 step 2 — same row, same snapshot as the scope above, so a
+            # proof landing mid-tick cannot make the two disagree.
+            candidate_ids = frozenset(int(r[0]) for r in rows if r[2])
             if not instruments:
                 # Same reasoning as daily_candle_refresh's empty-scope branch
                 # (#1293): an empty scope here is anomalous (no held positions,
@@ -3406,14 +3398,6 @@ def quotes_refresh() -> None:
                 )
                 tracker.row_count = 0
                 return
-
-            candidate_ids = frozenset(
-                int(r[0])
-                for r in conn.execute(
-                    CORE_CANDIDATE_QUOTE_SCOPE_SQL,
-                    {"pass_verdict": CORE_ELIGIBILITY_PASS_VERDICT},
-                ).fetchall()
-            )
 
             summary = refresh_quotes(provider, conn, instruments, observe_instrument_ids=candidate_ids)
             if summary.batch_error is not None:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -3441,13 +3441,24 @@ def quotes_refresh() -> None:
         # eToro returned with a wide spread, which is not the same as rows now
         # flagged in the table — a stale snapshot rejected by the monotonicity
         # guard still counts here (review NITPICK on #2275).
-        "quotes_refresh complete: requested=%d updated=%d no_quote=%d wide_spreads_fetched=%d core_observations=%d",
+        "quotes_refresh complete: requested=%d updated=%d no_quote=%d wide_spreads_fetched=%d "
+        "core_observations=%d core_observation_failures=%d",
         summary.instruments_requested,
         summary.quotes_updated,
         summary.quotes_skipped,
         summary.spread_flags_set,
         summary.core_observations_written,
+        summary.core_observation_failures,
     )
+    if summary.core_observation_failures:
+        # Escalated above the per-instrument log line: the evidence lane is
+        # deliberately isolated from the quote refresh, so a fault here is
+        # invisible in the job's own success state (#2833).
+        logger.warning(
+            "quotes_refresh: %d core quote observation write(s) FAILED — the candidate spread "
+            "sample is not accruing; #2833's pass bar cannot be measured until this is fixed",
+            summary.core_observation_failures,
+        )
 
 
 def _cik_destination_is_empty(conn: psycopg.Connection) -> bool:  # type: ignore[type-arg]

--- a/sql/366_strategy_core_quote_observations.sql
+++ b/sql/366_strategy_core_quote_observations.sql
@@ -1,0 +1,114 @@
+-- #2833 step 2 -- prospective spread evidence for CORE SLEEVE CANDIDATES.
+--
+-- Why a table and not a query over `quotes`:  `quotes` is intentionally ONE
+-- MUTABLE CURRENT ROW per instrument (`quotes_pkey` is UNIQUE on
+-- `instrument_id` alone), exactly as sql/306 already records.  #2833's pass
+-- bar is "a spread percentile over ~5 trading days of stored quote
+-- snapshots", and `quotes_refresh` arm 5 (#2864) correctly widened the
+-- REFRESH scope to the proved candidates -- but the store it feeds keeps one
+-- row per instrument, so five trading days of hourly refreshes still leave
+-- n=1.  Measured on dev 2026-08-23: every candidate (3417, 3418, 3434, 3075,
+-- 15445, 15446, 14465) had exactly ONE `quotes` row.  Waiting longer cannot
+-- change that; it is a property of the primary key, not of elapsed time.
+--
+-- Why not `strategy_quote_observations` (sql/306): that table is FK-bound to
+-- `strategy_intraday_universe_versions` and its members are the bounded
+-- intraday research panel -- 8 symbols whose "SPY" is instrument 3000, NOT
+-- the proved candidate SPY.RTH 3417.  Its bucket CHECK is also five-minute,
+-- while this lane samples on `quotes_refresh`'s hourly tick.  Relaxing a
+-- CHECK on an immutable evidence table to admit a different cohort is worse
+-- than a sibling with its own, honest constraints.
+--
+-- Membership is the arm-5 predicate itself (latest eligibility proof per
+-- (instrument, environment) passing), so a candidate leaves this lane the
+-- same way it leaves quoting: by being re-proved.  No extra provider calls --
+-- `refresh_quotes` already holds these Quote objects.
+
+CREATE TABLE IF NOT EXISTS strategy_core_quote_observations (
+    instrument_id      BIGINT NOT NULL
+        REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    sample_bucket      TIMESTAMPTZ NOT NULL,
+    observed_at        TIMESTAMPTZ NOT NULL,
+    quote_at           TIMESTAMPTZ,
+    bid                NUMERIC(18,6),
+    ask                NUMERIC(18,6),
+    last               NUMERIC(18,6),
+    spread_bps         NUMERIC(18,8),
+    -- eToro `conversionRateAsk`/`conversionRateBid` mid: the documented
+    -- "conversion rate from the INSTRUMENT'S currency to USD" (live portal
+    -- `market-data/get-instrument-market-rates`, verified 2026-08-23).  This
+    -- is the only per-instrument denomination signal the API exposes --
+    -- `get-instrument-display-data` carries no currency field at all, and
+    -- `instruments.currency` is a VENUE lookup off `exchanges.currency`
+    -- (universe.py: "currency is a property of where a listing trades"), so
+    -- every `.L` line reads GBP regardless of what it is actually
+    -- denominated in.  Measured 2026-08-23: CSPX.L / IUMO.L / IUQA.L /
+    -- R1VL.L all return EXACTLY 1.0 (USD-denominated) while stored as GBP;
+    -- IUSA.L returns 0.0136315 (GBX) and QDVA/QDVB/QDVI.DE 1.1677 (EUR).
+    -- ⚠ NULL means the provider OMITTED the rate -- it does NOT mean USD.
+    -- Readers must test `= 1` explicitly, never `IS NOT DISTINCT FROM NULL`
+    -- (same posture as data-engineer I23: NULL is "not yet checked").
+    conversion_rate    NUMERIC(24,12) CHECK (conversion_rate IS NULL OR conversion_rate > 0),
+    observation_status TEXT NOT NULL
+        CHECK (observation_status IN ('observed', 'missing', 'invalid')),
+    refusal_reason     TEXT CHECK (refusal_reason IS NULL OR (
+        btrim(refusal_reason) <> '' AND length(refusal_reason) <= 100
+    )),
+    source             TEXT NOT NULL CHECK (source ~ '^etoro/core_candidate/best_bid_ask$'),
+    PRIMARY KEY (instrument_id, sample_bucket),
+    CONSTRAINT strategy_core_quote_observation_bucket CHECK (
+        date_trunc('hour', sample_bucket) = sample_bucket
+        AND observed_at >= sample_bucket
+        AND observed_at < sample_bucket + interval '1 hour'
+    ),
+    CONSTRAINT strategy_core_quote_observation_shape CHECK (
+        (
+            observation_status = 'observed'
+            AND refusal_reason IS NULL
+            AND quote_at IS NOT NULL
+            AND bid > 0 AND ask > 0 AND ask >= bid
+            AND spread_bps IS NOT NULL AND spread_bps >= 0
+            AND (last IS NULL OR last > 0)
+        ) OR (
+            observation_status IN ('missing', 'invalid')
+            AND refusal_reason IS NOT NULL
+            AND quote_at IS NULL AND bid IS NULL AND ask IS NULL
+            AND last IS NULL AND spread_bps IS NULL
+            -- a refused observation carries no denomination either: the rate
+            -- rides on the same response the bid/ask came from.
+            AND conversion_rate IS NULL
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_core_quote_observations_retention
+    ON strategy_core_quote_observations (sample_bucket);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_core_quote_observations_lookup
+    ON strategy_core_quote_observations (instrument_id, sample_bucket DESC)
+    WHERE observation_status = 'observed';
+
+-- The first observation in an hourly bucket is the evidence.  A later manual
+-- dispatch must not replace it with a quote that knows more of the bucket --
+-- same reasoning as sql/307, and the reason the writer uses DO NOTHING.
+CREATE OR REPLACE FUNCTION reject_strategy_core_quote_observation_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'core quote observations are immutable; insert the next hourly bucket';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_strategy_core_quote_observation_immutable
+    ON strategy_core_quote_observations;
+
+CREATE TRIGGER trg_strategy_core_quote_observation_immutable
+BEFORE UPDATE ON strategy_core_quote_observations
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_core_quote_observation_update();
+
+COMMENT ON TABLE strategy_core_quote_observations IS
+    'Hourly prospective best-bid/ask samples for core sleeve candidates '
+    '(#2833 step 2), carrying the per-instrument USD conversion rate. '
+    'First observation in a bucket is immutable; missing/invalid coverage is '
+    'explicit. `quotes` cannot serve this: it is one mutable row per instrument.';

--- a/tests/test_quotes_refresh.py
+++ b/tests/test_quotes_refresh.py
@@ -41,6 +41,17 @@ def _passthrough_conn() -> MagicMock:
     return conn
 
 
+def _provider() -> MagicMock:
+    """A provider mock carrying the real ``quote_batch_size`` contract.
+
+    Without it the attribute is a MagicMock and the candidate cohort's
+    chunking arithmetic silently misbehaves.
+    """
+    provider = MagicMock()
+    provider.quote_batch_size = 50
+    return provider
+
+
 class TestRefreshQuotes:
     def test_empty_instruments_does_not_call_provider(self) -> None:
         provider = MagicMock()
@@ -52,7 +63,7 @@ class TestRefreshQuotes:
     def test_instrument_without_a_returned_quote_counts_as_skipped(self) -> None:
         """A provider that answers for only some IDs must not be read as a
         failure — it is the normal shape for untraded instruments."""
-        provider = MagicMock()
+        provider = _provider()
         provider.get_quotes.return_value = [_quote(1)]
 
         with patch("app.services.market_data._upsert_quote", return_value=False):
@@ -66,13 +77,13 @@ class TestRefreshQuotes:
         """#2833 — the lane is isolated from the quote refresh, so a bad
         column or bad SQL would otherwise log once an hour forever while the
         candidate sample never grows. The count is the detector."""
-        provider = MagicMock()
-        provider.get_quotes.return_value = [_quote(1)]
+        provider = _provider()
+        provider.get_quotes.side_effect = [[_quote(1)], [_quote(1)]]
 
         with (
             patch("app.services.market_data._upsert_quote", return_value=False),
             patch(
-                "app.services.market_data.record_core_quote_observation",
+                "app.services.market_data.record_core_quote_observations",
                 side_effect=RuntimeError("relation does not exist"),
             ),
         ):
@@ -90,12 +101,12 @@ class TestRefreshQuotes:
         assert summary.batch_failed is False
 
     def test_observations_are_only_written_for_named_candidates(self) -> None:
-        provider = MagicMock()
-        provider.get_quotes.return_value = [_quote(1), _quote(2)]
+        provider = _provider()
+        provider.get_quotes.side_effect = [[_quote(1), _quote(2)], [_quote(2)]]
 
         with (
             patch("app.services.market_data._upsert_quote", return_value=False),
-            patch("app.services.market_data.record_core_quote_observation", return_value=True) as record,
+            patch("app.services.market_data.record_core_quote_observations", return_value=1) as record,
         ):
             summary = refresh_quotes(
                 provider,
@@ -105,16 +116,16 @@ class TestRefreshQuotes:
             )
 
         assert summary.core_observations_written == 1
-        assert [c.args[1].instrument_id for c in record.call_args_list] == [2]
+        assert [o.instrument_id for o in record.call_args_list[0].args[1]] == [2]
 
     def test_a_missing_quote_still_records_coverage_for_a_candidate(self) -> None:
         """Absence is evidence: dropping it would shrink the sample silently."""
-        provider = MagicMock()
-        provider.get_quotes.return_value = []
+        provider = _provider()
+        provider.get_quotes.side_effect = [[], []]
 
         with (
             patch("app.services.market_data._upsert_quote", return_value=False),
-            patch("app.services.market_data.record_core_quote_observation", return_value=True) as record,
+            patch("app.services.market_data.record_core_quote_observations", return_value=1) as record,
         ):
             summary = refresh_quotes(
                 provider,
@@ -125,13 +136,91 @@ class TestRefreshQuotes:
 
         assert summary.quotes_skipped == 1
         assert summary.core_observations_written == 1
-        assert record.call_args_list[0].args[1].observation_status == "missing"
+        assert record.call_args_list[0].args[1][0].observation_status == "missing"
+
+    def test_a_failed_candidate_fetch_records_nothing_rather_than_absence(self) -> None:
+        """#2833 — `get_quotes` swallows a failed CHUNK and returns the rest,
+        so a candidate in that chunk looks identical to one eToro has no
+        quote for. Writing it as `provider_omitted_quote` would store a
+        transport failure as broker evidence."""
+        provider = _provider()
+        provider.get_quotes.side_effect = [[_quote(1)], RuntimeError("etoro chunk down")]
+
+        with (
+            patch("app.services.market_data._upsert_quote", return_value=False),
+            patch("app.services.market_data.record_core_quote_observations", return_value=0) as record,
+        ):
+            summary = refresh_quotes(
+                provider,
+                _passthrough_conn(),
+                [(1, "AAA")],
+                observe_instrument_ids=frozenset({1}),
+            )
+
+        record.assert_not_called()
+        assert summary.core_observations_written == 0
+        assert summary.core_observation_failures == 1
+        # The quote refresh itself is unaffected.
+        assert summary.quotes_updated == 1
+        assert summary.batch_failed is False
+
+    def test_the_candidate_cohort_is_split_by_the_provider_batch_size(self) -> None:
+        """#2833 — one call per upstream request, so no candidate can go
+        missing to a chunk the provider swallowed. A cohort larger than the
+        batch size must fan out, not ride in one ambiguous call."""
+        provider = MagicMock()
+        provider.quote_batch_size = 2
+        provider.get_quotes.side_effect = [
+            [_quote(1)],  # main scope
+            [_quote(1), _quote(2)],  # cohort chunk 1
+            [_quote(3)],  # cohort chunk 2
+        ]
+
+        with (
+            patch("app.services.market_data._upsert_quote", return_value=False),
+            patch("app.services.market_data.record_core_quote_observations", return_value=3) as record,
+        ):
+            refresh_quotes(
+                provider,
+                _passthrough_conn(),
+                [(1, "AAA")],
+                observe_instrument_ids=frozenset({1, 2, 3}),
+            )
+
+        cohort_calls = [c.args[0] for c in provider.get_quotes.call_args_list[1:]]
+        assert cohort_calls == [[1, 2], [3]]
+        assert [o.instrument_id for o in record.call_args_list[0].args[1]] == [1, 2, 3]
+
+    def test_one_failed_cohort_chunk_voids_the_whole_tick(self) -> None:
+        """Partial cohort coverage would still mislabel the failed chunk's
+        candidates as `provider_omitted_quote`, so nothing is written."""
+        provider = MagicMock()
+        provider.quote_batch_size = 2
+        provider.get_quotes.side_effect = [
+            [_quote(1)],
+            [_quote(1), _quote(2)],
+            RuntimeError("chunk down"),
+        ]
+
+        with (
+            patch("app.services.market_data._upsert_quote", return_value=False),
+            patch("app.services.market_data.record_core_quote_observations", return_value=0) as record,
+        ):
+            summary = refresh_quotes(
+                provider,
+                _passthrough_conn(),
+                [(1, "AAA")],
+                observe_instrument_ids=frozenset({1, 2, 3}),
+            )
+
+        record.assert_not_called()
+        assert summary.core_observation_failures == 3
 
     def test_batch_fetch_failure_is_distinguishable_from_no_quotes(self) -> None:
         """#2218 shape — a total upstream outage and a universe of untraded
         instruments both write zero quotes. The caller must be able to tell
         them apart, or an outage reports as a clean run."""
-        provider = MagicMock()
+        provider = _provider()
         provider.get_quotes.side_effect = RuntimeError("etoro down")
 
         summary = refresh_quotes(provider, _passthrough_conn(), [(1, "AAA"), (2, "BBB")])
@@ -141,7 +230,7 @@ class TestRefreshQuotes:
         assert summary.quotes_skipped == 2
 
     def test_one_bad_upsert_does_not_abort_the_rest(self) -> None:
-        provider = MagicMock()
+        provider = _provider()
         provider.get_quotes.return_value = [_quote(1), _quote(2), _quote(3)]
 
         with patch("app.services.market_data._upsert_quote", side_effect=[RuntimeError("boom"), False, True]):
@@ -155,7 +244,7 @@ class TestQuotesRefreshJob:
     """The job's wiring — scope query, connection shape, empty-scope signal."""
 
     @staticmethod
-    def _run(rows: list[tuple[int, str]]) -> tuple[MagicMock, MagicMock]:
+    def _run(rows: list[tuple[int, str, bool]]) -> tuple[MagicMock, MagicMock]:
         conn = _passthrough_conn()
         result = MagicMock()
         result.fetchall.return_value = rows
@@ -194,14 +283,20 @@ class TestQuotesRefreshJob:
         """#2269 — the scope SELECT opens an implicit transaction, which would
         turn refresh_quotes' per-instrument ``conn.transaction()`` into a
         savepoint and defer every write to connection close."""
-        mock_connect, _ = self._run([(1, "AAPL")])
+        mock_connect, _ = self._run([(1, "AAPL", False)])
         mock_connect.assert_called_once()
         assert mock_connect.call_args.kwargs.get("autocommit") is True
 
     def test_scope_rows_are_passed_through(self) -> None:
-        _, mock_refresh = self._run([(1, "AAPL"), (2, "MSFT")])
+        _, mock_refresh = self._run([(1, "AAPL", False), (2, "MSFT", True)])
         mock_refresh.assert_called_once()
         assert mock_refresh.call_args[0][2] == [(1, "AAPL"), (2, "MSFT")]
+
+    def test_candidacy_comes_from_the_same_scope_row(self) -> None:
+        """#2833 — one snapshot, so a proof landing mid-tick cannot make the
+        scope and the candidate set disagree."""
+        _, mock_refresh = self._run([(1, "AAPL", False), (2, "MSFT", True)])
+        assert mock_refresh.call_args.kwargs["observe_instrument_ids"] == frozenset({2})
 
     def test_empty_scope_warns_rather_than_reading_as_a_clean_no_op(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level("WARNING"):
@@ -221,7 +316,7 @@ class TestQuotesRefreshJob:
 
         conn = _passthrough_conn()
         result = MagicMock()
-        result.fetchall.return_value = [(1, "AAPL")]
+        result.fetchall.return_value = [(1, "AAPL", False)]
         conn.execute.return_value = result
         conn.__enter__ = MagicMock(return_value=conn)
         conn.__exit__ = MagicMock(return_value=False)

--- a/tests/test_quotes_refresh.py
+++ b/tests/test_quotes_refresh.py
@@ -62,6 +62,71 @@ class TestRefreshQuotes:
         assert summary.quotes_skipped == 1
         assert summary.batch_failed is False
 
+    def test_a_broken_observation_lane_is_counted_not_silently_swallowed(self) -> None:
+        """#2833 — the lane is isolated from the quote refresh, so a bad
+        column or bad SQL would otherwise log once an hour forever while the
+        candidate sample never grows. The count is the detector."""
+        provider = MagicMock()
+        provider.get_quotes.return_value = [_quote(1)]
+
+        with (
+            patch("app.services.market_data._upsert_quote", return_value=False),
+            patch(
+                "app.services.market_data.record_core_quote_observation",
+                side_effect=RuntimeError("relation does not exist"),
+            ),
+        ):
+            summary = refresh_quotes(
+                provider,
+                _passthrough_conn(),
+                [(1, "AAA")],
+                observe_instrument_ids=frozenset({1}),
+            )
+
+        assert summary.core_observation_failures == 1
+        assert summary.core_observations_written == 0
+        # The quote refresh eight headless services depend on still ran.
+        assert summary.quotes_updated == 1
+        assert summary.batch_failed is False
+
+    def test_observations_are_only_written_for_named_candidates(self) -> None:
+        provider = MagicMock()
+        provider.get_quotes.return_value = [_quote(1), _quote(2)]
+
+        with (
+            patch("app.services.market_data._upsert_quote", return_value=False),
+            patch("app.services.market_data.record_core_quote_observation", return_value=True) as record,
+        ):
+            summary = refresh_quotes(
+                provider,
+                _passthrough_conn(),
+                [(1, "AAA"), (2, "BBB")],
+                observe_instrument_ids=frozenset({2}),
+            )
+
+        assert summary.core_observations_written == 1
+        assert [c.args[1].instrument_id for c in record.call_args_list] == [2]
+
+    def test_a_missing_quote_still_records_coverage_for_a_candidate(self) -> None:
+        """Absence is evidence: dropping it would shrink the sample silently."""
+        provider = MagicMock()
+        provider.get_quotes.return_value = []
+
+        with (
+            patch("app.services.market_data._upsert_quote", return_value=False),
+            patch("app.services.market_data.record_core_quote_observation", return_value=True) as record,
+        ):
+            summary = refresh_quotes(
+                provider,
+                _passthrough_conn(),
+                [(1, "AAA")],
+                observe_instrument_ids=frozenset({1}),
+            )
+
+        assert summary.quotes_skipped == 1
+        assert summary.core_observations_written == 1
+        assert record.call_args_list[0].args[1].observation_status == "missing"
+
     def test_batch_fetch_failure_is_distinguishable_from_no_quotes(self) -> None:
         """#2218 shape — a total upstream outage and a universe of untraded
         instruments both write zero quotes. The caller must be able to tell

--- a/tests/test_strategy_core_quote_observation.py
+++ b/tests/test_strategy_core_quote_observation.py
@@ -1,0 +1,195 @@
+"""#2833 step 2 -- pure-logic tests for the core-candidate quote lane.
+
+No DB fixture on purpose: the decision this module makes (what is a usable
+observation, and what is its denomination) is a pure function of one provider
+response, so it is table-tested rather than exercised through Postgres.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.providers.market_data import Quote
+from app.services.strategy_core_quote_observation import (
+    MAX_QUOTE_AGE,
+    SOURCE,
+    normalise_quote,
+    sample_bucket,
+)
+
+OBSERVED_AT = datetime(2026, 8, 23, 14, 37, 12, tzinfo=UTC)
+BUCKET = datetime(2026, 8, 23, 14, 0, 0, tzinfo=UTC)
+
+
+def _quote(**overrides: object) -> Quote:
+    base: dict[str, object] = {
+        "instrument_id": 3417,
+        "timestamp": OBSERVED_AT,
+        "bid": Decimal("100.00"),
+        "ask": Decimal("100.10"),
+        "last": Decimal("100.05"),
+        "conversion_rate": Decimal("1"),
+    }
+    base.update(overrides)
+    return Quote(**base)  # type: ignore[arg-type]
+
+
+class TestSampleBucket:
+    def test_truncates_to_the_hour(self) -> None:
+        assert sample_bucket(OBSERVED_AT) == BUCKET
+
+    def test_converts_to_utc_before_truncating(self) -> None:
+        # The SAME instant expressed as 16:37+02:00 must land in the 14:00 UTC
+        # bucket, not a 16:00 one — otherwise a provider timestamp in a local
+        # offset would silently open a second bucket for one tick.
+        shifted = OBSERVED_AT.astimezone(timezone(timedelta(hours=2)))
+        assert shifted.hour == 16
+        assert sample_bucket(shifted) == BUCKET
+
+    def test_naive_timestamp_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="timezone-aware"):
+            sample_bucket(OBSERVED_AT.replace(tzinfo=None))
+
+
+class TestNormaliseQuote:
+    def test_observed_row_carries_spread_and_rate(self) -> None:
+        obs = normalise_quote(instrument_id=3417, quote=_quote(), observed_at=OBSERVED_AT)
+        assert obs.observation_status == "observed"
+        assert obs.refusal_reason is None
+        assert obs.sample_bucket == BUCKET
+        assert obs.source == SOURCE
+        assert obs.conversion_rate == Decimal("1")
+        # 0.10 spread on a 100.05 midpoint = 9.995... bps
+        assert obs.spread_bps is not None
+        assert obs.spread_bps == pytest.approx(Decimal("9.995"), abs=Decimal("0.001"))
+
+    def test_a_missing_quote_is_recorded_not_dropped(self) -> None:
+        """Absence of a quote is coverage evidence for the percentile."""
+        obs = normalise_quote(instrument_id=3417, quote=None, observed_at=OBSERVED_AT)
+        assert obs.observation_status == "missing"
+        assert obs.refusal_reason == "provider_omitted_quote"
+        assert obs.bid is None and obs.ask is None and obs.spread_bps is None
+        assert obs.conversion_rate is None
+
+    @pytest.mark.parametrize(
+        ("overrides", "reason"),
+        [
+            ({"bid": Decimal("0")}, "nonpositive_bid_or_ask"),
+            ({"ask": Decimal("0")}, "nonpositive_bid_or_ask"),
+            ({"bid": Decimal("101"), "ask": Decimal("100")}, "crossed_market"),
+            ({"last": Decimal("0")}, "nonpositive_last"),
+            ({"timestamp": OBSERVED_AT.replace(tzinfo=None)}, "quote_timestamp_naive"),
+        ],
+    )
+    def test_malformed_quotes_are_refused_with_a_reason(self, overrides: dict[str, object], reason: str) -> None:
+        obs = normalise_quote(instrument_id=3417, quote=_quote(**overrides), observed_at=OBSERVED_AT)
+        assert obs.observation_status == "invalid"
+        assert obs.refusal_reason == reason
+        # A refused row carries no denomination: the rate rides on the same
+        # response the bid/ask came from (sql/366's shape CHECK).
+        assert obs.conversion_rate is None
+
+    def test_a_stale_quote_is_refused_not_counted_again(self) -> None:
+        """The weekend case: a shut market re-serves Friday's quote hourly.
+
+        Recording it would inflate the five-day percentile with duplicates of
+        one spread — the single error that moves a percentile with no new
+        information arriving. Dev-measured 2026-08-23 (a Sunday).
+        """
+        friday = OBSERVED_AT - timedelta(days=2)
+        obs = normalise_quote(instrument_id=3417, quote=_quote(timestamp=friday), observed_at=OBSERVED_AT)
+        assert obs.observation_status == "invalid"
+        assert obs.refusal_reason == "quote_stale"
+        assert obs.spread_bps is None
+        assert obs.conversion_rate is None
+
+    def test_a_quote_just_inside_the_bound_is_still_evidence(self) -> None:
+        """A 5-second-old quote in a fresh bucket must NOT be refused."""
+        obs = normalise_quote(
+            instrument_id=3417,
+            quote=_quote(timestamp=OBSERVED_AT - timedelta(seconds=5)),
+            observed_at=OBSERVED_AT,
+        )
+        assert obs.observation_status == "observed"
+        assert obs.spread_bps is not None
+
+    def test_the_staleness_bound_is_the_sampling_interval(self) -> None:
+        """Exactly one interval old is accepted; a second beyond is not."""
+        at_bound = normalise_quote(
+            instrument_id=3417,
+            quote=_quote(timestamp=OBSERVED_AT - MAX_QUOTE_AGE),
+            observed_at=OBSERVED_AT,
+        )
+        just_past = normalise_quote(
+            instrument_id=3417,
+            quote=_quote(timestamp=OBSERVED_AT - MAX_QUOTE_AGE - timedelta(seconds=1)),
+            observed_at=OBSERVED_AT,
+        )
+        assert at_bound.observation_status == "observed"
+        assert just_past.observation_status == "invalid"
+        assert just_past.refusal_reason == "quote_stale"
+
+    def test_a_future_dated_quote_is_refused(self) -> None:
+        """The mirror of staleness: a negative age never expires.
+
+        Left accepted, one future-dated response could fill every later
+        bucket with the same quote — the same duplicate-evidence failure
+        arriving from the other direction.
+        """
+        obs = normalise_quote(
+            instrument_id=3417,
+            quote=_quote(timestamp=OBSERVED_AT + MAX_QUOTE_AGE + timedelta(seconds=1)),
+            observed_at=OBSERVED_AT,
+        )
+        assert obs.observation_status == "invalid"
+        assert obs.refusal_reason == "quote_future"
+
+    def test_small_clock_skew_is_tolerated(self) -> None:
+        """Sub-interval skew is normal and must not discard good evidence."""
+        obs = normalise_quote(
+            instrument_id=3417,
+            quote=_quote(timestamp=OBSERVED_AT + timedelta(seconds=2)),
+            observed_at=OBSERVED_AT,
+        )
+        assert obs.observation_status == "observed"
+
+    def test_a_malformed_quote_reports_its_own_reason_not_staleness(self) -> None:
+        """Shape guards run first so the operator sees the actionable reason."""
+        obs = normalise_quote(
+            instrument_id=3417,
+            quote=_quote(bid=Decimal("0"), timestamp=OBSERVED_AT - timedelta(days=2)),
+            observed_at=OBSERVED_AT,
+        )
+        assert obs.refusal_reason == "nonpositive_bid_or_ask"
+
+    def test_absent_conversion_rate_stays_null_and_is_not_read_as_usd(self) -> None:
+        """NULL means the provider did not tell us -- never 'USD'.
+
+        `instruments.currency` is a VENUE lookup, so it cannot be used as a
+        fallback: every `.L` line reads GBP whatever its real denomination.
+        """
+        obs = normalise_quote(instrument_id=3434, quote=_quote(conversion_rate=None), observed_at=OBSERVED_AT)
+        assert obs.observation_status == "observed"
+        assert obs.conversion_rate is None
+
+    def test_nonpositive_conversion_rate_is_dropped_to_null(self) -> None:
+        obs = normalise_quote(
+            instrument_id=3434,
+            quote=_quote(conversion_rate=Decimal("0")),
+            observed_at=OBSERVED_AT,
+        )
+        assert obs.observation_status == "observed"
+        assert obs.conversion_rate is None
+
+    def test_non_usd_denomination_is_preserved_verbatim(self) -> None:
+        """IUSA.L measured 0.0136315 on 2026-08-23 -- GBX, stored as GBP."""
+        obs = normalise_quote(
+            instrument_id=3075,
+            quote=_quote(conversion_rate=Decimal("0.0136315")),
+            observed_at=OBSERVED_AT,
+        )
+        assert obs.conversion_rate == Decimal("0.0136315")
+        assert obs.conversion_rate != Decimal("1")


### PR DESCRIPTION
## What this fixes

#2833 step 2's pass bar is *"a spread percentile over ~5 trading days of stored quote snapshots"*. `quotes_refresh` **arm 5** (#2864) correctly widened the refresh scope to the proved candidates — but `quotes` is **one mutable row per instrument** (`quotes_pkey` is UNIQUE on `instrument_id` alone), exactly as `sql/306` already records: *"`quotes` is intentionally one mutable current row per instrument. It cannot establish the cost that was observable at a historical decision or fill."*

So five trading days of hourly ticks still leave **n=1**. Waiting longer cannot change that — it is a property of the primary key, not of elapsed time.

Measured on dev 2026-08-23, every proved candidate had exactly one `quotes` row:

```
3417 SPY.RTH · 3418 QQQ.RTH · 3434 CSPX.L · 3075 IUSA.L
15445 IUMO.L · 15446 IUQA.L · 14465 R1VL.L      → 1 row each
```

The lane that *does* accumulate (`strategy_quote_observations`) is FK-bound to the intraday research panel — 8 symbols whose "SPY" is instrument **3000**, not the candidate SPY.**RTH** 3417 — and buckets at five minutes. Relaxing a CHECK on an immutable evidence table to admit a different cohort is worse than a sibling with its own honest constraints.

## What it adds

`strategy_core_quote_observations` (sql/366): one **immutable hourly row** per proved candidate, written from the `Quote` objects `refresh_quotes` already holds — **no extra provider calls**. Membership is the arm-5 predicate itself, so a candidate leaves this lane the same way it leaves quoting: by being re-proved.

### The denomination finding — this reverses #2833's own in-lane table

The rows also carry `conversion_rate`: eToro's documented *"conversion rate from the **instrument's** currency to USD"* (live portal `market-data/get-instrument-market-rates`, verified 2026-08-23).

This is the **only** per-instrument denomination signal the API exposes — `get-instrument-display-data` carries no currency field at all (verified live; the #1431 code comment still holds). `instruments.currency` is a **VENUE** lookup off `exchanges.currency` (`universe.py`: *"currency is a property of where a listing trades"*, no instrument-level override, #1233 §6.1), so every `.L` line reads GBP regardless of what it is denominated in.

Measured 2026-08-23:

| symbol | stored `currency` | conversion rate | actual |
| --- | --- | ---: | --- |
| CSPX.L, IUMO.L, IUQA.L, R1VL.L | GBP | **1.0** | **USD** |
| IUSA.L | GBP | 0.0136315 | GBX (×100 = 1.363 = GBP→USD) |
| QDVA/QDVB/QDVI.DE | EUR | 1.1677 | EUR |
| SPY.RTH, QQQ.RTH | USD | 1.0 | USD |

⚠ **This bears on #2834 ARM A before its declaration freezes.** That ticket records *"ARM A has no in-lane option → declares `fx_unmodelled` by construction"*, which is a permanent promotion refusal — and it was derived from the venue field. The three tilt ETFs (IUMO.L 15445, IUQA.L 15446, R1VL.L 14465) all measure **exactly 1.0**. This PR does not change ARM A's declaration; it makes the denomination measurable so that call rests on evidence rather than on `exchanges.currency`.

⚠ `NULL` means the provider omitted the rate — it does **not** mean USD. Readers must test `= 1` explicitly (same posture as data-engineer I23).

## Staleness — both bugs found by Codex ckpt-2

eToro re-serves the last quote when the market is shut (#2833: *"markets shut; the provider returns the last quote"*; the etoro-api skill records 18/20 preflight timestamps ~41 hours old). Dev-verified on a **Sunday**: all ten candidates returned Friday quotes and wrote ten `observed` rows. Left alone, a weekend would move the percentile with no new information arriving.

Quotes outside **one sampling interval** of the observation instant are now refused as `quote_stale` / `quote_future`. The bound is the tick cadence itself, not an invented threshold: at one sample per hour, anything older was already observable last tick. It is **symmetric** because a future-dated quote has a negative age and would otherwise never expire — the same duplicate-evidence failure from the other direction (Codex's second finding).

A bucket-relative test would be wrong in the other direction: a 14:59:58 quote recorded in the 15:00 bucket is five seconds old and is good evidence.

## Verification

| clause | evidence |
| --- | --- |
| Migration applied | `run_migrations()` → `['366_strategy_core_quote_observations.sql']` on dev |
| Real path exercised | `refresh_quotes(...)` with live provider, 10 candidates → `core_observations_written = 10` |
| Denomination correct | table above; venue-vs-actual divergence visible in the stored rows |
| Idempotent | second run in same bucket → `core_observations_written = 0`, row count stable at 10 |
| Immutable | `UPDATE` → `core quote observations are immutable; insert the next hourly bucket` |
| Staleness guard | post-fix Sunday re-run → 10/10 `invalid` / `quote_stale`, coverage recorded not fabricated |
| Gates | ruff 0, ruff-format 0, pyright 0 errors, `-m "not db"` 0, smoke 0, touched-module tests 157 passed |

⚠ Test note: `pytest tests/test_quotes_refresh.py` under the repo's default `-n 4 --dist=loadgroup` collected **0 tests and exited 0** — a false green. Run serially (`-n 0`) to actually exercise them; 157 passed that way. Not from this PR, flagged in one line per the incidental rule.

## Security

No new external input, no auth surface, no order path. The lane is read-only against the broker (market-data rates only) and writes one append-only table. Membership is bounded by the eligibility-proof predicate, which only the deliberate `prove` action writes.

Refs #2833. Refs #2834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
