### PR TITLE
fix(#2603 step 3b-2): the two broker minimums are different quantities, so the floor is max not or

### DIFF
--- a/app/services/broker_settlement_arms.py
+++ b/app/services/broker_settlement_arms.py
@@ -28,11 +28,16 @@ full eligibility rule.  The executor additionally requires exactly one matching
 row, an ``allowStopLossTakeProfit`` arm and a satisfied minimum; a core sleeve is
 a stop-less indefinite holding and must not inherit an entry rule.  Calling this
 does not make a caller eligible to trade.
+
+``effective_open_minimum`` lives here for the same shared-definition reason, and
+reads the same response: it is the second rule those two callers must not hold
+two copies of.  Spec: ``docs/proposals/ta/2026-08-23-broker-open-minimum.md``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from decimal import Decimal
 from types import MappingProxyType
 from typing import Final
 
@@ -42,6 +47,12 @@ from app.providers.broker import BrokerInstrumentEligibility, BrokerLeverageConf
 UNDERLYING_SETTLEMENT_TYPE = "real"
 UNDERLYING_DIRECTION = "long"
 UNLEVERAGED_LEVERAGE = 1
+
+#: The only response currency in which the two open minimums are comparable.
+#: ``minPositionExposure`` is documented as "always calculated in USD" whatever the
+#: response says; ``minPositionAmount`` documents no currency at all.  See
+#: :func:`effective_open_minimum`.
+_MINIMUM_QUOTE_CURRENCY: Final[str] = "USD"
 
 # --- The OPEN-POSITION vocabulary (#2602 item 3) ---------------------------
 #
@@ -144,6 +155,92 @@ def position_is_underlying(settlement_type_id: int | None) -> bool | None:
     return settlement_type_id == UNDERLYING_POSITION_INVESTMENT_TYPE_ID
 
 
+def _quoted_or_none(value: Decimal | None) -> Decimal | None:
+    """Keep a broker-quoted threshold only when it is finite and positive.
+
+    The same rule ``strategy_core_eligibility._positive_or_none`` applies before
+    storing, and that ``sql/346`` enforces on the column.  Applied HERE so both
+    callers agree: the stored-proof path sanitises and the executor's live path
+    does not, so without this the two would reach different verdicts on identical
+    broker data.  A nonsense threshold means "not quoted", which is what it
+    actually tells us -- it is not a licence to trade any size.
+    """
+    if value is None or not value.is_finite() or value <= 0:
+        return None
+    return value
+
+
+def effective_open_minimum(
+    *,
+    response_currency: str,
+    min_position_exposure: Decimal | None,
+    min_position_amount: Decimal | None,
+) -> Decimal | None:
+    """The binding floor on the USD notional of an order that OPENS a position.
+
+    Source rule (live portal 2026-08-23,
+    ``trading--demo/check-instrument-trading-eligibility``):
+
+    * ``minPositionExposure``, on the eligibility ROW -- *"Minimum exposure value
+      required to open a position on this instrument.  The exposure is always
+      calculated in USD as the number of units times the rate times the conversion
+      rate to USD."*
+    * ``minPositionAmount``, on a ``leverageConfigs`` ARM -- *"Minimum margin
+      required to open a position under this leverage configuration."*
+
+    ⚠⚠ THEY ARE DIFFERENT QUANTITIES, which is why this is ``max`` and not ``or``.
+    Exposure is units x rate x FX; margin is exposure / leverage.  The precedence
+    this replaces (``arm.min_position_amount or row.min_position_exposure``) treats
+    them as two spellings of one number and takes whichever appears first, which is
+    fail-OPEN by the gap between them whenever the arm quotes the smaller.
+
+    ⚠ ``max`` IS A SAFE BOUND, NOT A REPRODUCTION OF THE BROKER'S RULE, and the
+    difference is stated rather than glossed.  Testing a notional against the larger
+    threshold can never admit an order the broker would refuse on either dimension;
+    at leverage > x1 it CAN refuse one the broker would accept, because the notional
+    exceeds the margin by the leverage multiple.  Over-restriction is the safe
+    direction for a floor -- the posture ``strategy_core_sizing.QuotedTradeCost``
+    already takes for cost.  ⚠ Unreachable through today's callers, and enforced
+    rather than assumed: both select their arm through
+    :func:`select_underlying_long_arms`, which requires x1, and at x1 margin equals
+    exposure so ``max`` is exact.
+
+    ⚠⚠ OPEN ONLY.  The portal states both fields for opening and says nothing about
+    closing or partial-closing, so no close-side floor is derived here.  That is
+    UNKNOWN, not "no constraint": ``allowPartialClosePosition`` proves permission,
+    not unrestricted sizing.  A rebalance sell carries no broker floor from this
+    source, and if eToro constrains partial-close size we do not currently know it.
+
+    ``None`` means the broker quoted no usable threshold -- NOT that any size is
+    permitted.  Both callers fail closed on it.
+
+    :raises ValueError: when ``response_currency`` is not USD.  ``minPositionAmount``
+        carries NO documented currency, so rather than infer one, the two are
+        combined only where no non-USD denomination is in play.  A raise rather than
+        a returned refusal because both callers already refuse a mismatch first
+        (``strategy_paper_executor._eligibility_reason``,
+        ``strategy_core_eligibility.evaluate_core_eligibility``), so arriving here
+        with anything else is a caller bug -- the distinction
+        ``strategy_core_preflight._require_known_action`` draws on a public entry
+        point.  ⚠ #2603 scope item 4 (non-USD deployment) is the change that must
+        revisit this, and a loud failure there is the intended outcome.  Concretely
+        it becomes reachable when ``strategy_base_currency`` widens
+        ``SUPPORTED_DEPLOYMENT_CURRENCIES``, today the singleton ``{"USD"}``.
+    """
+    if response_currency.strip().upper() != _MINIMUM_QUOTE_CURRENCY:
+        raise ValueError(
+            f"open minimums are only combinable in {_MINIMUM_QUOTE_CURRENCY}: minPositionExposure is "
+            f"documented as always USD while minPositionAmount documents no currency, so a "
+            f"{response_currency!r} response cannot be compared (#2603 scope item 4)"
+        )
+    quoted = [
+        value
+        for value in (_quoted_or_none(min_position_exposure), _quoted_or_none(min_position_amount))
+        if value is not None
+    ]
+    return max(quoted) if quoted else None
+
+
 def select_underlying_long_arms(
     row: BrokerInstrumentEligibility,
 ) -> tuple[BrokerLeverageConfig, ...]:
@@ -161,6 +258,7 @@ __all__ = [
     "UNDERLYING_POSITION_INVESTMENT_TYPE_ID",
     "UNDERLYING_SETTLEMENT_TYPE",
     "UNLEVERAGED_LEVERAGE",
+    "effective_open_minimum",
     "is_underlying_long_arm",
     "offers_unleveraged",
     "position_investment_type_label",

--- a/app/services/strategy_core_allocator.py
+++ b/app/services/strategy_core_allocator.py
@@ -248,9 +248,14 @@ def evaluate_core_rebalance(
 
     ``broker_minimum`` is optional and ``None`` means THE CALLER HAS NO APPLICABLE
     MINIMUM TO SUPPLY, not that the broker has none.  ⚠ Whether a given broker
-    minimum applies to an incremental buy or a partial sell is the caller's
-    determination: item 1's spec cited eToro's `min_position_amount`, which is an
-    entry-path field, and nothing here establishes it governs a rebalance leg.
+    minimum applies to a given leg remains the caller's determination, and for
+    eToro it is now half-settled by the portal's own field definitions
+    (``broker_settlement_arms.effective_open_minimum``, 2026-08-23): both
+    ``minPositionExposure`` and ``minPositionAmount`` are documented as required
+    to OPEN a position, and NEITHER is documented for a close or partial close.
+    So a ``buy_core`` leg has a sourced floor and a ``sell_core`` leg does not --
+    a caller that supplies the open-side number for a sell is applying OUR rule,
+    not eToro's.
 
     Returns a verdict for every input.  No refusal raises: a caller that must catch
     to learn the mandate is disabled will eventually catch too broadly.

--- a/app/services/strategy_core_eligibility.py
+++ b/app/services/strategy_core_eligibility.py
@@ -16,11 +16,17 @@ exists, is tested, and sits on a path the decision does not take* nine times ove
 so the boundary is named here rather than left to be inferred.
 
 ⚠ Sizing is recorded, not decided.  ``min_position_amount`` /
-``min_position_exposure`` / ``max_units_per_order`` are stored as observed facts
-and no effective minimum is derived: the executor's
-``arm.min_position_amount or row.min_position_exposure`` precedence has no
-citation in the provider's documentation, and a missing floor is an order-sizing
-gap rather than evidence about what the product IS.
+``min_position_exposure`` / ``max_units_per_order`` are stored as observed FACTS
+and this module derives no floor from them, because a missing floor is an
+order-sizing gap rather than evidence about what the product IS.
+
+⚠ The rule for combining the two minimums IS now settled and cited --
+``broker_settlement_arms.effective_open_minimum``, from the portal's own field
+definitions (2026-08-23).  What it settles is narrow and worth reading there
+before relying on it: an OPEN only, at x1, in a USD response, and as a safe upper
+bound rather than an exact reproduction of the broker's rule.  It settles NOTHING
+about a close or partial close, which the portal does not document at all -- so a
+rebalance sell still has no broker floor from this source.
 
 Spec: ``docs/proposals/ta/2026-08-13-core-eligibility-proof.md``
 """

--- a/app/services/strategy_core_rebalance_intent.py
+++ b/app/services/strategy_core_rebalance_intent.py
@@ -174,12 +174,18 @@ def record_core_rebalance_intent(
     ⚠ ``broker_minimum`` is deliberately not a parameter, though
     ``evaluate_core_rebalance`` accepts one.  This slice performs no broker I/O and
     so cannot SOURCE a minimum; accepting one would store a caller assertion with
-    no provenance and no record of which provider rule was applied -- and whether
-    eToro's ``min_position_amount`` even governs an incremental buy or a partial
-    sell is unsettled (the allocator's docstring flags it).  The executor holds the
-    eligibility response and can answer it with evidence.  Consequence, so it is
-    not later read as a defect: ``floor_source`` can only be ``mandate`` here, and
-    ``broker_minimum_invalid`` is unreachable.
+    no provenance and no record of which provider rule was applied.  The executor
+    holds the eligibility response and can answer it with evidence.  Consequence,
+    so it is not later read as a defect: ``floor_source`` can only be ``mandate``
+    here, and ``broker_minimum_invalid`` is unreachable.
+
+    ⚠ The RULE the executor will apply is now settled and cited --
+    ``broker_settlement_arms.effective_open_minimum`` (portal, 2026-08-23) -- but
+    only for a ``buy_core`` leg: eToro documents both minimums for OPENING a
+    position and neither for a close, so a ``sell_core`` still has no sourced
+    floor.  That does not move this function, which cannot reach a broker either
+    way; it means the executor supplies a minimum on one leg and ``None`` on the
+    other, and ``None`` there will mean "undocumented", not "none exists".
     """
     mandate = load_core_mandate(conn)
     decision = evaluate_core_rebalance(mandate, state)

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -31,7 +31,7 @@ from app.providers.broker import (
     BrokerWhatIfCostResponse,
     BrokerWhatIfOrder,
 )
-from app.services.broker_settlement_arms import select_underlying_long_arms
+from app.services.broker_settlement_arms import effective_open_minimum, select_underlying_long_arms
 from app.services.cost_model import COST_MODEL_ID
 from app.services.market_calendar import us_market_status
 from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
@@ -647,7 +647,18 @@ def _eligibility_reason(response: BrokerEligibilityResponse, intent: _Intent, am
     arm = next(iter(arms))
     if arm.allow_stop_loss_take_profit is not True:
         return "fixed_exit_not_allowed"
-    minimum = arm.min_position_amount or matches[0].min_position_exposure
+    # ⚠ `max` of the two, not `or`. They are DIFFERENT quantities -- `minPositionExposure`
+    # is an exposure and `minPositionAmount` a margin -- and both gate an open, so the
+    # first-present-wins precedence this replaced was fail-OPEN by the gap between them.
+    # The source rule, the x1 precondition and the open-only scope are all on
+    # `effective_open_minimum`; the currency equality it requires is the one asserted at
+    # the top of this function.
+    minimum = effective_open_minimum(
+        response_currency=response.currency,
+        min_position_exposure=matches[0].min_position_exposure,
+        min_position_amount=arm.min_position_amount,
+    )
+    # Unchanged: no quoted minimum fails CLOSED, and the floor is inclusive.
     if minimum is None or amount < minimum:
         return "below_broker_minimum"
     return None

--- a/docs/proposals/ta/2026-08-23-broker-open-minimum.md
+++ b/docs/proposals/ta/2026-08-23-broker-open-minimum.md
@@ -1,0 +1,218 @@
+# The broker's open-position minimum: one source rule, one shared helper
+
+#2603 step 3b-2, the broker half of the core submission refusal vocabulary — the minimum
+only. Account-risk and cost are already covered elsewhere and are not rebuilt here.
+
+## The gap
+
+Three modules independently record that the effective broker minimum is unsettled, and
+each declines to derive one:
+
+- `app/services/strategy_core_eligibility.py:18-23` — *"no effective minimum is derived:
+  the executor's `arm.min_position_amount or row.min_position_exposure` precedence has no
+  citation in the provider's documentation"*.
+- `app/services/strategy_core_allocator.py:249-253` — *"Whether a given broker minimum
+  applies to an incremental buy or a partial sell is the caller's determination …
+  nothing here establishes it governs a rebalance leg."*
+- `app/services/strategy_core_rebalance_intent.py:174-183` — *"whether eToro's
+  `min_position_amount` even governs an incremental buy or a partial sell is unsettled …
+  The executor holds the eligibility response and can answer it with evidence."*
+
+Meanwhile `app/services/strategy_paper_executor.py:650` applies the uncited precedence:
+
+```python
+minimum = arm.min_position_amount or matches[0].min_position_exposure
+if minimum is None or amount < minimum:
+    return "below_broker_minimum"
+```
+
+## Source rule
+
+Live portal, fetched 2026-08-23 via the `.claude/skills/data-sources/etoro-api.md`
+protocol (`llms.txt` → per-endpoint `.md`, WebFetch not curl):
+`api-reference/trading--demo/check-instrument-trading-eligibility.md`.
+
+| field | object | documented as |
+| --- | --- | --- |
+| `minPositionExposure` | `InstrumentEligibility` (the top-level row) | *"Minimum exposure value required to open a position on this instrument. The exposure is always calculated in USD as the number of units times the rate times the conversion rate to USD."* |
+| `minPositionAmount` | `LeverageConfiguration` (a `leverageConfigs` entry) | *"Minimum margin required to open a position under this leverage configuration."* |
+
+### 1. They are different quantities, so `or` is the wrong combinator
+
+Exposure is units × rate × FX; margin is exposure ÷ leverage. `or` treats them as two
+spellings of one number and takes whichever appears first. They are two constraints.
+
+### 2. `max` is a SAFE BOUND, not a reproduction of the broker's rule — and that is the claim being made
+
+Each field says *"required to open a position"*, so an order must clear both. Testing the
+order's USD notional against `max` of the quoted figures:
+
+- **can never admit** an order the broker would refuse on either dimension, because the
+  notional is tested against the larger of the two thresholds;
+- **can refuse** an order the broker would accept, at leverage > x1, where the notional
+  exceeds the margin by the leverage multiple and the margin threshold is thereby
+  over-applied.
+
+Over-restriction is the safe direction for a floor, and this is the same posture
+`strategy_core_sizing.QuotedTradeCost` already takes for cost (*"An upper bound,
+deliberately, and every decode rule leans that way"*). It is stated as a bound rather
+than sold as exact, because the exact rule needs a margin figure neither caller computes.
+
+⚠ **The over-restriction is unreachable through today's callers and that is enforced, not
+assumed.** Both minimum consumers select their arm through
+`broker_settlement_arms.select_underlying_long_arms`, which requires `offers_unleveraged`
+— x1. At x1 margin equals exposure, so the two thresholds are the same quantity and `max`
+is exact. Measured: all 12 qualifying stored proofs carry `leverage_values = [1]` exactly.
+
+### 3. `minPositionAmount` has NO documented currency — so the helper requires USD rather than assuming one
+
+`minPositionExposure` is currency-PINNED to USD by its own wording — *"always calculated
+in USD"* — independently of the response's `currency` field. The portal documents no
+currency for `minPositionAmount` at all. Rather than infer one (that inference is what
+this whole ticket exists to stop), the helper refuses to combine unless the response
+currency is USD, under which no non-USD denomination is in play on either field.
+
+This stops being satisfiable at #2603 scope item 4 (the non-USD deployment lift), which is
+precisely the change that would otherwise silently `max()` a USD figure against a GBP one.
+
+### 4. Closes are UNDOCUMENTED — which is "unknown", not "no constraint"
+
+The portal states both fields for opening and says nothing about closing or
+partial-closing. This spec therefore derives **no close-side floor**, and that is a named
+gap rather than a proof of absence: a `sell_core` rebalance leg carries no broker floor
+*from this source*, and `allowPartialClosePosition` proves permission, not unrestricted
+sizing. If eToro constrains partial-close size, we do not currently know it and would not
+refuse on it.
+
+### 5. An entry order IS an open — measured, not asserted
+
+Codex checkpoint 1 raised that a buy into an instrument already held might increment an
+existing position rather than open a new one, which would put it outside the documented
+scope. It does not: eToro tracks positions individually and does not net.
+
+```sql
+select instrument_id, count(*) from broker_positions group by 1 order by 2 desc;
+-- 1699|2  1571|2  1181|1  4238|1  3006|1
+select count(*), count(distinct instrument_id) from broker_positions;  -- 7 | 5
+```
+
+Two instruments hold two positions each on the demo account, so a second order in a held
+name opened a second position. Applying an open-side minimum to every entry is therefore
+in scope for this broker.
+
+## Full-population verification, and exactly what it does and does not bound
+
+Every stored proof, not a sample — `strategy_core_eligibility_proofs`, 23 rows:
+
+```sql
+select count(*) total,
+       count(*) filter (where min_position_amount is not null) has_amount,
+       count(*) filter (where min_position_exposure is not null) has_exposure,
+       count(*) filter (where min_position_amount is not null
+                          and min_position_exposure is not null
+                          and min_position_amount <> min_position_exposure) differ
+  from strategy_core_eligibility_proofs;
+-- total=23  has_amount=12  has_exposure=23  differ=0
+```
+
+```sql
+select leverage_values, count(*), min(min_position_amount), max(min_position_amount),
+       min(min_position_exposure), max(min_position_exposure)
+  from strategy_core_eligibility_proofs where verdict='underlying' group by 1;
+-- [1] | 12 | 10.000000 | 10.000000 | 10.000000 | 10.000000
+```
+
+eToro's demo quotes a flat 10.00 for both fields, every qualifying arm is exactly `[1]`,
+and the 12 rows carrying both agree exactly. `min_position_amount` is NULL on the 11
+`not_underlying` rows because it is read off the qualifying arm, of which they have none.
+
+⚠⚠ **This census bounds the CORE side only, and does not bound the executor's.**
+`strategy_paper_executor._eligibility_reason` reads a LIVE `BrokerEligibilityResponse`
+per call and never touches `strategy_core_eligibility_proofs`, so no stored row records
+what the executor has seen. The honest claim is therefore: **the correction moves no
+verdict this repo has stored**, and it is soundness against the documented rule rather
+than repair of an observed wrong number. What the census does establish is that the two
+fields are populated, agree where both appear, and are x1-only — so a `max` that is exact
+today.
+
+⚠ Also measured, and it is why the comparability check normalises: `response_currency` is
+**`usd` in lower case** on all 23 rows, against a `requested_currency` of `USD`.
+
+## The change
+
+One helper, in `app/services/broker_settlement_arms.py` — the module that already exists
+because two callers shared a definition of "the underlying product" and a second copy is
+the drift #2437 keeps recording:
+
+```python
+def effective_open_minimum(
+    *,
+    response_currency: str,
+    min_position_exposure: Decimal | None,
+    min_position_amount: Decimal | None,
+) -> Decimal | None
+```
+
+- **Takes the two figures, not the two objects**, so the executor (which holds
+  `BrokerInstrumentEligibility` + `BrokerLeverageConfig`) and the core proof (which holds
+  two NUMERIC columns) share one rule with no object coupling.
+- **Sanitises both inputs itself** — a non-finite or non-positive figure is dropped to
+  "not quoted", the `_positive_or_none` rule `strategy_core_eligibility.py:156` already
+  applies and `sql/346` already enforces. This closes a real divergence Codex found: the
+  stored-proof path sanitises and the executor path does not, so today the two callers
+  would reach different verdicts on identical broker data.
+- **Returns `max` of the surviving values**; `None` only when neither survives. `None`
+  means "the broker quoted no usable minimum", and each caller fails closed on it —
+  unchanged from today's `minimum is None or amount < minimum`.
+- **Raises `ValueError` when `response_currency` is not USD**, naming scope item 4.
+
+### Why the currency failure raises rather than returning a refusal
+
+Codex checkpoint 1 argued for a returned refusal, on the grounds that a currency mismatch
+is external-data state and that raising could abort an execution cycle in the exact state
+scope item 4 creates. Rebutted, on the call sites:
+
+- `strategy_paper_executor._eligibility_reason:624` already returns
+  `eligibility_unresolved` unless `response.currency.upper() == intent.currency`.
+- `strategy_core_eligibility.evaluate_core_eligibility:214` already returns
+  `eligibility_currency_mismatch` unless the response currency matches the requested one.
+
+Both callers refuse non-USD **before** reaching the helper. Arriving here with a non-USD
+currency means a caller skipped its own check, which is a bug rather than a state of the
+world — the distinction `strategy_core_submission_gate.StrategyCoreSubmissionError` draws
+for the unheld lock, and `strategy_core_preflight._require_known_action` draws for an
+unknown action on a public entry point (*"a guard that only exists on the other caller's
+path is not a guard"*). Scope item 4 is a code change that must handle this deliberately;
+a loud failure at that moment is the intended outcome, not a regression.
+
+### Boundary and precision — deliberately unchanged
+
+The comparison stays `amount < minimum` → refuse, so the minimum is INCLUSIVE (an amount
+exactly equal to the floor passes). No rounding tolerance is introduced: the portal
+publishes no precision rule for either field, and inventing one would be the uncited
+treatment this ticket exists to remove.
+
+### Call sites
+
+- `strategy_paper_executor._eligibility_reason` — replaces the `or`. Scope matches: an
+  entry is an open (§5 above), it is a buy, and the arm is x1.
+- The three docstrings quoted at the top. Each defers a question that now has an answer
+  for the OPEN side, and each must be corrected to state precisely what is settled
+  (open-side, x1, USD, as a safe bound) and what is not (any close-side floor). A
+  docstring that still says "unsettled" after it is settled is the stale-claim shape
+  `sql/348` was corrected for on this same ticket; a docstring that claims more than §2-§4
+  support would be the opposite error.
+
+**Not in scope, stated so it is not read as an omission:**
+
+- no `sell_core` floor — undocumented, see §4;
+- no new stored column — the rule is derived on read, so a re-derivation cannot leave a
+  stale copy;
+- no account-risk preflight — `observe_core_sleeve` already consumes the snapshot and
+  refuses on drift, so a second module would be the duplicate this ticket keeps finding
+  rather than the missing control;
+- no cost fetch — `strategy_core_sizing.decode_quoted_trade_cost` already decodes one, and
+  the FETCH belongs with the submitter that holds the sized ticket;
+- no broker-rejection code — that is an outcome of submission, not a preflight.
+
+Refs #2603. Refs #2437.

--- a/tests/test_2603_broker_open_minimum.py
+++ b/tests/test_2603_broker_open_minimum.py
@@ -1,0 +1,155 @@
+"""#2603 step 3b-2 — the broker's OPEN-position minimum, from the portal's own fields.
+
+Source rule (live portal 2026-08-23,
+``api-reference/trading--demo/check-instrument-trading-eligibility``):
+
+* ``minPositionExposure``, on the eligibility ROW — *"Minimum exposure value required to
+  open a position on this instrument. The exposure is always calculated in USD as the
+  number of units times the rate times the conversion rate to USD."*
+* ``minPositionAmount``, on a ``leverageConfigs`` ARM — *"Minimum margin required to open
+  a position under this leverage configuration."*
+
+Two constraints on one act, not two spellings of one number — so the combinator is
+``max`` and the precedence it replaces (``arm.min_position_amount or
+row.min_position_exposure``) was fail-OPEN by the gap between them.
+
+Spec: ``docs/proposals/ta/2026-08-23-broker-open-minimum.md``.
+
+⚠ Pure-logic tests. No DB, no broker.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.broker_settlement_arms import effective_open_minimum
+
+_USD = "USD"
+
+
+class TestCombination:
+    """``max``, because both figures gate the same act."""
+
+    def test_the_larger_of_the_two_binds(self) -> None:
+        """The regression the ``or`` precedence allowed.
+
+        An arm quoting a SMALLER margin than the row's exposure is the fail-open case:
+        ``or`` returned 10 and admitted a ticket the instrument-level rule refuses.
+        """
+        assert effective_open_minimum(
+            response_currency=_USD,
+            min_position_exposure=Decimal("50"),
+            min_position_amount=Decimal("10"),
+        ) == Decimal("50")
+
+    def test_the_larger_binds_in_the_other_direction_too(self) -> None:
+        assert effective_open_minimum(
+            response_currency=_USD,
+            min_position_exposure=Decimal("10"),
+            min_position_amount=Decimal("50"),
+        ) == Decimal("50")
+
+    def test_equal_figures_are_that_figure(self) -> None:
+        """The shape every stored proof carries today: 12 of 12 agree at 10.00."""
+        assert effective_open_minimum(
+            response_currency=_USD,
+            min_position_exposure=Decimal("10"),
+            min_position_amount=Decimal("10"),
+        ) == Decimal("10")
+
+    @pytest.mark.parametrize(
+        ("exposure", "amount", "expected"),
+        [
+            (Decimal("10"), None, Decimal("10")),
+            (None, Decimal("10"), Decimal("10")),
+        ],
+    )
+    def test_one_quoted_figure_is_the_floor(
+        self, exposure: Decimal | None, amount: Decimal | None, expected: Decimal
+    ) -> None:
+        """The 11 ``not_underlying`` proofs carry an exposure and no arm amount."""
+        assert (
+            effective_open_minimum(response_currency=_USD, min_position_exposure=exposure, min_position_amount=amount)
+            == expected
+        )
+
+    def test_neither_quoted_is_None_and_callers_fail_closed_on_it(self) -> None:
+        """``None`` means "the broker quoted no usable threshold", NOT "any size".
+
+        Both call sites keep ``minimum is None or amount < minimum`` → refuse, so this
+        value can only ever refuse.
+        """
+        assert (
+            effective_open_minimum(response_currency=_USD, min_position_exposure=None, min_position_amount=None) is None
+        )
+
+
+class TestSanitisation:
+    """Applied HERE so the stored-proof path and the executor's live path agree.
+
+    ``strategy_core_eligibility._positive_or_none`` drops these before storing and
+    ``sql/346`` refuses to store them; the executor's live response was never sanitised at
+    all, so without this the two callers reach different verdicts on identical broker
+    data.
+    """
+
+    @pytest.mark.parametrize("bad", [Decimal("0"), Decimal("-1"), Decimal("NaN"), Decimal("Infinity")])
+    def test_an_unusable_figure_reads_as_not_quoted(self, bad: Decimal) -> None:
+        assert effective_open_minimum(
+            response_currency=_USD, min_position_exposure=Decimal("10"), min_position_amount=bad
+        ) == Decimal("10")
+
+    @pytest.mark.parametrize("bad", [Decimal("0"), Decimal("-1"), Decimal("NaN"), Decimal("Infinity")])
+    def test_an_unusable_figure_does_not_win_the_max(self, bad: Decimal) -> None:
+        """⚠ ``Decimal("NaN")`` compares FALSE against everything, and ``Infinity`` would
+        win a naive ``max`` outright and refuse every order.  Dropping first is what
+        keeps both out of the comparison."""
+        assert effective_open_minimum(
+            response_currency=_USD, min_position_exposure=bad, min_position_amount=Decimal("10")
+        ) == Decimal("10")
+
+    def test_two_unusable_figures_read_as_not_quoted(self) -> None:
+        assert (
+            effective_open_minimum(
+                response_currency=_USD, min_position_exposure=Decimal("0"), min_position_amount=Decimal("-5")
+            )
+            is None
+        )
+
+
+class TestCurrencyComparability:
+    """``minPositionAmount`` documents NO currency, so the two combine only in USD."""
+
+    @pytest.mark.parametrize("currency", ["USD", "usd", " Usd "])
+    def test_a_usd_response_combines_however_it_is_cased(self, currency: str) -> None:
+        """⚠ Measured, not hypothetical: ``response_currency`` is lower-case ``usd`` on
+        all 23 stored proofs against a ``requested_currency`` of ``USD``."""
+        assert effective_open_minimum(
+            response_currency=currency,
+            min_position_exposure=Decimal("10"),
+            min_position_amount=Decimal("10"),
+        ) == Decimal("10")
+
+    @pytest.mark.parametrize("currency", ["GBP", "EUR", ""])
+    def test_a_non_usd_response_raises_rather_than_comparing_two_denominations(self, currency: str) -> None:
+        """A caller bug, not a state of the world.
+
+        Both callers refuse a currency mismatch BEFORE reaching here
+        (``_eligibility_reason`` → ``eligibility_unresolved``,
+        ``evaluate_core_eligibility`` → ``eligibility_currency_mismatch``), so arriving
+        with anything else means a caller skipped its own check.  #2603 scope item 4 is
+        the change that must revisit it.
+        """
+        with pytest.raises(ValueError, match="scope item 4"):
+            effective_open_minimum(
+                response_currency=currency,
+                min_position_exposure=Decimal("10"),
+                min_position_amount=Decimal("10"),
+            )
+
+    def test_the_currency_is_checked_even_when_nothing_is_quoted(self) -> None:
+        """Otherwise the guard is skippable by sending two nulls."""
+        with pytest.raises(ValueError):
+            effective_open_minimum(response_currency="GBP", min_position_exposure=None, min_position_amount=None)


### PR DESCRIPTION
## What changed

`strategy_paper_executor._eligibility_reason` treated eToro's two eligibility minimums as alternatives:

```python
minimum = arm.min_position_amount or matches[0].min_position_exposure
```

They are not alternatives. They are two constraints on the same act, so the binding floor is `max` of the quoted ones. This replaces the precedence with a shared helper carrying the source rule, and corrects three docstrings that recorded the question as unsettled.

Part of #2603 step 3b-2 — the broker half of the core submission refusal vocabulary, minimum only.

## Source rule

Live portal, fetched 2026-08-23 via the `.claude/skills/data-sources/etoro-api.md` protocol (`llms.txt` → per-endpoint `.md`, WebFetch not curl): `api-reference/trading--demo/check-instrument-trading-eligibility.md`.

| field | object | documented as |
| --- | --- | --- |
| `minPositionExposure` | eligibility ROW | *"Minimum exposure value required to open a position on this instrument. The exposure is always calculated in USD as the number of units times the rate times the conversion rate to USD."* |
| `minPositionAmount` | `leverageConfigs` ARM | *"Minimum margin required to open a position under this leverage configuration."* |

Exposure is units × rate × FX; margin is exposure ÷ leverage. Both say *"required to open a position"*.

**So `or` is fail-OPEN by the gap between them** whenever the arm quotes the smaller number — at leverage > x1, by the leverage multiple.

Three modules had each independently recorded this as unsettled and declined to derive a floor: `strategy_core_eligibility.py:18-23` (*"has no citation in the provider's documentation"*), `strategy_core_allocator.py:249-253`, `strategy_core_rebalance_intent.py:174-183` (*"The executor holds the eligibility response and can answer it with evidence"*). This is that answer.

## `max` is a SAFE BOUND, not a reproduction of the broker's rule

Stated rather than glossed. Testing a notional against the larger threshold:

- **can never admit** an order the broker would refuse on either dimension;
- **can refuse** one the broker would accept, at leverage > x1, where the notional exceeds the margin by the leverage multiple.

Over-restriction is the safe direction for a floor — the posture `strategy_core_sizing.QuotedTradeCost` already takes for cost. ⚠ Unreachable through today's callers and **enforced, not assumed**: both select their arm through `select_underlying_long_arms`, which requires x1, and at x1 margin equals exposure so `max` is exact.

## Full-population verification — and exactly what it does not bound

Every stored proof, not a sample (`strategy_core_eligibility_proofs`, 23 rows):

```sql
select count(*) total,
       count(*) filter (where min_position_amount is not null) has_amount,
       count(*) filter (where min_position_exposure is not null) has_exposure,
       count(*) filter (where min_position_amount is not null
                          and min_position_exposure is not null
                          and min_position_amount <> min_position_exposure) differ
  from strategy_core_eligibility_proofs;
-- total=23  has_amount=12  has_exposure=23  differ=0

select leverage_values, count(*), min(min_position_amount), max(min_position_amount),
       min(min_position_exposure), max(min_position_exposure)
  from strategy_core_eligibility_proofs where verdict='underlying' group by 1;
-- [1] | 12 | 10.000000 | 10.000000 | 10.000000 | 10.000000
```

**The defect is LATENT, not live.** eToro's demo quotes a flat 10.00 both ways, every qualifying arm is exactly `[1]`, and the 12 rows carrying both agree exactly. This is soundness against the documented rule, not repair of an observed wrong number.

⚠⚠ **That census bounds the CORE side only.** `_eligibility_reason` reads a LIVE `BrokerEligibilityResponse` per call and never touches the proofs table, so no stored row records what the executor has seen. The honest claim is "moves no verdict this repo has stored".

⚠ `response_currency` is lower-case `usd` on all 23 rows against a `requested_currency` of `USD` — which is why the comparability check normalises.

## The helper

`broker_settlement_arms.effective_open_minimum(*, response_currency, min_position_exposure, min_position_amount) -> Decimal | None`

Lives beside `select_underlying_long_arms` for the same reason that one does: two callers sharing a rule read off the same response, and a second copy is the drift #2437 keeps recording. Takes the two figures rather than the two objects, so the executor (which holds the row + arm) and the core proof (which holds two NUMERIC columns) share one rule with no object coupling.

- **Sanitises both inputs.** This closes a real divergence: the stored-proof path applies `_positive_or_none` (and `sql/346` enforces it) while the executor's live path applied nothing, so the two callers would reach **different verdicts on identical broker data**. It also keeps `NaN` (compares false against everything) and `Infinity` (would win a naive `max` outright and refuse every order) out of the comparison.
- **`None` only when neither figure survives** — meaning "the broker quoted no usable threshold", never "any size". Both callers keep `minimum is None or amount < minimum` → refuse.
- **Raises on a non-USD response currency.** `minPositionExposure` is pinned to USD by its own wording; `minPositionAmount` documents no currency at all. Rather than infer one, the two combine only where no non-USD denomination is in play.

### Why the currency failure raises rather than returning a refusal

Codex checkpoint 1 argued for a returned refusal. Rebutted on the call sites: `_eligibility_reason:624` already returns `eligibility_unresolved` unless `response.currency.upper() == intent.currency`, and `evaluate_core_eligibility:214` already returns `eligibility_currency_mismatch`. Both refuse non-USD **before** reaching the helper, so arriving here otherwise means a caller skipped its own check — a bug, not a state of the world. That is the distinction `StrategyCoreSubmissionError` draws for an unheld lock and `_require_known_action` draws on a public entry point (*"a guard that only exists on the other caller's path is not a guard"*).

Concretely it becomes reachable when `strategy_base_currency.SUPPORTED_DEPLOYMENT_CURRENCIES` widens from today's singleton `{"USD"}` — #2603 scope item 4 — and a loud failure there is the intended outcome.

## OPEN only — and that is a named gap, not a proof of absence

The portal documents both fields for opening and says **nothing** about closing or partial-closing. So no `sell_core` floor is derived. That is UNKNOWN, not "no constraint": `allowPartialClosePosition` proves permission, not unrestricted sizing. If eToro constrains partial-close size, we do not currently know it and would not refuse on it. The three corrected docstrings say exactly this rather than reading as fully settled.

## An entry IS an open — measured, against a checkpoint-1 challenge

Codex raised that a buy into an already-held instrument might increment rather than open, putting it outside the documented scope. It does not — eToro does not net:

```sql
select instrument_id, count(*) from broker_positions group by 1 order by 2 desc;
-- 1699|2  1571|2  1181|1  4238|1  3006|1
select count(*), count(distinct instrument_id) from broker_positions;  -- 7 | 5
```

Two instruments hold two positions each, so a second order in a held name opened a second position.

## Not in scope, stated so it is not read as an omission

- no `sell_core` floor — undocumented, above;
- no new stored column — derived on read, so a re-derivation cannot leave a stale copy;
- no account-risk preflight — `observe_core_sleeve` already consumes the snapshot and refuses on drift, so a second module would be the duplicate this ticket keeps finding rather than the missing control;
- no cost fetch — `decode_quoted_trade_cost` already decodes one; the FETCH belongs with the submitter holding the sized ticket;
- no broker-rejection code — an outcome of submission, not a preflight;
- boundary and precision unchanged — `amount < minimum` refuses, so the floor stays inclusive, and no rounding tolerance is invented (the portal publishes no precision rule, and inventing one is the uncited treatment this change exists to remove).

## Security model

No new trust boundary. No user-controlled input reaches the helper — both inputs are broker-reported figures already parsed by `_parse_eligibility_response`, and the change makes the gate strictly *more* restrictive (`max` ≥ `or`) or equal. No SQL, no new endpoint, no credential path. The one behavioural direction that could matter — a floor becoming lower — is impossible by construction, since `max` of a set is never below any member and the sanitisation only removes candidates that were unusable as thresholds.

## Verification

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run pyright` — 0 errors, 0 warnings
- `uv run pytest -m "not db"` — 9595 passed, 14 skipped
- `uv run pytest tests/smoke` — 155 passed, 3 skipped
- `tests/test_2603_broker_open_minimum.py` — 22 passed (pure logic: combination, sanitisation incl. NaN/Infinity, currency comparability incl. the lower-case `usd` the demo actually returns)
- Codex checkpoint 1 on the spec (four findings taken: `max`-as-bound framing, the uncited `minPositionAmount` currency, close-side silence as unknown-not-none, and the increment-vs-open challenge — the last settled by the `broker_positions` measurement above)
- Codex checkpoint 2 on the staged diff — no findings

No jobs-daemon restart needed: no job, ingest, parser or scheduler code is touched, and no stored output changes.

Refs #2603. Refs #2437.
