### PR TITLE
feature(#2602 item 5): the benchmark fields refuse by name, and the refusal is true

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -13,7 +13,7 @@ import psycopg
 import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from psycopg.pq import TransactionStatus
-from pydantic import BaseModel, Field, StringConstraints, model_validator
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 
 from app.api.auth import require_session, require_session_or_service_token
 from app.api.portfolio import get_portfolio
@@ -739,6 +739,117 @@ class AccountEquityEvidenceView(BaseModel):
     incomplete_reasons: list[str]
 
 
+#: #2602 item 5.  Named refusal states for the two benchmark fields F-0 owes the
+#: operator — S&P 500 total return in base currency, and CPIH real return.  The
+#: rendering IS the v1 deliverable for those fields: no splice, and no price-only
+#: substitution labelled as total return.
+#:
+#: ⚠ A refusal code can itself be a false claim, which is the same dishonesty
+#: read backwards.  The two codes the ticket names are attached only where they
+#: are TRUE; where neither is, the third code below says what is actually the
+#: case.  See ``BENCHMARK_REFUSALS`` for the per-benchmark reasoning.
+#:
+#: ⚠⚠ Each code's meaning is its DEFINITION here, not its English connotation —
+#: a consumer acting on the token alone must be acting on the line beneath it.
+#: This block is the contract; ``detail`` is the evidence for one application of
+#: it (Codex ckpt-2 P2, which read ``unlicensed`` as a finding about a licensor).
+
+#: NOT "this source's licence forbids us". It asserts OUR review state: no free
+#: total-return source has been reviewed and found legally usable. #2602's own
+#: wording defines it that way — *"until a legal free source passes review"*.
+BENCHMARK_SOURCE_UNLICENSED: Final = "benchmark_source_unlicensed"
+#: A candidate series exists but is not the thing the field names.
+BENCHMARK_IDENTITY_UNVERIFIED: Final = "benchmark_identity_unverified"
+#: Neither of the above applies: nothing is ingested, so there is no candidate
+#: series whose licence or identity could be at issue. A fact about our schema.
+BENCHMARK_SERIES_NOT_INGESTED: Final = "benchmark_series_not_ingested"
+
+BENCHMARK_REFUSAL_CODES: Final = (
+    BENCHMARK_SOURCE_UNLICENSED,
+    BENCHMARK_IDENTITY_UNVERIFIED,
+    BENCHMARK_SERIES_NOT_INGESTED,
+)
+
+
+class BenchmarkRefusalReason(BaseModel):
+    """One named reason a benchmark comparison is refused, with its evidence.
+
+    ``detail`` travels with the code deliberately.  The alternative — the client
+    mapping code to sentence — puts a claim about a third party's licence terms
+    in two places, and the copy nobody re-reads is the one that goes stale.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    code: str
+    detail: str
+
+
+class BenchmarkRefusal(BaseModel):
+    """Why one benchmark field carries no number.
+
+    Shape follows the codebase's existing capability idiom —
+    ``live_strategy_activation_available: Literal[False]`` paired with
+    ``live_strategy_activation_blocker`` on :class:`StrategyOverviewResponse` —
+    generalised to N benchmarks with N reasons, because more than one blocker
+    genuinely applies to the S&P field.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    benchmark: str
+    label: str
+    reasons: tuple[BenchmarkRefusalReason, ...]
+
+
+BENCHMARK_REFUSALS: Final = (
+    BenchmarkRefusal(
+        benchmark="sp500_total_return",
+        label="S&P 500 total return",
+        reasons=(
+            BenchmarkRefusalReason(
+                code=BENCHMARK_SOURCE_UNLICENSED,
+                detail=(
+                    "We have reviewed no free S&P 500 total-return source and found it "
+                    "legally usable. This states our review status, not a finding about "
+                    "any licensor's terms — the index licensor's terms page refuses "
+                    "automated fetches and has not been read here."
+                ),
+            ),
+            BenchmarkRefusalReason(
+                code=BENCHMARK_IDENTITY_UNVERIFIED,
+                detail=(
+                    "Every S&P series we hold is a tracking ETF's PRICE (SPY, IVV, VOO) "
+                    "or eToro's SPX500 price index, not the index's total return. "
+                    "Substituting one is the mislabelling this refusal exists to prevent."
+                ),
+            ),
+        ),
+    ),
+    BenchmarkRefusal(
+        benchmark="cpih_real_return",
+        label="CPIH real return",
+        # ⚠ NOT `benchmark_source_unlicensed`.  ONS publishes most of its website
+        # content under the Open Government Licence, which permits commercial
+        # reuse with attribution — so "unlicensed" is not established, and a code
+        # asserting it would be the mirror image of a price-only splice.  We also
+        # cannot claim the converse: "most content" is not the same as "this
+        # series".  What IS verifiable is a fact about our own system, and that is
+        # what the code states.
+        reasons=(
+            BenchmarkRefusalReason(
+                code=BENCHMARK_SERIES_NOT_INGESTED,
+                detail=(
+                    "No CPI/CPIH series is ingested — no inflation table exists in "
+                    "the schema. This is an unbuilt ingest, not a licensing or "
+                    "identity blocker."
+                ),
+            ),
+        ),
+    ),
+)
+
+
 class StrategyOverviewResponse(BaseModel):
     as_of: datetime
     demo_connection: bool
@@ -754,6 +865,12 @@ class StrategyOverviewResponse(BaseModel):
     automation_readiness: AutomationReadinessView
     account_equity_evidence: AccountEquityEvidenceView
     evidence_refresh: EvidenceRefreshView
+    #: #2602 item 5.  Page-level, not per-series: the operator must learn why
+    #: there is no benchmark even when the P&L history request is the one that
+    #: failed, and this payload is the one the Strategies workspace cannot render
+    #: without.  The two history responses carry the same constant so a client
+    #: reading either alone still gets the reason next to the flag.
+    benchmark_refusals: tuple[BenchmarkRefusal, ...] = BENCHMARK_REFUSALS
     strategies: list[StrategyOverview]
 
 
@@ -874,6 +991,8 @@ class StrategyPnlHistoryResponse(BaseModel):
     basis: Literal["exact_owned_realised_pnl_only"] = "exact_owned_realised_pnl_only"
     total_return_available: Literal[False] = False
     benchmark_comparison_available: Literal[False] = False
+    #: #2602 item 5 — the flag above says there is no benchmark; this says why.
+    benchmark_refusals: tuple[BenchmarkRefusal, ...] = BENCHMARK_REFUSALS
     points: list[StrategyPnlHistoryPoint]
 
 
@@ -893,6 +1012,8 @@ class StrategyWealthHistoryResponse(BaseModel):
     basis: Literal["exact_owned_mark_to_market_nav"] = "exact_owned_mark_to_market_nav"
     total_return_available: Literal[False] = False
     benchmark_comparison_available: Literal[False] = False
+    #: #2602 item 5 — the flag above says there is no benchmark; this says why.
+    benchmark_refusals: tuple[BenchmarkRefusal, ...] = BENCHMARK_REFUSALS
     points: list[StrategyWealthHistoryPoint]
 
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2879,7 +2879,26 @@ export interface StrategyOverviewResponse {
     last_error: string | null;
     progress: Record<string, unknown> | null;
   };
+  benchmark_refusals: BenchmarkRefusal[];
   strategies: StrategyOverview[];
+}
+
+/**
+ * #2602 item 5. Why a benchmark field carries no number.
+ *
+ * ⚠ `detail` is server-supplied and must be RENDERED, never re-authored here:
+ * it carries a claim about a third party's licence terms, and a client-side
+ * `code -> sentence` map is a second copy of that claim that nobody re-reads.
+ */
+export interface BenchmarkRefusalReason {
+  code: "benchmark_source_unlicensed" | "benchmark_identity_unverified" | "benchmark_series_not_ingested";
+  detail: string;
+}
+
+export interface BenchmarkRefusal {
+  benchmark: string;
+  label: string;
+  reasons: BenchmarkRefusalReason[];
 }
 
 export interface StrategyEvidenceRefreshResponse {
@@ -2941,10 +2960,18 @@ export interface StrategyPnlHistoryPoint {
   incomplete_reasons: string[];
 }
 
+/**
+ * ⚠ Named "Pnl" but mirrors the `/strategies/wealth-history` payload, which is
+ * what `fetchStrategyPnlHistory` actually calls. The SHAPE is right (basis,
+ * principal, pot_value); only the name is stale. Do not "fix" it by editing the
+ * fields to match `/pnl-history` — that endpoint returns a different point type.
+ */
 export interface StrategyPnlHistoryResponse {
   basis: "exact_owned_mark_to_market_nav";
   total_return_available: false;
   benchmark_comparison_available: false;
+  /** #2602 item 5 — the flag above says there is no benchmark; this says why. */
+  benchmark_refusals: BenchmarkRefusal[];
   points: StrategyPnlHistoryPoint[];
 }
 

--- a/frontend/src/components/strategies/StrategyPortfolioPanels.tsx
+++ b/frontend/src/components/strategies/StrategyPortfolioPanels.tsx
@@ -3,7 +3,7 @@ import type { FormEvent } from "react";
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import { updateStrategyPaperPool } from "@/api/strategies";
-import type { StrategyOverviewResponse } from "@/api/types";
+import type { BenchmarkRefusal, StrategyOverviewResponse } from "@/api/types";
 import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { Badge } from "@/components/ui/Badge";
 import { formatDate, formatMoney, formatNumber } from "@/lib/format";
@@ -215,6 +215,59 @@ export function PnlChart({ history }: { history: Array<{ date: string; total_pnl
           <Line type="stepAfter" dataKey="pnl" stroke={theme.primaryLine} strokeWidth={2} dot={{ r: 2 }} isAnimationActive={false} />
         </LineChart>
       </ResponsiveContainer>
+    </div>
+  );
+}
+
+/**
+ * #2602 item 5 — why the chart above has no benchmark line.
+ *
+ * ⚠ Fed from `/strategies/overview`, NOT from the P&L history response, even
+ * though that response carries the same field. The history request is the one
+ * that can fail or return empty, and the refusal must not disappear in exactly
+ * the case where an operator is most likely to fill the gap with an assumption.
+ * The lens cannot render at all without `overview`, so sourcing it here means
+ * the notice is present whenever the section is.
+ *
+ * ⚠ No empty cell and no "—": a blank next to a chart reads as a number that
+ * happens to be zero. Every field states its own refusal by name.
+ *
+ * Kept to two lines per benchmark. The page's steer is toggles and summaries,
+ * not narration — but the `detail` is VISIBLE rather than a `title` tooltip,
+ * which is unreachable on touch and unreliable for assistive tech. The evidence
+ * is the point of the panel; hiding it behind a hover would defeat it.
+ */
+export function BenchmarkRefusals({ refusals }: { refusals: BenchmarkRefusal[] }) {
+  // ⚠ An older or foreign payload can omit the field. Rendering nothing would
+  // put the section back to an unexplained absence, which is the whole defect;
+  // crashing the lens would be worse. Say that the reason itself is missing —
+  // that is true, and it is loud.
+  const items = refusals ?? [];
+  return (
+    <div className="mt-4 border-t border-slate-200 pt-3 dark:border-slate-800">
+      <p className="text-xs font-medium text-slate-500">No benchmark comparison</p>
+      {items.length === 0 ? (
+        <p className="mt-2 text-xs text-slate-500">
+          The server sent no refusal state, so the reason for the absence is unknown here.
+        </p>
+      ) : null}
+      <ul className="mt-2 space-y-2">
+        {items.map((refusal) => (
+          <li key={refusal.benchmark}>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm text-slate-700 dark:text-slate-200">{refusal.label}</span>
+              {refusal.reasons.map((reason) => (
+                <Badge key={reason.code} tone="warn">
+                  {reason.code}
+                </Badge>
+              ))}
+            </div>
+            <p className="mt-1 text-xs text-slate-500">
+              {refusal.reasons.map((reason) => reason.detail).join(" ")}
+            </p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/src/components/strategies/__fixtures__/benchmarkRefusals.ts
+++ b/frontend/src/components/strategies/__fixtures__/benchmarkRefusals.ts
@@ -1,0 +1,29 @@
+import type { BenchmarkRefusal } from "@/api/types";
+
+/**
+ * #2602 item 5 — mirrors `app/api/strategies.py::BENCHMARK_REFUSALS`.
+ *
+ * ⚠ One copy, because two would drift from the server independently and a test
+ * asserting a refusal the server no longer sends is worse than no test (review
+ * NITPICK on PR #2883). The backend constant is the source of truth; the codes
+ * here are the same tokens, and `detail` is abridged — the tests assert the
+ * codes and one substring, never the full prose.
+ */
+export const BENCHMARK_REFUSALS: BenchmarkRefusal[] = [
+  {
+    benchmark: "sp500_total_return",
+    label: "S&P 500 total return",
+    reasons: [
+      {
+        code: "benchmark_source_unlicensed",
+        detail: "We have reviewed no free S&P 500 total-return source and found it legally usable.",
+      },
+      { code: "benchmark_identity_unverified", detail: "Every S&P series we hold is a tracking ETF's PRICE." },
+    ],
+  },
+  {
+    benchmark: "cpih_real_return",
+    label: "CPIH real return",
+    reasons: [{ code: "benchmark_series_not_ingested", detail: "No CPI/CPIH series is ingested." }],
+  },
+];

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -4,7 +4,13 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as strategiesApi from "@/api/strategies";
-import type { FiredSignal, StrategyOverviewResponse, StrategyOwnedPosition, StrategyResultArm } from "@/api/types";
+import type {
+  BenchmarkRefusal,
+  FiredSignal,
+  StrategyOverviewResponse,
+  StrategyOwnedPosition,
+  StrategyResultArm,
+} from "@/api/types";
 import { StrategiesHubPage } from "@/pages/StrategiesHubPage";
 
 const ARM: StrategyResultArm = {
@@ -81,6 +87,23 @@ const ARM: StrategyResultArm = {
     },
   ],
 };
+
+/** #2602 item 5 — mirrors `app/api/strategies.py::BENCHMARK_REFUSALS`. */
+const BENCHMARK_REFUSALS: BenchmarkRefusal[] = [
+  {
+    benchmark: "sp500_total_return",
+    label: "S&P 500 total return",
+    reasons: [
+      { code: "benchmark_source_unlicensed", detail: "No legal free S&P 500 total-return series has passed review." },
+      { code: "benchmark_identity_unverified", detail: "Every S&P series we hold is a tracking ETF's PRICE." },
+    ],
+  },
+  {
+    benchmark: "cpih_real_return",
+    label: "CPIH real return",
+    reasons: [{ code: "benchmark_series_not_ingested", detail: "No CPI/CPIH series is ingested." }],
+  },
+];
 
 const OVERVIEW: StrategyOverviewResponse = {
   as_of: "2026-08-09T12:00:00Z",
@@ -226,6 +249,7 @@ const OVERVIEW: StrategyOverviewResponse = {
     last_error: null,
     progress: null,
   },
+  benchmark_refusals: BENCHMARK_REFUSALS,
   strategies: [{
     strategy_id: "s1-time-series-momentum",
     strategy_version: "strategy-registry-v1+abc",
@@ -484,6 +508,7 @@ describe("StrategiesPage", () => {
       basis: "exact_owned_mark_to_market_nav",
       total_return_available: false,
       benchmark_comparison_available: false,
+      benchmark_refusals: BENCHMARK_REFUSALS,
       points: [],
     });
     vi.spyOn(strategiesApi, "fetchStrategyOwnedPositions").mockResolvedValue({
@@ -1098,6 +1123,7 @@ describe("StrategiesPage", () => {
       basis: "exact_owned_mark_to_market_nav",
       total_return_available: false,
       benchmark_comparison_available: false,
+      benchmark_refusals: BENCHMARK_REFUSALS,
       points: [{
         date: "2026-08-09",
         principal: "1000",

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -4,13 +4,8 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as strategiesApi from "@/api/strategies";
-import type {
-  BenchmarkRefusal,
-  FiredSignal,
-  StrategyOverviewResponse,
-  StrategyOwnedPosition,
-  StrategyResultArm,
-} from "@/api/types";
+import type { FiredSignal, StrategyOverviewResponse, StrategyOwnedPosition, StrategyResultArm } from "@/api/types";
+import { BENCHMARK_REFUSALS } from "@/components/strategies/__fixtures__/benchmarkRefusals";
 import { StrategiesHubPage } from "@/pages/StrategiesHubPage";
 
 const ARM: StrategyResultArm = {
@@ -87,23 +82,6 @@ const ARM: StrategyResultArm = {
     },
   ],
 };
-
-/** #2602 item 5 — mirrors `app/api/strategies.py::BENCHMARK_REFUSALS`. */
-const BENCHMARK_REFUSALS: BenchmarkRefusal[] = [
-  {
-    benchmark: "sp500_total_return",
-    label: "S&P 500 total return",
-    reasons: [
-      { code: "benchmark_source_unlicensed", detail: "No legal free S&P 500 total-return series has passed review." },
-      { code: "benchmark_identity_unverified", detail: "Every S&P series we hold is a tracking ETF's PRICE." },
-    ],
-  },
-  {
-    benchmark: "cpih_real_return",
-    label: "CPIH real return",
-    reasons: [{ code: "benchmark_series_not_ingested", detail: "No CPI/CPIH series is ingested." }],
-  },
-];
 
 const OVERVIEW: StrategyOverviewResponse = {
   as_of: "2026-08-09T12:00:00Z",

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -9,9 +9,27 @@ import type { StrategyOverviewResponse } from "@/api/types";
 import { StrategiesHubPage } from "@/pages/StrategiesHubPage";
 import { StrategyPortfolioLens } from "@/pages/StrategyPortfolioLens";
 
+/** #2602 item 5 — mirrors `app/api/strategies.py::BENCHMARK_REFUSALS`. */
+const BENCHMARK_REFUSALS = [
+  {
+    benchmark: "sp500_total_return",
+    label: "S&P 500 total return",
+    reasons: [
+      { code: "benchmark_source_unlicensed", detail: "No legal free S&P 500 total-return series has passed review." },
+      { code: "benchmark_identity_unverified", detail: "Every S&P series we hold is a tracking ETF's PRICE." },
+    ],
+  },
+  {
+    benchmark: "cpih_real_return",
+    label: "CPIH real return",
+    reasons: [{ code: "benchmark_series_not_ingested", detail: "No CPI/CPIH series is ingested." }],
+  },
+];
+
 /** The state the operator actually has today: kill switch on, nothing funded. */
 const BLOCKED = {
   as_of: "2026-08-23T00:00:00Z",
+  benchmark_refusals: BENCHMARK_REFUSALS,
   demo_connection: true,
   execution_enabled: false,
   live_execution_enabled: false,
@@ -161,6 +179,30 @@ describe("StrategyPortfolioLens", () => {
     expect(await screen.findByText("Nothing held")).toBeInTheDocument();
     // Nothing to close, so the destructive control is absent rather than disabled.
     expect(screen.queryByRole("button", { name: /Close all/ })).not.toBeInTheDocument();
+  });
+
+  it("names why there is no benchmark, by code and by evidence", async () => {
+    renderLens();
+    expect(await screen.findByText("No benchmark comparison")).toBeInTheDocument();
+    expect(screen.getByText("S&P 500 total return")).toBeInTheDocument();
+    expect(screen.getByText("CPIH real return")).toBeInTheDocument();
+    expect(screen.getByText("benchmark_source_unlicensed")).toBeInTheDocument();
+    expect(screen.getByText("benchmark_identity_unverified")).toBeInTheDocument();
+    expect(screen.getByText("benchmark_series_not_ingested")).toBeInTheDocument();
+    // The evidence is rendered, not hidden behind a hover: `title` is unreachable
+    // on touch and unreliable for assistive tech, and the evidence is the point.
+    expect(screen.getByText(/No CPI\/CPIH series is ingested/)).toBeInTheDocument();
+  });
+
+  it("still names the benchmark refusal when the P&L history request fails", async () => {
+    // #2602 item 5, Codex ckpt-1. The refusal is fed from the overview, not from
+    // the history response that also carries it — an absent benchmark must stay
+    // explained in exactly the branch where the operator is most likely to fill
+    // the gap with an assumption.
+    vi.mocked(strategiesApi.fetchStrategyPnlHistory).mockRejectedValue(new Error("boom"));
+    renderLens();
+    expect(await screen.findByText("No benchmark comparison")).toBeInTheDocument();
+    expect(screen.getByText("benchmark_series_not_ingested")).toBeInTheDocument();
   });
 
   it("reports the pot as halted", async () => {

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -6,25 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as configApi from "@/api/config";
 import * as strategiesApi from "@/api/strategies";
 import type { StrategyOverviewResponse } from "@/api/types";
+import { BENCHMARK_REFUSALS } from "@/components/strategies/__fixtures__/benchmarkRefusals";
 import { StrategiesHubPage } from "@/pages/StrategiesHubPage";
 import { StrategyPortfolioLens } from "@/pages/StrategyPortfolioLens";
-
-/** #2602 item 5 — mirrors `app/api/strategies.py::BENCHMARK_REFUSALS`. */
-const BENCHMARK_REFUSALS = [
-  {
-    benchmark: "sp500_total_return",
-    label: "S&P 500 total return",
-    reasons: [
-      { code: "benchmark_source_unlicensed", detail: "No legal free S&P 500 total-return series has passed review." },
-      { code: "benchmark_identity_unverified", detail: "Every S&P series we hold is a tracking ETF's PRICE." },
-    ],
-  },
-  {
-    benchmark: "cpih_real_return",
-    label: "CPIH real return",
-    reasons: [{ code: "benchmark_series_not_ingested", detail: "No CPI/CPIH series is ingested." }],
-  },
-];
 
 /** The state the operator actually has today: kill switch on, nothing funded. */
 const BLOCKED = {

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -17,6 +17,7 @@ import { OpenStrategyPositions, StrategyCloseModal } from "@/components/strategi
 import {
   AccountEvidence,
   AutomationControl,
+  BenchmarkRefusals,
   EmptyPnlChart,
   PnlChart,
 } from "@/components/strategies/StrategyPortfolioPanels";
@@ -235,6 +236,10 @@ export function StrategyPortfolioLens() {
         ) : (
           <EmptyPnlChart />
         )}
+        {/* #2602 item 5. Sourced from `overview`, not `pnlHistory` — see the
+            component. A benchmark that is absent must say so by name in every
+            branch above, including the error one. */}
+        <BenchmarkRefusals refusals={data.benchmark_refusals} />
         {/* Whether our P&L agrees with the broker's own equity. Kept when the
             page was trimmed to a control panel: it is the reason to trust the
             number above it, not commentary about it. */}

--- a/tests/test_benchmark_refusal_states.py
+++ b/tests/test_benchmark_refusal_states.py
@@ -1,0 +1,140 @@
+"""#2602 item 5 — the benchmark fields refuse by name, and the refusal is true.
+
+⚠ Deliberately its OWN module rather than an addition to
+``tests/test_strategy_monitoring.py``.  The ``db`` marker is applied per-MODULE at
+collection, so a pure-logic test living beside a DB-backed one is evicted from the
+``-m "not db"`` push gate and stops guarding anything on the path that runs.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from app.api.strategies import (
+    BENCHMARK_IDENTITY_UNVERIFIED,
+    BENCHMARK_REFUSAL_CODES,
+    BENCHMARK_REFUSALS,
+    BENCHMARK_SERIES_NOT_INGESTED,
+    BENCHMARK_SOURCE_UNLICENSED,
+    StrategyOverviewResponse,
+    StrategyPnlHistoryPoint,
+    StrategyPnlHistoryResponse,
+    StrategyWealthHistoryPoint,
+    StrategyWealthHistoryResponse,
+)
+
+#: The models that make a benchmark claim, and therefore owe a reason for it.
+REFUSING_RESPONSES: tuple[type[BaseModel], ...] = (
+    StrategyOverviewResponse,
+    StrategyPnlHistoryResponse,
+    StrategyWealthHistoryResponse,
+)
+
+#: The two fields F-0 owes the operator.  Named here so a silent removal fails.
+REQUIRED_BENCHMARKS = {"sp500_total_return", "cpih_real_return"}
+
+
+def test_every_refusing_response_carries_a_reason() -> None:
+    """A flag saying "no benchmark" without a reason is what item 5 replaces."""
+    for model in REFUSING_RESPONSES:
+        refusals = model.model_fields["benchmark_refusals"].default
+        assert refusals, f"{model.__name__} claims no benchmark and gives no reason"
+
+
+def test_all_three_responses_share_one_refusal_constant() -> None:
+    """Three copies of a licence claim is three chances for one to go stale."""
+    for model in REFUSING_RESPONSES:
+        assert model.model_fields["benchmark_refusals"].default is BENCHMARK_REFUSALS
+
+
+def test_both_required_benchmarks_are_present_exactly_once() -> None:
+    keys = [refusal.benchmark for refusal in BENCHMARK_REFUSALS]
+    assert sorted(keys) == sorted(REQUIRED_BENCHMARKS)
+    assert len(keys) == len(set(keys))
+
+
+def test_every_refusal_is_well_formed() -> None:
+    for refusal in BENCHMARK_REFUSALS:
+        assert refusal.label.strip(), f"{refusal.benchmark} has no operator-facing label"
+        assert refusal.reasons, f"{refusal.benchmark} refuses without saying why"
+        for reason in refusal.reasons:
+            assert reason.code in BENCHMARK_REFUSAL_CODES, f"undeclared code {reason.code}"
+            # The detail is what the UI renders; an empty one puts the client back
+            # in the business of inventing prose about a third party's licence.
+            assert len(reason.detail.strip()) > 20, f"{reason.code} carries no evidence"
+
+
+def test_cpih_is_not_stamped_with_a_licence_or_identity_blocker() -> None:
+    """The finding this test exists to pin (#2602, 2026-08-23).
+
+    ONS publishes most of its website content under the Open Government Licence,
+    which permits commercial reuse with attribution — so ``unlicensed`` is NOT
+    established for CPIH, and a code asserting it would be a false statement about
+    a public dataset: the mirror image of the price-only splice item 5 forbids.
+    ``identity_unverified`` is equally false — there is no candidate series whose
+    identity could be in doubt, because none is ingested.
+
+    ⚠ The converse is not claimed either: "most content" is not "this series".
+    The code we DO use states a fact about our own system, which is verifiable
+    here.  A later tidy-up that closes the vocabulary back to the ticket's two
+    literal codes must fail this test rather than pass quietly.
+    """
+    cpih = next(r for r in BENCHMARK_REFUSALS if r.benchmark == "cpih_real_return")
+    codes = {reason.code for reason in cpih.reasons}
+    assert codes == {BENCHMARK_SERIES_NOT_INGESTED}
+    assert BENCHMARK_SOURCE_UNLICENSED not in codes
+    assert BENCHMARK_IDENTITY_UNVERIFIED not in codes
+
+
+def test_sp500_names_both_blockers_that_are_true_of_it() -> None:
+    sp500 = next(r for r in BENCHMARK_REFUSALS if r.benchmark == "sp500_total_return")
+    assert {reason.code for reason in sp500.reasons} == {
+        BENCHMARK_SOURCE_UNLICENSED,
+        BENCHMARK_IDENTITY_UNVERIFIED,
+    }
+
+
+def test_the_constant_cannot_be_mutated_in_place() -> None:
+    """Module-global model instances are shared by every response in the process."""
+    with pytest.raises(ValidationError):
+        BENCHMARK_REFUSALS[0].reasons[0].code = "anything"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("model", [StrategyPnlHistoryResponse, StrategyWealthHistoryResponse])
+def test_availability_flags_cannot_be_flipped_to_true(model: type[BaseModel]) -> None:
+    for field in ("benchmark_comparison_available", "total_return_available"):
+        with pytest.raises(ValidationError):
+            model(points=[], **{field: True})
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        StrategyPnlHistoryResponse,
+        StrategyWealthHistoryResponse,
+        StrategyPnlHistoryPoint,
+        StrategyWealthHistoryPoint,
+    ],
+)
+def test_no_benchmark_valued_field_exists_on_the_history_contract(model: type[BaseModel]) -> None:
+    """A splice would have to add a benchmark-named field. This is that tripwire.
+
+    ⚠ Scope, stated honestly: this binds the SHAPE of these four models only.  It
+    catches ``benchmark_total_return: Decimal`` on a response or a point; it does
+    NOT catch a field named ``sp500_return``, a client deriving a comparison from
+    ETF closes, or a new endpoint.  The rule those need is the one in the module
+    comment — no price-only series labelled as total return — and no test replaces
+    reading it.
+    """
+    allowed = {"benchmark_comparison_available", "benchmark_refusals"}
+    named = {name for name in model.model_fields if "benchmark" in name}
+    assert named <= allowed, f"{model.__name__} grew an unreviewed benchmark field: {named - allowed}"
+
+
+def test_a_numeric_benchmark_value_is_not_silently_accepted() -> None:
+    """Extra keys must not survive into the payload as though they were a series."""
+    response = StrategyPnlHistoryResponse(points=[], benchmark_total_return=Decimal("12.5"))  # type: ignore[call-arg]
+    assert "benchmark_total_return" not in response.model_dump()


### PR DESCRIPTION
## What changed

#2602 item 5. The two benchmark fields F-0 owes the operator — S&P 500 total return in base currency, CPIH real return — carried only `benchmark_comparison_available: Literal[False]` on the two strategy history responses. That flag says there is no benchmark and never says why. The ticket's acceptance is that the **refusal rendering IS the v1 deliverable** for those fields, so this adds the why, in a form both a client and an operator can read.

- `app/api/strategies.py` — three refusal-code constants with their **definitions**, `BenchmarkRefusalReason` (`code` + `detail`) and `BenchmarkRefusal` (`benchmark`, `label`, `reasons`), both `frozen`, and one module constant `BENCHMARK_REFUSALS`.
- The constant is attached to `StrategyOverviewResponse`, `StrategyPnlHistoryResponse` and `StrategyWealthHistoryResponse` — one object, three references, so the licence claim has no second copy to go stale.
- `frontend/` — mirrored types, and a `BenchmarkRefusals` panel under the P&L chart on the Portfolio lens.
- `tests/test_benchmark_refusal_states.py` — new pure-logic module (12 tests).

Shape is not invented: it generalises this file's existing capability idiom, `live_strategy_activation_available: Literal[False]` paired with `live_strategy_activation_blocker`, to N benchmarks with N reasons.

## The judgement call: a third reason code

The ticket names two codes. **`benchmark_source_unlicensed` would be FALSE for CPIH.** ONS publishes most of its website content under the Open Government Licence, which permits commercial reuse with attribution — so "unlicensed" is not established. `benchmark_identity_unverified` is equally false: no CPIH series is ingested, so there is no candidate whose identity could be in doubt.

Stamping either would state something untrue about a public dataset — the mirror image of the price-only splice item 5 exists to prevent. **A refusal state can be false too.** So CPIH carries one new code, `benchmark_series_not_ingested`, which asserts a fact about our own schema and needs no claim about anyone's licence in either direction (note the converse is *not* claimed either: "most ONS content" is not "this series").

This is an evidenced extension of the operator's vocabulary, not a reversal of it: the two given codes describe a LEGAL blocker and an IDENTITY blocker, and CPIH has neither. Pinned by `test_cpih_is_not_stamped_with_a_licence_or_identity_blocker` so a later tidy-up that closes the vocabulary back to two fails loudly.

## Evidence

Re-measured on dev, not inherited from the prior session's research comment:

```
select table_name from information_schema.tables where table_schema='public'
 and (table_name ilike '%cpi%' or table_name ilike '%inflation%'
      or table_name ilike '%total_return%' or table_name ilike '%benchmark%');
-- 0 rows

select instrument_id, symbol from instruments where symbol in ('SPX500','SPY','IVV','VOO');
-- (27, SPX500) (3000, SPY) (3138, IVV) (4238, VOO)
```

The "price, not total return" claim in the shipped `detail` is sourced, not reasoned: `.claude/skills/data-sources/etoro-api.md:313` — *"eToro candles are **price, not total return** — no dividend adjustment"*. So every S&P series we hold is a tracking ETF's price or eToro's price index, and substituting one is the mislabelling the refusal exists to prevent.

⚠ Not to be confused with `equity_curve.BENCHMARK_RULE_ID` (`equal_weight_buy_and_hold_v1`) — an internal equal-weight book over a strategy's own universe. No collision.

Serialised wire shape verified by dumping the model (`model_dump(mode="json")`), not asserted.

## Why the UI reads `overview`, not the history response

Codex ckpt-1's one load-bearing finding. Both history responses carry the field, but the lens renders from `/strategies/overview`: the history request is the one that can fail or return empty, and the refusal must not disappear in exactly the branch where an operator is most likely to fill the gap with an assumption. `test_still_names_the_benchmark_refusal_when_the_pnl_history_request_fails` pins it. The lens cannot render at all without `overview`, so the notice is present whenever the section is.

Two smaller rendering decisions: `detail` is **visible text, not a `title` tooltip** (unreachable on touch, unreliable for assistive tech, and the evidence is the point of the panel); and there is no empty cell or "—", because a blank next to a chart reads as a number that happens to be zero.

## Codex ckpt-2 — one P2, resolved by defining the vocabulary

Codex read `benchmark_source_unlicensed` on the S&P field as a machine-readable claim *about the licensor*, contradicted by its own `detail` (which says their terms were not read), and proposed renaming it.

Kept the code; fixed the ambiguity. #2602 defines this code in the same sentence it names it — *"until a legal free source passes review"* — i.e. the operator's intended semantics is **our review state**, not a finding about S&P DJI. A code's meaning is its definition, not its etymology, so the definition is now written above each constant and the S&P `detail` leads with the review status. Renaming an operator-chosen token on a connotation, having just argued for keeping their vocabulary where it is true, would be the less consistent move. Cheap to overrule if the operator disagrees — it is one constant.

## Scope of the no-splice test, stated honestly

`test_no_benchmark_valued_field_exists_on_the_history_contract` binds the shape of four models: it catches `benchmark_total_return: Decimal` appearing on a response or a point. It does **not** catch a field named `sp500_return`, a client deriving a comparison from ETF closes, or a new endpoint. Codex ckpt-1 called the broader version of this test theatre and was right; the docstring now says what it does and does not bind rather than implying more. The rule those cases need is the module comment — no price-only series labelled as total return.

## Security

No new surface. Read-only response fields on three existing authenticated endpoints; no new input, no query change, no credential or broker path touched. All values are compile-time constants.

## Checks

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` · `pytest tests/smoke` · `pytest -m db tests/test_strategy_monitoring.py` · `pnpm typecheck` · `pnpm test:unit` (139 files, 1583 tests) — all green.

Not an ETL/parser/schema change: no migration, no backfill, no corpus effect, so DoD clauses 8-12 do not apply.

## Incidental, noted not ticketed

`frontend/src/api/types.ts::StrategyPnlHistoryResponse` is named "Pnl" but mirrors the `/strategies/wealth-history` payload — `fetchStrategyPnlHistory` calls that endpoint. The **shape is correct**; only the name is stale. Added a comment warning against "fixing" it by editing the fields to match `/pnl-history`, which returns a different point type. Left the name alone as unrelated churn.

Refs #2602. Refs #2437.
