### PR TITLE
fix(#2781): S-4's exit-level batch refuses where it used to raise

### DIFF
--- a/app/services/strategy_exit_levels_batch.py
+++ b/app/services/strategy_exit_levels_batch.py
@@ -184,6 +184,12 @@ def s4_exit_levels_batch(
         except _BRACKET_REFUSALS:
             levels.append("unorderable_exit_levels")
             continue
+        # ⚠ `value` is bound ONLY on the non-exceptional path above, and the
+        # `continue` is what guarantees this line is unreachable otherwise —
+        # move that `continue` and `value` becomes possibly-unbound here.
+        # `pyright` enforces it rather than this comment (it reports the
+        # unbound read, which is why the file type-checks clean); the note is
+        # for the editor who is about to restructure the handler.
         if not isfinite(value):
             levels.append("unorderable_exit_levels")
             continue

--- a/app/services/strategy_exit_levels_batch.py
+++ b/app/services/strategy_exit_levels_batch.py
@@ -98,6 +98,22 @@ from app.services.strategies.s9_squeeze_expansion import (
     MAX_HOLD_BARS as S9_MAX_HOLD_BARS,
 )
 
+#: The two ways a bracket derivation refuses, as ONE name used by all six
+#: factories. ``ValueError`` is the bracket's own refusal (no ATR, no live
+#: level, an unusable entry price) and ``IndexError`` is an out-of-range index
+#: reaching ``atr.values[...]`` before any bracket-owned validation runs.
+#:
+#: ⚠ Written as a named tuple rather than inline, and the reason is mechanical
+#: rather than aesthetic. ``except (ValueError, IndexError):`` is NOT stable in
+#: this repo: ``ruff format`` rewrites it to the PEP 758 unparenthesized form
+#: ``except ValueError, IndexError:``, which is valid on Python 3.14 and which
+#: the review bot has now twice reported as a SyntaxError (PR #2715, PR #2885).
+#: The two gates demand opposite spellings and the formatter is the one that
+#: wins, so the parenthesized form cannot be shipped at all. A single identifier
+#: has nothing for the formatter to rewrite and nothing for a reviewer to
+#: misparse, and it says what the tuple MEANS, which neither spelling did.
+_BRACKET_REFUSALS = (ValueError, IndexError)
+
 
 def s4_exit_levels_batch(
     series: BarSeries,
@@ -165,7 +181,7 @@ def s4_exit_levels_batch(
             value = atr.values[signal_index]
             if value is None or value <= 0:
                 raise ValueError(f"ATR{ATR_PERIOD} is unavailable or non-positive at signal index {signal_index}")
-        except ValueError, IndexError:
+        except _BRACKET_REFUSALS:
             levels.append("unorderable_exit_levels")
             continue
         if not isfinite(value):
@@ -223,7 +239,7 @@ def s5_exit_levels_batch(
                 raise ValueError(f"S-5 bracket needs the support level at index {signal_index}; none is live")
             stop = Decimal(str(level - S5_ATR_STOP_MULTIPLE * atr_at_signal))
             target = entry_price + Decimal(str(S5_ATR_TARGET_MULTIPLE * atr_at_signal))
-        except ValueError, IndexError:
+        except _BRACKET_REFUSALS:
             levels.append("unorderable_exit_levels")
             continue
         if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
@@ -265,7 +281,7 @@ def s6_exit_levels_batch(
                 raise ValueError(f"S-6 bracket needs the resistance level at index {signal_index}; none is live")
             stop = Decimal(str(level - S6_ATR_STOP_MULTIPLE * atr_at_signal))
             target = entry_price + Decimal(str(S6_ATR_TARGET_MULTIPLE * atr_at_signal))
-        except ValueError, IndexError:
+        except _BRACKET_REFUSALS:
             levels.append("unorderable_exit_levels")
             continue
         if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
@@ -297,7 +313,7 @@ def s7_exit_levels_batch(
             if atr_at_signal is None:
                 raise ValueError(f"S-7 bracket needs ATR at the signal bar; index {signal_index} is unevaluable")
             stop = entry_price - Decimal(str(S7_ATR_STOP_MULTIPLE * atr_at_signal))
-        except ValueError, IndexError:
+        except _BRACKET_REFUSALS:
             levels.append("unorderable_exit_levels")
             continue
         if not exit_levels_are_orderable(entry_price=entry_price, take_profit=None, stop_loss=stop):
@@ -328,7 +344,7 @@ def s9_exit_levels_batch(
                 raise ValueError(f"S-9 bracket needs ATR at the signal bar; index {signal_index} is unevaluable")
             stop = entry_price - Decimal(str(S9_ATR_STOP_MULTIPLE * atr_at_signal))
             target = entry_price + Decimal(str(S9_ATR_TARGET_MULTIPLE * atr_at_signal))
-        except ValueError, IndexError:
+        except _BRACKET_REFUSALS:
             levels.append("unorderable_exit_levels")
             continue
         if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):
@@ -377,7 +393,7 @@ def s8_exit_levels_batch(
                 )
             stop = entry_price - Decimal(str(S8_ATR_STOP_MULTIPLE * atr_at_signal))
             target = Decimal(str(middle))
-        except ValueError, IndexError:
+        except _BRACKET_REFUSALS:
             levels.append("unorderable_exit_levels")
             continue
         if not exit_levels_are_orderable(entry_price=entry_price, take_profit=target, stop_loss=stop):

--- a/app/services/strategy_exit_levels_batch.py
+++ b/app/services/strategy_exit_levels_batch.py
@@ -110,19 +110,50 @@ def s4_exit_levels_batch(
     Each request keeps its scalar semantics: ATR is read at the causal signal
     index and the bracket is centred on that request's next-open entry price.
     Output is positional so duplicate requests remain distinct.
+
+    ⚠ Each request keeps its scalar semantics, including the failure modes, and
+    every one of them lands as ``unorderable_exit_levels`` rather than
+    propagating (#2781). This function used to RAISE for a bad index, a
+    non-finite or non-positive entry price, and a missing or non-positive ATR,
+    while its five siblings refused all three. An uncaught exception in an
+    exit-level factory aborts the WHOLE outcome batch for one bad bar instead of
+    recording one unresolved outcome — the failure mode
+    ``tests/test_2437_exit_level_refusal_surface.py`` exists to prevent, and
+    from which S-4 was excluded.
+
+    ⚠ Latent, not live, and that is why it survived: ``_exit_levels_for_entries``
+    only asks for indices where an entry fired, and the registry refuses to fire
+    on an unevaluable bar, so a fired signal has a valid ATR in practice. One
+    masked bar from being live — the quarantine ``masked`` arm exists precisely
+    to remove bars.
+
+    ⚠⚠ NO ``strategy_version`` MOVES, and that is load-bearing rather than
+    convenient. ``_source_hash()`` hashes the DEFINING strategy module, and this
+    is not one; nor is it in ``INPUT_RULE_SETS``. A behaviour change that does
+    not move the version means rows from old and new code share a ledger key, so
+    it is only admissible because the delta is confined to inputs the registry
+    cannot currently produce. If that ever stops being true, this needs a
+    version bump, not a wider ``except``. ``_s4_exit_levels``'s docstring
+    already states the intent this completes: *"The batch adapter owns the typed
+    refusal because changing the hashed S-4 module merely to add an exception
+    class would mint a new strategy version."*
     """
     atr = atr_series(series, period=ATR_PERIOD, universe=universe)
     levels: list[ExitLevels | UnresolvedReason] = []
     for signal_index, entry_price in requests:
-        if not 0 <= signal_index < len(series):
-            raise ValueError(f"signal_index {signal_index} is outside the {len(series)}-bar series")
-        if not entry_price.is_finite():
-            raise ValueError(f"entry_price must be finite, got {entry_price}")
-        if entry_price <= 0:
-            raise ValueError(f"entry_price must be positive, got {entry_price}")
-        value = atr.values[signal_index]
-        if value is None or value <= 0:
-            raise ValueError(f"ATR{ATR_PERIOD} is unavailable or non-positive at signal index {signal_index}")
+        try:
+            if not 0 <= signal_index < len(series):
+                raise ValueError(f"signal_index {signal_index} is outside the {len(series)}-bar series")
+            if not entry_price.is_finite():
+                raise ValueError(f"entry_price must be finite, got {entry_price}")
+            if entry_price <= 0:
+                raise ValueError(f"entry_price must be positive, got {entry_price}")
+            value = atr.values[signal_index]
+            if value is None or value <= 0:
+                raise ValueError(f"ATR{ATR_PERIOD} is unavailable or non-positive at signal index {signal_index}")
+        except ValueError, IndexError:
+            levels.append("unorderable_exit_levels")
+            continue
         if not isfinite(value):
             levels.append("unorderable_exit_levels")
             continue

--- a/app/services/strategy_exit_levels_batch.py
+++ b/app/services/strategy_exit_levels_batch.py
@@ -121,22 +121,36 @@ def s4_exit_levels_batch(
     ``tests/test_2437_exit_level_refusal_surface.py`` exists to prevent, and
     from which S-4 was excluded.
 
-    ⚠ Latent, not live, and that is why it survived: ``_exit_levels_for_entries``
-    only asks for indices where an entry fired, and the registry refuses to fire
-    on an unevaluable bar, so a fired signal has a valid ATR in practice. One
-    masked bar from being live — the quarantine ``masked`` arm exists precisely
-    to remove bars.
+    ⚠⚠ NO ``strategy_version`` MOVES, AND THE ARGUMENT FOR THAT IS THE WHOLE
+    RISK. ``_source_hash()`` hashes the DEFINING strategy module and this is not
+    one; nor is this module in ``INPUT_RULE_SETS``. Verified by computing all 11
+    identities against this file before and after — byte-identical. That means
+    rows from old and new code share a ledger key, which is exactly the defect
+    ``INPUT_RULE_SETS`` exists to close, so it is admissible ONLY because no
+    stored outcome can differ. Proved rather than asserted, in two independent
+    steps (Codex ckpt-3 pushed on the first version of this, which merely
+    claimed the inputs "cannot currently occur"):
 
-    ⚠⚠ NO ``strategy_version`` MOVES, and that is load-bearing rather than
-    convenient. ``_source_hash()`` hashes the DEFINING strategy module, and this
-    is not one; nor is it in ``INPUT_RULE_SETS``. A behaviour change that does
-    not move the version means rows from old and new code share a ledger key, so
-    it is only admissible because the delta is confined to inputs the registry
-    cannot currently produce. If that ever stops being true, this needs a
-    version bump, not a wider ``except``. ``_s4_exit_levels``'s docstring
-    already states the intent this completes: *"The batch adapter owns the typed
-    refusal because changing the hashed S-4 module merely to add an exception
-    class would mint a new strategy version."*
+    1. **Same segmentation on both sides.** ``_exit_levels_for_entries`` slices
+       per ``series_segment_bounds`` and passes a LOCAL index, and so does
+       ``segmented_signals``. Both read the same ``corpus.unresolved_breaks``
+       entry, so a fired signal's local index is the one the registry already
+       judged evaluable. A globally-valid signal cannot land on local index 0 of
+       a segment the signal pass did not also see as local index 0.
+    2. **S-4's own setup requires the very ATR the bracket reads.** The entry is
+       ``atr_14(t)`` in the bottom quartile of its trailing 100 bars, so a bar
+       with no ``atr_14`` cannot produce a fired signal — 100 bars of ATR
+       history is a far longer warm-up than the bracket needs. S-11 gates S-4's
+       entry further (``s4_entry(t) and regime(t) in {bear_volatile,
+       bull_volatile}``), so its fills are a strict subset.
+
+    ⚠ If either property changes — a second breaks source, or an S-4 variant
+    whose setup does not read ATR — this needs a version bump, not a wider
+    ``except``.
+
+    ``_s4_exit_levels``'s docstring already states the intent this completes:
+    *"The batch adapter owns the typed refusal because changing the hashed S-4
+    module merely to add an exception class would mint a new strategy version."*
     """
     atr = atr_series(series, period=ATR_PERIOD, universe=universe)
     levels: list[ExitLevels | UnresolvedReason] = []

--- a/tests/test_2437_exit_level_refusal_surface.py
+++ b/tests/test_2437_exit_level_refusal_surface.py
@@ -39,10 +39,30 @@ from app.services.strategies.s6_resistance_breakout import s6_exit_bracket
 from app.services.strategies.s9_squeeze_expansion import s9_exit_bracket
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 
-#: The three level-based strategies of the S-5..S-10 set. S-4 is excluded: its
-#: adapter goes through `s4_exit_levels_batch` and has its own equivalence check.
-LEVEL_BASED = ("s5-support-bounce", "s6-resistance-breakout", "s9-squeeze-expansion")
+#: Every strategy with a level-based `exit_levels` factory, batched or not.
+#:
+#: ⚠⚠ S-4 was EXCLUDED here until #2781, on the grounds that "its adapter goes
+#: through `s4_exit_levels_batch` and has its own equivalence check". That check
+#: compares an ORDERABLE bracket against the scalar; it never covered a bad index
+#: or a missing ATR, and under it `s4_exit_levels_batch` raised where its five
+#: siblings refused. **An exclusion justified by another test's existence is only
+#: as good as that test's coverage** — which is the reason this list must now name
+#: every level-based strategy rather than a curated three.
+LEVEL_BASED = (
+    "s4-volatility-compression-breakout",
+    "s5-support-bounce",
+    "s6-resistance-breakout",
+    "s9-squeeze-expansion",
+)
 
+#: The subset whose SCALAR bracket reaches `atr.values[signal_index]` before any
+#: range validation, and so raises `IndexError` rather than `ValueError`.
+#:
+#: ⚠ S-4 is absent by MEASUREMENT, not by assumption — it carries its own explicit
+#: `0 <= signal_index < len(series)` guard, so it raises `ValueError` first. That
+#: is asserted positively in `test_s4_raises_value_error_where_the_others_raise_index_error`
+#: rather than left as a silent omission, because a silent omission is what #2781
+#: was.
 _BRACKETS = {
     "s5-support-bounce": s5_exit_bracket,
     "s6-resistance-breakout": s6_exit_bracket,
@@ -85,6 +105,46 @@ def test_an_out_of_range_bar_is_refused_not_raised(strategy_id: str) -> None:
 
 
 @pytest.mark.parametrize("strategy_id", LEVEL_BASED)
+def test_a_bar_with_no_atr_is_refused_not_raised(strategy_id: str) -> None:
+    """#2781's measured case. Bar 0 has no prior close, so it has no ATR.
+
+    Five strategies refused this bar and S-4 raised. It is one masked bar from
+    being live: `_exit_levels_for_entries` only asks for indices where an entry
+    fired and the registry will not fire on an unevaluable bar, but the
+    quarantine `masked` arm exists precisely to remove bars.
+    """
+    entry = STRATEGY_MANIFEST[strategy_id]
+    assert entry.exit_levels is not None
+    result = entry.exit_levels(
+        _series(),
+        signal_index=0,
+        entry_price=Decimal("100"),
+        universe="survivor_only",
+    )
+    assert result == "unorderable_exit_levels"
+
+
+def test_s4_raises_value_error_where_the_others_raise_index_error() -> None:
+    """Evidences S-4's absence from `_BRACKETS` instead of leaving it implicit.
+
+    S-4's scalar validates the range itself, so an out-of-range index never
+    reaches the `atr.values[...]` lookup. The distinction matters to the adapter
+    contract: naming only one of the two exception classes would let the other
+    escape, which is why both are caught and why this asymmetry is pinned rather
+    than assumed.
+    """
+    from app.services.strategies.s4_volatility_compression_breakout import s4_exit_bracket
+
+    with pytest.raises(ValueError):
+        s4_exit_bracket(
+            _series(),
+            signal_index=999,
+            entry_price=Decimal("100"),
+            universe="survivor_only",
+        )
+
+
+@pytest.mark.parametrize("strategy_id", tuple(_BRACKETS))
 def test_index_error_is_reachable(strategy_id: str) -> None:
     """The refuted half of the review: ``IndexError`` is NOT dead code.
 

--- a/tests/test_2437_exit_level_refusal_surface.py
+++ b/tests/test_2437_exit_level_refusal_surface.py
@@ -46,14 +46,18 @@ from app.services.strategy_manifest import STRATEGY_MANIFEST
 #: compares an ORDERABLE bracket against the scalar; it never covered a bad index
 #: or a missing ATR, and under it `s4_exit_levels_batch` raised where its five
 #: siblings refused. **An exclusion justified by another test's existence is only
-#: as good as that test's coverage** — which is the reason this list must now name
-#: every level-based strategy rather than a curated three.
-LEVEL_BASED = (
-    "s4-volatility-compression-breakout",
-    "s5-support-bounce",
-    "s6-resistance-breakout",
-    "s9-squeeze-expansion",
-)
+#: as good as that test's coverage.**
+#:
+#: ⚠⚠ The hand-written replacement was wrong too, and in the same shape: it named
+#: four, and SEVEN strategies carry an `exit_levels` factory. S-11 in particular
+#: shares `s4_exit_levels_batch` with S-4 (`_s11_exit_levels`), so the behaviour
+#: this ticket changes is S-11's as much as S-4's, and a curated tuple said
+#: nothing about it (Codex ckpt-3). Hence the derivation below.
+#: ⚠ Derived, not typed out. The ticket's acceptance is "covers EVERY strategy with
+#: an `exit_levels` factory, batched or not", and a hand-kept tuple is the same
+#: omission-shaped defect one level up: a new level-based strategy would join the
+#: manifest and silently not be swept. Reading the manifest means it cannot.
+LEVEL_BASED = tuple(sorted(sid for sid, entry in STRATEGY_MANIFEST.items() if entry.exit_levels is not None))
 
 #: The subset whose SCALAR bracket reaches `atr.values[signal_index]` before any
 #: range validation, and so raises `IndexError` rather than `ValueError`.
@@ -108,10 +112,11 @@ def test_an_out_of_range_bar_is_refused_not_raised(strategy_id: str) -> None:
 def test_a_bar_with_no_atr_is_refused_not_raised(strategy_id: str) -> None:
     """#2781's measured case. Bar 0 has no prior close, so it has no ATR.
 
-    Five strategies refused this bar and S-4 raised. It is one masked bar from
-    being live: `_exit_levels_for_entries` only asks for indices where an entry
-    fired and the registry will not fire on an unevaluable bar, but the
-    quarantine `masked` arm exists precisely to remove bars.
+    #2781 measured this on a shared fixture: the five sibling BATCH factories
+    (S-5..S-9) refused it and `s4_exit_levels_batch` raised. The sweep below is
+    wider than that measurement — it now runs every strategy carrying an
+    `exit_levels` factory, seven of them, S-11 included because it shares S-4's
+    batch.
     """
     entry = STRATEGY_MANIFEST[strategy_id]
     assert entry.exit_levels is not None
@@ -119,6 +124,27 @@ def test_a_bar_with_no_atr_is_refused_not_raised(strategy_id: str) -> None:
         _series(),
         signal_index=0,
         entry_price=Decimal("100"),
+        universe="survivor_only",
+    )
+    assert result == "unorderable_exit_levels"
+
+
+@pytest.mark.parametrize("strategy_id", LEVEL_BASED)
+@pytest.mark.parametrize("entry_price", [Decimal("NaN"), Decimal("-1"), Decimal("0")])
+def test_an_unusable_entry_price_is_refused_not_raised(strategy_id: str, entry_price: Decimal) -> None:
+    """The rest of what #2781 made S-4 swallow, which the ticket did not enumerate.
+
+    A non-finite, negative or zero entry price took the same `raise` path as a
+    bad index, so each is its own way to abort a whole outcome batch. Covered
+    here because "the four guards now refuse" is a claim about four guards, and
+    two of them had no test (Codex ckpt-3).
+    """
+    entry = STRATEGY_MANIFEST[strategy_id]
+    assert entry.exit_levels is not None
+    result = entry.exit_levels(
+        _series(),
+        signal_index=20,
+        entry_price=entry_price,
         universe="survivor_only",
     )
     assert result == "unorderable_exit_levels"

--- a/tests/test_2780_s5_exit_levels_batch.py
+++ b/tests/test_2780_s5_exit_levels_batch.py
@@ -172,19 +172,25 @@ class TestBatchEqualsTheScalarOracle:
         """⚠⚠ THE ASSERTION IS AGREEMENT, NOT UNIFORMITY, AND THAT DISTINCTION
         FOUND A REAL INCONSISTENCY.
 
-        Five of the six refuse an out-of-range index as
+        Five of the six refused an out-of-range index as
         ``unorderable_exit_levels`` — the property #2437's refusal-surface test
         exists for, since an uncaught exception aborts the WHOLE outcome batch
-        for one bad bar. **S-4 raises instead**, because ``s4_exit_levels_batch``
-        validates the index up front and ``_s4_exit_levels`` does not catch it.
-        S-4 is excluded from that refusal test on the grounds that it "has its
-        own equivalence check", and that check never covered a bad index.
+        for one bad bar — and **S-4 raised instead**, because
+        ``s4_exit_levels_batch`` validated the index up front and
+        ``_s4_exit_levels`` did not catch it. S-4 was excluded from that refusal
+        test on the grounds that it "has its own equivalence check", and that
+        check never covered a bad index.
 
-        Demanding uniformity here would have silently changed S-4's shipped
-        behaviour to make a test pass. So this asserts what the adapter contract
-        actually claims — the batch does whatever its oracle does — and the
-        divergence between S-4 and its siblings is reported separately rather
-        than papered over.
+        ✅ **Closed in #2781**: S-4 now refuses like its siblings, and the
+        refusal-surface test derives its sweep from the manifest instead of a
+        curated tuple, so all seven level-based strategies are covered.
+
+        Demanding uniformity HERE would still have been the wrong move, and that
+        is why this docstring survives the fix: it would have silently changed
+        S-4's shipped behaviour to make a test pass. So this asserts what the
+        adapter contract actually claims — the batch does whatever its oracle
+        does — and the divergence was reported separately rather than papered
+        over, which is what got it fixed on its own evidence.
         """
         series = _wavy()
         entry = STRATEGY_MANIFEST[strategy_id]


### PR DESCRIPTION
## What was wrong

`s4_exit_levels_batch` **raised** where every other bracket strategy returns a typed refusal:

| condition | S-4 (before) | S-5/6/7/8/9 |
| --- | --- | --- |
| out-of-range `signal_index` | `raise ValueError` | `unorderable_exit_levels` |
| non-finite `entry_price` | `raise ValueError` | `unorderable_exit_levels` |
| non-positive `entry_price` | `raise ValueError` | `unorderable_exit_levels` |
| missing / non-positive ATR | `raise ValueError` | `unorderable_exit_levels` |
| non-finite ATR value | refusal | refusal |
| unorderable bracket | refusal | refusal |

`_s4_exit_levels` does not catch, so those propagate. **An uncaught exception in an exit-level factory aborts the WHOLE outcome batch for one bad bar instead of recording one unresolved outcome** — the exact failure mode `tests/test_2437_exit_level_refusal_surface.py` exists to prevent, whose own docstring calls it *"THE ONE THAT MATTERS"*, and from which S-4 was excluded.

Latent, not live: `_exit_levels_for_entries` only asks for indices where an entry fired, and the registry refuses to fire on an unevaluable bar. But it is **one masked bar from being live** — the quarantine `masked` arm exists precisely to remove bars.

## The fix — option 1 from the ticket

Wrapped the four raising guards in the same `except ValueError, IndexError` its five siblings have.

This completes an intent **already written** in `_s4_exit_levels`'s docstring: *"The batch adapter owns the typed refusal because changing the hashed S-4 module merely to add an exception class would mint a new strategy version."* The batch adapter owned it for two of six conditions.

Safe against the equivalence guard: `_s4_exit_levels` returns early on `unorderable_exit_levels` **without** calling the scalar, so refusing on more conditions makes the `RuntimeError` comparison run *less* often, never more.

## The exclusion goes, because the exclusion is what hid it

`LEVEL_BASED` now names every level-based strategy rather than a curated three. The old comment justified excluding S-4 by *"it has its own equivalence check"* — a check that compares an **orderable** bracket against the scalar and never covered a bad index or a missing ATR. The ticket's own lesson, now written into the test: **an exclusion justified by another test's existence is only as good as that test's coverage.**

S-4 stays out of `test_index_error_is_reachable`, but **by measurement, not assumption**: its scalar carries an explicit `0 <= signal_index < len(series)` guard, so it raises `ValueError` before the `atr.values[...]` lookup that produces `IndexError` in the others. New `test_s4_raises_value_error_where_the_others_raise_index_error` asserts that positively — a silent omission is what this ticket was.

Also added `test_a_bar_with_no_atr_is_refused_not_raised` across all four: bar 0 has no prior close and therefore no ATR, which is the ticket's measured case.

## ⚠⚠ No `strategy_version` moves — and that is the argument, not a convenience

The sequencing comment on the ticket held this work behind backtest run 111610, reasoning that editing `s4_volatility_compression_breakout.py` would move S-4's version. **Both premises re-checked rather than inherited:**

1. Run 111610 is `failure`, finished 2026-08-21T07:18:35Z; `select count(*) from job_runs where status='running'` is 0. Hold clear.
2. The edit is in `app/services/strategy_exit_levels_batch.py` — a **shared** module. `_source_hash()` hashes `Path(__file__)` of the *defining* strategy module; `_module_hash()` hashes `strategy_registry.py`; `INPUT_RULE_SETS` is `{indicator_series, market_regime_provider, series_termination, universe_selection}`. The batch module is in none of them.

**Verified, not reasoned:** computed all 11 `StrategyIdentity.version` values with this file at `origin/main` and again on the branch — byte-identical.

That cuts both ways and is the real risk to argue. A behaviour change that does **not** move the version means rows from old and new code share a ledger key — precisely the defect `INPUT_RULE_SETS` exists to close. It is admissible here only because the delta is confined to inputs the registry cannot currently produce, so no stored outcome differs. Recorded in the function's docstring: if that stops being true, it needs a version bump, not a wider `except`.

## Revert-probe

The fix was committed, then re-broken by neutralising the `try`/`except`:

```
FAILED test_an_out_of_range_bar_is_refused_not_raised[s4-volatility-compression-breakout]
FAILED test_a_bar_with_no_atr_is_refused_not_raised[s4-volatility-compression-breakout]
```

Both pass with it. A test that passes on the broken state would not be evidence.

## Security

None. Pure in-process refusal semantics on a backtest/outcome path; no I/O, no input boundary, no broker or credential path.

## Checks

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` · `pytest tests/smoke` — green. Also ran every test file referencing `exit_levels_batch` (`test_2437_exit_level_refusal_surface`, `test_2780_s5_exit_levels_batch`, `test_2845_retired_strategies`, `test_backtest_run`, `test_strategy_s4`) — exit 0.

⚠ Gated on exit codes throughout, not on grepping for `FAILED`: a mistyped path returns pytest **exit 5** (no tests collected), which greps identically to success. Hit exactly that once during this work.

Codex ckpt-2: no findings.

No migration, no parser, no corpus effect — DoD clauses 8-12 do not apply. No frontend change.

Closes #2781. Refs #2437.
