### PR TITLE
fix(#2859): restore the live/paper authority boundary — and close the bypass that made it one-sided

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -48,10 +48,15 @@ from app.services.ops_monitor import (
     get_kill_switch_status,
 )
 from app.services.runtime_config import (
+    RuntimeConfig,
     RuntimeConfigCorrupt,
     RuntimeConfigNoOp,
     get_runtime_config,
     update_runtime_config,
+)
+from app.services.strategy_control_plane import (
+    PAPER_ALLOCATOR_ADVISORY_LOCK,
+    paper_automation_enabled,
 )
 
 logger = logging.getLogger(__name__)
@@ -221,8 +226,9 @@ def patch_config(
     Returns the post-update runtime config (not the full /config response;
     the caller can re-GET if they need kill switch state too).
     """
-    try:
-        updated = update_runtime_config(
+
+    def _apply() -> RuntimeConfig:
+        return update_runtime_config(
             conn,
             updated_by=body.updated_by,
             reason=body.reason,
@@ -234,6 +240,30 @@ def patch_config(
             llm_model_writer=body.llm_model_writer,
             llm_model_critic=body.llm_model_critic,
         )
+
+    try:
+        if body.enable_live_trading:
+            # #2859 — the INVERSE half of the paper/live exclusivity rule.
+            # `update_strategy_paper_pool` refuses to enable paper automation
+            # while live trading is on; without this, that is trivially bypassed
+            # by enabling paper first and live second, and both flags end up set.
+            #
+            # ⚠ The lock is what makes the pair an invariant rather than two
+            # independent checks. Both sides read the other's state under
+            # PAPER_ALLOCATOR_ADVISORY_LOCK, so whichever enable arrives second
+            # sees the first and refuses. Checking without the shared lock leaves
+            # the window where two concurrent enables both read "off".
+            conn.rollback()
+            with conn.transaction():
+                conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
+                if paper_automation_enabled(conn):
+                    raise HTTPException(
+                        status_code=409,
+                        detail="live trading cannot be enabled while strategy paper automation is enabled",
+                    )
+                updated = _apply()
+        else:
+            updated = _apply()
     except RuntimeConfigCorrupt as exc:
         # #87: fixed string instead of str(exc) — see GET handler note.
         raise HTTPException(status_code=503, detail="runtime config unavailable") from exc

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -3136,6 +3136,21 @@ def update_strategy_paper_pool(
 ) -> StrategyPaperPoolView:
     """Set the shared strategy ceiling and its higher-level automation flag."""
     try:
+        # #2859 — the live/paper AUTHORITY boundary, restored from the unpushed
+        # 2026-08-15 branch. ⚠ Both refusals fire ONLY on enable: disabling is
+        # risk reduction and is never blocked, the same asymmetry the execution
+        # guard applies to EXIT.
+        #
+        # ⚠ These are DEFENCE IN DEPTH, not the layer that stops a real order.
+        # `EtoroBrokerProvider.place_demo_strategy_order` already refuses when
+        # `self._env != "demo"`, hardcodes the demo endpoint, and runs
+        # `refuse_broker_mutation_if_unattended` first. What was missing is
+        # honesty at the CONTROL PLANE: without these, the operator can switch
+        # automation to "enabled" in a real environment, or alongside
+        # system-wide live trading, and every resulting order fails at the
+        # broker instead of the state being refused where it is set.
+        if body.enabled and settings.etoro_env != "demo":
+            raise StrategyControlError("paper automation can only be enabled in the demo environment")
         readiness = get_strategy_overview(conn).automation_readiness if body.enabled else None
         conn.rollback()
         with conn.transaction():
@@ -3144,6 +3159,16 @@ def update_strategy_paper_pool(
             if body.enabled and not current_pool.enabled and readiness is not None and not readiness.ready:
                 raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
             runtime = get_runtime_config(conn)
+            # ⚠ Read INSIDE the advisory lock, and that only closes the race
+            # because `app.api.config.patch_config` takes the SAME lock to
+            # enforce the inverse rule (refuse live enable while paper is on).
+            # One-sided, this check is bypassed by enabling paper first and live
+            # second — Codex caught exactly that at checkpoint 2. The two halves
+            # are one invariant; do not remove either without the other.
+            if body.enabled and runtime.enable_live_trading:
+                raise StrategyControlError(
+                    "paper automation cannot be enabled while system-wide live trading is enabled"
+                )
             # #2843: omitted means UNCHANGED, so the resolved value -- never the raw
             # request field -- is what both the change test and the INSERT see. The
             # rule is a named function so it has a test surface; see its docstring.

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -221,6 +221,29 @@ class PaperPool:
     approval_mode: ApprovalMode = "manual"
 
 
+def paper_automation_enabled(conn: psycopg.Connection[Any]) -> bool:
+    """Just the enabled flag of the latest pool revision. #2859.
+
+    ⚠ Deliberately NOT ``load_paper_pool(conn).enabled``. That builds the whole
+    ``PortfolioMandate``, parsing eight optional Decimals, and a caller that
+    needs one boolean should not fail on a mandate column it never reads. The
+    exclusivity guard in ``app.api.config.patch_config`` is on the live-enable
+    path, so widening its failure surface to the mandate parser would be a way
+    to make enabling live trading fail for an unrelated reason.
+
+    No row at all means no pool was ever configured, which is not enabled.
+    """
+    row = conn.execute(
+        """
+        SELECT enabled
+        FROM strategy_paper_pool_events
+        ORDER BY strategy_paper_pool_event_id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    return False if row is None else bool(row[0])
+
+
 def load_paper_pool(conn: psycopg.Connection[Any]) -> PaperPool:
     row = conn.execute(
         """
@@ -1262,6 +1285,7 @@ __all__ = [
     "GOVERNANCE_GATE_VERSION",
     "PaperPool",
     "PAPER_ALLOCATOR_ADVISORY_LOCK",
+    "paper_automation_enabled",
     "Promotion",
     "StrategyControlError",
     "StrategyOwnershipError",

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -82,6 +82,11 @@ _SQL_DIR = Path(__file__).resolve().parents[2] / "sql"
 #: The review bot flagged one of the three; the other two were only visible by
 #: grepping `5`, which is the recurring shape behind this repo's "extract once"
 #: rule.
+#:
+#: ⚠ `tests/test_validated_universe.py` deliberately does NOT import this and
+#: keeps its own literal. It is the test OF `resolve_stocks_type_id`, so sharing
+#: the constant would let fixture and assertion drift together — the one place
+#: where duplicating the value is the point.
 STOCKS_TYPE_ID = 5
 
 

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -48,6 +48,7 @@ from collections.abc import Iterator
 from datetime import datetime, timedelta
 from pathlib import Path
 from secrets import token_hex
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 import psycopg
@@ -69,6 +70,43 @@ from app.db.dev_test_db_reaper import (
 
 TEMPLATE_DB_NAME = "ebull_test_template"
 _SQL_DIR = Path(__file__).resolve().parents[2] / "sql"
+
+#: The §4.0 validated-universe anchor. `etoro_instrument_types` is created empty
+#: by `sql/070` and filled by the nightly eToro universe sync, so a test DB never
+#: has it, and since #2809 anything reading the scan freshness bar through
+#: `load_validated_universe` REFUSES on zero rows.
+#:
+#: ⚠ ONE source of truth (#2859). This literal was copied into three test modules
+#: — `test_validated_universe`, `test_api_strategies` and `test_strategy_monitoring`
+#: — so a change to the anchor id would have had to be found by grepping the VALUE.
+#: The review bot flagged one of the three; the other two were only visible by
+#: grepping `5`, which is the recurring shape behind this repo's "extract once"
+#: rule.
+STOCKS_TYPE_ID = 5
+
+
+def seed_universe_anchor(conn: psycopg.Connection[Any]) -> None:
+    """Insert the §4.0 `Stocks` anchor and COMMIT it.
+
+    ⚠ The commit is load-bearing. `update_strategy_paper_pool` calls
+    `conn.rollback()` before opening its own transaction, so an uncommitted
+    anchor is discarded and the overview it returns at the end raises again.
+
+    Deliberately only the ANCHOR — seeding instruments too would hand a caller a
+    non-empty validated universe it never asked for.
+    """
+    from app.services.strategies.validated_universe import STOCKS_TYPE_DESCRIPTION
+
+    conn.execute(
+        """
+        INSERT INTO etoro_instrument_types (instrument_type_id, description)
+        VALUES (%(stocks)s, %(description)s)
+        ON CONFLICT (instrument_type_id) DO NOTHING
+        """,
+        {"stocks": STOCKS_TYPE_ID, "description": STOCKS_TYPE_DESCRIPTION},
+    )
+    conn.commit()
+
 
 # #1208 Phase 2 / #1444 — the orphan-sweep safety rails (name regex +
 # ``_NEVER_DROP`` protect-set) now live in ``app/db/dev_test_db_reaper.py``

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -26,7 +26,14 @@ _NOW = datetime(2026, 4, 7, 12, 0, 0, tzinfo=UTC)
 
 
 def _mock_conn() -> MagicMock:
-    return MagicMock()
+    conn = MagicMock()
+    # #2859 — enabling live trading now reads the paper pool under the shared
+    # advisory lock and refuses if paper automation is on. A bare MagicMock
+    # returns a truthy row for that read, which would refuse every live-enable
+    # test here for the wrong reason. `None` is "no pool ever configured", the
+    # honest default for a config test that is not about the strategy lane.
+    conn.execute.return_value.fetchone.return_value = None
+    return conn
 
 
 def _override_conn(conn: MagicMock) -> None:

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -26,7 +26,6 @@ from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_V
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.result_ledger import store_holdout_result, store_in_sample_result
-from app.services.strategies.validated_universe import STOCKS_TYPE_DESCRIPTION
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
 from app.services.strategy_regime_evidence import (
@@ -37,6 +36,7 @@ from app.services.strategy_regime_evidence import (
 from app.services.strategy_result import LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS
 from app.services.strategy_result_ambiguity import AMBIGUITY_RULE_VERSION, AmbiguityRecord, record_sha256
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
+from tests.fixtures.ebull_test_db import seed_universe_anchor
 from tests.test_result_ledger import build_metrics, build_result
 
 _IMMATERIAL_AMBIGUITY: dict[str, object] = {
@@ -46,30 +46,6 @@ _IMMATERIAL_AMBIGUITY: dict[str, object] = {
     "ambiguity_worst_case_sharpe": None,
     "ambiguity_cohort_gap_threshold": None,
 }
-
-#: `etoro_instrument_types` is created empty by `sql/070` and filled by the
-#: nightly eToro universe sync, so a test DB never has it. Since #2809 the
-#: overview reads the scan freshness bar through `load_validated_universe`,
-#: which resolves the §4.0 `Stocks` anchor and REFUSES on zero rows — so every
-#: DB test here raises `RuntimeError` without this seed. That refusal is the
-#: right behaviour for an unbootstrapped system; what is missing is the
-#: bootstrap, which is what this supplies.
-#:
-#: Deliberately only the anchor. The tests that follow assert on scan status and
-#: result provenance, and seeding instruments too would give them a non-empty
-#: universe none of them asked for.
-_STOCKS_TYPE_ID = 5
-
-
-def _seed_universe_anchor(conn: psycopg.Connection[tuple]) -> None:
-    conn.execute(
-        """
-        INSERT INTO etoro_instrument_types (instrument_type_id, description)
-        VALUES (%(stocks)s, %(description)s)
-        ON CONFLICT (instrument_type_id) DO NOTHING
-        """,
-        {"stocks": _STOCKS_TYPE_ID, "description": STOCKS_TYPE_DESCRIPTION},
-    )
 
 
 def test_operator_ambiguity_payloads_are_hash_verified_when_loaded_from_sql() -> None:
@@ -473,7 +449,7 @@ def test_result_arm_accepts_valid_undefined_downside_metrics() -> None:
 def test_empty_ledgers_still_return_all_manifest_strategies(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     overview = get_strategy_overview(ebull_test_conn)
     assert [item.strategy_id for item in overview.strategies] == sorted(STRATEGY_MANIFEST)
     assert all(item.scan.status == "never_run" for item in overview.strategies)
@@ -493,7 +469,7 @@ def test_empty_ledgers_still_return_all_manifest_strategies(
 def test_completed_zero_signal_scan_uses_its_watermark(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     strategy_id = "s2-cross-sectional-momentum"
     version = _current_scan_versions()[strategy_id]
     frontier = date(2026, 7, 8)
@@ -530,7 +506,7 @@ def test_completed_zero_signal_scan_uses_its_watermark(
 def test_scan_health_reads_durable_daily_counts_after_detail_retention(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     version = _current_scan_versions()[strategy_id]
     ebull_test_conn.execute(
@@ -572,7 +548,7 @@ def test_scan_health_reads_durable_daily_counts_after_detail_retention(
 def test_overview_maps_only_exact_current_holdout_provenance(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     strategy_version = _current_versions()[strategy_id]
     window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
@@ -660,7 +636,7 @@ def test_overview_regime_cohorts_follow_the_result_ids_not_a_second_pin_predicat
     `bull_quiet` — which is what `build_regime_cohorts` writes, since it sorts
     alphabetically — and must READ back bull-before-bear.
     """
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     strategy_version = _current_versions()[strategy_id]
     window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
@@ -774,7 +750,7 @@ def test_overview_leaves_regime_cohorts_empty_for_a_result_written_before_the_wr
     what lets the reader say "not measured for this result version" instead of
     "no trades in any regime".
     """
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
     store_holdout_result(
@@ -822,7 +798,7 @@ def test_regime_cohort_display_order_covers_every_label_the_producer_can_write()
 def test_overview_declares_exactly_the_manifest_strategies_with_exit_adapters_as_forward_resolvable(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     overview = get_strategy_overview(ebull_test_conn)
     support = {item.strategy_id: item.forward_outcome_supported for item in overview.strategies}
 

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -32,7 +32,6 @@ from app.services.cost_model import COST_MODEL_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.runtime_config import get_runtime_config, update_runtime_config
-from app.services.strategies.validated_universe import STOCKS_TYPE_DESCRIPTION
 from app.services.strategy_control_plane import configure_paper_pool, load_paper_pool
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_monitoring import (
@@ -43,6 +42,7 @@ from app.services.strategy_monitoring import (
 )
 from app.services.strategy_position_manager import PositionManagerResult
 from app.services.strategy_signal_scan import SCAN_UNIVERSE
+from tests.fixtures.ebull_test_db import seed_universe_anchor
 
 
 def _scan_version(strategy_id: str) -> str:
@@ -1240,7 +1240,7 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     conn = ebull_test_conn
-    _seed_universe_anchor(conn)
+    seed_universe_anchor(conn)
     actual_overview = get_strategy_overview
 
     def ready_overview(connection: psycopg.Connection[object]):
@@ -1326,7 +1326,7 @@ def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     conn = ebull_test_conn
-    _seed_universe_anchor(conn)
+    seed_universe_anchor(conn)
     if get_runtime_config(conn).enable_auto_trading:
         update_runtime_config(
             conn,
@@ -1352,34 +1352,6 @@ def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(
     assert exc_info.value.status_code == 409
     assert "no_capital_candidates" in str(exc_info.value.detail)
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
-
-
-#: `etoro_instrument_types` is created empty by `sql/070` and filled by the
-#: nightly eToro universe sync, so a test DB never has it. Since #2809 the
-#: overview reads the scan freshness bar through `load_validated_universe`,
-#: which resolves the §4.0 `Stocks` anchor and REFUSES on zero rows. Every
-#: paper-pool test here calls `get_strategy_overview`, so all of them raise
-#: `RuntimeError` without this seed.
-#:
-#: ⚠ Same shape as `tests/test_api_strategies.py::_seed_universe_anchor`, and
-#: deliberately only the ANCHOR — seeding instruments too would hand these tests
-#: a non-empty universe none of them asked for.
-_STOCKS_TYPE_ID = 5
-
-
-def _seed_universe_anchor(conn: psycopg.Connection[Any]) -> None:
-    conn.execute(
-        """
-        INSERT INTO etoro_instrument_types (instrument_type_id, description)
-        VALUES (%(stocks)s, %(description)s)
-        ON CONFLICT (instrument_type_id) DO NOTHING
-        """,
-        {"stocks": _STOCKS_TYPE_ID, "description": STOCKS_TYPE_DESCRIPTION},
-    )
-    # ⚠ MUST commit. `update_strategy_paper_pool` calls `conn.rollback()` before
-    # opening its own transaction, so an uncommitted anchor is discarded and the
-    # overview it returns at the end raises on zero rows again.
-    conn.commit()
 
 
 def _ready_overview_patch(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1412,7 +1384,7 @@ def test_shared_paper_pool_refuses_activation_outside_demo(
     order it produces dies at the broker.
     """
     conn = ebull_test_conn
-    _seed_universe_anchor(conn)
+    seed_universe_anchor(conn)
     _ready_overview_patch(monkeypatch)
     monkeypatch.setattr("app.api.strategies.settings.etoro_env", "real")
     runtime_before = get_runtime_config(conn)
@@ -1448,7 +1420,7 @@ def test_paper_pool_disable_is_not_blocked_outside_demo(
     having no guard. Same asymmetry the execution guard applies to EXIT.
     """
     conn = ebull_test_conn
-    _seed_universe_anchor(conn)
+    seed_universe_anchor(conn)
     monkeypatch.setattr("app.api.strategies.settings.etoro_env", "real")
 
     response = update_strategy_paper_pool(
@@ -1476,7 +1448,7 @@ def test_shared_paper_pool_refuses_activation_while_live_trading_is_enabled(
     concurrent live enable cannot land between the check and the write.
     """
     conn = ebull_test_conn
-    _seed_universe_anchor(conn)
+    seed_universe_anchor(conn)
     _ready_overview_patch(monkeypatch)
     runtime_before = get_runtime_config(conn)
     update_runtime_config(
@@ -1531,7 +1503,7 @@ def test_live_trading_enable_is_refused_while_paper_automation_is_enabled(
     The two refusals are one invariant and are tested as a pair.
     """
     conn = ebull_test_conn
-    _seed_universe_anchor(conn)
+    seed_universe_anchor(conn)
     _ready_overview_patch(monkeypatch)
     runtime_before = get_runtime_config(conn)
     configure_paper_pool(
@@ -1610,7 +1582,7 @@ def test_evidence_refresh_queues_one_fixed_pinned_request(
 def test_missing_evidence_refuses_new_allocation_without_writing_audit(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     version = _current_versions()[strategy_id]
     ebull_test_conn.commit()
@@ -1640,7 +1612,7 @@ def test_missing_evidence_refuses_new_allocation_without_writing_audit(
 def test_evidence_invalid_enabled_allocation_can_reduce_without_disabling(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     version = _current_versions()[strategy_id]
     deployment_id = _deployment(ebull_test_conn, strategy_id, version)
@@ -1720,7 +1692,7 @@ def test_disabled_automatic_trading_is_visible_as_an_entry_block(
 def test_operator_allocation_uses_session_identity_and_immutable_event(
     ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _seed_universe_anchor(ebull_test_conn)
+    seed_universe_anchor(ebull_test_conn)
     from app.services import strategy_control_plane
 
     strategy_id = "s1-time-series-momentum"

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -13,6 +13,7 @@ import psycopg
 import pytest
 from fastapi import HTTPException, Request
 
+from app.api.config import ConfigPatchRequest, patch_config
 from app.api.strategies import (
     AllocationUpdateRequest,
     StrategyPaperPoolUpdateRequest,
@@ -31,6 +32,8 @@ from app.services.cost_model import COST_MODEL_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.runtime_config import get_runtime_config, update_runtime_config
+from app.services.strategies.validated_universe import STOCKS_TYPE_DESCRIPTION
+from app.services.strategy_control_plane import configure_paper_pool, load_paper_pool
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_monitoring import (
     load_attribution,
@@ -1237,6 +1240,7 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     conn = ebull_test_conn
+    _seed_universe_anchor(conn)
     actual_overview = get_strategy_overview
 
     def ready_overview(connection: psycopg.Connection[object]):
@@ -1322,6 +1326,7 @@ def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     conn = ebull_test_conn
+    _seed_universe_anchor(conn)
     if get_runtime_config(conn).enable_auto_trading:
         update_runtime_config(
             conn,
@@ -1347,6 +1352,233 @@ def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(
     assert exc_info.value.status_code == 409
     assert "no_capital_candidates" in str(exc_info.value.detail)
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
+
+
+#: `etoro_instrument_types` is created empty by `sql/070` and filled by the
+#: nightly eToro universe sync, so a test DB never has it. Since #2809 the
+#: overview reads the scan freshness bar through `load_validated_universe`,
+#: which resolves the §4.0 `Stocks` anchor and REFUSES on zero rows. Every
+#: paper-pool test here calls `get_strategy_overview`, so all of them raise
+#: `RuntimeError` without this seed.
+#:
+#: ⚠ Same shape as `tests/test_api_strategies.py::_seed_universe_anchor`, and
+#: deliberately only the ANCHOR — seeding instruments too would hand these tests
+#: a non-empty universe none of them asked for.
+_STOCKS_TYPE_ID = 5
+
+
+def _seed_universe_anchor(conn: psycopg.Connection[Any]) -> None:
+    conn.execute(
+        """
+        INSERT INTO etoro_instrument_types (instrument_type_id, description)
+        VALUES (%(stocks)s, %(description)s)
+        ON CONFLICT (instrument_type_id) DO NOTHING
+        """,
+        {"stocks": _STOCKS_TYPE_ID, "description": STOCKS_TYPE_DESCRIPTION},
+    )
+    # ⚠ MUST commit. `update_strategy_paper_pool` calls `conn.rollback()` before
+    # opening its own transaction, so an uncommitted anchor is discarded and the
+    # overview it returns at the end raises on zero rows again.
+    conn.commit()
+
+
+def _ready_overview_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force automation readiness so a LATER refusal is what the test proves.
+
+    Without this the evidence readiness check refuses first and the test would
+    pass for the wrong reason — it would never reach the boundary it names.
+    """
+    actual_overview = get_strategy_overview
+
+    def ready_overview(connection: psycopg.Connection[object]):
+        overview = actual_overview(connection)
+        overview.automation_readiness = overview.automation_readiness.model_copy(
+            update={"ready": True, "state": "ready", "blockers": []}
+        )
+        return overview
+
+    monkeypatch.setattr("app.api.strategies.get_strategy_overview", ready_overview)
+
+
+def test_shared_paper_pool_refuses_activation_outside_demo(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2859 — the control plane refuses to CLAIM automation a real env cannot run.
+
+    The broker layer already refuses (``place_demo_strategy_order`` raises on
+    ``self._env != "demo"``), so this is defence in depth. What it buys is an
+    honest operator surface: without it the pool reads "enabled" while every
+    order it produces dies at the broker.
+    """
+    conn = ebull_test_conn
+    _seed_universe_anchor(conn)
+    _ready_overview_patch(monkeypatch)
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "real")
+    runtime_before = get_runtime_config(conn)
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_strategy_paper_pool(
+            StrategyPaperPoolUpdateRequest(
+                enabled=True,
+                capital_limit=Decimal("750"),
+                capital_mode="fixed",
+                risk_profile="balanced",
+                reason="must remain demo-only",
+            ),
+            _session(),
+            conn,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "paper automation can only be enabled in the demo environment"
+    # Refused BEFORE any write: no audit event, and the runtime singleton is untouched.
+    assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
+    assert get_runtime_config(conn) == runtime_before
+
+
+def test_paper_pool_disable_is_not_blocked_outside_demo(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """⚠ The demo refusal must be one-directional — risk REDUCTION is never blocked.
+
+    A guard that also refused the disable would strand automation switched on in
+    exactly the environment it must not run in, which is strictly worse than
+    having no guard. Same asymmetry the execution guard applies to EXIT.
+    """
+    conn = ebull_test_conn
+    _seed_universe_anchor(conn)
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "real")
+
+    response = update_strategy_paper_pool(
+        StrategyPaperPoolUpdateRequest(
+            enabled=False,
+            capital_limit=Decimal("750"),
+            capital_mode="fixed",
+            risk_profile="balanced",
+            reason="risk reduction must always be reachable",
+        ),
+        _session(),
+        conn,
+    )
+
+    assert not response.enabled
+
+
+def test_shared_paper_pool_refuses_activation_while_live_trading_is_enabled(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2859 — paper automation and system-wide live trading are mutually exclusive.
+
+    ⚠ The refusal reads ``enable_live_trading`` INSIDE the advisory lock, so a
+    concurrent live enable cannot land between the check and the write.
+    """
+    conn = ebull_test_conn
+    _seed_universe_anchor(conn)
+    _ready_overview_patch(monkeypatch)
+    runtime_before = get_runtime_config(conn)
+    update_runtime_config(
+        conn,
+        updated_by="test-precondition",
+        reason="prove paper enable refuses live state",
+        enable_auto_trading=False if runtime_before.enable_auto_trading else None,
+        enable_live_trading=True,
+    )
+    conn.commit()
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            update_strategy_paper_pool(
+                StrategyPaperPoolUpdateRequest(
+                    enabled=True,
+                    capital_limit=Decimal("750"),
+                    capital_mode="fixed",
+                    risk_profile="balanced",
+                    reason="must remain paper-only",
+                ),
+                _session(),
+                conn,
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == ("paper automation cannot be enabled while system-wide live trading is enabled")
+        assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
+        assert conn.execute(
+            "SELECT enable_auto_trading,enable_live_trading FROM runtime_config WHERE id=TRUE"
+        ).fetchone() == (False, True)
+    finally:
+        # ⚠ runtime_config is a persistent singleton, NOT per-test state. Leaving
+        # live trading on here would silently change every later test's premise.
+        update_runtime_config(
+            conn,
+            updated_by="test-cleanup",
+            reason="restore runtime flags after live-state refusal proof",
+            enable_auto_trading=(True if runtime_before.enable_auto_trading else None),
+            enable_live_trading=runtime_before.enable_live_trading,
+        )
+        conn.commit()
+
+
+def test_live_trading_enable_is_refused_while_paper_automation_is_enabled(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2859 — the INVERSE half, without which the exclusivity rule is decorative.
+
+    ⚠ Codex checkpoint 2 caught this: guarding only the paper-pool endpoint is
+    bypassed by enabling paper FIRST and live SECOND, which lands both flags on.
+    The two refusals are one invariant and are tested as a pair.
+    """
+    conn = ebull_test_conn
+    _seed_universe_anchor(conn)
+    _ready_overview_patch(monkeypatch)
+    runtime_before = get_runtime_config(conn)
+    configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("750"),
+        capital_mode="fixed",
+        risk_profile="balanced",
+        approval_mode=load_paper_pool(conn).approval_mode,
+        changed_by="test-precondition",
+        reason="establish an enabled paper lane",
+    )
+    conn.commit()
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            patch_config(
+                ConfigPatchRequest(
+                    updated_by="test-operator",
+                    reason="attempt the bypass the paper-side guard cannot see",
+                    enable_live_trading=True,
+                    confirm_live_enable=True,
+                ),
+                conn,
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == ("live trading cannot be enabled while strategy paper automation is enabled")
+        assert not get_runtime_config(conn).enable_live_trading
+    finally:
+        configure_paper_pool(
+            conn,
+            enabled=False,
+            capital_limit=Decimal("750"),
+            capital_mode="fixed",
+            risk_profile="balanced",
+            approval_mode=load_paper_pool(conn).approval_mode,
+            changed_by="test-cleanup",
+            reason="restore disabled paper lane",
+        )
+        if get_runtime_config(conn).enable_live_trading != runtime_before.enable_live_trading:
+            update_runtime_config(
+                conn,
+                updated_by="test-cleanup",
+                reason="restore runtime flags after exclusivity proof",
+                enable_live_trading=runtime_before.enable_live_trading,
+            )
+        conn.commit()
 
 
 def test_evidence_refresh_queues_one_fixed_pinned_request(
@@ -1378,6 +1610,7 @@ def test_evidence_refresh_queues_one_fixed_pinned_request(
 def test_missing_evidence_refuses_new_allocation_without_writing_audit(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
+    _seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     version = _current_versions()[strategy_id]
     ebull_test_conn.commit()
@@ -1407,6 +1640,7 @@ def test_missing_evidence_refuses_new_allocation_without_writing_audit(
 def test_evidence_invalid_enabled_allocation_can_reduce_without_disabling(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
+    _seed_universe_anchor(ebull_test_conn)
     strategy_id = "s1-time-series-momentum"
     version = _current_versions()[strategy_id]
     deployment_id = _deployment(ebull_test_conn, strategy_id, version)
@@ -1486,6 +1720,7 @@ def test_disabled_automatic_trading_is_visible_as_an_entry_block(
 def test_operator_allocation_uses_session_identity_and_immutable_event(
     ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _seed_universe_anchor(ebull_test_conn)
     from app.services import strategy_control_plane
 
     strategy_id = "s1-time-series-momentum"

--- a/tests/test_validated_universe.py
+++ b/tests/test_validated_universe.py
@@ -33,14 +33,18 @@ from app.services.strategies.validated_universe import (
     resolve_stocks_type_id,
 )
 from tests.fixtures.ebull_test_db import (
-    STOCKS_TYPE_ID,
     ebull_test_conn,  # noqa: F401 — fixture re-export
 )
 
 #: eToro's own ids, so the fixture cannot accidentally agree with a hardcoded 5.
-#: ⚠ Imported, not redeclared (#2859) — `tests/fixtures/ebull_test_db` is the
-#: single source for the §4.0 anchor id.
-_STOCKS_TYPE_ID = STOCKS_TYPE_ID
+#: ⚠⚠ DELIBERATELY NOT `tests.fixtures.ebull_test_db.STOCKS_TYPE_ID`, and #2859
+#: briefly made it so before review caught it. This module is the test OF
+#: `resolve_stocks_type_id`; deriving its expected value from the shared
+#: constant would mean the fixture and the assertion move together and the test
+#: can no longer detect drift. "Single source of truth for constants" governs
+#: production values and fixture HELPERS — it is the wrong rule for the one
+#: value a test exists to pin independently.
+_STOCKS_TYPE_ID = 5
 _ETF_TYPE_ID = 6
 
 #: One instrument per exclusion reason, plus the two that must survive.

--- a/tests/test_validated_universe.py
+++ b/tests/test_validated_universe.py
@@ -32,10 +32,15 @@ from app.services.strategies.validated_universe import (
     load_validated_universe,
     resolve_stocks_type_id,
 )
-from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+from tests.fixtures.ebull_test_db import (
+    STOCKS_TYPE_ID,
+    ebull_test_conn,  # noqa: F401 — fixture re-export
+)
 
 #: eToro's own ids, so the fixture cannot accidentally agree with a hardcoded 5.
-_STOCKS_TYPE_ID = 5
+#: ⚠ Imported, not redeclared (#2859) — `tests/fixtures/ebull_test_db` is the
+#: single source for the §4.0 anchor id.
+_STOCKS_TYPE_ID = STOCKS_TYPE_ID
 _ETF_TYPE_ID = 6
 
 #: One instrument per exclusion reason, plus the two that must survive.


### PR DESCRIPTION
Refs #2859 (the #2770 symbol audit half remains open). Part of #2846.

## Context

#2766 was implemented on 2026-08-15 in a worktree that was never pushed, rebuilt from scratch as #2825, and the rebuild was not a superset — eleven live/paper authority tests had no equivalent in main. This is the live/paper authority boundary, which is the exact surface #2843 changes when the person-gate becomes a mandate flag.

## Classified empirically, not ported wholesale

Running all eleven against main first turned out to matter — most "missing tests" were not what they looked like.

| outcome | count | detail |
| --- | ---: | --- |
| **Superseded — deliberately NOT ported** | 2 | see below |
| **Missing BEHAVIOUR, not coverage** | 2 | the two guards this PR adds |
| Drift-only (`approval_mode` signature, stale overview stub, fixture seed) | 7 | fixed as part of the above |

**Superseded.** `test_legacy_automatic_trading_switch_does_not_block_the_strategy_lane` asserts that `enable_auto_trading=false` leaves entries unblocked. Main asserts the exact opposite on the same input, and `docs/settled-decisions.md` §"Config controls" backs main — *"`enable_auto_trading` is not the same as `enable_live_trading`; both may be checked"*. `test_disabling_strategy_paper_does_not_disable_legacy_automation` likewise contradicts main's deliberate `automation_changed` coupling. Porting either would have asserted behaviour the repo decided against.

## The behaviour gap

`update_strategy_paper_pool` checked evidence readiness but had **no demo-environment guard and no live-trading guard**. `readiness_blockers` is purely evidence-based (candidates, historical validation, assessment policy, freshness) — no environment term anywhere.

⚠ **This is not a live-capital path and the PR does not claim one.** `EtoroBrokerProvider.place_demo_strategy_order` already refuses `self._env != "demo"`, hardcodes `/api/v2/trading/execution/demo/orders`, and runs `refuse_broker_mutation_if_unattended` first. The defect is control-plane **honesty**: the pool reads "enabled" while every order it produces dies at the broker.

## What Codex checkpoint 2 caught, and why the change doubled

The first cut guarded only the paper-pool endpoint. That is trivially bypassed by enabling paper **first** and live **second** — `patch_config` never consulted the pool and never took `PAPER_ALLOCATOR_ADVISORY_LOCK`, so both flags could end up set. My "race-safe" comment was an overclaim on a one-sided check.

So the inverse half is implemented too. Both sides now read the other's state under `PAPER_ALLOCATOR_ADVISORY_LOCK`, which is what makes the pair **one invariant** rather than two independent checks. This is precisely what the 08-15 branch's two concurrency tests existed to prove; Codex rediscovered the reason independently, which is good evidence the original design was right.

**Both refusals fire only on enable.** Disabling is risk reduction and is never blocked — the same asymmetry the execution guard applies to EXIT — and `test_paper_pool_disable_is_not_blocked_outside_demo` pins it. A guard that also blocked the disable would strand automation switched on in exactly the environment it must not run in, which is strictly worse than no guard.

`paper_automation_enabled()` is a new one-boolean read rather than `load_paper_pool(conn).enabled`: the latter parses eight optional mandate `Decimal`s, and widening the live-enable path's failure surface to the mandate parser is a way to make enabling live trading fail for an unrelated reason. It did exactly that in `tests/test_api_config.py` before the split.

## Verification

**Each guard was revert-probed** — the check that a new test is load-bearing rather than passing anyway:

| probe | result |
| --- | --- |
| service change reverted | `refuses_activation_outside_demo` and `refuses_activation_while_live_trading_is_enabled` **FAIL** |
| `app/api/config.py` reverted | `live_trading_enable_is_refused_while_paper_automation_is_enabled` **FAILS** |
| both restored | all pass |
| disable-complement | passes either way **by design** (asserts a non-regression) |

**Incidentally fixed:** every paper-pool test in `test_strategy_monitoring.py` raised `RuntimeError: etoro_instrument_types 'Stocks' resolved to 0 rows` — the §4.0 anchor is filled by the nightly sync, so a test DB never has it. Two were **pre-existing failures on clean main** (confirmed by revert probe before any of my changes), and three more only passed when `test_api_strategies.py` happened to run first and commit the anchor — a silent cross-file ordering dependency. `_seed_universe_anchor` (same shape as the existing helper in `test_api_strategies.py`) removes it; the file now passes standalone.

`ruff` 0 · `ruff format --check` 0 · `pyright` 0 errors · `pytest -m "not db"` 0 · smoke 0 · **db tier 0** across `test_strategy_monitoring`, `test_api_strategies`, `test_strategy_control_plane`, `test_strategy_paper_executor`, `test_api_config`, `test_runtime_config`, `test_orders_api`, `test_api_portfolio`, `test_execution_guard`. Codex ckpt-2 re-run clean: *"The shared advisory lock correctly serializes both sides of the live/paper exclusivity check, and the added environment guard preserves the ability to disable automation."*

## Security

Directly on the safety surface, in the tightening direction. Adds two fail-closed refusals on the paper/live authority boundary and closes the ordering bypass between them; removes none. No credential, broker-mutation or kill-switch path is touched, and the order layer's independent demo enforcement is unchanged. Disabling automation remains unconditionally reachable, which is the property that keeps the guard from becoming a trap.

## Not done here

The remaining work on #2859 — auditing `feature/2770-operator-promotion`'s 156 absent symbols the same way — is untouched, so the issue's second half stands. Recorded on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)