### PR TITLE
fix(#2830): the sealed-outcome guard selects by provenance, not by filename

### DIFF
--- a/tests/test_sealed_outcome_scripts_are_gated.py
+++ b/tests/test_sealed_outcome_scripts_are_gated.py
@@ -9,6 +9,35 @@ outcome always goes through the ledger was never checked.
 ⚠ THIS IS A TEST AND NOT A CONVENTION ON PURPOSE. "Remember to call the helper"
 is exactly what failed five consecutive times before #2599 existed, so the rule
 that a new sealed opener must be gated is enforced by something that fails.
+
+⚠⚠ #2830 — MEMBERSHIP IS NOW DECIDED BY PROVENANCE, NOT BY FILENAME. Until this
+was fixed the verdict was an AST walk (chosen over a substring search precisely
+because a substring "passes on a mention in a comment, a docstring, an unused
+import or a dead branch") while MEMBERSHIP was a filename glob — the rigour
+applied to the wrong half. `scripts/measure_2827_gross_vs_net.py` opens the
+withheld side and was invisible to this file purely because it is called
+`measure_*`. It was gated because Codex caught it at checkpoint 2, not because
+anything here fired.
+
+Same shape as the scan-basis arc (#2803/#2806/#2807/#2809/#2811/#2814), whose
+recorded lesson is *"guards key on AST PROVENANCE, not naming"*.
+
+⚠ THE DOOR IS `_resolve_invocation_window`, AND THAT IS A SOURCE RULE RATHER
+THAN A GUESS. `app/services/backtest_run.py:3528` makes the hold-out reachable
+only through a registered `evidence_window_id` WITH `holdout_requested` — it
+raises on either alone. So "this module opens the withheld side" is exactly
+"it passes one of those two to a backtest entry point", and that is what
+`_opens_sealed_outcome` looks for.
+
+⚠⚠ THREE ACCEPTED GATE FORMS, NOT ONE, AND THE THIRD IS EASY TO MISS.
+`run_backtest` does not require a script-level gate call: it takes the
+`holdout_purpose` / `holdout_accessed_by` audit pair, `_check_holdout_pairing`
+enforces both-or-neither, and the engine writes the access row itself. A rule
+accepting only the script-level doors would have failed
+`run_2825_decisive_holdout_evidence.py`, `verify_2429_total_return.py` and
+`benchmark_2488_evidence_refresh.py` — all three correctly audited. Measured
+before this change shipped; reporting them as ungated would have been three
+false findings.
 """
 
 from __future__ import annotations
@@ -44,8 +73,103 @@ _GATE_CALLS: Final[frozenset[str]] = frozenset(
 _PRE_CUTOFF_UNGATED: Final[dict[str, str]] = {}
 
 
+#: Backtest entry points that can resolve the hold-out namespace. Anything that
+#: reaches the withheld side goes through one of these — `_resolve_invocation_window`
+#: is the door itself, the others accept `evidence_window_id` and pass it down.
+_BACKTEST_ENTRY_POINTS: Final[frozenset[str]] = frozenset(
+    {
+        "run_backtest",
+        "evaluate_arm",
+        "evaluate_level_arms",
+        "evaluate_strategy",
+        "_resolve_invocation_window",
+    }
+)
+
+#: Supplied TOGETHER to a backtest entry point, these make the engine write the
+#: access row itself (`_check_holdout_pairing`, `backtest_run.py:3497`). This is a
+#: real gate, not a bypass — see the module docstring's third-form warning.
+_AUDIT_FIELDS: Final[frozenset[str]] = frozenset({"holdout_purpose", "holdout_accessed_by"})
+
+#: Records the look without asserting a declaration permits it. Accepted
+#: deliberately: #2829 shows the ten live strategies cannot pass
+#: `require_outcome_access` at all, so accepting only the strict door would force
+#: either a false declaration or a permanent allowlist entry — both worse than
+#: the thing being prevented.
+_ACCESS_RECORD_CALLS: Final[frozenset[str]] = frozenset({"record_holdout_access"})
+
+
+def _callee_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _is_not_literal(node: ast.expr, value: object) -> bool:
+    """True unless the argument is written as exactly that literal.
+
+    ``evidence_window_id=None`` and ``holdout_requested=False`` are the explicit
+    in-sample spellings and must not select the module; anything else — a
+    variable, a constant, an expression — is treated as possibly opening.
+    """
+    return not (isinstance(node, ast.Constant) and node.value is value)
+
+
+def _opens_sealed_outcome(tree: ast.Module) -> bool:
+    """Does this module ask a backtest entry point for the withheld side?
+
+    ⚠ The callee is checked, not just the keyword name. A bare
+    ``evidence_window_id=...`` keyword match also fires on dataclass
+    construction and on row parsing — measured while building this, where it
+    wrongly selected `verify_2697_metric_axis_derivation.py`, a module whose own
+    docstring says it "reads provenance only, never result performance".
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _callee_name(node) not in _BACKTEST_ENTRY_POINTS:
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == "holdout_requested" and _is_not_literal(keyword.value, False):
+                return True
+            if keyword.arg == "evidence_window_id" and _is_not_literal(keyword.value, None):
+                return True
+    return False
+
+
+def _passes_holdout_audit_fields(tree: ast.Module) -> bool:
+    """Both audit fields supplied to one backtest entry point — the engine gate."""
+    return any(
+        _AUDIT_FIELDS <= {keyword.arg for keyword in node.keywords if keyword.arg is not None}
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _callee_name(node) in _BACKTEST_ENTRY_POINTS
+    )
+
+
 def _sealed_outcome_scripts() -> list[Path]:
-    return sorted(set(_SCRIPTS.glob("evaluate_*.py")) | set(_SCRIPTS.glob("*_outcomes.py")))
+    """Provenance first, with the historical glob kept as a floor.
+
+    ⚠ The glob stays in the UNION rather than being replaced. It costs nothing,
+    and dropping it would silently narrow coverage if the provenance rule ever
+    misses a shape — a narrowing this test could not report on itself.
+    """
+    selected = set(_SCRIPTS.glob("evaluate_*.py")) | set(_SCRIPTS.glob("*_outcomes.py"))
+    for path in _SCRIPTS.glob("*.py"):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - a script that cannot parse cannot open anything
+            continue
+        if _opens_sealed_outcome(tree):
+            selected.add(path)
+    return sorted(selected)
+
+
+def _is_gated(source: str) -> bool:
+    """Any of the three accepted forms. See the module docstring."""
+    tree = ast.parse(source)
+    called = _called_names(source)
+    return bool(called & (_GATE_CALLS | _ACCESS_RECORD_CALLS)) or _passes_holdout_audit_fields(tree)
 
 
 def _called_names(source: str) -> set[str]:
@@ -83,12 +207,91 @@ def test_every_sealed_outcome_script_calls_a_declaration_check_or_is_allowlisted
     ungated = [
         path.name
         for path in _sealed_outcome_scripts()
-        if path.name not in _PRE_CUTOFF_UNGATED and not (_called_names(path.read_text()) & _GATE_CALLS)
+        if path.name not in _PRE_CUTOFF_UNGATED and not _is_gated(path.read_text())
     ]
     assert ungated == [], (
         f"sealed outcome openers with no declaration check: {ungated}. A script that reads forward outcome "
-        f"windows must call one of {sorted(_GATE_CALLS)}, or be added to _PRE_CUTOFF_UNGATED with the reason."
+        f"windows must call one of {sorted(_GATE_CALLS | _ACCESS_RECORD_CALLS)}, or pass "
+        f"{sorted(_AUDIT_FIELDS)} together to a backtest entry point, or be added to _PRE_CUTOFF_UNGATED "
+        f"with the reason."
     )
+
+
+def test_selection_is_by_provenance_and_not_by_filename() -> None:
+    """#2830's regression: the opener this guard could not see.
+
+    `measure_2827_gross_vs_net.py` matches NEITHER glob — it is not `evaluate_*`
+    and not `*_outcomes` — and opens the withheld side. Before #2830 it was
+    invisible here purely because of its name.
+    """
+    selected = {path.name for path in _sealed_outcome_scripts()}
+    assert "measure_2827_gross_vs_net.py" in selected, (
+        "the provenance rule no longer selects the opener #2830 was filed for; membership has regressed to naming"
+    )
+    assert not any(
+        name.startswith("evaluate_") or name.endswith("_outcomes.py") for name in {"measure_2827_gross_vs_net.py"}
+    ), "this assertion is vacuous unless the witness really is outside both globs"
+
+
+def test_the_provenance_rule_admits_more_than_the_glob() -> None:
+    """A rule that selects exactly the glob would be the old bug wearing an AST.
+
+    ⚠ Asserts a STRICT superset, not a count. Pinning "8 scripts" would fail on
+    every unrelated script added later, which trains the next reader to edit the
+    number rather than look at what changed.
+    """
+    glob_only = set(_SCRIPTS.glob("evaluate_*.py")) | set(_SCRIPTS.glob("*_outcomes.py"))
+    selected = set(_sealed_outcome_scripts())
+
+    assert glob_only < selected, "provenance selection must be a strict superset of the historical glob"
+
+
+def test_the_engine_audit_pair_counts_as_a_gate() -> None:
+    """The third accepted form, pinned because omitting it produces FALSE findings.
+
+    `run_backtest` writes the access row itself when both audit fields are
+    supplied, so these scripts are gated without any script-level gate call. A
+    rule that recognised only `_GATE_CALLS` would report all three as ungated —
+    which is what a first cut of #2830 did before the pairing was checked.
+    """
+    for name in (
+        "run_2825_decisive_holdout_evidence.py",
+        "verify_2429_total_return.py",
+        "benchmark_2488_evidence_refresh.py",
+    ):
+        source = (_SCRIPTS / name).read_text()
+        assert not (_called_names(source) & (_GATE_CALLS | _ACCESS_RECORD_CALLS)), (
+            f"{name} now calls a script-level gate, so it no longer witnesses the audit-pair form"
+        )
+        assert _passes_holdout_audit_fields(ast.parse(source)), name
+        assert _is_gated(source), name
+
+
+def test_an_explicit_in_sample_call_is_not_selected() -> None:
+    """`evidence_window_id=None` / `holdout_requested=False` are the in-sample spellings.
+
+    Without this the rule would select every backtest caller and the gate would
+    stop discriminating.
+    """
+    in_sample = ast.parse(
+        "run_backtest(conn, evidence_window_id=None, holdout_requested=False)\n",
+    )
+    opening = ast.parse("run_backtest(conn, evidence_window_id='primary-2022-plus')\n")
+
+    assert not _opens_sealed_outcome(in_sample)
+    assert _opens_sealed_outcome(opening)
+
+
+def test_the_keyword_alone_does_not_select_a_non_backtest_call() -> None:
+    """The callee is load-bearing — a bare keyword match selects row parsing.
+
+    Measured while building #2830: matching `evidence_window_id=` anywhere
+    wrongly selected `verify_2697_metric_axis_derivation.py`, which constructs a
+    dataclass from stored columns and reads provenance only.
+    """
+    dataclass_construction = ast.parse("StoredRow(result_id=1, evidence_window_id=str(row[12]))\n")
+
+    assert not _opens_sealed_outcome(dataclass_construction)
 
 
 def test_the_allowlist_names_only_scripts_that_still_exist() -> None:

--- a/tests/test_sealed_outcome_scripts_are_gated.py
+++ b/tests/test_sealed_outcome_scripts_are_gated.py
@@ -138,13 +138,48 @@ def _opens_sealed_outcome(tree: ast.Module) -> bool:
     return False
 
 
+def _is_blank_literal(node: ast.expr) -> bool:
+    """A literal that `_check_holdout_pairing` reads as NOT SUPPLIED.
+
+    ⚠ `None` AND whitespace-only strings both count. `backtest_run.py:3506` uses
+    `.strip()` and not bare truthiness, because `"   "` is truthy and would
+    otherwise land in `strategy_holdout_accesses.purpose` as an audit record
+    that records nothing — the #2286 shape. Mirroring it here keeps this guard's
+    reading of "supplied" identical to the engine's.
+    """
+    if not isinstance(node, ast.Constant):
+        return False
+    if node.value is None:
+        return True
+    return isinstance(node.value, str) and not node.value.strip()
+
+
 def _passes_holdout_audit_fields(tree: ast.Module) -> bool:
-    """Both audit fields supplied to one backtest entry point — the engine gate."""
-    return any(
-        _AUDIT_FIELDS <= {keyword.arg for keyword in node.keywords if keyword.arg is not None}
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call) and _callee_name(node) in _BACKTEST_ENTRY_POINTS
-    )
+    """Both audit fields supplied NON-BLANK to one backtest entry point.
+
+    ⚠ The VALUES are checked, not just the keyword names. Review caught the
+    name-only version: `run_backtest(..., holdout_purpose=None,
+    holdout_accessed_by=None)` would have read as gated here.
+
+    ⚠ In practice that combination cannot open anything — `_check_holdout_pairing`
+    reads two blanks as "neither supplied", and `_resolve_invocation_window` then
+    raises on an `evidence_window_id` without the pair, so such a script crashes
+    rather than opening the withheld side. This is therefore hardening of the
+    static rule rather than a live hole. It is still worth having: a guard that
+    accepts a spelling the engine rejects is a guard that has stopped modelling
+    the engine, and the next reader would take its acceptance as proof.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _callee_name(node) not in _BACKTEST_ENTRY_POINTS:
+            continue
+        supplied = {
+            keyword.arg
+            for keyword in node.keywords
+            if keyword.arg in _AUDIT_FIELDS and not _is_blank_literal(keyword.value)
+        }
+        if _AUDIT_FIELDS <= supplied:
+            return True
+    return False
 
 
 def _sealed_outcome_scripts() -> list[Path]:
@@ -265,6 +300,32 @@ def test_the_engine_audit_pair_counts_as_a_gate() -> None:
         )
         assert _passes_holdout_audit_fields(ast.parse(source)), name
         assert _is_gated(source), name
+
+
+def test_blank_audit_fields_do_not_count_as_a_gate() -> None:
+    """Review WARNING on #2830: the pair must be non-blank, not merely present.
+
+    ⚠ `_check_holdout_pairing` reads `None` and whitespace-only alike as NOT
+    SUPPLIED (`backtest_run.py:3506` strips before testing), so a guard that
+    accepted them would model the engine wrongly.
+    """
+    blank_none = ast.parse("run_backtest(conn, holdout_purpose=None, holdout_accessed_by=None)\n")
+    blank_space = ast.parse("run_backtest(conn, holdout_purpose='   ', holdout_accessed_by='x')\n")
+    real = ast.parse("run_backtest(conn, holdout_purpose='issue #2830', holdout_accessed_by='scripts/x.py')\n")
+
+    assert not _passes_holdout_audit_fields(blank_none)
+    assert not _passes_holdout_audit_fields(blank_space)
+    assert _passes_holdout_audit_fields(real)
+
+
+def test_a_blank_paired_opener_is_reported_ungated() -> None:
+    """End to end: selected as an opener, and NOT excused by a blank pair."""
+    source = (
+        "run_backtest(conn, evidence_window_id='primary-2022-plus', holdout_purpose=None, holdout_accessed_by=None)\n"
+    )
+
+    assert _opens_sealed_outcome(ast.parse(source))
+    assert not _is_gated(source)
 
 
 def test_an_explicit_in_sample_call_is_not_selected() -> None:


### PR DESCRIPTION
Closes #2830. Refs #2827, #2614, #2599, #2829.

## The bug

`tests/test_sealed_outcome_scripts_are_gated.py` is the guard that makes #2599's rule enforceable rather than a convention. Its **verdict** was already a careful AST walk — chosen over a substring search precisely because a substring *"passes on a mention in a comment, a docstring, an unused import or a dead branch"*. Its **membership** was a filename glob:

```python
return sorted(set(_SCRIPTS.glob("evaluate_*.py")) | set(_SCRIPTS.glob("*_outcomes.py")))
```

The rigour was applied to the wrong half. `scripts/measure_2827_gross_vs_net.py` opens the withheld side and was invisible to this file purely because it is named `measure_*`. It was gated because Codex caught it at checkpoint 2, **not** because anything here fired.

Same shape as the scan-basis arc (#2803/#2806/#2807/#2809/#2811/#2814), whose recorded lesson is *"guards key on AST PROVENANCE, not naming"*.

## The rule is read off the source, not invented

`_resolve_invocation_window` (`app/services/backtest_run.py:3528`) makes the hold-out reachable **only** through a registered `evidence_window_id` **with** `holdout_requested` — it raises on either alone. So "this module opens the withheld side" is exactly "it passes one of those two to a backtest entry point". That is the whole detector.

The glob stays in the union as a **floor** rather than being replaced: it costs nothing, and dropping it would silently narrow coverage if the provenance rule ever missed a shape — a narrowing this test could not report on itself.

## Censused before adopting, per the ticket's own instruction

| candidate rule | newly selected | would newly FAIL | verdict |
| --- | ---: | ---: | --- |
| any `hold_out` literal or backtest-ish call | 15 | **14** | too broad — rejected |
| keyword match, callee ignored | 5 | 4 | wrongly selects `verify_2697_metric_axis_derivation.py` (dataclass construction) — rejected |
| **keyword bound to a backtest CALLEE** | **4** | **0** | adopted |

Final state: **8 selected (4 by glob, 4 newly by provenance), 0 failing.** No script needs changing, and `_PRE_CUTOFF_UNGATED` stays empty — no allowlist entry was added or needed.

## ⚠⚠ Three accepted gate forms — finding the third avoided three false findings

A first cut recognised only `_GATE_CALLS` and flagged `run_2825_decisive_holdout_evidence.py`, `verify_2429_total_return.py` and `benchmark_2488_evidence_refresh.py` as ungated openers. **They are not.** `run_backtest` takes the `holdout_purpose` / `holdout_accessed_by` audit pair, `_check_holdout_pairing` enforces both-or-neither, and the **engine** writes the access row — so they are gated without any script-level call. All three were verified to supply both fields before this shipped.

`record_holdout_access` is the second accepted form, deliberately: #2829 shows the ten live strategies cannot pass `require_outcome_access` at all, so accepting only the strict door would force either a false declaration or a permanent allowlist entry — both worse than the thing being prevented. (This is the ticket's own instruction and it is followed.)

## Verified by planting a violation

A temporary `scripts/tmp_2830_probe_ungated.py` calling `run_backtest(evidence_window_id="primary-2022-plus")` — under a name matching **neither** glob — makes the guard fail with the full remediation message:

```
AssertionError: sealed outcome openers with no declaration check: ['tmp_2830_probe_ungated.py'].
A script that reads forward outcome windows must call one of ['record_holdout_access',
'require_outcome_access', 'require_outcome_gate', 'verify_outcome_access_provenance'], or pass
['holdout_accessed_by', 'holdout_purpose'] together to a backtest entry point, or be added to
_PRE_CUTOFF_UNGATED with the reason.
```

Probe removed after the run. The old rule provably could not have selected it.

New tests pin: the #2830 witness is selected; selection is a **strict superset** of the glob (asserted as a superset, not a count — pinning "8 scripts" would fail on every unrelated script added later and train the next reader to edit the number); the audit-pair form counts as a gate; an explicit in-sample call (`evidence_window_id=None`, `holdout_requested=False`) is **not** selected; and a bare keyword on a non-backtest callee is **not** selected.

## Security

No security surface — a test-only diff. It strengthens a research-governance guard (widens what it inspects, accepts no new exemption, leaves the allowlist empty) and touches no runtime, credential, broker or kill-switch path.

`ruff` 0 · `ruff format --check` 0 · `pyright` 0 errors · `pytest -m "not db"` 0 · smoke 0.

Per the review-intensity ladder this is the narrow rung — one test file, no production code or data semantics — so self-review + pre-push hook + review bot, and no Codex checkpoint 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
