### PR TITLE
feature(#2602 item 3): product identity per position, from the broker's own field

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -39,6 +39,7 @@ from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.db.snapshot import snapshot_read
 from app.domain.positions import PositionSource
+from app.services.broker_settlement_arms import position_investment_type_label, position_is_underlying
 from app.services.fx import FxRateNotFound, convert, load_live_fx_rates_with_metadata
 from app.services.portfolio_value_history import (
     carry_forward_rate_map,
@@ -64,7 +65,31 @@ router = APIRouter(
 # ---------------------------------------------------------------------------
 
 
-class BrokerPositionItem(BaseModel):
+class PositionProductIdentity(BaseModel):
+    """What a position IS, from the broker's own field (#2602 item 3).
+
+    A mixin rather than two copies: `BrokerPositionItem` and `NativeTradeItem`
+    are both per-trade views of the same row, and "a contract field wired into
+    one model but not its sibling" is a recurring defect class in this repo
+    (#1955). Adding the next identity field here reaches both by construction.
+
+    Sourced from eToro's `settlementTypeID` on the open-positions response —
+    *"Position investment type. 0 - CFD, 1 - Real Asset, 2 - SWAP,
+    3 - Crypto MarginTrade, 4 - Future Contract"* (live portal 2026-08-23).
+    NOT from `strategy_core_eligibility_proofs`: that answers what this account
+    could open *today*, which is a different question from what an already-open
+    position is.
+    """
+
+    #: The provider's documented label, verbatim. `None` = the broker reported
+    #: no type we recognise — deliberately distinct from "it is a derivative",
+    #: so a panel can say "not observed" rather than assert the wrong product.
+    investment_type: str | None = None
+    #: `True` only for the real asset held outright; `None` when unobserved.
+    is_underlying: bool | None = None
+
+
+class BrokerPositionItem(PositionProductIdentity):
     """Individual eToro position (one trade) within a stock holding."""
 
     position_id: int
@@ -146,7 +171,7 @@ class PortfolioResponse(BaseModel):
     live_quote_instrument_ids: list[int] = []
 
 
-class NativeTradeItem(BaseModel):
+class NativeTradeItem(PositionProductIdentity):
     """Individual trade in the instrument's native currency."""
 
     position_id: int
@@ -330,6 +355,7 @@ def get_portfolio(
                bp.open_date_time,
                bp.stop_loss_rate, bp.take_profit_rate,
                bp.is_tsl_enabled, bp.leverage, bp.total_fees,
+               bp.settlement_type_id,
                i.currency
         FROM broker_positions bp
         JOIN instruments i USING (instrument_id)
@@ -434,6 +460,8 @@ def get_portfolio(
                 leverage=br["leverage"],
                 total_fees=float(br["total_fees"]),
                 currency=trade_currency,
+                investment_type=position_investment_type_label(br["settlement_type_id"]),
+                is_underlying=position_is_underlying(br["settlement_type_id"]),
             )
         )
 
@@ -554,7 +582,8 @@ def get_instrument_positions(
         SELECT bp.position_id, bp.is_buy, bp.units, bp.amount,
                bp.open_rate, bp.open_conversion_rate, bp.open_date_time,
                bp.stop_loss_rate, bp.take_profit_rate,
-               bp.is_tsl_enabled, bp.leverage, bp.total_fees
+               bp.is_tsl_enabled, bp.leverage, bp.total_fees,
+               bp.settlement_type_id
         FROM broker_positions bp
         WHERE bp.instrument_id = %(iid)s AND bp.units > 0
         ORDER BY bp.amount DESC
@@ -641,6 +670,8 @@ def get_instrument_positions(
                 is_tsl_enabled=tr["is_tsl_enabled"],
                 leverage=tr["leverage"],
                 total_fees=float(tr["total_fees"]),
+                investment_type=position_investment_type_label(tr["settlement_type_id"]),
+                is_underlying=position_is_underlying(tr["settlement_type_id"]),
             )
         )
 

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -347,6 +347,13 @@ class BrokerPosition:
     leverage: int = 1
     is_tsl_enabled: bool = False
     total_fees: Decimal = Decimal("0")
+    # #2602 item 3 — the broker's own per-position product identity.
+    # eToro ``settlementTypeID``: "Position investment type. 0 - CFD,
+    # 1 - Real Asset, 2 - SWAP, 3 - Crypto MarginTrade, 4 - Future Contract"
+    # (live portal 2026-08-23, get-account-pnl-and-portfolio-details).
+    # ``None`` = the payload did not carry it; see
+    # ``app.services.broker_settlement_arms.position_investment_type_label``.
+    settlement_type_id: int | None = None
 
 
 @dataclass(frozen=True)

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import decimal
 import logging
+import re
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -1407,7 +1408,60 @@ def _parse_direct_position(payload: dict[str, Any]) -> BrokerPosition:
         leverage=int(payload.get("leverage", 1)),
         is_tsl_enabled=bool(payload.get("isTslEnabled", False)),
         total_fees=Decimal(str(payload.get("totalFees", 0))),
+        settlement_type_id=_opt_settlement_type_id(payload),
     )
+
+
+#: An integral decimal string, with optional sign and no fractional part.
+#: `settlementTypeID` is an enumeration, so "1.5" is malformed input, not a
+#: value to round (Codex ckpt-2, #2602 item 3).
+_INTEGRAL_STRING = re.compile(r"-?\d+")
+
+#: Range of `broker_positions.settlement_type_id` (SMALLINT, `sql/367`). Mirrored
+#: here because the parser is the only writer on the live path, and handing the
+#: upsert an out-of-range value trades one unreadable label for the entire sync.
+_SMALLINT_MIN = -32768
+_SMALLINT_MAX = 32767
+
+
+def _opt_settlement_type_id(payload: dict[str, Any]) -> int | None:
+    """``settlementTypeID`` as an int, or ``None`` if absent/unreadable (#2602 item 3).
+
+    Never raises. This is evidence about the position, not a field the position
+    depends on: refusing to parse the whole position because its investment type
+    is malformed would lose the holding itself over a label. ``bool`` is excluded
+    explicitly — it is an ``int`` subclass in Python, so ``isinstance(True, int)``
+    would quietly store ``1`` ("Real Asset") for a payload that sent ``true``.
+
+    ⚠ Only INTEGRAL values are accepted, because this is an enumeration and
+    ``int()`` truncates. A payload sending ``1.5`` is malformed, and coercing it
+    would present it to the operator as ``1`` — "Real Asset", an ownership claim
+    the broker never made. Unreadable must stay unreadable (Codex ckpt-2).
+    ``1.0`` is admitted: JSON has one number type, so a whole value can legally
+    arrive as a float.
+
+    ⚠⚠ Values outside ``SMALLINT`` are dropped, because the storage column is
+    ``SMALLINT`` (``sql/367``). Returning one would push the overflow down into
+    ``_upsert_broker_positions``, where it aborts the WHOLE portfolio sync — every
+    position lost over one unreadable label, which is precisely the outcome the
+    first paragraph promises not to have. The migration's backfill already
+    range-guards for the same reason; this is its runtime twin (Codex ckpt-2).
+    """
+    value = payload.get("settlementTypeID")
+    if value is None or isinstance(value, bool):
+        return None
+    parsed: int | None
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, float):
+        parsed = int(value) if value.is_integer() else None
+    elif isinstance(value, str) and _INTEGRAL_STRING.fullmatch(value.strip()):
+        parsed = int(value)
+    else:
+        parsed = None
+    if parsed is None or not (_SMALLINT_MIN <= parsed <= _SMALLINT_MAX):
+        return None
+    return parsed
 
 
 def _parse_closed_trade(payload: dict[str, Any]) -> BrokerClosedTrade:

--- a/app/services/broker_settlement_arms.py
+++ b/app/services/broker_settlement_arms.py
@@ -32,7 +32,9 @@ does not make a caller eligible to trade.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
+from types import MappingProxyType
+from typing import Final
 
 from app.providers.broker import BrokerInstrumentEligibility, BrokerLeverageConfig
 
@@ -40,6 +42,24 @@ from app.providers.broker import BrokerInstrumentEligibility, BrokerLeverageConf
 UNDERLYING_SETTLEMENT_TYPE = "real"
 UNDERLYING_DIRECTION = "long"
 UNLEVERAGED_LEVERAGE = 1
+
+# --- The OPEN-POSITION vocabulary (#2602 item 3) ---------------------------
+#
+# A second, separate enumeration the provider publishes on a different endpoint.
+# See ``position_investment_type_label`` for the citation and for why it is NOT
+# mapped onto the four-value eligibility vocabulary above.
+_POSITION_INVESTMENT_TYPES: Final[Mapping[int, str]] = MappingProxyType(
+    {
+        0: "CFD",
+        1: "Real Asset",
+        2: "SWAP",
+        3: "Crypto MarginTrade",
+        4: "Future Contract",
+    }
+)
+
+#: The one investment type that means ownership at full value, unleveraged.
+UNDERLYING_POSITION_INVESTMENT_TYPE_ID: Final[int] = 1
 
 
 def offers_unleveraged(leverage_values: Iterable[object]) -> bool:
@@ -80,6 +100,50 @@ def is_underlying_long_arm(arm: BrokerLeverageConfig) -> bool:
     )
 
 
+def position_investment_type_label(settlement_type_id: int | None) -> str | None:
+    """The provider's own label for an OPEN POSITION's ``settlementTypeID``.
+
+    Source rule (live portal 2026-08-23,
+    ``trading--demo/get-account-pnl-and-portfolio-details``): the open-positions
+    response documents the field as *"Position investment type. 0 - CFD,
+    1 - Real Asset, 2 - SWAP, 3 - Crypto MarginTrade, 4 - Future Contract"*.
+
+    ⚠⚠ **This is a DIFFERENT vocabulary from the eligibility one above** — five
+    numeric values against four strings, and ``SWAP`` has no counterpart there.
+    The two are deliberately not mapped onto each other: eToro publishes them as
+    separate enumerations on separate endpoints, so an equivalence table would be
+    ours, not theirs. The labels are returned verbatim as documented rather than
+    normalised into ``real``/``cfd``/… for the same reason.
+
+    They also answer different questions. The eligibility vocabulary answers
+    *"can this account open the underlying today"*; this one answers *"what is
+    the position that already exists"*. A position opened as a CFD stays a CFD
+    after the underlying becomes available, so #2602 item 3's identity cannot be
+    read off ``strategy_core_eligibility_proofs``.
+
+    Returns ``None`` for an unrecognised or absent id — an unknown investment
+    type must read as "not observed", never as one of the known ones.
+    """
+    return _POSITION_INVESTMENT_TYPES.get(settlement_type_id) if settlement_type_id is not None else None
+
+
+def position_is_underlying(settlement_type_id: int | None) -> bool | None:
+    """True when the position is the real asset held outright.
+
+    Tri-state on purpose: ``None`` means the broker did not report an id we
+    recognise, which is a different fact from "this is a derivative" and must not
+    collapse into ``False`` on an operator-facing panel.
+
+    ⚠ ``2 - SWAP`` and ``4 - Future Contract`` are derivatives by the provider's
+    own wording, and ``3 - Crypto MarginTrade`` is the real asset but leveraged,
+    which the standing no-leverage posture bars — so exactly one id qualifies,
+    mirroring ``UNDERLYING_SETTLEMENT_TYPE`` on the eligibility side.
+    """
+    if settlement_type_id is None or settlement_type_id not in _POSITION_INVESTMENT_TYPES:
+        return None
+    return settlement_type_id == UNDERLYING_POSITION_INVESTMENT_TYPE_ID
+
+
 def select_underlying_long_arms(
     row: BrokerInstrumentEligibility,
 ) -> tuple[BrokerLeverageConfig, ...]:
@@ -94,9 +158,12 @@ def select_underlying_long_arms(
 
 __all__ = [
     "UNDERLYING_DIRECTION",
+    "UNDERLYING_POSITION_INVESTMENT_TYPE_ID",
     "UNDERLYING_SETTLEMENT_TYPE",
     "UNLEVERAGED_LEVERAGE",
     "is_underlying_long_arm",
     "offers_unleveraged",
+    "position_investment_type_label",
+    "position_is_underlying",
     "select_underlying_long_arms",
 ]

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -161,6 +161,7 @@ def _upsert_broker_positions(
                 stop_loss_rate, take_profit_rate,
                 is_no_stop_loss, is_no_take_profit,
                 leverage, is_tsl_enabled, total_fees,
+                settlement_type_id,
                 source, raw_payload, updated_at
             )
             VALUES (
@@ -170,6 +171,7 @@ def _upsert_broker_positions(
                 %(stop_loss_rate)s, %(take_profit_rate)s,
                 %(is_no_stop_loss)s, %(is_no_take_profit)s,
                 %(leverage)s, %(is_tsl_enabled)s, %(total_fees)s,
+                %(settlement_type_id)s,
                 %(source)s, %(raw_payload)s, %(now)s
             )
             ON CONFLICT (position_id) DO UPDATE SET
@@ -183,6 +185,15 @@ def _upsert_broker_positions(
                 leverage                 = EXCLUDED.leverage,
                 is_tsl_enabled           = EXCLUDED.is_tsl_enabled,
                 total_fees               = EXCLUDED.total_fees,
+                -- #2602 item 3: the broker restates the investment type on
+                -- every sync, so it refreshes like any other observed field.
+                -- COALESCE keeps a previously-observed identity when a later
+                -- payload omits the key -- losing the product identity of a
+                -- position we already classified is worse than a stale label,
+                -- and eToro documents no "type cleared" state.
+                settlement_type_id       = COALESCE(
+                    EXCLUDED.settlement_type_id, broker_positions.settlement_type_id
+                ),
                 -- Preserve source: if position was created by eBull, keep
                 -- 'ebull' even when sync refreshes it.
                 source                   = CASE
@@ -211,6 +222,7 @@ def _upsert_broker_positions(
                 "leverage": bp.leverage,
                 "is_tsl_enabled": bp.is_tsl_enabled,
                 "total_fees": bp.total_fees,
+                "settlement_type_id": bp.settlement_type_id,
                 "source": "broker_sync",
                 "raw_payload": psycopg.types.json.Jsonb(bp.raw_payload),
                 "now": now,
@@ -239,14 +251,14 @@ def _upsert_broker_positions(
              amount, initial_amount_in_dollars, open_rate,
              open_conversion_rate, open_date_time, stop_loss_rate,
              take_profit_rate, is_no_stop_loss, is_no_take_profit,
-             leverage, is_tsl_enabled, total_fees, source, raw_payload,
-             updated_at, closed_detected_at)
+             leverage, is_tsl_enabled, total_fees, settlement_type_id,
+             source, raw_payload, updated_at, closed_detected_at)
         SELECT position_id, instrument_id, is_buy, units, initial_units,
                amount, initial_amount_in_dollars, open_rate,
                open_conversion_rate, open_date_time, stop_loss_rate,
                take_profit_rate, is_no_stop_loss, is_no_take_profit,
-               leverage, is_tsl_enabled, total_fees, source, raw_payload,
-               updated_at, %(now)s
+               leverage, is_tsl_enabled, total_fees, settlement_type_id,
+               source, raw_payload, updated_at, %(now)s
         FROM broker_positions
         WHERE position_id >= 0
           AND position_id != ALL(%(ids)s::bigint[])

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -759,6 +759,15 @@ export interface BrokerPositionItem {
   is_tsl_enabled: boolean;
   leverage: number;
   total_fees: number;
+  /** #2602 item 3 — what this position IS, from eToro's own `settlementTypeID`
+   *  ("Position investment type. 0 - CFD, 1 - Real Asset, 2 - SWAP,
+   *  3 - Crypto MarginTrade, 4 - Future Contract"). The provider's label,
+   *  verbatim. `null` = the broker reported no type we recognise, which is a
+   *  different fact from "it is a derivative" — render it as unknown, never as
+   *  a product. */
+  investment_type: string | null;
+  /** `true` only for the real asset held outright; `null` when unobserved. */
+  is_underlying: boolean | null;
   /** Currency the money fields above are actually in (#2129): the display
    *  currency normally, or the native currency on an FX-rate-missing degrade. */
   currency: string;
@@ -915,6 +924,15 @@ export interface NativeTradeItem {
   is_tsl_enabled: boolean;
   leverage: number;
   total_fees: number;
+  /** #2602 item 3 — what this position IS, from eToro's own `settlementTypeID`
+   *  ("Position investment type. 0 - CFD, 1 - Real Asset, 2 - SWAP,
+   *  3 - Crypto MarginTrade, 4 - Future Contract"). The provider's label,
+   *  verbatim. `null` = the broker reported no type we recognise, which is a
+   *  different fact from "it is a derivative" — render it as unknown, never as
+   *  a product. */
+  investment_type: string | null;
+  /** `true` only for the real asset held outright; `null` when unobserved. */
+  is_underlying: boolean | null;
 }
 
 export interface InstrumentPositionDetail {

--- a/frontend/src/components/instrument/InstrumentTradesTable.test.tsx
+++ b/frontend/src/components/instrument/InstrumentTradesTable.test.tsx
@@ -24,6 +24,8 @@ function trade(overrides: Partial<NativeTradeItem> = {}): NativeTradeItem {
     is_tsl_enabled: false,
     leverage: 1,
     total_fees: 1.25,
+    investment_type: null,
+    is_underlying: null,
     ...overrides,
   };
 }
@@ -76,5 +78,74 @@ describe("InstrumentTradesTable", () => {
       <InstrumentTradesTable currency="USD" trades={[]} />,
     );
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("InstrumentTradesTable — product identity (#2602 item 3)", () => {
+  it("labels a real-asset position with the broker's own wording", () => {
+    render(
+      <InstrumentTradesTable
+        currency="USD"
+        trades={[trade({ investment_type: "Real Asset", is_underlying: true })]}
+      />,
+    );
+    const badge = screen.getByText("Real Asset");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", expect.stringContaining("you own the underlying"));
+  });
+
+  it("labels a CFD as not the real asset held outright", () => {
+    render(
+      <InstrumentTradesTable
+        currency="USD"
+        trades={[trade({ investment_type: "CFD", is_underlying: false })]}
+      />,
+    );
+    const badge = screen.getByText("CFD");
+    expect(badge).toHaveAttribute("title", expect.stringContaining("not the real asset held outright"));
+  });
+
+  it("does not call Crypto MarginTrade a contract with the broker", () => {
+    // Type 3 IS the real asset by eToro's own wording, held on margin — so it
+    // is not underlying (the no-leverage posture bars it) but it is also not a
+    // derivative, and the tooltip must not claim otherwise (Codex ckpt-2).
+    render(
+      <InstrumentTradesTable
+        currency="USD"
+        trades={[trade({ investment_type: "Crypto MarginTrade", is_underlying: false })]}
+      />,
+    );
+    const title = screen.getByText("Crypto MarginTrade").getAttribute("title") ?? "";
+    expect(title).toContain("not the real asset held outright");
+    expect(title).not.toContain("contract with the broker");
+  });
+
+  it("renders an unreported type as Unknown rather than guessing a product", () => {
+    // The distinction is load-bearing: "the broker told us nothing" must not
+    // render as "this is a derivative", or the panel asserts a product identity
+    // that was never observed.
+    render(
+      <InstrumentTradesTable
+        currency="USD"
+        trades={[trade({ investment_type: null, is_underlying: null })]}
+      />,
+    );
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+    expect(screen.queryByText("CFD")).not.toBeInTheDocument();
+    expect(screen.queryByText("Real Asset")).not.toBeInTheDocument();
+  });
+
+  it("shows a per-row product, since two trades on one instrument can differ", () => {
+    render(
+      <InstrumentTradesTable
+        currency="USD"
+        trades={[
+          trade({ position_id: 1, investment_type: "Real Asset", is_underlying: true }),
+          trade({ position_id: 2, investment_type: "CFD", is_underlying: false }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Real Asset")).toBeInTheDocument();
+    expect(screen.getByText("CFD")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/instrument/InstrumentTradesTable.tsx
+++ b/frontend/src/components/instrument/InstrumentTradesTable.tsx
@@ -21,6 +21,50 @@ function SideBadge({ isBuy }: { isBuy: boolean }) {
   return <Badge tone={isBuy ? "ok" : "risk"}>{isBuy ? "Buy" : "Sell"}</Badge>;
 }
 
+/**
+ * What the position actually IS (#2602 item 3), from eToro's own
+ * `settlementTypeID`. Two trades on the same instrument can differ, so this
+ * belongs per-row rather than on the tab header.
+ *
+ * `null` renders as "Unknown", NOT as a product: the broker reporting no type
+ * we recognise is a different fact from the position being a derivative, and a
+ * panel that guesses here tells the operator they own something they do not.
+ *
+ * ⚠ The non-underlying tooltip says "not the real asset held outright" and NOT
+ * "a contract with the broker". Those are not the same claim: `3 - Crypto
+ * MarginTrade` IS the real asset by the provider's own wording, just held on
+ * margin, so calling it a contract would be wrong (Codex ckpt-2). The weaker
+ * sentence is true of all four non-underlying types, and it avoids restating
+ * eToro's taxonomy in the frontend where it would drift.
+ */
+function ProductBadge({
+  investmentType,
+  isUnderlying,
+}: {
+  investmentType: string | null;
+  isUnderlying: boolean | null;
+}) {
+  if (investmentType === null) {
+    return (
+      <Badge tone="neutral" title="The broker did not report a product type for this position">
+        Unknown
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      tone={isUnderlying ? "ok" : "info"}
+      title={
+        isUnderlying
+          ? "Real asset held outright — you own the underlying"
+          : `${investmentType} — not the real asset held outright`
+      }
+    >
+      {investmentType}
+    </Badge>
+  );
+}
+
 export function InstrumentTradesTable({
   trades,
   currency,
@@ -40,6 +84,7 @@ export function InstrumentTradesTable({
           <tr>
             <th className="py-2 pr-4">Opened</th>
             <th className="py-2 pr-4">Side</th>
+            <th className="py-2 pr-4">Product</th>
             <th className="py-2 pr-4 text-right">Units</th>
             <th className="py-2 pr-4 text-right">Entry</th>
             <th className="py-2 pr-4 text-right">Price</th>
@@ -62,6 +107,12 @@ export function InstrumentTradesTable({
                 </td>
                 <td className="py-2 pr-4">
                   <SideBadge isBuy={t.is_buy} />
+                </td>
+                <td className="py-2 pr-4">
+                  <ProductBadge
+                    investmentType={t.investment_type}
+                    isUnderlying={t.is_underlying}
+                  />
                 </td>
                 <td className="py-2 pr-4 text-right tabular-nums">
                   {formatNumber(t.units)}

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -138,6 +138,8 @@ function heldPosition(): InstrumentPositionDetail {
         is_tsl_enabled: false,
         leverage: 1,
         total_fees: 0,
+        investment_type: null,
+        is_underlying: null,
       },
     ],
   };

--- a/frontend/src/components/orders/ClosePositionModal.test.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.test.tsx
@@ -82,6 +82,8 @@ function tradeFor(
     is_tsl_enabled: false,
     leverage: 1,
     total_fees: 0,
+    investment_type: null,
+    is_underlying: null,
     ...overrides,
   };
 }

--- a/frontend/src/components/orders/OrderEntryModal.test.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.test.tsx
@@ -90,6 +90,8 @@ function detailFor(instrumentId: number): InstrumentPositionDetail {
         is_tsl_enabled: false,
         leverage: 1,
         total_fees: 0,
+        investment_type: null,
+        is_underlying: null,
       },
     ],
   };

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -92,6 +92,8 @@ function trade(
     is_tsl_enabled: false,
     leverage: 1,
     total_fees: 0,
+    investment_type: null,
+    is_underlying: null,
     currency: "GBP",
     ...overrides,
   };
@@ -227,6 +229,8 @@ beforeEach(() => {
         is_tsl_enabled: false,
         leverage: 1,
         total_fees: 0,
+        investment_type: null,
+        is_underlying: null,
       },
     ],
   });

--- a/sql/367_broker_position_settlement_type.sql
+++ b/sql/367_broker_position_settlement_type.sql
@@ -1,0 +1,71 @@
+-- #2602 item 3 -- product identity PER POSITION, from the broker's own field.
+--
+-- Source rule (live portal 2026-08-23,
+-- `api-reference/trading--demo/get-account-pnl-and-portfolio-details`): the
+-- open-positions response documents
+--
+--     settlementTypeID -- "Position investment type. 0 - CFD, 1 - Real Asset,
+--                          2 - SWAP, 3 - Crypto MarginTrade, 4 - Future Contract"
+--
+-- That is the authority for what an EXISTING position IS. It is deliberately
+-- not `strategy_core_eligibility_proofs`: that table answers "can this account
+-- open the underlying TODAY", which is a different question from "what product
+-- is this position I opened months ago". Labelling a held position from today's
+-- eligibility would be an inference dressed as evidence.
+--
+-- ⚠ The two vocabularies are NOT the same set. The eligibility response uses a
+-- four-value STRING vocabulary (`real` / `realFutures` / `marginTrade` / `cfd`,
+-- see app/services/broker_settlement_arms.py); this is a five-value NUMERIC one
+-- and `SWAP` has no counterpart there. They are kept apart on purpose -- a
+-- hand-written equivalence between two vendor enums is exactly the kind of
+-- invented mapping the source-rule discipline exists to stop.
+--
+-- ⚠ `isSettled` sits next to it in the same payload and correlates PERFECTLY
+-- with this field on all seven positions currently held. It is documented
+-- "Obsolete" and must not be used. A 7-row correlation is not corroboration.
+--
+-- No CHECK on the value set. The vendor can add a sixth type without notice,
+-- and a constraint would turn that into a hard failure of position INGEST over
+-- an evidence field -- refusing to record the whole position because we cannot
+-- label it is strictly worse than recording it with an unlabelled type. The
+-- closed vocabulary lives in code (`position_investment_type_label`), which
+-- returns NULL for an unrecognised id rather than guessing.
+--
+-- Backfill is exact and needs no re-sync: `raw_payload` has retained the field
+-- verbatim for every position ever written. Measured on dev before this ran --
+-- 7 of 7 open positions carry it (4 at 0, 3 at 1).
+
+ALTER TABLE broker_positions
+    ADD COLUMN IF NOT EXISTS settlement_type_id SMALLINT;
+
+ALTER TABLE broker_positions_closed
+    ADD COLUMN IF NOT EXISTS settlement_type_id SMALLINT;
+
+COMMENT ON COLUMN broker_positions.settlement_type_id IS
+    'eToro settlementTypeID -- "Position investment type. 0 - CFD, 1 - Real Asset, '
+    '2 - SWAP, 3 - Crypto MarginTrade, 4 - Future Contract" (live portal 2026-08-23, '
+    'get-account-pnl-and-portfolio-details). Per-POSITION product identity; not the '
+    'same vocabulary as the eligibility response settlementType. NULL = the broker '
+    'did not report it.';
+
+COMMENT ON COLUMN broker_positions_closed.settlement_type_id IS
+    'Archived copy of broker_positions.settlement_type_id -- see that column comment.';
+
+UPDATE broker_positions
+   SET settlement_type_id = (raw_payload->>'settlementTypeID')::smallint
+ WHERE settlement_type_id IS NULL
+   AND raw_payload ? 'settlementTypeID'
+   -- Guard the cast BOTH ways: the column is evidence, so a value we cannot
+   -- read must leave the row NULL rather than abort the migration for every
+   -- other position. The regex alone is not enough -- it admits '999999', which
+   -- then overflows ::smallint and takes the whole migration down (Codex
+   -- ckpt-2). ::numeric on a matched digit-string cannot itself throw.
+   AND raw_payload->>'settlementTypeID' ~ '^-?[0-9]+$'
+   AND (raw_payload->>'settlementTypeID')::numeric BETWEEN -32768 AND 32767;
+
+UPDATE broker_positions_closed
+   SET settlement_type_id = (raw_payload->>'settlementTypeID')::smallint
+ WHERE settlement_type_id IS NULL
+   AND raw_payload ? 'settlementTypeID'
+   AND raw_payload->>'settlementTypeID' ~ '^-?[0-9]+$'
+   AND (raw_payload->>'settlementTypeID')::numeric BETWEEN -32768 AND 32767;

--- a/tests/test_2602_position_investment_type.py
+++ b/tests/test_2602_position_investment_type.py
@@ -1,0 +1,169 @@
+"""#2602 item 3 — product identity PER POSITION, from the broker's own field.
+
+Source rule (live portal 2026-08-23,
+``api-reference/trading--demo/get-account-pnl-and-portfolio-details``): the
+open-positions response documents ``settlementTypeID`` as *"Position investment
+type. 0 - CFD, 1 - Real Asset, 2 - SWAP, 3 - Crypto MarginTrade, 4 - Future
+Contract"*.
+
+⚠ These are pure-logic tests over the vocabulary and the parser. The backfill SQL
+and the read path are exercised against a real DB in
+``tests/test_2602_position_investment_type_db.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.providers.implementations.etoro_broker import _opt_settlement_type_id, _parse_direct_position
+from app.services.broker_settlement_arms import (
+    UNDERLYING_POSITION_INVESTMENT_TYPE_ID,
+    UNDERLYING_SETTLEMENT_TYPE,
+    position_investment_type_label,
+    position_is_underlying,
+)
+
+
+class TestVocabulary:
+    @pytest.mark.parametrize(
+        ("settlement_type_id", "label"),
+        [
+            (0, "CFD"),
+            (1, "Real Asset"),
+            (2, "SWAP"),
+            (3, "Crypto MarginTrade"),
+            (4, "Future Contract"),
+        ],
+    )
+    def test_documented_ids_render_the_providers_own_label(self, settlement_type_id: int, label: str) -> None:
+        """Verbatim, not normalised into the eligibility vocabulary.
+
+        eToro publishes the two enumerations on two endpoints; an equivalence
+        between them would be ours, not theirs.
+        """
+        assert position_investment_type_label(settlement_type_id) == label
+
+    @pytest.mark.parametrize("unknown", [-1, 5, 99])
+    def test_an_undocumented_id_is_not_observed_rather_than_guessed(self, unknown: int) -> None:
+        assert position_investment_type_label(unknown) is None
+        assert position_is_underlying(unknown) is None
+
+    def test_absent_id_is_not_observed(self) -> None:
+        assert position_investment_type_label(None) is None
+        assert position_is_underlying(None) is None
+
+    @pytest.mark.parametrize(
+        ("settlement_type_id", "expected"),
+        [(0, False), (1, True), (2, False), (3, False), (4, False)],
+    )
+    def test_exactly_one_documented_type_is_ownership_at_full_value(
+        self, settlement_type_id: int, expected: bool
+    ) -> None:
+        """SWAP and Future Contract are derivatives by the provider's own wording;
+        Crypto MarginTrade is the real asset but leveraged, which the standing
+        no-leverage posture bars."""
+        assert position_is_underlying(settlement_type_id) is expected
+
+    def test_unknown_is_tri_state_not_false(self) -> None:
+        """The distinction is load-bearing on an operator panel.
+
+        "we did not observe a product type" and "this is a derivative" are
+        different facts, and collapsing the first into the second would have the
+        panel assert a product identity the broker never reported.
+        """
+        assert position_is_underlying(None) is not False
+        assert position_is_underlying(999) is not False
+
+    def test_the_two_vocabularies_are_kept_distinct(self) -> None:
+        """Pin that the position enum is NOT the eligibility string set.
+
+        If someone later "tidies" the labels into ``real``/``cfd``/… this fails —
+        which is the point: the eligibility vocabulary has four values and no
+        SWAP, so the sets are not interchangeable.
+        """
+        labels = {position_investment_type_label(i) for i in range(5)}
+        assert UNDERLYING_SETTLEMENT_TYPE not in labels
+        assert "SWAP" in labels
+        assert position_investment_type_label(UNDERLYING_POSITION_INVESTMENT_TYPE_ID) == "Real Asset"
+
+
+class TestParser:
+    def test_reads_the_documented_key(self) -> None:
+        assert _opt_settlement_type_id({"settlementTypeID": 1}) == 1
+
+    def test_accepts_the_string_form_the_payload_actually_stores(self) -> None:
+        """``raw_payload->>'settlementTypeID'`` round-trips as text, and eToro has
+        sent numerics as strings elsewhere in this API."""
+        assert _opt_settlement_type_id({"settlementTypeID": "0"}) == 0
+
+    def test_absent_key_is_none(self) -> None:
+        assert _opt_settlement_type_id({}) is None
+        assert _opt_settlement_type_id({"settlementTypeID": None}) is None
+
+    @pytest.mark.parametrize("bogus", ["", "cfd", [], {}, 3.5j])
+    def test_unreadable_value_is_none_and_never_raises(self, bogus: object) -> None:
+        """Evidence about the position, not a field the position depends on.
+
+        Refusing to parse the whole position because its investment type is
+        malformed would lose the HOLDING over a label.
+        """
+        assert _opt_settlement_type_id({"settlementTypeID": bogus}) is None
+
+    @pytest.mark.parametrize("fractional", [1.5, 0.5, "1.5", 3.9])
+    def test_a_fractional_value_is_rejected_not_truncated(self, fractional: object) -> None:
+        """`settlementTypeID` is an ENUMERATION, so `int()` truncation is a lie.
+
+        `int(1.5)` is 1, which the panel renders as "Real Asset" — an ownership
+        claim the broker never made, from a payload we could not read.
+        Caught at Codex ckpt-2.
+        """
+        assert _opt_settlement_type_id({"settlementTypeID": fractional}) is None
+
+    @pytest.mark.parametrize("whole", [1.0, 0.0, 4.0])
+    def test_a_whole_float_is_admitted(self, whole: float) -> None:
+        """JSON has one number type, so a whole value can legally arrive as a
+        float — rejecting it would drop evidence the broker did send."""
+        assert _opt_settlement_type_id({"settlementTypeID": whole}) == int(whole)
+
+    @pytest.mark.parametrize("out_of_range", [32768, -32769, 999999, "999999", 70000.0])
+    def test_a_value_too_large_for_the_column_is_dropped_not_passed_on(self, out_of_range: object) -> None:
+        """`broker_positions.settlement_type_id` is SMALLINT (sql/367).
+
+        Passing an out-of-range value on would push the overflow into
+        `_upsert_broker_positions`, aborting the WHOLE portfolio sync — every
+        position lost over one unreadable label. Caught at Codex ckpt-2 round 2.
+        """
+        assert _opt_settlement_type_id({"settlementTypeID": out_of_range}) is None
+
+    @pytest.mark.parametrize("boundary", [32767, -32768])
+    def test_the_column_boundaries_themselves_are_admitted(self, boundary: int) -> None:
+        """Off-by-one guard: the bound is inclusive on both ends."""
+        assert _opt_settlement_type_id({"settlementTypeID": boundary}) == boundary
+
+    @pytest.mark.parametrize("truthy", [True, False])
+    def test_bool_is_rejected_not_coerced(self, truthy: bool) -> None:
+        """``bool`` is an ``int`` subclass in Python, so a naive ``int(value)``
+        would store 1 = "Real Asset" for a payload that sent ``true``. Mirrors the
+        same guard in ``offers_unleveraged`` on the eligibility side."""
+        assert _opt_settlement_type_id({"settlementTypeID": truthy}) is None
+
+    def test_parsed_position_carries_the_identity(self) -> None:
+        payload = {
+            "positionID": 3308441892,
+            "instrumentID": 4238,
+            "units": "16.929336",
+            "openRate": "512.34",
+            "amount": "8672.15",
+            "settlementTypeID": 0,
+        }
+        assert _parse_direct_position(payload).settlement_type_id == 0
+
+    def test_a_position_without_the_key_still_parses(self) -> None:
+        payload = {
+            "positionID": 1,
+            "instrumentID": 2,
+            "units": "1",
+            "openRate": "10",
+            "amount": "10",
+        }
+        assert _parse_direct_position(payload).settlement_type_id is None

--- a/tests/test_2602_position_investment_type_db.py
+++ b/tests/test_2602_position_investment_type_db.py
@@ -1,0 +1,120 @@
+"""#2602 item 3 — the SQL half, against a real database.
+
+The vocabulary and the parser are pure and live in
+``tests/test_2602_position_investment_type.py``. What needs a real Postgres is
+the ON CONFLICT branch: ``settlement_type_id`` is the one field on the
+``broker_positions`` upsert that does NOT take ``EXCLUDED`` unconditionally, and
+whether a later payload can erase a known product identity is not answerable
+from a mocked cursor.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+
+from app.providers.broker import BrokerPosition
+from app.services.portfolio_sync import _upsert_broker_positions
+
+INSTRUMENT_ID = 990_602
+POSITION_ID = 990_602_001
+_NOW = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+
+
+def _seed_instrument(conn: psycopg.Connection[Any]) -> int:
+    """``is_tradable`` listed explicitly per #1233 §6.2 (chokepoint lint)."""
+    conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,is_tradable) "
+        "VALUES (%s,'POS.IDENT','Position Identity Test',TRUE) ON CONFLICT DO NOTHING",
+        (INSTRUMENT_ID,),
+    )
+    return INSTRUMENT_ID
+
+
+def _position(settlement_type_id: int | None, raw_payload: dict[str, Any] | None = None) -> BrokerPosition:
+    return BrokerPosition(
+        instrument_id=INSTRUMENT_ID,
+        units=Decimal("10"),
+        open_price=Decimal("100"),
+        current_price=Decimal("100"),
+        raw_payload=raw_payload if raw_payload is not None else {"positionID": POSITION_ID},
+        position_id=POSITION_ID,
+        amount=Decimal("1000"),
+        initial_amount_in_dollars=Decimal("1000"),
+        open_date_time=_NOW,
+        settlement_type_id=settlement_type_id,
+    )
+
+
+def _stored(conn: psycopg.Connection[Any]) -> int | None:
+    row = conn.execute(
+        "SELECT settlement_type_id FROM broker_positions WHERE position_id = %s", (POSITION_ID,)
+    ).fetchone()
+    assert row is not None
+    return row[0]
+
+
+def test_first_sync_stores_the_investment_type(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _seed_instrument(ebull_test_conn)
+    _upsert_broker_positions(ebull_test_conn, [_position(0)], _NOW)
+    assert _stored(ebull_test_conn) == 0
+
+
+def test_a_later_sync_restates_a_changed_investment_type(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The broker sends the field on every payload, so it refreshes like any
+    other observed value. A stale label would be its own defect."""
+    _seed_instrument(ebull_test_conn)
+    _upsert_broker_positions(ebull_test_conn, [_position(0)], _NOW)
+    _upsert_broker_positions(ebull_test_conn, [_position(1)], _NOW)
+    assert _stored(ebull_test_conn) == 1
+
+
+def test_a_payload_that_omits_the_field_does_not_erase_what_we_knew(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The COALESCE branch — the reason this test needs a real database.
+
+    Taking ``EXCLUDED`` unconditionally would blank a position's product
+    identity the first time eToro omitted the key, and the provider documents no
+    "type cleared" state, so NULL means "not reported", never "no longer a CFD".
+    A blanked row reads as Unknown on the panel and silently drops evidence we
+    already had.
+    """
+    _seed_instrument(ebull_test_conn)
+    _upsert_broker_positions(ebull_test_conn, [_position(1)], _NOW)
+    _upsert_broker_positions(ebull_test_conn, [_position(None)], _NOW)
+    assert _stored(ebull_test_conn) == 1
+
+
+def test_migration_backfill_reads_the_retained_payload(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """sql/367's backfill is exact — the field was retained all along.
+
+    Pinned as a query rather than trusted from the one-off run: ``raw_payload``
+    is the evidence the backfill claimed, so the claim is that the column agrees
+    with it for every row that carries the key.
+    """
+    _seed_instrument(ebull_test_conn)
+    _upsert_broker_positions(
+        ebull_test_conn,
+        [_position(2, raw_payload={"positionID": POSITION_ID, "settlementTypeID": 2})],
+        _NOW,
+    )
+    row = ebull_test_conn.execute(
+        """
+        SELECT count(*) FILTER (
+            WHERE settlement_type_id IS DISTINCT FROM (raw_payload->>'settlementTypeID')::smallint
+        )
+          FROM broker_positions
+         WHERE raw_payload ? 'settlementTypeID'
+           AND raw_payload->>'settlementTypeID' ~ '^-?[0-9]+$'
+        """
+    ).fetchone()
+    assert row is not None
+    assert row[0] == 0

--- a/tests/test_api_portfolio.py
+++ b/tests/test_api_portfolio.py
@@ -1025,6 +1025,7 @@ def _make_broker_position_row(
     is_tsl_enabled: bool = False,
     leverage: int = 1,
     total_fees: float = 0.0,
+    settlement_type_id: int | None = None,
 ) -> dict[str, Any]:
     """Build a row matching the trades_sql shape in get_instrument_positions."""
     return {
@@ -1040,6 +1041,12 @@ def _make_broker_position_row(
         "is_tsl_enabled": is_tsl_enabled,
         "leverage": leverage,
         "total_fees": total_fees,
+        # #2602 item 3. The endpoint indexes this strictly (`tr[...]`), like
+        # every other trades_sql column: the SELECT guarantees the key, so a
+        # KeyError here means the fixture has drifted from the query — which is
+        # exactly what it should say, rather than `.get()` quietly rendering
+        # every position as "Unknown" forever.
+        "settlement_type_id": settlement_type_id,
     }
 
 

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -680,6 +680,7 @@ def _detailed_pos(
     current_price: Decimal = Decimal("110"),
     stop_loss_rate: Decimal | None = None,
     take_profit_rate: Decimal | None = None,
+    settlement_type_id: int | None = None,
 ) -> BrokerPosition:
     """BrokerPosition with per-position fields populated (for broker_positions tests)."""
     return BrokerPosition(
@@ -694,6 +695,7 @@ def _detailed_pos(
         initial_amount_in_dollars=open_price * units,
         stop_loss_rate=stop_loss_rate,
         take_profit_rate=take_profit_rate,
+        settlement_type_id=settlement_type_id,
     )
 
 
@@ -755,6 +757,43 @@ class TestUpsertBrokerPositions:
         params = upsert_calls[0].args[1]
         # Must fall back to `now`, not pass None (which would violate NOT NULL)
         assert params["open_date_time"] == _NOW
+
+    def test_persists_the_position_investment_type(self) -> None:
+        """#2602 item 3 — the broker's ``settlementTypeID`` reaches storage.
+
+        It was being received and dropped: `raw_payload` retained it verbatim on
+        every position ever synced while no column carried it, so "what product
+        is this position" could only be answered by re-parsing JSON.
+        """
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_cursor.__iter__ = MagicMock(return_value=iter([]))
+        conn.cursor.return_value = mock_cursor
+
+        bp = _detailed_pos(position_id=5001, instrument_id=42, settlement_type_id=0)
+        _upsert_broker_positions(conn, [bp], _NOW)
+
+        upsert_calls = [c for c in conn.execute.call_args_list if _is_broker_positions_upsert(c.args[0])]
+        assert upsert_calls[0].args[1]["settlement_type_id"] == 0
+
+    def test_an_unreported_investment_type_is_passed_as_null(self) -> None:
+        """Not defaulted to 0 ("CFD"). A missing type is unobserved, and the
+        ON CONFLICT COALESCE relies on NULL to mean "keep what we already knew"."""
+        conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_cursor.__iter__ = MagicMock(return_value=iter([]))
+        conn.cursor.return_value = mock_cursor
+
+        bp = _detailed_pos(position_id=5001, instrument_id=42)
+        assert bp.settlement_type_id is None
+        _upsert_broker_positions(conn, [bp], _NOW)
+
+        upsert_calls = [c for c in conn.execute.call_args_list if _is_broker_positions_upsert(c.args[0])]
+        assert upsert_calls[0].args[1]["settlement_type_id"] is None
 
     def test_skips_position_without_id(self) -> None:
         """Legacy BrokerPosition fixtures (position_id=None) are skipped.


### PR DESCRIPTION
Refs #2602 (item 3 of five — the ticket stays open). Refs #2844. Refs #2437.

**Leaves #2602 open** — this is one scope item, not the whole F-0 completion.

## The question, and where the answer already was

Which of the seven positions on the demo book do we actually **own**, and which
are contracts with the broker? The distinction drives the cost model, the risk
posture (a CFD short is unbounded and carries financing), and #2833's beta
sleeve, which needs the underlying.

The answer was arriving on every portfolio sync and being discarded. eToro's
open-positions payload carries `settlementTypeID`; `broker_positions.raw_payload`
has retained it verbatim for every position ever written; no column, contract or
panel read it.

## Source rule

Live portal 2026-08-23,
`api-reference/trading--demo/get-account-pnl-and-portfolio-details`:

> `settlementTypeID` — *"Position investment type. 0 - CFD, 1 - Real Asset,
> 2 - SWAP, 3 - Crypto MarginTrade, 4 - Future Contract"*

Three things that check bought, none of which were available by reasoning:

1. **The numeric enum itself.** Nothing in the repo mapped these ids.
2. **`isSettled` is documented "Obsolete".** It sits beside the field and
   correlates *perfectly* with it across all seven held positions — so treating
   it as a corroborating signal would have raised confidence in a field the
   vendor has deprecated. A 7-row correlation is not corroboration.
3. **It is a different vocabulary from the eligibility response.** That one is
   four *strings* (`real` / `realFutures` / `marginTrade` / `cfd`, see
   `app/services/broker_settlement_arms.py`); this is five *numbers* and `SWAP`
   has no counterpart. They are stored apart and the labels kept verbatim — a
   hand-written equivalence between two vendor enums would be ours, not theirs.

⚠ **Not sourced from `strategy_core_eligibility_proofs`**, which was the obvious
place to look. That table answers *"can this account open the underlying
today"*; a position opened as a CFD stays a CFD after the underlying becomes
available. Reading identity off it would be an inference dressed as evidence.

## What changed

- **`sql/367`** — `settlement_type_id SMALLINT` on `broker_positions` **and**
  `broker_positions_closed` (the archive INSERT lists columns explicitly, so
  omitting it there would drop identity on close), backfilled from the retained
  payload. **No CHECK on the value set**: the vendor can add a sixth type without
  notice, and refusing to record an entire position over an unlabelled type is
  strictly worse than recording it unlabelled. The closed vocabulary lives in
  code and returns `None` for an unrecognised id rather than guessing.
- **Vocabulary** in `broker_settlement_arms.py`, beside the eligibility one that
  already owns "what counts as the underlying" — one module, two clearly-separated
  enumerations, rather than a second module that drifts.
- **Parser + contract + sync** carry the field; the upsert's ON CONFLICT uses
  `COALESCE` so a later payload that omits the key cannot erase an identity we
  already observed (eToro documents no "type cleared" state).
- **Read path** — `/portfolio` and `/portfolio/instruments/{id}` expose
  `investment_type` and `is_underlying` via a shared Pydantic mixin, so the pair
  cannot reach one model and miss its sibling (#1955's recurring class).
- **Panel** — a per-row Product badge on the instrument Positions tab. Per-row,
  not per-instrument: two trades on one instrument can differ. `null` renders
  "Unknown", never a guessed product.

`is_underlying` is deliberately **tri-state**. "The broker reported no type we
recognise" and "this is a derivative" are different facts, and collapsing the
first into the second makes the panel assert a product identity that was never
observed.

## Verification

**Backfill executed on dev, exact — 7 of 7, zero NULL, every row agreeing with
`raw_payload`:**

| symbol | `settlement_type_id` | label | `is_underlying` |
| --- | ---: | --- | --- |
| GME ×2 | 1 | Real Asset | true |
| NXH | 1 | Real Asset | true |
| IEP ×2 | 0 | CFD | false |
| QQQ | 0 | CFD | false |
| VOO | 0 | CFD | false |

**Cross-source, one instrument, two independent eToro endpoints:** VOO's position
field says CFD / not-underlying, and `strategy_core_eligibility_proofs` carries an
independently-observed `not_underlying` verdict for instrument 4238 (2026-08-22).
They agree. The other four held instruments have never been proved, which is why
the position field — not the proof table — is the source here.

Consistent with the separately-recorded eToro UK landscape: QQQ and VOO are
US-listed ETFs (CFD-only); GME and NXH are stocks.

**Operator-visible figure on the real endpoints** — driven from this branch
against the dev DB with a real session cookie (`scripts/dev_browser_session.py`),
not a fixture:

```
GET /portfolio -> 200
  GME   pos=3308442058 investment_type='Real Asset' is_underlying=True
  GME   pos=3310085041 investment_type='Real Asset' is_underlying=True
  QQQ   pos=3308441899 investment_type='CFD'        is_underlying=False
  VOO   pos=3308441892 investment_type='CFD'        is_underlying=False
  NXH   pos=3368088761 investment_type='Real Asset' is_underlying=True
  IEP   pos=3324253560 investment_type='CFD'        is_underlying=False
  IEP   pos=3308441934 investment_type='CFD'        is_underlying=False
GET /portfolio/instruments/1699 -> 200  (GME, both trades 'Real Asset')
```

**Gates:** ruff / ruff-format / pyright clean; fast tier + smoke green; frontend
typecheck + `test:unit` green (1581 tests); DB tier green on the touched modules
(`test_2602_position_investment_type_db`, `test_api_portfolio`,
`test_portfolio_sync`).

**Revert-probed** — each fails with its own change backed out:

| test | probe | result |
| --- | --- | --- |
| `test_a_payload_that_omits_the_field_does_not_erase_what_we_knew` | ON CONFLICT takes `EXCLUDED` unconditionally | exit 1 |
| `test_a_value_too_large_for_the_column_is_dropped_not_passed_on` | drop the SMALLINT range guard | exit 1 |

⚠ **The DB tier caught a real regression the push gate could not.**
`_make_broker_position_row` in `test_api_portfolio.py` mirrors `trades_sql`'s
shape by hand and had drifted — five tests failed with `KeyError:
'settlement_type_id'`. That file is `db`-marked (TestClient), so it is off the
push gate. Fixture updated; the endpoint keeps indexing strictly (`tr[...]`) like
every other column, so future drift stays loud rather than rendering every
position "Unknown" forever.

⚠ `sql/367` had already been applied to dev when review asked for changes, so its
`content_sha256` no longer matched. Its `schema_migrations` row was deleted and
the corrected file re-applied (unmerged migration, `IF NOT EXISTS` DDL,
`WHERE ... IS NULL` backfill — idempotent). A subsequent `run_migrations()`
returns `[]`, i.e. the drift guard now passes on the merged bytes.

## Codex

**Checkpoint 2 round 1** — three P2s, all real, all fixed:
`int(1.5)` truncating to 1 and presenting a malformed payload as "Real Asset";
the badge tooltip calling **Crypto MarginTrade** "a contract with the broker"
when it is the real asset held on margin by the provider's own wording; and the
backfill regex admitting `999999`, which overflows `::smallint` and aborts the
whole migration.

**Round 2** — one P1, also real and also fixed: the runtime parser had no
equivalent range guard, so an out-of-range id would push the overflow into
`_upsert_broker_positions` and abort the entire portfolio sync — every position
lost over one unreadable label, the exact outcome the parser's docstring promises
not to have.

## Security model

None touched. No new endpoint, no auth change, no credential read, no broker
mutation. `settlementTypeID` arrives on a payload we already fetch, store and
retain; this reads a field out of it. Both routes keep their existing
`require_session_or_service_token` dependency.

## Definition-of-Done ETL clauses

Clauses 8–12 are scoped to ownership / fundamentals / observations data and do
not bind here (broker position data). Their substance is met anyway and recorded
above: backfill executed on dev, cross-source verified against a second eToro
endpoint, and the operator-visible figure confirmed on both live routes.

## Operator follow-up

Jobs daemon restart **not** required for correctness — `daily_portfolio_sync`
running the pre-merge code simply leaves `settlement_type_id` unchanged, and the
COALESCE branch means it cannot erase the backfilled values. Restart at the next
convenient point so new positions are stamped on arrival. The dev API (`:8000`)
serves `~/Dev/eBull` and will pick the field up when that checkout is re-detached
at the merged commit; the verification above was driven from this branch.
