### PR TITLE
fix(#2880): an APScheduler misfire left no trace, so a once-daily fire vanished

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -52,9 +52,15 @@ from typing import Any, Final, TypedDict
 
 import psycopg
 import psycopg.sql
-from apscheduler.events import EVENT_JOB_MAX_INSTANCES, JobSubmissionEvent
+from apscheduler.events import (
+    EVENT_JOB_MAX_INSTANCES,
+    EVENT_JOB_MISSED,
+    JobExecutionEvent,
+    JobSubmissionEvent,
+)
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.util import undefined
 from psycopg.types.json import Jsonb
 from psycopg_pool import ConnectionPool
 
@@ -68,7 +74,12 @@ from app.jobs.background_pool import BackgroundConnectionPool
 from app.jobs.locks import JobAlreadyRunning, JobLock
 from app.jobs.sec_lane_gate import SEC_LANE_MAX_CONCURRENCY
 from app.jobs.sources import JobInvoker, source_for
-from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX, fetch_latest_successful_runs, record_job_skip
+from app.services.ops_monitor import (
+    LANE_BUSY_SKIP_PREFIX,
+    MISFIRE_SKIP_PREFIX,
+    fetch_latest_successful_runs,
+    record_job_skip,
+)
 from app.services.process_stop import acquire_prelude_lock
 from app.services.processes.bootstrap_gate import check_bootstrap_state_gate
 from app.services.processes.param_metadata import (
@@ -1457,8 +1468,21 @@ class JobRuntime:
                 # integer APScheduler accepts (0 raises TypeError).
                 # Combined with the absence of a persistent jobstore,
                 # a fire that is more than 1 second late is dropped.
-                # Catch-up is driven by ``_catch_up()`` reading
-                # ``job_runs``, not by APScheduler grace windows.
+                # BOOT catch-up is driven by ``_catch_up()`` reading
+                # ``job_runs``, not by APScheduler grace windows, and
+                # raising the grace cannot change that: with the default
+                # ``MemoryJobStore`` there is no pre-boot ``run_time`` for
+                # the executor to test — ``scheduler.start()`` computes
+                # ``next_run_time`` from ``now`` (APScheduler 3.11.2,
+                # ``BaseScheduler._real_add_job``).
+                #
+                # ⚠ #2880 — this default is right for the FREQUENT jobs it
+                # was chosen for and lossy for the daily ones: a 5-minute
+                # producer that loses a fire runs again in 5 minutes, while
+                # a daily one loses its whole slot with no row to show it.
+                # A job that can tolerate a late fire opts in per-job via
+                # ``ScheduledJob.misfire_grace_seconds``; see the field's
+                # docstring for why this is NOT derived from cadence kind.
                 "misfire_grace_time": 1,
                 # One concurrent instance per job. The per-job
                 # advisory lock is the source of truth for
@@ -1475,6 +1499,19 @@ class JobRuntime:
         # ALERT/MARK-ONLY: it cannot decrement ``_instances`` or un-wedge (that
         # is PR0's connect-timeout + a jobs restart).
         self._scheduler.add_listener(self._on_job_max_instances, EVENT_JOB_MAX_INSTANCES)
+        # #2880 — the THIRD way a fire can be declined, and the only one that
+        # was invisible. ``EVENT_JOB_MAX_INSTANCES`` above covers "a prior
+        # instance is still active"; ``_record_lane_busy_skip`` covers "the lane
+        # advisory lock stayed held". Neither covers ``EVENT_JOB_MISSED``, which
+        # APScheduler raises from ``executors/base.py::run_job`` when the WORKER
+        # finally reaches the fire more than ``misfire_grace_time`` after its
+        # scheduled run time — the whole batch queued behind saturated executor
+        # threads. That path wrote no ``job_runs`` row at all, so a once-daily
+        # job lost its whole day while the schedule still read green off
+        # yesterday's success. Measured: ``portfolio_eod_snapshot`` has no row
+        # for 2026-08-12 / 08-15 / 08-21 22:30 UTC, in windows where nine other
+        # jobs DID record ``max_instances_active`` at the same instant.
+        self._scheduler.add_listener(self._on_job_missed, EVENT_JOB_MISSED)
         # Manual-trigger executor sized so that distinct jobs do NOT
         # queue behind each other -- one slot per wired invoker means
         # every wired job can be in flight simultaneously without
@@ -1519,6 +1556,14 @@ class JobRuntime:
                 id=f"recurring:{job.name}",
                 name=job.name,
                 replace_existing=True,
+                # #2880 — per-job override of the 1-second ``job_defaults``
+                # grace, for the jobs that can afford a late fire more than
+                # they can afford a lost one. ``undefined`` is APScheduler's
+                # own "inherit the default" sentinel: ``add_job`` strips every
+                # ``undefined`` kwarg before applying ``job_defaults``, so this
+                # is not the same as passing ``None`` (which would mean "never
+                # misfire" and disable the check entirely).
+                misfire_grace_time=(job.misfire_grace_seconds if job.misfire_grace_seconds is not None else undefined),
             )
             registered += 1
         self._scheduler.start()
@@ -1594,6 +1639,57 @@ class JobRuntime:
         except Exception:
             logger.exception(
                 "max-instances listener failed for event job_id=%r",
+                getattr(event, "job_id", "?"),
+            )
+
+    def _on_job_missed(self, event: JobExecutionEvent) -> None:
+        """APScheduler ``EVENT_JOB_MISSED`` handler (#2880).
+
+        Runs on the executor's callback thread (``run_job`` returns the event
+        and ``_run_job_success`` dispatches it) whenever a worker reached a fire
+        later than its ``misfire_grace_time`` and therefore did NOT run the
+        body. Records a ``job_runs`` 'skipped' row so the loss is visible.
+
+        The row is stamped at ``event.scheduled_run_time``, not at detection
+        time: the fact worth keeping is WHICH slot was lost, and a
+        detection-time stamp would put the row wherever the pool happened to
+        drain. The reason carries ``MISFIRE_SKIP_PREFIX`` so
+        ``scheduled_adapter`` excludes it from the ``expected_fire_at`` anchor —
+        a misfire is "work was due, couldn't start", so it must not reset the
+        schedule-missed clock the way a benign prereq skip does.
+
+        Kept short and fully fail-safe for the same reason as
+        ``_on_job_max_instances``: a listener that raised would break
+        APScheduler's event dispatch. ⚠ The write happens on a pool thread
+        during exactly the congestion that caused the misfire, so it uses the
+        bounded background-write seam and swallows its own failure — losing the
+        telemetry row is strictly better than turning it into a second fault.
+        """
+        try:
+            job_id = getattr(event, "job_id", None)
+            if not isinstance(job_id, str) or not job_id.startswith(_RECURRING_JOB_ID_PREFIX):
+                # Manual / non-recurring add_job ids are not scheduled fires.
+                return
+            job_name = job_id.removeprefix(_RECURRING_JOB_ID_PREFIX)
+            scheduled_for = getattr(event, "scheduled_run_time", None)
+            lateness = (datetime.now(UTC) - scheduled_for).total_seconds() if scheduled_for is not None else None
+            reason = MISFIRE_SKIP_PREFIX + (
+                f"fire due {scheduled_for.isoformat()} discarded by APScheduler; "
+                f"worker reached it {lateness:.1f}s late, past misfire_grace_time"
+                if scheduled_for is not None and lateness is not None
+                else "fire discarded by APScheduler past misfire_grace_time (no scheduled_run_time on event)"
+            )
+            with background_write_connection() as conn:
+                record_job_skip(conn, job_name, reason, now=scheduled_for)
+            logger.warning(
+                "scheduled job %s: fire due %s MISSED (%.1fs late) — recorded 'skipped' job_runs row",
+                job_name,
+                scheduled_for,
+                lateness if lateness is not None else float("nan"),
+            )
+        except Exception:
+            logger.exception(
+                "misfire listener failed for event job_id=%r",
                 getattr(event, "job_id", "?"),
             )
 

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -697,6 +697,20 @@ def reap_orphaned_job_runs(
 # must NOT reset the schedule-missed clock.
 LANE_BUSY_SKIP_PREFIX: Final[str] = "lane_busy: "
 
+# #2880 — machine-checkable reason prefix for a scheduled fire APScheduler
+# DISCARDED as too late (``EVENT_JOB_MISSED``: the worker thread reached
+# ``run_job`` more than ``misfire_grace_time`` after the scheduled run time).
+# Same classification as ``lane_busy``: work was due and could not start, so it
+# must NOT reset the ``expected_fire_at`` schedule-missed clock — but a separate
+# prefix because the cause is different and ``lane_busy`` would be untrue.
+# Written by ``app/jobs/runtime.py``'s ``EVENT_JOB_MISSED`` listener; excluded
+# from the anchor in ``app/services/processes/scheduled_adapter.py``.
+#
+# ⚠ This is telemetry, not recovery. The fire is already gone when the event is
+# emitted; the row exists so the loss is visible rather than silent. Recovery,
+# where a job can tolerate it, is ``ScheduledJob.misfire_grace_seconds``.
+MISFIRE_SKIP_PREFIX: Final[str] = "misfire: "
+
 
 def record_job_skip(
     conn: psycopg.Connection[Any],

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -34,7 +34,7 @@ import psycopg.rows
 
 from app.services.data_freshness import cadence_for
 from app.services.job_liveness import cadence_period
-from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX, TERMINAL_STATUS_SQL
+from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX, MISFIRE_SKIP_PREFIX, TERMINAL_STATUS_SQL
 from app.services.processes import (
     ActiveRunSummary,
     ErrorClassSummary,
@@ -311,30 +311,34 @@ def _read_latest_terminal_run(conn: psycopg.Connection[Any], *, job_name: str) -
     return row
 
 
-def _is_lane_busy_skip(row: dict[str, Any] | None) -> bool:
-    """True when *row* is a ``lane_busy`` skip (#2052).
+# Skip reasons that mean "work was due, couldn't start" — unlike a benign
+# prereq/gate skip these must NOT anchor the ``expected_fire_at`` clock, or a
+# permanently-starved job would read green forever (each nightly skip row
+# resetting the schedule-missed threshold). ``lane_busy`` (#2052) is the lane
+# advisory lock staying held; ``misfire`` (#2880) is APScheduler discarding the
+# fire as later than its grace window.
+_NON_ANCHORING_SKIP_PREFIXES: Final[tuple[str, ...]] = (LANE_BUSY_SKIP_PREFIX, MISFIRE_SKIP_PREFIX)
 
-    A lane-busy skip means "work was due, couldn't start" — unlike a benign
-    prereq/gate skip it must NOT anchor the ``expected_fire_at`` clock, or a
-    permanently-starved job would read green forever (each nightly skip row
-    resetting the schedule-missed threshold).
-    """
+
+def _is_non_anchoring_skip(row: dict[str, Any] | None) -> bool:
+    """True when *row* is a work-was-due-couldn't-start skip (#2052, #2880)."""
     return (
         row is not None
         and row.get("status") == "skipped"
-        and str(row.get("error_msg") or "").startswith(LANE_BUSY_SKIP_PREFIX)
+        and str(row.get("error_msg") or "").startswith(_NON_ANCHORING_SKIP_PREFIXES)
     )
 
 
 def _read_latest_anchor_terminal_run(conn: psycopg.Connection[Any], *, job_name: str) -> dict[str, Any] | None:
     """Latest terminal run eligible to anchor ``expected_fire_at`` (#2052).
 
-    Same population as ``_read_latest_terminal_run`` MINUS ``lane_busy`` skip
-    rows. Deliberately a SECOND resolver: the unfiltered latest terminal keeps
-    driving ``last_run`` / the status pill / the retry+cancel look-throughs,
-    and this one is only consulted when the latest terminal IS a lane-busy
-    skip (the rare starved path), so the extra query costs nothing on the
-    steady-state path. Only the columns the anchor math reads are selected.
+    Same population as ``_read_latest_terminal_run`` MINUS the non-anchoring
+    skip rows (``lane_busy`` #2052, ``misfire`` #2880). Deliberately a SECOND
+    resolver: the unfiltered latest terminal keeps driving ``last_run`` / the
+    status pill / the retry+cancel look-throughs, and this one is only
+    consulted when the latest terminal IS one of those (the rare starved path),
+    so the extra query costs nothing on the steady-state path. Only the columns
+    the anchor math reads are selected.
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
@@ -343,11 +347,14 @@ def _read_latest_anchor_terminal_run(conn: psycopg.Connection[Any], *, job_name:
               FROM job_runs
              WHERE job_name = %(name)s
                AND status   IN {TERMINAL_STATUS_SQL}
-               AND NOT (status = 'skipped' AND error_msg LIKE %(lane_busy_pat)s)
+               AND NOT (
+                     status = 'skipped'
+                     AND error_msg LIKE ANY (%(non_anchoring_pats)s::text[])
+                   )
              ORDER BY started_at DESC
              LIMIT 1
             """,
-            {"name": job_name, "lane_busy_pat": LANE_BUSY_SKIP_PREFIX + "%"},
+            {"name": job_name, "non_anchoring_pats": [p + "%" for p in _NON_ANCHORING_SKIP_PREFIXES]},
         )
         return cur.fetchone()
 
@@ -906,16 +913,20 @@ def _build_row(
     # next fire from compute_next_run(cadence, now), so it could never
     # satisfy ``< now - threshold`` and the rule was unreachable.
     expected_fire_at: datetime | None = None
-    # #2052 — a ``lane_busy`` skip must not anchor the overdue clock ("work
-    # was due, couldn't start" is not a completed cycle). When the latest
-    # terminal is one, re-resolve the anchor from the latest NON-lane-busy
-    # terminal; when the ENTIRE history is lane-busy skips, fall back to the
-    # persisted ``job_first_seen`` anchor (#1508 C6 — the ``terminal_row is
-    # None`` never-started path below cannot arm here because the skip rows
-    # make ``terminal_row`` non-null). Benign skips (prereq/gate) still
-    # anchor exactly as before.
+    # #2052 / #2880 — a ``lane_busy`` or ``misfire`` skip must not anchor the
+    # overdue clock ("work was due, couldn't start" is not a completed cycle).
+    # When the latest terminal is one, re-resolve the anchor from the latest
+    # non-anchoring-free terminal; when the ENTIRE history is such skips, fall
+    # back to the persisted ``job_first_seen`` anchor (#1508 C6 — the
+    # ``terminal_row is None`` never-started path below cannot arm here because
+    # the skip rows make ``terminal_row`` non-null). Benign skips (prereq/gate)
+    # still anchor exactly as before.
     anchor_row = terminal_row
-    if _is_lane_busy_skip(terminal_row) and terminal_row is not None and terminal_row.get("terminal_kind") == "job_run":
+    if (
+        _is_non_anchoring_skip(terminal_row)
+        and terminal_row is not None
+        and terminal_row.get("terminal_kind") == "job_run"
+    ):
         anchor_row = _read_latest_anchor_terminal_run(conn, job_name=job.name)
         if anchor_row is None:
             first_seen = _job_first_seen(conn, job_name=job.name)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -325,6 +325,23 @@ class ScheduledJob:
     # so are unbounded — the desired exemption for the heavy operator-initiated
     # jobs. See docs/specs/infra/job-statement-timeout.md.
     statement_timeout_ms: int | None = _DEFAULT_JOB_STATEMENT_TIMEOUT_MS
+    # #2880 — per-job APScheduler ``misfire_grace_time`` (seconds). ``None``
+    # keeps the global ``job_defaults`` value of 1 second, which is correct for
+    # the frequent jobs it was chosen for: a 5-minute producer that loses a fire
+    # runs again in 5 minutes.
+    #
+    # ⚠ Deliberately OPT-IN per job, NOT derived from ``cadence.kind``. A
+    # cadence-wide rule looks principled and is unsafe, because ``coalesce=True``
+    # does NOT collapse a fire that has already been handed to the executor:
+    # APScheduler advances ``next_run_time`` at SUBMISSION
+    # (``BaseExecutor.submit_job`` increments ``_instances`` before the body
+    # runs), so a long grace lets a stale fire execute hours later while its
+    # successor is suppressed with ``max_instances_active``. For
+    # ``execute_approved_orders`` — whose contract is that execution happens at
+    # its scheduled time, never as a surprise catch-up — that is a defect, not a
+    # recovery. Only a job that is idempotent, side-effect-bounded and
+    # indifferent to its own fire time may set this.
+    misfire_grace_seconds: int | None = None
 
 
 # Job-name constants. Every ``_tracked_job(...)`` call site below references
@@ -1057,9 +1074,33 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # db_eod_snapshot runs concurrently with ingest with no write race.
         source="db_eod_snapshot",
         description="Persist daily portfolio equity (value, cash, per-position) + dated FX.",
-        # 22:30 UTC — after US market close (~21:00 UTC) so today's price_daily
-        # closes are in. snapshot_date is data-anchored, not this fire time.
+        # 22:30 UTC — after US market close (~21:00 UTC). snapshot_date is
+        # data-anchored, not this fire time. ⚠ The bars for the session that just
+        # closed frequently are NOT in yet: the sweep that advances
+        # ``MAX(price_daily.price_date)`` for held instruments is
+        # ``orchestrator_full_sync`` at 03:00 UTC, so this fire routinely stamps
+        # the PREVIOUS session and the current one is captured by tomorrow's
+        # fire. Measured on ``portfolio_eod_snapshots`` (#2880): 32 rows at
+        # lag 0, 6 at lag 1, 9 at lag 2, 1 at lag 3 —
+        #   select (computed_at at time zone 'UTC')::date - snapshot_date,
+        #          count(*) from portfolio_eod_snapshots group by 1;
         cadence=Cadence.daily(hour=22, minute=30),
+        # #2880 — this job is the one registered job that is genuinely
+        # indifferent to WHEN it runs, so it opts in to a late fire rather than
+        # losing the session. Losing one is permanent: ``snapshot_date`` is
+        # ``MAX(price_daily.price_date)`` over held instruments, so the next
+        # night's fire writes a LATER date and nothing ever backfills the gap.
+        # Two of the nine weekday sessions carrying a demo broker snapshot had
+        # no local row for exactly this reason (2026-08-12, 2026-08-20), and
+        # #2844's last acceptance clause needs five CONSECUTIVE reconciled days.
+        #
+        # 4h by construction, not by taste: the fire is due 22:30 and the next
+        # frontier-advancing sweep (``orchestrator_full_sync``) is due 03:00, so
+        # a window expiring 02:30 is the largest one that cannot let a late fire
+        # leap onto the following session. The body is ON CONFLICT-idempotent
+        # and mutates no broker state, so running it late is a strictly better
+        # outcome than not running it.
+        misfire_grace_seconds=4 * 60 * 60,
         prerequisite=_bootstrap_complete,
         catch_up_on_boot=False,
     ),

--- a/tests/test_jobs_max_instances_listener.py
+++ b/tests/test_jobs_max_instances_listener.py
@@ -143,3 +143,75 @@ def _job_runs_count(url: str) -> int:
         row = conn.execute("SELECT count(*) FROM job_runs").fetchone()
     assert row is not None
     return int(row[0])
+
+
+# ---------------------------------------------------------------------------
+# #2880 — the sibling EVENT_JOB_MISSED listener.
+#
+# Same shape, different cause: APScheduler discards a fire whose worker reached
+# ``run_job`` later than ``misfire_grace_time``. That path wrote NO row at all,
+# so a once-daily job lost its whole slot while the console read green off
+# yesterday's success. Only the genuinely-new mechanism is exercised against the
+# DB here — stamping the row at the LOST SLOT rather than at detection time.
+# The reason text, the non-recurring-id guard and the never-raise contract are
+# pure-logic tests in ``tests/test_jobs_runtime.py``.
+# ---------------------------------------------------------------------------
+
+
+def _missed_event(job_id: str | None, scheduled_run_time: object) -> object:
+    from apscheduler.events import EVENT_JOB_MISSED, JobExecutionEvent
+
+    return JobExecutionEvent(EVENT_JOB_MISSED, job_id, "default", scheduled_run_time)
+
+
+def test_listener_registered_for_missed_event() -> None:
+    from apscheduler.events import EVENT_JOB_MISSED
+
+    rt = _runtime()
+    listeners = rt._scheduler._listeners
+    assert any(cb == rt._on_job_missed and (mask & EVENT_JOB_MISSED) for cb, mask in listeners), (
+        "misfire listener not registered"
+    )
+
+
+@pytest.mark.skipif(not test_db_available(), reason="test DB unavailable")
+def test_missed_handler_stamps_the_row_at_the_lost_slot(settings_use_test_db: str) -> None:
+    from datetime import UTC, datetime
+
+    from app.services.ops_monitor import MISFIRE_SKIP_PREFIX
+
+    rt = _runtime()
+    job_name = "nightly_universe_sync"
+    scheduled_for = datetime(2026, 8, 21, 22, 30, tzinfo=UTC)
+
+    with psycopg.connect(settings_use_test_db, autocommit=True) as setup:
+        setup.execute(
+            "DELETE FROM job_runs WHERE job_name = %s AND error_msg LIKE %s",
+            (job_name, MISFIRE_SKIP_PREFIX + "%"),
+        )
+
+    rt._on_job_missed(_missed_event(f"recurring:{job_name}", scheduled_for))  # type: ignore[arg-type]
+
+    try:
+        with psycopg.connect(settings_use_test_db, autocommit=True) as verify:
+            row = verify.execute(
+                "SELECT status, started_at, finished_at, error_msg FROM job_runs "
+                " WHERE job_name = %s AND error_msg LIKE %s "
+                " ORDER BY run_id DESC LIMIT 1",
+                (job_name, MISFIRE_SKIP_PREFIX + "%"),
+            ).fetchone()
+        assert row is not None
+        assert row[0] == "skipped"
+        # The row sits where the fire belonged. A detection-time stamp would put
+        # it wherever the executor pool happened to drain, which says nothing
+        # about which slot was lost.
+        assert row[1] == scheduled_for
+        assert row[2] == scheduled_for
+        assert str(row[3]).startswith(MISFIRE_SKIP_PREFIX)
+        assert scheduled_for.isoformat() in str(row[3])
+    finally:
+        with psycopg.connect(settings_use_test_db, autocommit=True) as cleanup:
+            cleanup.execute(
+                "DELETE FROM job_runs WHERE job_name = %s AND error_msg LIKE %s",
+                (job_name, MISFIRE_SKIP_PREFIX + "%"),
+            )

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -1866,3 +1866,157 @@ class TestFundStageInvokerRegistration:
         # Both names reached the runtime — neither rejected at the listener gate.
         assert sorted(accepted_calls) == ["mf_directory_sync", "sec_n_csr_bootstrap_drain"]
         assert rejected_calls == []
+
+
+class TestMisfireVisibilityAndGrace:
+    """#2880 — an APScheduler ``EVENT_JOB_MISSED`` must leave a row behind.
+
+    Before this, a fire the executor reached later than ``misfire_grace_time``
+    was discarded with no ``job_runs`` row, no retry candidate and no reset of
+    the schedule-missed clock — so a once-daily job lost its whole slot while
+    the console still read green off yesterday's success.
+    """
+
+    def test_per_job_grace_reaches_add_job_only_when_set(
+        self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``misfire_grace_seconds`` is an opt-in override, not a default."""
+        from app.workers.scheduler import JOB_ORCHESTRATOR_FULL_SYNC, JOB_PORTFOLIO_EOD_SNAPSHOT
+
+        kwargs_by_id: dict[str, dict[str, object]] = {}
+
+        rt = _make_runtime(
+            {
+                JOB_ORCHESTRATOR_FULL_SYNC: lambda: None,
+                JOB_PORTFOLIO_EOD_SNAPSHOT: lambda: None,
+            }
+        )
+
+        def fake_add_job(*args: object, **kwargs: object) -> None:
+            kwargs_by_id[str(kwargs.get("id", ""))] = dict(kwargs)
+
+        monkeypatch.setattr(rt._scheduler, "add_job", fake_add_job)
+        monkeypatch.setattr(rt._scheduler, "start", lambda: None)
+        monkeypatch.setattr(rt, "_catch_up", lambda: None)
+
+        rt.start()
+
+        from apscheduler.util import undefined
+
+        eod = kwargs_by_id[f"recurring:{JOB_PORTFOLIO_EOD_SNAPSHOT}"]
+        assert eod["misfire_grace_time"] == 4 * 60 * 60
+        # Every other job inherits the 1-second ``job_defaults`` value.
+        # ``undefined`` is the sentinel ``add_job`` strips before applying
+        # ``job_defaults``; ``None`` would mean "never misfire" and is a
+        # different, much worse, thing to pass by accident.
+        assert kwargs_by_id[f"recurring:{JOB_ORCHESTRATOR_FULL_SYNC}"]["misfire_grace_time"] is undefined
+
+    def test_missed_fire_records_skip_stamped_at_the_lost_slot(
+        self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from apscheduler.events import EVENT_JOB_MISSED, JobExecutionEvent
+
+        from app.services.ops_monitor import MISFIRE_SKIP_PREFIX
+
+        scheduled_for = datetime(2026, 8, 21, 22, 30, tzinfo=UTC)
+        recorded: list[tuple[str, str, datetime | None]] = []
+
+        @contextmanager
+        def fake_conn() -> Iterator[object]:
+            yield object()
+
+        monkeypatch.setattr("app.jobs.runtime.background_write_connection", fake_conn)
+        monkeypatch.setattr(
+            "app.jobs.runtime.record_job_skip",
+            lambda _conn, name, reason, **kw: recorded.append((name, reason, kw.get("now"))) or 1,
+        )
+
+        rt = _make_runtime({})
+        rt._on_job_missed(
+            JobExecutionEvent(EVENT_JOB_MISSED, "recurring:portfolio_eod_snapshot", "default", scheduled_for)
+        )
+
+        assert len(recorded) == 1
+        name, reason, now = recorded[0]
+        assert name == "portfolio_eod_snapshot"
+        assert reason.startswith(MISFIRE_SKIP_PREFIX)
+        assert scheduled_for.isoformat() in reason
+        # Stamped at the LOST slot, not at detection time — the row has to sit
+        # where the fire belonged or it says nothing about which slot was lost.
+        assert now == scheduled_for
+
+    def test_missed_listener_ignores_manual_job_ids(
+        self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from apscheduler.events import EVENT_JOB_MISSED, JobExecutionEvent
+
+        recorded: list[str] = []
+        monkeypatch.setattr(
+            "app.jobs.runtime.record_job_skip",
+            lambda _conn, name, _reason, **_kw: recorded.append(name) or 1,
+        )
+
+        rt = _make_runtime({})
+        rt._on_job_missed(JobExecutionEvent(EVENT_JOB_MISSED, "manual:whatever", "default", datetime.now(UTC)))
+
+        assert recorded == []
+
+    def test_missed_listener_never_raises_into_event_dispatch(
+        self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A listener that raised would break APScheduler's dispatch loop.
+
+        The write runs on a pool thread during exactly the congestion that
+        caused the misfire, so its failure must stay contained.
+        """
+        from apscheduler.events import EVENT_JOB_MISSED, JobExecutionEvent
+
+        @contextmanager
+        def exploding_conn() -> Iterator[object]:
+            raise RuntimeError("pool exhausted")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr("app.jobs.runtime.background_write_connection", exploding_conn)
+
+        rt = _make_runtime({})
+        rt._on_job_missed(
+            JobExecutionEvent(EVENT_JOB_MISSED, "recurring:portfolio_eod_snapshot", "default", datetime.now(UTC))
+        )
+
+    def test_grace_opt_in_is_an_explicit_allow_list(self) -> None:
+        """A late fire is only safe for a job indifferent to its own fire time.
+
+        ``execute_approved_orders`` is the counter-example the policy exists
+        for: its contract is that execution happens at the scheduled time, not
+        as a surprise catch-up hours later. Adding a name here is a deliberate
+        act — assert the set so one cannot be opted in silently.
+        """
+        from app.workers.scheduler import SCHEDULED_JOBS
+
+        opted_in = {j.name for j in SCHEDULED_JOBS if j.misfire_grace_seconds is not None}
+        assert opted_in == {"portfolio_eod_snapshot"}
+
+    def test_grace_cannot_reach_the_next_frontier_advance(self) -> None:
+        """The EOD grace must expire before the sweep that moves its anchor.
+
+        ``portfolio_eod_snapshot`` stamps ``MAX(price_daily.price_date)`` over
+        held instruments. ``orchestrator_full_sync`` is what advances that
+        frontier, so a grace window reaching past it would let a late fire
+        write the FOLLOWING session under the previous slot's identity.
+        """
+        from app.workers.scheduler import (
+            JOB_ORCHESTRATOR_FULL_SYNC,
+            JOB_PORTFOLIO_EOD_SNAPSHOT,
+            SCHEDULED_JOBS,
+            compute_next_run,
+        )
+
+        by_name = {j.name: j for j in SCHEDULED_JOBS}
+        eod = by_name[JOB_PORTFOLIO_EOD_SNAPSHOT]
+        full_sync = by_name[JOB_ORCHESTRATOR_FULL_SYNC]
+        assert eod.misfire_grace_seconds is not None
+
+        anchor = datetime(2026, 1, 1, tzinfo=UTC)
+        eod_fire = compute_next_run(eod.cadence, anchor)
+        next_sweep = compute_next_run(full_sync.cadence, eod_fire)
+        assert eod.misfire_grace_seconds < (next_sweep - eod_fire).total_seconds()

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -1945,6 +1945,42 @@ class TestMisfireVisibilityAndGrace:
         # where the fire belonged or it says nothing about which slot was lost.
         assert now == scheduled_for
 
+    def test_missed_fire_without_a_scheduled_time_still_records(
+        self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The defensive branch: APScheduler always supplies
+        ``scheduled_run_time`` on ``EVENT_JOB_MISSED``, so this path exists only
+        so a malformed event degrades to a row rather than to nothing. The row
+        must still land — losing the fire silently is the defect being fixed —
+        and ``now=None`` lets ``record_job_skip`` stamp its own clock, because
+        there is no lost slot to point at.
+        """
+        from apscheduler.events import EVENT_JOB_MISSED, JobExecutionEvent
+
+        from app.services.ops_monitor import MISFIRE_SKIP_PREFIX
+
+        recorded: list[tuple[str, str, datetime | None]] = []
+
+        @contextmanager
+        def fake_conn() -> Iterator[object]:
+            yield object()
+
+        monkeypatch.setattr("app.jobs.runtime.background_write_connection", fake_conn)
+        monkeypatch.setattr(
+            "app.jobs.runtime.record_job_skip",
+            lambda _conn, name, reason, **kw: recorded.append((name, reason, kw.get("now"))) or 1,
+        )
+
+        rt = _make_runtime({})
+        rt._on_job_missed(JobExecutionEvent(EVENT_JOB_MISSED, "recurring:portfolio_eod_snapshot", "default", None))
+
+        assert len(recorded) == 1
+        name, reason, now = recorded[0]
+        assert name == "portfolio_eod_snapshot"
+        assert reason.startswith(MISFIRE_SKIP_PREFIX)
+        assert "no scheduled_run_time" in reason
+        assert now is None
+
     def test_missed_listener_ignores_manual_job_ids(
         self, patched_runtime: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -11,7 +11,7 @@ import psycopg
 import pytest
 from psycopg.types.json import Jsonb
 
-from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX
+from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX, MISFIRE_SKIP_PREFIX
 from app.services.processes import scheduled_adapter
 from app.services.processes.param_metadata import ParamMetadata
 from app.workers.scheduler import JOB_FUNDAMENTALS_SYNC, JOB_RETRY_DEFERRED
@@ -1014,6 +1014,38 @@ def test_all_lane_busy_history_falls_back_to_first_seen_anchor(
     row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
     assert row is not None
     assert "schedule_missed" in row.stale_reasons
+
+
+def test_misfire_skip_does_not_reset_schedule_missed_anchor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#2880 — a ``misfire`` skip is the same class as ``lane_busy``.
+
+    APScheduler discarded the fire as later than its grace window, so the work
+    was due and never started. Anchoring on it would let a job that misfires
+    every cadence read green forever — which is precisely the invisible state
+    this row was added to end.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status)
+        VALUES (%s, now() - interval '2 hours',
+                now() - interval '2 hours' + interval '30 seconds', 'success')
+        """,
+        (JOB_RETRY_DEFERRED,),
+    )
+    _insert_skip(
+        ebull_test_conn,
+        job_name=JOB_RETRY_DEFERRED,
+        error_msg=MISFIRE_SKIP_PREFIX + "fire due 2026-08-21T22:30:00+00:00 discarded by APScheduler",
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
+    assert row is not None
+    assert "schedule_missed" in row.stale_reasons
+    assert row.status == "idle"  # pill still reflects the true latest terminal
 
 
 def test_prereq_skip_still_resets_schedule_missed_anchor(


### PR DESCRIPTION
Closes #2880. Refs #2844. Refs #2602. Refs #2437.

## The symptom

`portfolio_eod_snapshots` has no row for **2 of the 9 weekday sessions** that
carry a demo broker equity snapshot — 2026-08-12 and 2026-08-20. Those two days
can never reconcile, and #2844's last open acceptance clause is *"reconciliation
job green for **5 consecutive days** on demo"*.

```sql
select b.snapshot_date
  from (select distinct snapshot_date from broker_account_equity_snapshots where environment='demo') b
  left join portfolio_eod_snapshots p on p.snapshot_date = b.snapshot_date
 where p.snapshot_date is null and extract(isodow from b.snapshot_date) < 6;
-- 2026-08-12, 2026-08-20   (denominator: 9 weekday broker days)
```

## Root cause — the one declined-fire outcome with no listener

APScheduler can decline a scheduled fire three ways. Two were already visible:

| outcome | recorded before this PR |
| --- | --- |
| lane advisory lock stayed held | yes — `lane_busy: ` skip row (#2052) |
| `max_instances=1`, prior instance active | yes — `max_instances_active` skip row (#1472) |
| **`EVENT_JOB_MISSED`** | **no row, no retry candidacy, no schedule-missed signal** |

`job_defaults` sets `misfire_grace_time: 1` — one second, correct for the
5-minute jobs it was chosen for, applied to every job. `EVENT_JOB_MAX_INSTANCES`
had a listener; `EVENT_JOB_MISSED` did not.

Verified in APScheduler 3.11.2 (`apscheduler/executors/base.py::run_job`): the
scheduler SUBMITS the fire, and the executor's worker checks lateness when it
eventually starts. So the event means "a worker got here too late", and the body
never runs.

Nothing recovers it. `_catch_up()` runs **on boot only** and skips
`catch_up_on_boot=False` jobs; `jobs_retry_sweeper` re-fires rows carrying
`next_retry_at`, and a misfire leaves no row to carry one.

### Evidence the fire was declined, not the daemon down

2026-08-21 22:29–22:31 UTC — the window `portfolio_eod_snapshot` fires in:

```
skipped | expected_filings_poller          | max_instances_active
skipped | jobs_liveness_watchdog           | max_instances_active
skipped | jobs_retry_sweeper               | max_instances_active
skipped | orchestrator_high_frequency_sync | max_instances_active
skipped | sec_atom_fast_lane               | max_instances_active
skipped | sec_manifest_worker              | max_instances_active
skipped | strategy_halt_feed_refresh       | max_instances_active
skipped | strategy_intraday_harvest        | max_instances_active
skipped | strategy_paper_cycle             | max_instances_active
```

Nine rows written at that instant; `portfolio_eod_snapshot` wrote none. Same
shape on 2026-08-12. ⚠ I do **not** claim which job saturated the executor —
`BaseExecutor.submit_job` increments `_instances` at submission, before the body
runs, so these rows prove the executor was backed up and identify no culprit. An
earlier draft named `thesis_refresh`; withdrawn on #2880.

### Why the loss is permanent for this job

`snapshot_date = MAX(price_daily.price_date)` over held instruments
(`portfolio_eod.py::_resolve_snapshot_date`). The next night's fire therefore
writes a **later** session, and nothing backfills the skipped one. That is the
opposite of `fundamentals_sync`, whose next fire re-covers the same work — the
same `catch_up_on_boot=False` flag is safe there and lossy here.

## The fix

**1. Record it.** `_on_job_missed` mirrors `_on_job_max_instances`: a `skipped`
`job_runs` row, stamped at `event.scheduled_run_time` rather than at detection
time, because the fact worth keeping is *which slot* was lost. Reason carries a
new `MISFIRE_SKIP_PREFIX`, added to the `expected_fire_at` anchor exclusion in
`scheduled_adapter.py` beside `lane_busy: ` — a misfire is "work was due,
couldn't start", so it must not reset the schedule-missed clock the way a benign
prereq skip does. Fully fail-safe: the write lands on a pool thread during
exactly the congestion that caused the misfire, so losing the telemetry row is
better than turning it into a second fault.

**2. Stop losing it — opt-in, per job.** `ScheduledJob.misfire_grace_seconds`,
default `None` (inherit the 1 s `job_defaults` value via APScheduler's
`undefined` sentinel — *not* `None`, which would disable the misfire check
entirely).

⚠ **Deliberately not derived from `cadence.kind`.** That was the first design and
it is unsafe: `coalesce=True` does **not** collapse a fire already handed to the
executor — the scheduler advances `next_run_time` at submission, so a long grace
lets a stale fire execute hours later while its successor is suppressed with
`max_instances_active`. A cadence-wide rule would let any daily job run nearly a
day late. `execute_approved_orders` alone rules that out (its contract is
execution at the scheduled time, never a surprise catch-up); SEC daily-index
reconcile reads "yesterday"; several daily jobs encode ordering or
data-readiness assumptions. Caught at Codex checkpoint 1.

Only `portfolio_eod_snapshot` opts in, at **4 h — by construction, not taste**:
it fires 22:30 and `orchestrator_full_sync` (which advances
`MAX(price_daily.price_date)`) fires 03:00, so a window expiring 02:30 is the
largest that cannot let a late fire leap onto the following session. A test
asserts that inequality against the two **registered cadences**, so the constant
cannot silently outlive its justification. The body is `ON CONFLICT`-idempotent
and mutates no broker state, so a late run is strictly better than none.

## What this does NOT fix, stated plainly

`_read_positions` reads `broker_positions`, which is **current** state — a
snapshot for session D is D's closes applied to the positions held at run time,
not a historically faithful observation of D. Pre-existing and visible today: 16
of 48 stored rows have `computed_at` a day or more after `snapshot_date`
(`select (computed_at at time zone 'UTC')::date - snapshot_date, count(*) from
portfolio_eod_snapshots group by 1` → 0:32, 1:6, 2:9, 3:1). Not binding for
#2844's countdown on a static demo book — the previous session measured
`mark_rounding_tolerance` at 23.10 GBP on a 44,682.61 GBP book, 5.2 bps — but a
faithful per-session positions/cash observation is a real #2602 requirement this
PR does not deliver.

The recovery question for every **other** job is also left open on purpose:
until these rows exist there is no per-job misfire count to decide it on. The
"days with zero `job_runs` rows" figures on #2880 are an upper bound that cannot
separate a misfire from daemon downtime.

## Security model

None touched. No new endpoint, no auth path, no credential read, no broker
mutation, no schema change. The listener writes one `job_runs` telemetry row
through the existing bounded background-write seam.

## Verification

Lint / format / pyright clean; fast tier + smoke green; the touched DB-tier
modules run green.

Every new test was **revert-probed** — each fails with its own change backed out:

| test | probe | result |
| --- | --- | --- |
| `test_misfire_skip_does_not_reset_schedule_missed_anchor` | drop `MISFIRE_SKIP_PREFIX` from `_NON_ANCHORING_SKIP_PREFIXES` | exit 1 |
| `TestMisfireVisibilityAndGrace` (3 cases) | remove `misfire_grace_seconds=4*60*60` from the registry | exit 1, 3 FAILED |
| `test_missed_fire_records_skip_stamped_at_the_lost_slot` | drop `now=scheduled_for` | exit 1 |

Coverage split follows the repo's lean-test policy: pure-logic cases on the push
gate (`tests/test_jobs_runtime.py`), and the two genuinely-new mechanisms
against a real DB — the anchor-exclusion SQL
(`tests/test_scheduled_adapter.py`) and the past-dated stamp actually landing
(`tests/test_jobs_max_instances_listener.py`, beside its #1472 sibling).

Codex checkpoint 2 on the branch diff: no findings.

**No ETL / parser / schema-migration clauses apply** — no migration, no parser,
no ingest path, no ownership or observations data touched.

### Operator follow-up

The jobs daemon needs a restart onto the merged commit for the listener to be
live (scheduler change). No `sec_rebuild`, no backfill: the fix changes no
stored output, only whether a declined fire leaves a row.
