### PR TITLE
feature(#2603 step 3b-2): the broker half of the core submission preflight

### DIFF
--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -76,6 +76,15 @@ _ALLOWED_PLACE_ORDER_ACTIONS = frozenset({"BUY", "ADD"})
 _ETORO_READ_INTERVAL_S = 1.1
 _ETORO_WRITE_INTERVAL_S = 3.5
 
+#: Per-phase HTTP timeout handed to ``httpx.Client``.
+#:
+#: ⚠ ``httpx`` applies this to connect, read, write and pool INDIVIDUALLY -- it is not a
+#: total wall-clock cap on one attempt.  Named rather than inline because
+#: ``strategy_core_broker_preflight`` derives its account-risk age bound from it, and a
+#: coupling test asserts the two agree; an unnamed literal makes that derivation
+#: unverifiable and lets a retune invalidate it silently.
+_ETORO_HTTP_TIMEOUT_S = 30.0
+
 _STATUS_MAP: dict[str, OrderStatus] = {
     "Executed": "filled",
     "Filled": "filled",
@@ -162,7 +171,7 @@ class EtoroBrokerProvider(BrokerProvider):
                 "x-user-key": user_key,
                 "Content-Type": "application/json",
             },
-            timeout=30.0,
+            timeout=_ETORO_HTTP_TIMEOUT_S,
         )
         # Separate throttle rates for reads (GET 60/min) and writes (POST 20/min).
         # Both share the same _last_request_at timestamp so interleaved

--- a/app/services/broker_settlement_arms.py
+++ b/app/services/broker_settlement_arms.py
@@ -44,9 +44,14 @@ from typing import Final
 from app.providers.broker import BrokerInstrumentEligibility, BrokerLeverageConfig
 
 # The one settlement type that means ownership at full value.
-UNDERLYING_SETTLEMENT_TYPE = "real"
-UNDERLYING_DIRECTION = "long"
-UNLEVERAGED_LEVERAGE = 1
+#
+# ⚠ ``Final`` is load-bearing, not decoration: without it pyright widens the value to
+# ``str``, and a caller passing it to ``BrokerWhatIfOrder.settlement_type`` (a
+# ``Literal``) fails to typecheck -- which pushes that caller into re-typing ``"real"``
+# inline, i.e. back into the second copy this module exists to prevent.
+UNDERLYING_SETTLEMENT_TYPE: Final = "real"
+UNDERLYING_DIRECTION: Final = "long"
+UNLEVERAGED_LEVERAGE: Final = 1
 
 #: The only response currency in which the two open minimums are comparable.
 #: ``minPositionExposure`` is documented as "always calculated in USD" whatever the

--- a/app/services/strategy_core_broker_preflight.py
+++ b/app/services/strategy_core_broker_preflight.py
@@ -35,6 +35,7 @@ Spec: ``docs/proposals/ta/2026-08-23-core-broker-preflight.md``
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -64,6 +65,8 @@ from app.services.strategy_core_sizing import (
     resolve_core_trade_size,
 )
 from app.services.strategy_core_sleeve import CoreSleeveObservationError, observe_core_sleeve
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "CORE_BROKER_PREFLIGHT_POLICY_VERSION",
@@ -292,6 +295,12 @@ def assess_core_broker_preflight(
     except Exception:
         # Broad on purpose: transport, auth, parse and shape failures are one condition
         # to a submission -- the broker's view of the account is not available.
+        #
+        # ⚠ Logged with the traceback because the verdict deliberately cannot carry it: a
+        # 503 and a TypeError in our own parse collapse to one refusal code, and without
+        # this line a programming bug is indistinguishable from a broker outage in
+        # production -- which is the shape that keeps a real defect looking like weather.
+        logger.warning("core broker preflight: account risk snapshot unavailable", exc_info=True)
         return _refused("core_account_risk_unavailable")
 
     if snapshot.observed_at.tzinfo is None:
@@ -347,6 +356,9 @@ def assess_core_broker_preflight(
             )
         )
     except Exception:
+        # Same reason as the snapshot fetch above: the code cannot carry the cause, so the
+        # log must.
+        logger.warning("core broker preflight: what-if cost quote unavailable", exc_info=True)
         return _refused("core_cost_assessment_unavailable", snapshot_observed_at=snapshot.observed_at)
 
     if not _age_within_bound(snapshot.observed_at, now=clock()):
@@ -370,7 +382,13 @@ def assess_core_broker_preflight(
 
     sized = resolve_core_trade_size(mandate, state, fresh, cost)
     if not sized.sized:
-        assert sized.refusal_code is not None
+        if sized.refusal_code is None:
+            # NOT an `assert`: `python -O` strips those, and the stripped form would
+            # return `admitted=False` with `reason_code=None` -- an unnamed refusal, which
+            # is the one thing this module's whole closed vocabulary exists to prevent.
+            raise StrategyCoreBrokerPreflightError(
+                "resolve_core_trade_size refused without a refusal code; the sizing contract is broken"
+            )
         return _refused(sized.refusal_code, snapshot_observed_at=snapshot.observed_at)
 
     return CoreBrokerPreflightVerdict(

--- a/app/services/strategy_core_broker_preflight.py
+++ b/app/services/strategy_core_broker_preflight.py
@@ -1,0 +1,382 @@
+"""May a core rebalance be submitted against the BROKER right now? (#2603 item 3, step 3b-2).
+
+Step 3b-1 (:mod:`app.services.strategy_core_preflight`) is the DB-and-clock half of the
+submission refusal vocabulary, and it closes by naming what it leaves out: *"account-risk
+availability, broker minimums, cost assessment and broker rejection"*.  The broker
+minimum landed separately (``broker_settlement_arms.effective_open_minimum``).  This
+module is the other two.
+
+The split between 3b-1 and this one is "does it need a broker": 3b-1 holds no broker
+handle and every refusal it names is provable in a pure test; every refusal here is
+observable only against a live account.
+
+⚠⚠ AUTHORISES NOTHING TODAY.  No caller in ``app/`` or ``scripts/``; it writes nothing.
+Named plainly, as every step of this arc has been, because #2437's R4 comment records *a
+control that exists, is tested, and sits on a path the decision does not take* nine times
+over on this ticket alone.
+
+⚠⚠ BUY ONLY.  ``sell_core`` refuses before any broker call --
+``core_close_side_cost_quote_unavailable``.  See :data:`CoreBrokerPreflightRefusal`.
+
+⚠ Both broker calls are INFORMATIONAL and are deliberately not covered by
+``refuse_broker_mutation_if_unattended`` (#2645): ruling informational work out was the
+other half of that error.
+
+⚠ What this still does NOT carry, so the reader does not take 3b-1 + this for the whole
+set: broker REJECTION and the uncertain-submission resume path (both outcomes of
+submission, not preconditions); ``maxUnitsPerOrder`` (quoted in units while this sizes in
+currency, so it needs the price 3b-1 holds); and any coherence guarantee ACROSS the five
+reads that inform a submission -- the advisory lock serialises our actors, not the
+broker's.  The ticket owes "eligibility read and submission in ONE transaction" to the
+submitter, and this module does not discharge it.
+
+Spec: ``docs/proposals/ta/2026-08-23-core-broker-preflight.md``
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Final, Literal
+
+from app.providers.broker import (
+    BrokerProvider,
+    BrokerWhatIfOrder,
+)
+from app.services.broker_settlement_arms import (
+    UNDERLYING_SETTLEMENT_TYPE,
+    UNLEVERAGED_LEVERAGE,
+    effective_open_minimum,
+)
+from app.services.strategy_core_allocator import (
+    CoreMandate,
+    CoreRebalanceDecision,
+    CoreRebalanceReasonCode,
+    CoreSleeveState,
+    evaluate_core_rebalance,
+)
+from app.services.strategy_core_sizing import (
+    CoreSizingRefusalCode,
+    QuotedTradeCost,
+    decode_quoted_trade_cost,
+    resolve_core_trade_size,
+)
+from app.services.strategy_core_sleeve import CoreSleeveObservationError, observe_core_sleeve
+
+__all__ = [
+    "CORE_BROKER_PREFLIGHT_POLICY_VERSION",
+    "CORE_MAX_ACCOUNT_RISK_AGE_SECONDS",
+    "CoreBrokerPreflightRefusal",
+    "CoreBrokerPreflightVerdict",
+    "StrategyCoreBrokerPreflightError",
+    "assess_core_broker_preflight",
+]
+
+
+class StrategyCoreBrokerPreflightError(RuntimeError):
+    """A caller contract breach -- not a refusal, and deliberately not returnable.
+
+    The same distinction ``StrategyCorePreflightError`` and ``CoreSleeveObservationError``
+    draw: a refusal is a verdict about the WORLD and belongs in the returned vocabulary,
+    whereas asking to preflight a decision that is not a trade is a defect in the code
+    doing the asking.  Returning it would put a caller bug and a broker condition behind
+    one ``reason_code``, and the caller would learn about its own bug by catching a code
+    that means the broker said something.
+    """
+
+
+#: Frozen with the rule set it stamps.  v1 fixes, BY CONSTRUCTION: the account-risk age
+#: bound below, the buy-only restriction, and the refusal precedence order.
+#:
+#: ⚠⚠ Widening the bound is a VERSION BUMP, never an edit to the constant.  Editing it in
+#: place silently re-verdicts every past comparison, including ones already read -- the
+#: rule ``account_equity_evidence.RECONCILIATION_RULE_VERSION`` states for the same
+#: reason.
+CORE_BROKER_PREFLIGHT_POLICY_VERSION: Final = "core-broker-preflight-v1"
+
+#: One write-lane throttle wait, ``etoro_broker._ETORO_WRITE_INTERVAL_S`` = 3.5 s.
+#: ``get_what_if_costs`` posts on ``_http_write``, NOT the 1.1 s read lane.
+_NOMINAL_WRITE_THROTTLE_SECONDS: Final = Decimal("3.5")
+
+#: One HTTP round trip, from ``etoro_broker``'s ``httpx.Client(timeout=30.0)``.
+#:
+#: ⚠ ``httpx`` applies that value to connect, read, write and pool INDIVIDUALLY; it is
+#: not a total wall-clock cap on one attempt.  It is used here as a single-phase proxy
+#: for the nominal round trip, which is what "nominal" means, and is not claimed as a
+#: hard bound.
+_NOMINAL_HTTP_ROUND_TRIP_SECONDS: Final = Decimal("30.0")
+
+#: How old the account snapshot may be when this verdict is reached.
+#:
+#: There is no producer cadence to derive from -- the snapshot is a LIVE read stamped at
+#: receipt (``_parse_account_risk_snapshot`` takes ``observed_at`` as a parameter; the
+#: payload carries no broker valuation stamp).  So ``strategy_core_preflight
+#: ._freshness_bound``, which derives from a producer's nominal PERIOD, does not apply
+#: and is deliberately not reused.
+#:
+#: ⚠⚠ A first draft derived this from the WORST-CASE duration of the one intervening
+#: call.  That is unsound and is recorded so it is not re-attempted: the throttle is paid
+#: once per ATTEMPT (``resilient_client.py`` ``_request``), and on a 429 ``Retry-After``
+#: OVERRIDES the backoff schedule with no upper cap (``_retry_delay``; only a 0.1 s
+#: floor).  The worst case is therefore unbounded, and a constant derived from it could
+#: never fire -- decoration wearing a derivation.
+#:
+#: Fixed instead at the NOMINAL single-attempt duration of that call: one write-lane
+#: throttle wait plus one round trip, rounded up.  A retrying call will typically exceed
+#: it and refusing is the INTENDED outcome -- a submission whose cost quote needed
+#: retries is one whose account view we no longer trust, and the caller re-runs from a
+#: fresh snapshot.  This bound is meant to bite.
+#:
+#: ⚠ It bounds a STALL, not market movement.  Nothing here makes the snapshot and the
+#: what-if simultaneous, and no second snapshot is taken after the cost call.  The
+#: sleeve-vs-cost coherence question is separately bounded, by ``decode_quoted_trade_cost``
+#: refusing ``cost_quote_stale`` against ``CoreSleeveState.as_of``.
+CORE_MAX_ACCOUNT_RISK_AGE_SECONDS: Final = int(
+    (_NOMINAL_WRITE_THROTTLE_SECONDS + _NOMINAL_HTTP_ROUND_TRIP_SECONDS).to_integral_value(rounding="ROUND_CEILING")
+)
+
+#: Tolerated clock skew on the snapshot stamp, matching ``strategy_core_preflight
+#: ._FUTURE_SKEW``.  A stamp further into the future than this is refused rather than
+#: treated as maximally fresh -- without it a corrupted future timestamp never ages out.
+_FUTURE_SKEW: Final = timedelta(seconds=5)
+
+CoreBrokerPreflightRefusal = Literal[
+    "core_close_side_cost_quote_unavailable",
+    "core_account_risk_unavailable",
+    "core_account_risk_stale",
+    "core_account_risk_unobservable",
+    "core_sleeve_moved_since_decision",
+    "core_minimum_currency_unsupported",
+    "core_broker_open_minimum_unquoted",
+    "core_cost_assessment_unavailable",
+]
+"""The closed vocabulary of reasons the BROKER refuses a core submission.
+
+A ``Literal`` rather than ``str`` so pyright checks every ``return`` site and a code
+cannot be introduced without appearing here -- step 3a's device, and the allocator's
+before it.
+
+⚠ PRECEDENCE IS THE DECLARATION ORDER and it is load-bearing: an input can be a sell,
+stale AND uncostable at once, and without a fixed order the recorded explanation moves
+with a refactor.
+
+``core_close_side_cost_quote_unavailable`` leads because it is decided before any broker
+call.  ⚠⚠ It is a REAL limitation of the core arm and not a formality -- a rebalance that
+can only buy is half an allocator.  ``BrokerWhatIfOrder``'s docstring carries the two
+measurements that force it (#2712, 2026-08-14): the close arm REQUIRES ``position_ids``
+(400 without them) and an open-arm quote does NOT bound the close-arm cost -- measured
+dearer on 4 of 5 held positions by 5.7x, 8.5x, 13.0x and 18.5x.  Neither
+``CoreSleeveState`` nor ``BrokerInstrumentInvestment`` carries a position id, so no close
+quote is constructible from this module's inputs, and the one substitution available
+would under-state a cost bound by an order of magnitude -- the single direction a cost
+bound must never be wrong in.  What unblocks it: position ids threaded from
+``broker_positions``, plus a close-side floor rule, which the portal does NOT document
+(``effective_open_minimum`` states both minimums for OPENING only).
+
+``core_broker_open_minimum_unquoted`` fails CLOSED, and the distinction matters:
+``effective_open_minimum`` returning ``None`` means the broker quoted no usable
+threshold, whereas ``evaluate_core_rebalance``'s ``broker_minimum=None`` means THE CALLER
+HAS NO APPLICABLE MINIMUM TO SUPPLY.  Passing the first through as the second would read
+an unanswered question as an answered one.
+"""
+
+#: Codes this module passes through UNCHANGED rather than re-coding.  Re-coding would
+#: put two names on one condition and lose which layer decided it.
+CoreBrokerPreflightReason = CoreBrokerPreflightRefusal | CoreRebalanceReasonCode | CoreSizingRefusalCode
+
+
+@dataclass(frozen=True)
+class CoreBrokerPreflightVerdict:
+    """The broker's answer: a cost-adjusted size, or one named refusal.
+
+    ``amount`` is ``0`` on a refusal and is otherwise the currency amount to trade in the
+    mandate's base currency -- the same contract ``CoreSizingResult.amount`` carries,
+    because it IS that number.
+
+    ``snapshot_observed_at`` stays populated on a refusal wherever it is known: an
+    operator diagnosing ``core_account_risk_stale`` needs the stamp that was too old, and
+    blanking it would ship the refusal without its evidence.
+    """
+
+    admitted: bool
+    reason_code: CoreBrokerPreflightReason | None
+    amount: Decimal
+    cost_rate: Decimal | None
+    snapshot_observed_at: datetime | None
+    max_account_risk_age_seconds: int = CORE_MAX_ACCOUNT_RISK_AGE_SECONDS
+    policy_version: str = CORE_BROKER_PREFLIGHT_POLICY_VERSION
+
+
+_ZERO: Final = Decimal("0")
+
+
+def _refused(
+    reason_code: CoreBrokerPreflightReason,
+    *,
+    snapshot_observed_at: datetime | None = None,
+) -> CoreBrokerPreflightVerdict:
+    return CoreBrokerPreflightVerdict(
+        admitted=False,
+        reason_code=reason_code,
+        amount=_ZERO,
+        cost_rate=None,
+        snapshot_observed_at=snapshot_observed_at,
+    )
+
+
+def _age_within_bound(observed_at: datetime, *, now: datetime) -> bool:
+    """Is the snapshot young enough, and not implausibly future-stamped?"""
+    delta = now - observed_at
+    if delta < -_FUTURE_SKEW:
+        return False
+    return delta.total_seconds() <= CORE_MAX_ACCOUNT_RISK_AGE_SECONDS
+
+
+def assess_core_broker_preflight(
+    broker: BrokerProvider,
+    *,
+    mandate: CoreMandate,
+    decision: CoreRebalanceDecision,
+    core_instrument_id: int,
+    eligibility_response_currency: str,
+    eligibility_min_position_exposure: Decimal | None,
+    eligibility_min_position_amount: Decimal | None,
+    clock: Callable[[], datetime],
+) -> CoreBrokerPreflightVerdict:
+    """Re-prove a recorded rebalance against the broker, and size it after cost.
+
+    ⚠⚠ A CLOCK, not a ``now``, and the difference is the whole point of the age bound.
+    An earlier draft took one ``now`` and tested the snapshot's age BEFORE the what-if
+    call -- i.e. before the one thing whose duration the bound exists to cover.  Since
+    that call is the only wall clock in the assembly, the bound could never fire: a
+    request delayed by throttling, retries or an uncapped ``Retry-After`` still returned
+    an ADMITTED verdict on an hour-old snapshot.  The clock is therefore read twice and
+    **the second reading is the binding one**; the first only avoids spending a write-lane
+    request on a snapshot that is already too old.
+
+    ``decision`` is the verdict already recorded on the intent.  It is NOT trusted as a
+    sizing input: step 4 below re-derives it from a freshly observed sleeve, so a
+    decision computed from a sleeve that has since moved is REFUSED here rather than
+    raising later out of ``resolve_core_trade_size._assert_decision_describes``.
+
+    ⚠ ``CoreSizingContractError`` is allowed to propagate rather than being caught into a
+    refusal -- a decision that does not describe its own ``(mandate, state)`` is a CALLER
+    DEFECT, the distinction ``CoreSleeveObservationError`` and
+    ``StrategyCorePreflightError`` both draw.  The re-derivation makes it unreachable
+    through this module's own path, which is why it is a contract breach and not a
+    verdict.
+
+    The eligibility figures are the caller's ALREADY-PROVED ones (``strategy_core_
+    eligibility``); this module does not re-fetch eligibility, and the request it does
+    make echoes back neither direction, settlement type, leverage nor account -- see
+    ``QuotedTradeCost``, which says so of the response it decodes.
+    """
+    if decision.action not in ("buy_core", "sell_core"):
+        # A hold or a refusal is not a submission, so there is nothing to preflight.
+        # Raised rather than returned for the reason `StrategyCorePreflightError` gives:
+        # this is a CALLER CONTRACT BREACH, not a verdict about the world, and folding it
+        # into the refusal vocabulary would let a caller learn it by catching a code that
+        # means something else entirely.
+        raise StrategyCoreBrokerPreflightError(
+            f"decision.action is {decision.action!r}; only a trade can be submission-preflighted"
+        )
+    if decision.action == "sell_core":
+        # Decided before any broker call: a request we know returns 400, or a quote we
+        # know does not bound the cost, is not worth spending against the write lane.
+        return _refused("core_close_side_cost_quote_unavailable")
+
+    try:
+        snapshot = broker.get_account_risk_snapshot()
+    except Exception:
+        # Broad on purpose: transport, auth, parse and shape failures are one condition
+        # to a submission -- the broker's view of the account is not available.
+        return _refused("core_account_risk_unavailable")
+
+    if snapshot.observed_at.tzinfo is None:
+        # `observe_core_sleeve` refuses this too, but the age test runs first and a naive
+        # stamp cannot be subtracted from an aware clock reading without raising.
+        return _refused("core_account_risk_unobservable")
+    if not _age_within_bound(snapshot.observed_at, now=clock()):
+        # Cheap pre-check only: it saves a write-lane request on a snapshot already too
+        # old.  The check that BINDS is the one after the cost call.
+        return _refused("core_account_risk_stale", snapshot_observed_at=snapshot.observed_at)
+
+    try:
+        state: CoreSleeveState = observe_core_sleeve(snapshot, core_instrument_id=core_instrument_id)
+    except CoreSleeveObservationError:
+        return _refused("core_account_risk_unobservable", snapshot_observed_at=snapshot.observed_at)
+
+    if eligibility_response_currency.strip().upper() != "USD":
+        # Runs BEFORE `effective_open_minimum` so its documented `ValueError` on non-USD
+        # stays unreachable: its docstring already contracts that "both callers refuse a
+        # mismatch first".  #2603 scope item 4 is the change that revisits this.
+        return _refused("core_minimum_currency_unsupported", snapshot_observed_at=snapshot.observed_at)
+    broker_minimum = effective_open_minimum(
+        response_currency=eligibility_response_currency,
+        min_position_exposure=eligibility_min_position_exposure,
+        min_position_amount=eligibility_min_position_amount,
+    )
+    if broker_minimum is None:
+        return _refused("core_broker_open_minimum_unquoted", snapshot_observed_at=snapshot.observed_at)
+
+    # The floor is applied INSIDE the allocator, which already owns the precedence
+    # between it and the mandate's own minimum and reports which one bound
+    # (`floor_source`).  A second comparison here would be a copy of that rule.
+    fresh = evaluate_core_rebalance(mandate, state, broker_minimum=broker_minimum)
+    if fresh.action != "buy_core":
+        # Includes `below_min_rebalance_amount` -- the broker floor biting, which is the
+        # whole reason the minimum is passed in.  A refusal keeps ITS code; a fresh
+        # verdict that merely wants a different trade is drift.
+        return _refused(
+            fresh.reason_code if fresh.reason_code is not None else "core_sleeve_moved_since_decision",
+            snapshot_observed_at=snapshot.observed_at,
+        )
+    if fresh.amount != decision.amount:
+        return _refused("core_sleeve_moved_since_decision", snapshot_observed_at=snapshot.observed_at)
+
+    try:
+        response = broker.get_what_if_costs(
+            BrokerWhatIfOrder(
+                instrument_id=core_instrument_id,
+                transaction="buy",
+                settlement_type=UNDERLYING_SETTLEMENT_TYPE,
+                amount=fresh.amount,
+                leverage=UNLEVERAGED_LEVERAGE,
+            )
+        )
+    except Exception:
+        return _refused("core_cost_assessment_unavailable", snapshot_observed_at=snapshot.observed_at)
+
+    if not _age_within_bound(snapshot.observed_at, now=clock()):
+        # THE BINDING CHECK.  The call above is the assembly's only wall clock, and it can
+        # run arbitrarily long -- the throttle is paid per attempt and a 429's
+        # `Retry-After` overrides the backoff with no upper cap.  Refusing here is the
+        # behaviour the bound is FOR: a submission whose cost quote needed retries is one
+        # whose account view we no longer trust, and the caller re-runs from a fresh
+        # snapshot.  Same condition as the pre-check, so deliberately the same code.
+        return _refused("core_account_risk_stale", snapshot_observed_at=snapshot.observed_at)
+
+    cost = decode_quoted_trade_cost(
+        response,
+        instrument_id=core_instrument_id,
+        ticket_amount=fresh.amount,
+        base_currency=mandate.base_currency,
+        valuation_as_of=state.as_of,
+    )
+    if not isinstance(cost, QuotedTradeCost):
+        return _refused(cost, snapshot_observed_at=snapshot.observed_at)
+
+    sized = resolve_core_trade_size(mandate, state, fresh, cost)
+    if not sized.sized:
+        assert sized.refusal_code is not None
+        return _refused(sized.refusal_code, snapshot_observed_at=snapshot.observed_at)
+
+    return CoreBrokerPreflightVerdict(
+        admitted=True,
+        reason_code=None,
+        amount=sized.amount,
+        cost_rate=sized.cost_rate,
+        snapshot_observed_at=snapshot.observed_at,
+    )

--- a/docs/proposals/ta/2026-08-23-core-broker-preflight.md
+++ b/docs/proposals/ta/2026-08-23-core-broker-preflight.md
@@ -1,0 +1,191 @@
+# Core submission preflight — the BROKER half (#2603 item 3, step 3b-2)
+
+Status: proposed, 2026-08-23. Revised after Codex checkpoint 1, which falsified the
+first draft's age-bound derivation and its sell arm. Both corrections are recorded below
+rather than quietly applied.
+
+## Why
+
+Step 3b-1 (`app/services/strategy_core_preflight.py`) closes by naming what it does not
+carry: *"account-risk availability, broker minimums, cost assessment and broker
+rejection"*. It calls those "the broker half" and defers them to 3b-2.
+
+3b-2 has shipped one of the four — the broker minimum (`578e5393`,
+`broker_settlement_arms.effective_open_minimum`). This slice ships the other two
+preflight-shaped ones. Broker rejection is deliberately excluded: it is an OUTCOME of
+submission, not a precondition, and it belongs with the submitter alongside the
+uncertain-submission resume path.
+
+Measured before speccing, not inherited from the step-3b-2 close-out comment:
+
+| owed item | claim re-checked against the tree | verdict |
+| --- | --- | --- |
+| account-risk | `get_account_risk_snapshot` callers are `strategy_paper_executor.py:1183`, `:305` and `scheduler.py:5748` (the core-sleeve OBSERVATION chain) | no submission-time re-read on the core arm — confirmed absent |
+| cost assessment | `get_what_if_costs` callers are `strategy_paper_executor.py:1206` and two `scripts/` probes | `decode_quoted_trade_cost` is a decoder with no producer on this arm — confirmed |
+| broker minimum | `effective_open_minimum` callers: `strategy_paper_executor.py:656` only | shipped, but unreachable from the core arm until this module calls it |
+
+## What it is
+
+One module, `app/services/strategy_core_broker_preflight.py`, symmetric with 3b-1:
+3b-1 is the DB-and-clock half (no broker handle), this is the broker half (holds a
+broker handle, makes only informational reads).
+
+Input: an already-decided `(mandate, decision)` pair, the broker handle, the eligibility
+figures already proved by `strategy_core_eligibility`, and `now`.
+Output: `CoreBrokerPreflightVerdict` — admitted with a cost-adjusted size, or one named
+refusal.
+
+It **authorises nothing**: no caller in `app/` or `scripts/`, and it writes nothing.
+
+### BUY ONLY — the sell arm refuses, and why
+
+`sell_core` returns `core_close_side_cost_quote_unavailable`, unconditionally.
+
+`BrokerWhatIfOrder`'s own docstring records the two measurements that force this
+(#2712, 2026-08-14): the close arm **requires `position_ids`** — without them the
+endpoint returns 400 *"PositionIds must be provided for close action"* — and an open-arm
+quote **does not bound the close-arm cost**, measured dearer on 4 of 5 held positions by
+5.7x, 8.5x, 13.0x and 18.5x. Neither `CoreSleeveState` nor `BrokerInstrumentInvestment`
+carries a position id, so a close quote cannot be constructed from this module's inputs,
+and the one substitution available would under-state a cost bound by an order of
+magnitude — the single direction a cost bound must never be wrong in.
+
+⚠ A refused sell is a REAL limitation of the core arm, not a formality: a rebalance that
+can only buy is half an allocator. What unblocks it is threading position ids from
+`broker_positions` plus a close-side floor rule, and the floor half is **unknown from the
+source** (below). Named here so the submitter inherits a stated gap rather than a
+silence.
+
+### Sequence, and the refusal at each step
+
+1. `broker.get_account_risk_snapshot()` — any exception → `core_account_risk_unavailable`.
+2. Age bound on `snapshot.observed_at` → `core_account_risk_stale`.
+   A stamp further into the future than the skew tolerance is stale, not maximally
+   fresh — `strategy_core_preflight._FUTURE_SKEW`'s rule, for its reason.
+
+   ⚠⚠ **Tested TWICE, and the second time is the binding one.** The entry point takes a
+   `clock`, not a `now`. Codex checkpoint 2 caught the draft that took a single `now` and
+   tested the age only here — before the one call whose duration the bound exists to
+   cover. Since that call is the assembly's only wall clock, the bound could never fire:
+   a what-if delayed by throttling, retries or an uncapped `Retry-After` still returned
+   an ADMITTED verdict on an hour-old snapshot. This first test is a cheap pre-check that
+   avoids spending a write-lane request on an already-stale snapshot; step 7a is the one
+   that binds.
+3. `observe_core_sleeve(snapshot, ...)` — `CoreSleeveObservationError` →
+   `core_account_risk_unobservable`.
+4. **Drift re-proof.** Re-run `evaluate_core_rebalance(mandate, fresh_state)`. If the
+   fresh decision is not the one handed in → `core_sleeve_moved_since_decision`.
+   This is what the account-risk read is FOR; fetching it and not comparing it would be
+   a call with no consequence. Distinct from the submission gate's supersession check,
+   which asks whether a NEWER STORED ROW exists — this asks whether the WORLD still
+   matches the row. It also means a mismatched input decision is REFUSED here rather
+   than raising later out of `resolve_core_trade_size._assert_decision_describes`.
+5. Minimum-currency guard: the eligibility response currency must be USD, else
+   `core_minimum_currency_unsupported`. This runs BEFORE the cost fetch so
+   `effective_open_minimum`'s documented `ValueError` on non-USD stays unreachable —
+   its docstring already contracts that "both callers refuse a mismatch first".
+6. `broker.get_what_if_costs(...)` for the decision's pre-cost amount — any exception →
+   `core_cost_assessment_unavailable`.
+7a. **Re-test the snapshot age against a second clock reading** → `core_account_risk_stale`.
+   Same condition, so deliberately the same code. This is the check the bound is for.
+7. `decode_quoted_trade_cost(...)` — returns a `CoreSizingRefusalCode` on failure, which
+   is passed through unchanged rather than re-coded.
+8. `resolve_core_trade_size(...)` — likewise passes its own refusal code through. Its
+   `_MAX_TICKET_EXTRAPOLATION` guard is what bounds quoting the PRE-cost amount and
+   sizing to a different final amount: a solve landing more than 2x from its own quote
+   refuses rather than extrapolating.
+9. Broker floor: `effective_open_minimum(...)`; `None` →
+   `core_broker_open_minimum_unquoted` (fail closed — `None` means the broker quoted no
+   usable threshold, not that any size is permitted); sized amount below it →
+   `core_below_broker_open_minimum`.
+
+⚠ **No close-side floor exists to apply.** The portal documents both minimums for
+OPENING and says nothing about closing or partial closing (`effective_open_minimum`,
+portal 2026-08-23). That is UNKNOWN, not "no constraint" — and with the sell arm refused
+outright, nothing in this module proceeds through the unknown.
+
+## Source rule — the account-risk age bound
+
+There is no producer cadence to derive from: the snapshot is a LIVE read stamped at
+receipt (`_parse_account_risk_snapshot` takes `observed_at` as a parameter; the payload
+carries no broker valuation stamp). So `strategy_core_preflight._freshness_bound`, which
+derives from a producer's nominal period, does not apply and is deliberately not reused.
+
+⚠⚠ **The first draft derived this bound from the worst-case duration of the intervening
+what-if call. That derivation is unsound and is recorded here so it is not re-attempted.**
+Measured in the transport:
+
+- `get_what_if_costs` posts on `_http_write` (`etoro_broker.py:775`), whose interval is
+  `_ETORO_WRITE_INTERVAL_S = 3.5`, not the 1.1 s read lane.
+- The throttle runs INSIDE the retry loop (`resilient_client.py:186`), so it is paid once
+  per attempt, not once per call.
+- On a 429, `Retry-After` **overrides** the backoff schedule with no upper cap — only a
+  0.1 s floor (`resilient_client.py:259`, `_parse_retry_after`). A server sending
+  `Retry-After: 3600` is honoured three times over.
+
+So the worst case is **unbounded**, and a bound derived from it would be a constant that
+can never fire — decoration wearing a derivation.
+
+The bound is therefore fixed by construction at the **nominal single-attempt duration**
+of the one intervening call:
+
+| input | value | source |
+| --- | --- | --- |
+| one write-lane throttle wait | 3.5 s | `etoro_broker._ETORO_WRITE_INTERVAL_S` |
+| one HTTP round trip | 30.0 s | `etoro_broker` `httpx.Client(timeout=...)` |
+
+`3.5 + 30.0 = 33.5` → **34 s**, rounded up.
+
+⚠ `httpx`'s `timeout=30.0` sets connect, read, write and pool timeouts to 30 s each; it
+is NOT a total wall-clock cap on one attempt. It is used here as a single-phase proxy for
+the nominal round trip, which is what "nominal" means. It is not claimed as a hard bound.
+
+**A retrying call will typically exceed 34 s, and refusing is the intended outcome.** A
+submission whose cost quote needed retries is one whose account view we no longer trust;
+the caller re-runs from a fresh snapshot. The direction matters: this bound is meant to
+bite, whereas one sized to the transport's worst case never would.
+
+⚠ It bounds a STALL, not market movement. Nothing here makes the snapshot and the what-if
+simultaneous, and no second snapshot is taken after the cost call — cash, holdings and
+pending orders can move inside the window and still be admitted. The sleeve-vs-cost
+coherence question is separately bounded, by `decode_quoted_trade_cost`'s
+`cost_quote_stale` against `CoreSleeveState.as_of`.
+
+⚠ Frozen in `CORE_BROKER_PREFLIGHT_POLICY_VERSION`. Widening it is a version bump, never
+an edit to the constant — the rule every stamped policy in this arc already follows.
+
+A coupling test asserts both inputs still hold, so a provider retuning its throttle or
+timeout fails there rather than silently invalidating the derivation. `timeout=30.0` is
+hoisted to a named constant in `etoro_broker.py` for that test to import; the service
+module does NOT import the provider implementation.
+
+## Not carried — stated, not silent
+
+- **Broker rejection**, and the **uncertain-submission resume path**: outcomes of
+  submission.
+- **`max_units_per_order`**: quoted by eligibility in UNITS while this module sizes in
+  currency, so applying it needs the price, which 3b-1 holds and this module does not.
+  Owed to the submitter that holds both.
+- **One-world coherence.** Eligibility, account state, quote, cost quote and the DB
+  preflight are five reads at five instants. The advisory lock serialises OUR actors, not
+  the broker's. The ticket already owes "eligibility read and submission in ONE
+  transaction" and "the intent's absolute freshness bound via one lock hold" to the
+  submitter; this module does not discharge either.
+- **The acting caller.** Shipping the vocabulary before the caller is this arc's
+  established order (3a before 3b, each naming itself AUTHORISES NOTHING).
+- **Any broker mutation.** Both reads are informational and deliberately NOT covered by
+  `refuse_broker_mutation_if_unattended` (#2645).
+
+`CoreSizingContractError` is allowed to propagate rather than being caught into a
+refusal: a decision that does not describe its own (mandate, state) is a CALLER DEFECT,
+the distinction `CoreSleeveObservationError` and `StrategyCorePreflightError` both draw.
+Step 4's drift re-proof means it is unreachable through this module's own path.
+
+## Tests
+
+Pure-logic, table-driven, with a broker double: one test per refusal code; the age-bound
+boundary (exactly at, one second past, and a future stamp beyond skew); pass-through of
+`decode_quoted_trade_cost` and `resolve_core_trade_size` codes; the sell arm refusing
+before any broker call is made; the request shape handed to `get_what_if_costs` (action,
+transaction, settlement type, leverage, amount) asserted against the decision, since the
+response echoes none of them; and the coupling test above.

--- a/tests/test_2603_core_broker_preflight.py
+++ b/tests/test_2603_core_broker_preflight.py
@@ -382,6 +382,50 @@ def test_a_cost_quote_older_than_the_sleeve_valuation_is_passed_through_as_stale
     assert verdict.reason_code == "cost_quote_stale"
 
 
+def test_a_sizing_refusal_with_no_code_raises_rather_than_returning_an_unnamed_one() -> None:
+    """`python -O` strips asserts, and the stripped form of the guard this replaces would
+    return `admitted=False` with `reason_code=None` -- an unnamed refusal, which is the one
+    thing the closed vocabulary exists to prevent."""
+    from app.services import strategy_core_broker_preflight as module
+    from app.services.strategy_core_sizing import CoreSizingResult
+
+    codeless = CoreSizingResult(
+        sized=False,
+        refusal_code=None,
+        amount=Decimal("0"),
+        pre_cost_amount=_EXPECTED_BUY,
+        cost_rate=None,
+        resulting_core_pct_at_bound=None,
+        resulting_core_pct_at_zero_cost=None,
+    )
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(module, "resolve_core_trade_size", lambda *_args, **_kwargs: codeless)
+
+        with pytest.raises(StrategyCoreBrokerPreflightError, match="sizing contract is broken"):
+            assess(FakeBroker())
+
+
+@pytest.mark.parametrize(
+    ("broker_kwargs", "message"),
+    [
+        ({"snapshot_result": RuntimeError("503")}, "account risk snapshot unavailable"),
+        ({"cost_result": RuntimeError("timeout")}, "what-if cost quote unavailable"),
+    ],
+)
+def test_a_swallowed_broker_exception_still_reaches_the_log_with_its_traceback(
+    broker_kwargs: dict[str, Any], message: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The refusal code cannot carry the cause -- a 503 and a TypeError in our own parse
+    collapse to one code -- so a programming bug would otherwise be indistinguishable from
+    a broker outage in production."""
+    caplog.set_level("WARNING")
+
+    assess(FakeBroker(**broker_kwargs))
+
+    record = next(r for r in caplog.records if message in r.getMessage())
+    assert record.exc_info is not None
+
+
 # --- the derivation the age bound rests on ----------------------------------
 
 

--- a/tests/test_2603_core_broker_preflight.py
+++ b/tests/test_2603_core_broker_preflight.py
@@ -1,0 +1,416 @@
+"""#2603 step 3b-2: the BROKER half of the core submission refusal vocabulary.
+
+Pure-logic tier -- no DB, no clock, no network.  The broker is a double whose only job
+is to return a canned answer or raise, because every refusal under test is about what the
+broker SAID, not about how it was reached.
+
+Spec: ``docs/proposals/ta/2026-08-23-core-broker-preflight.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.providers.broker import (
+    BrokerAccountRiskSnapshot,
+    BrokerCostComponent,
+    BrokerInstrumentInvestment,
+    BrokerWhatIfCostResponse,
+    BrokerWhatIfOrder,
+)
+from app.services.broker_settlement_arms import (
+    UNDERLYING_SETTLEMENT_TYPE,
+    UNLEVERAGED_LEVERAGE,
+)
+from app.services.strategy_core_allocator import CoreRebalanceDecision, evaluate_core_rebalance
+from app.services.strategy_core_broker_preflight import (
+    CORE_MAX_ACCOUNT_RISK_AGE_SECONDS,
+    StrategyCoreBrokerPreflightError,
+    assess_core_broker_preflight,
+)
+from app.services.strategy_core_mandate import CORE_MANDATE_POLICY_VERSION, CoreMandate
+
+CORE_ID = 4242
+NOW = datetime(2026, 8, 23, 14, 30, tzinfo=UTC)
+
+# 50% core on a 60+-5 mandate -> buy to the 55 edge: 0.55*1000 - 500 = 50.
+_CORE_MV = "500"
+_CASH = "500"
+_EXPECTED_BUY = Decimal("50")
+
+
+def mandate(*, base_currency: str = "USD", floor: str = "1") -> CoreMandate:
+    return CoreMandate(
+        event_id=1,
+        revision=1,
+        enabled=True,
+        base_currency=base_currency,
+        core_instrument_id=CORE_ID,
+        core_target_pct=Decimal("60"),
+        liquidity_reserve_pct=Decimal("5"),
+        rebalance_band_pct=Decimal("5"),
+        min_rebalance_amount=Decimal(floor),
+        policy_version=CORE_MANDATE_POLICY_VERSION,
+    )
+
+
+def snapshot(
+    *,
+    core_market_value: str = _CORE_MV,
+    cash: str = _CASH,
+    observed_at: datetime = NOW,
+    currency_id: int | None = 1,
+    shorts: int = 0,
+) -> BrokerAccountRiskSnapshot:
+    return BrokerAccountRiskSnapshot(
+        available_cash=Decimal(cash),
+        total_invested=Decimal(core_market_value),
+        unrealized_pnl=Decimal("0"),
+        equity=Decimal(core_market_value) + Decimal(cash),
+        instrument_investments=(
+            BrokerInstrumentInvestment(CORE_ID, Decimal(core_market_value), Decimal(core_market_value), 1, shorts),
+        ),
+        observed_at=observed_at,
+        raw_payload={},
+        account_currency_id=currency_id,
+    )
+
+
+def cost_response(
+    *,
+    amount: str = "0.10",
+    instrument_id: int = CORE_ID,
+    last_updated: datetime = NOW,
+) -> BrokerWhatIfCostResponse:
+    return BrokerWhatIfCostResponse(
+        instrument_id=instrument_id,
+        symbol="IVV",
+        costs=(
+            BrokerCostComponent(
+                cost_type="marketSpread", amount=None, value=Decimal(amount), currency="USD", raw_payload={}
+            ),
+        ),
+        last_updated=last_updated,
+        raw_payload={},
+    )
+
+
+class FakeBroker:
+    """Records what it was asked; raises where a test wants the failure branch."""
+
+    def __init__(
+        self,
+        *,
+        snapshot_result: BrokerAccountRiskSnapshot | Exception | None = None,
+        cost_result: BrokerWhatIfCostResponse | Exception | None = None,
+    ) -> None:
+        self._snapshot = snapshot() if snapshot_result is None else snapshot_result
+        self._cost = cost_response() if cost_result is None else cost_result
+        self.snapshot_calls = 0
+        self.cost_orders: list[BrokerWhatIfOrder] = []
+
+    def get_account_risk_snapshot(self) -> BrokerAccountRiskSnapshot:
+        self.snapshot_calls += 1
+        if isinstance(self._snapshot, Exception):
+            raise self._snapshot
+        return self._snapshot
+
+    def get_what_if_costs(self, order: BrokerWhatIfOrder) -> BrokerWhatIfCostResponse:
+        self.cost_orders.append(order)
+        if isinstance(self._cost, Exception):
+            raise self._cost
+        return self._cost
+
+
+def decision(*, amount: Decimal | None = None) -> CoreRebalanceDecision:
+    """The verdict the intent recorded -- by default the one the world still yields."""
+    fresh = evaluate_core_rebalance(mandate(), _state())
+    if amount is None:
+        return fresh
+    return CoreRebalanceDecision(**{**fresh.__dict__, "amount": amount})
+
+
+def _state() -> Any:
+    from app.services.strategy_core_sleeve import observe_core_sleeve
+
+    return observe_core_sleeve(snapshot(), core_instrument_id=CORE_ID)
+
+
+def assess(broker: FakeBroker, **overrides: Any) -> Any:
+    kwargs: dict[str, Any] = {
+        "mandate": mandate(),
+        "decision": decision(),
+        "core_instrument_id": CORE_ID,
+        "eligibility_response_currency": "USD",
+        "eligibility_min_position_exposure": Decimal("10"),
+        "eligibility_min_position_amount": Decimal("10"),
+        "clock": lambda: NOW,
+    }
+    kwargs.update(overrides)
+    return assess_core_broker_preflight(broker, **kwargs)  # type: ignore[arg-type]
+
+
+# --- the happy path, and the request shape the response cannot echo ----------
+
+
+def test_a_live_buy_is_admitted_and_sized_after_cost() -> None:
+    verdict = assess(FakeBroker())
+
+    assert verdict.admitted is True
+    assert verdict.reason_code is None
+    # Cost is charged, so the solved size is not the pre-cost 50 exactly.
+    assert verdict.amount > Decimal("0")
+    assert verdict.cost_rate is not None
+    assert verdict.snapshot_observed_at == NOW
+
+
+def test_the_what_if_request_is_bound_to_the_decision_field_by_field() -> None:
+    """The response echoes none of these, so nothing downstream can check them."""
+    broker = FakeBroker()
+    assess(broker)
+
+    assert len(broker.cost_orders) == 1
+    order = broker.cost_orders[0]
+    assert order.instrument_id == CORE_ID
+    assert order.action == "open"
+    assert order.transaction == "buy"
+    assert order.settlement_type == UNDERLYING_SETTLEMENT_TYPE
+    assert order.leverage == UNLEVERAGED_LEVERAGE
+    assert order.amount == _EXPECTED_BUY
+    assert order.units is None
+    assert order.position_ids == ()
+
+
+# --- the sell arm -----------------------------------------------------------
+
+
+def test_a_sell_refuses_before_any_broker_call_is_spent() -> None:
+    """#2712: the close arm needs position ids we do not hold, and an open quote
+    under-states the close cost by up to 18.5x.  Refusing early also keeps a request
+    we know returns 400 off the write lane."""
+    broker = FakeBroker()
+    sell = CoreRebalanceDecision(**{**decision().__dict__, "action": "sell_core"})
+
+    verdict = assess(broker, decision=sell)
+
+    assert verdict.reason_code == "core_close_side_cost_quote_unavailable"
+    assert verdict.admitted is False
+    assert broker.snapshot_calls == 0
+    assert broker.cost_orders == []
+
+
+@pytest.mark.parametrize("action", ["hold", "refused"])
+def test_a_decision_that_is_not_a_trade_is_a_caller_bug_and_not_a_refusal(action: str) -> None:
+    """Folding it into the vocabulary would make a caller learn about its own defect by
+    catching a code that means the broker said something."""
+    broker = FakeBroker()
+    not_a_trade = CoreRebalanceDecision(**{**decision().__dict__, "action": action})
+
+    with pytest.raises(StrategyCoreBrokerPreflightError, match="only a trade"):
+        assess(broker, decision=not_a_trade)
+
+    assert broker.snapshot_calls == 0
+
+
+def test_an_instrument_that_is_not_the_mandates_keeps_the_allocators_own_code() -> None:
+    """The sleeve is observed for the id the caller named, so a mismatch must surface
+    as `sleeve_instrument_mismatch` rather than as a cost quote for the wrong name."""
+    verdict = assess(FakeBroker(), core_instrument_id=CORE_ID + 1)
+
+    assert verdict.reason_code == "sleeve_instrument_mismatch"
+
+
+# --- account risk -----------------------------------------------------------
+
+
+def test_an_unreachable_account_is_one_condition_however_it_failed() -> None:
+    verdict = assess(FakeBroker(snapshot_result=RuntimeError("503")))
+
+    assert verdict.reason_code == "core_account_risk_unavailable"
+    assert verdict.snapshot_observed_at is None
+
+
+@pytest.mark.parametrize(
+    ("age_seconds", "expected"),
+    [
+        (CORE_MAX_ACCOUNT_RISK_AGE_SECONDS, None),
+        (CORE_MAX_ACCOUNT_RISK_AGE_SECONDS + 1, "core_account_risk_stale"),
+    ],
+)
+def test_the_age_bound_is_inclusive_at_the_bound_and_refuses_one_second_past(
+    age_seconds: int, expected: str | None
+) -> None:
+    broker = FakeBroker(snapshot_result=snapshot(observed_at=NOW - timedelta(seconds=age_seconds)))
+
+    verdict = assess(broker)
+
+    assert verdict.reason_code == expected
+
+
+def test_a_stamp_far_in_the_future_is_stale_and_not_maximally_fresh() -> None:
+    """Without this a corrupted future timestamp never ages out."""
+    broker = FakeBroker(snapshot_result=snapshot(observed_at=NOW + timedelta(seconds=6)))
+
+    verdict = assess(broker)
+
+    assert verdict.reason_code == "core_account_risk_stale"
+
+
+def test_a_stamp_inside_the_skew_tolerance_is_still_usable() -> None:
+    broker = FakeBroker(snapshot_result=snapshot(observed_at=NOW + timedelta(seconds=4)))
+
+    assert assess(broker).admitted is True
+
+
+def test_a_naive_stamp_refuses_rather_than_raising_on_the_subtraction() -> None:
+    broker = FakeBroker(snapshot_result=snapshot(observed_at=NOW.replace(tzinfo=None)))
+
+    verdict = assess(broker)
+
+    assert verdict.reason_code == "core_account_risk_unobservable"
+
+
+def test_a_snapshot_that_cannot_describe_the_sleeve_refuses() -> None:
+    """A direct short on the core instrument: `observe_core_sleeve` raises, and this
+    module turns a raise into a verdict rather than propagating it."""
+    broker = FakeBroker(snapshot_result=snapshot(shorts=1))
+
+    verdict = assess(broker)
+
+    assert verdict.reason_code == "core_account_risk_unobservable"
+    assert verdict.snapshot_observed_at == NOW
+
+
+# --- drift ------------------------------------------------------------------
+
+
+def test_a_decision_the_world_no_longer_yields_is_refused_as_drift() -> None:
+    """The recorded amount is stale against a sleeve that has since moved.  Refusing
+    here is what makes `_assert_decision_describes` unreachable from this path."""
+    verdict = assess(FakeBroker(), decision=decision(amount=Decimal("49")))
+
+    assert verdict.reason_code == "core_sleeve_moved_since_decision"
+
+
+def test_the_broker_floor_biting_keeps_the_allocators_own_code() -> None:
+    """`below_min_rebalance_amount` is the floor refusing, and it is passed through
+    rather than re-coded -- two names on one condition loses which layer decided."""
+    broker = FakeBroker()
+
+    verdict = assess(broker, eligibility_min_position_exposure=Decimal("100"))
+
+    assert verdict.reason_code == "below_min_rebalance_amount"
+    assert broker.cost_orders == []
+
+
+def test_an_unquoted_minimum_fails_closed_and_is_not_passed_on_as_no_minimum() -> None:
+    """`effective_open_minimum` returning None means the broker quoted no usable
+    threshold; the allocator's `broker_minimum=None` means the CALLER has none to
+    supply.  Conflating them reads an unanswered question as an answered one."""
+    verdict = assess(
+        FakeBroker(),
+        eligibility_min_position_exposure=None,
+        eligibility_min_position_amount=None,
+    )
+
+    assert verdict.reason_code == "core_broker_open_minimum_unquoted"
+
+
+def test_a_non_usd_eligibility_response_refuses_before_the_minimum_can_raise() -> None:
+    verdict = assess(FakeBroker(), eligibility_response_currency="GBP")
+
+    assert verdict.reason_code == "core_minimum_currency_unsupported"
+
+
+def test_the_binding_age_check_runs_after_the_cost_call_not_before_it() -> None:
+    """The regression this module's whole bound exists for.  An earlier draft tested the
+    age once, on entry -- i.e. before the ONE call whose duration the bound covers -- so a
+    request delayed by throttling, retries or an uncapped `Retry-After` still returned an
+    ADMITTED verdict on an arbitrarily old snapshot.  The clock is read twice; this fake
+    advances past the bound only on the second reading."""
+    readings = iter([NOW, NOW + timedelta(seconds=CORE_MAX_ACCOUNT_RISK_AGE_SECONDS + 1)])
+    broker = FakeBroker()
+
+    verdict = assess(broker, clock=lambda: next(readings))
+
+    assert verdict.reason_code == "core_account_risk_stale"
+    assert verdict.admitted is False
+    # The pre-check passed, so the request WAS spent -- which is what makes the second
+    # check the one that binds.
+    assert len(broker.cost_orders) == 1
+
+
+def test_a_slow_cost_call_that_stays_inside_the_bound_is_still_admitted() -> None:
+    """The bound must bite on a stall without refusing an ordinary round trip."""
+    readings = iter([NOW, NOW + timedelta(seconds=CORE_MAX_ACCOUNT_RISK_AGE_SECONDS)])
+
+    assert assess(FakeBroker(), clock=lambda: next(readings)).admitted is True
+
+
+# --- cost -------------------------------------------------------------------
+
+
+def test_an_unreachable_cost_endpoint_refuses_after_the_snapshot_was_taken() -> None:
+    broker = FakeBroker(cost_result=RuntimeError("timeout"))
+
+    verdict = assess(broker)
+
+    assert verdict.reason_code == "core_cost_assessment_unavailable"
+    assert verdict.snapshot_observed_at == NOW
+
+
+def test_a_decode_refusal_is_passed_through_with_the_sizing_layers_own_code() -> None:
+    """The response is for a different instrument -- the one identity the decoder can
+    check.  `cost_quote_unusable` is the sizing layer's code and stays its code."""
+    broker = FakeBroker(cost_result=cost_response(instrument_id=CORE_ID + 1))
+
+    verdict = assess(broker)
+
+    assert verdict.reason_code == "cost_quote_unusable"
+    assert verdict.admitted is False
+
+
+def test_a_cost_quote_older_than_the_sleeve_valuation_is_passed_through_as_stale() -> None:
+    broker = FakeBroker(cost_result=cost_response(last_updated=NOW - timedelta(hours=2)))
+
+    verdict = assess(broker)
+
+    assert verdict.reason_code == "cost_quote_stale"
+
+
+# --- the derivation the age bound rests on ----------------------------------
+
+
+def test_the_age_bound_still_matches_the_transport_it_was_derived_from() -> None:
+    """A coupling test, not a restatement: the bound is one write-lane throttle wait
+    plus one nominal HTTP round trip, and a provider retuning either must fail HERE
+    rather than silently invalidating the derivation.
+
+    ⚠ It deliberately does NOT assert a worst case.  The throttle is paid once per
+    ATTEMPT and `Retry-After` overrides the backoff with no upper cap, so no worst case
+    exists to bound -- see the constant's docstring.
+    """
+    from app.providers.implementations.etoro_broker import (
+        _ETORO_HTTP_TIMEOUT_S,
+        _ETORO_WRITE_INTERVAL_S,
+    )
+
+    assert _ETORO_WRITE_INTERVAL_S == 3.5
+    assert _ETORO_HTTP_TIMEOUT_S == 30.0
+    assert CORE_MAX_ACCOUNT_RISK_AGE_SECONDS == 34
+
+
+def test_the_what_if_call_is_on_the_write_lane_the_bound_assumes() -> None:
+    """The first draft of the bound used the 1.1s READ interval.  `get_what_if_costs`
+    is an informational POST on `_http_write`, so it pays 3.5s."""
+    import inspect
+
+    from app.providers.implementations import etoro_broker
+
+    source = inspect.getsource(etoro_broker.EtoroBrokerProvider.get_what_if_costs)
+    assert "_http_write.post" in source
+    assert "_http_read" not in source


### PR DESCRIPTION
## What

Step 3b-2 of #2603's execution arc: the **broker half** of the core submission refusal
vocabulary.

Step 3b-1 (`strategy_core_preflight.py`) is the DB-and-clock half, and it closes by naming
what it leaves out — *"account-risk availability, broker minimums, cost assessment and
broker rejection"*. The minimum landed separately (`578e5393`). This PR ships the other
two preflight-shaped ones. **Broker rejection is deliberately excluded**: it is an OUTCOME
of submission, not a precondition, and belongs with the submitter alongside the
uncertain-submission resume path.

New module `app/services/strategy_core_broker_preflight.py`: fetch the account-risk
snapshot, re-derive the rebalance from the freshly observed sleeve, fetch the what-if cost
quote, and return either a cost-adjusted size or one named refusal.

**It authorises nothing.** No caller in `app/` or `scripts/`; it writes nothing. Shipping
the vocabulary before the caller is this arc's established order (3a before 3b, each
naming itself the same way).

## Why the premise was re-checked, not inherited

The step-3b-2 close-out comment listed what was still owed. Re-measured against the tree
before speccing:

| owed item | measured | verdict |
| --- | --- | --- |
| account-risk | `get_account_risk_snapshot` callers: `strategy_paper_executor.py:1183`, `:305`, `scheduler.py:5748` (the core-sleeve OBSERVATION chain) | no submission-time re-read on the core arm — confirmed absent |
| cost assessment | `get_what_if_costs` callers: `strategy_paper_executor.py:1206` + two `scripts/` probes | `decode_quoted_trade_cost` was a decoder with no producer on this arm — confirmed |
| broker minimum | `effective_open_minimum` callers: `strategy_paper_executor.py:656` only | shipped, but unreachable from the core arm until this module calls it |

## ⚠⚠ BUY ONLY — a real limitation, named rather than papered over

`sell_core` returns `core_close_side_cost_quote_unavailable` before any broker call.

`BrokerWhatIfOrder`'s docstring carries the two measurements that force it (#2712,
2026-08-14): the close arm **requires `position_ids`** (400 without them), and an open-arm
quote **does not bound** the close-arm cost — measured dearer on 4 of 5 held positions by
5.7x, 8.5x, 13.0x and 18.5x. Neither `CoreSleeveState` nor `BrokerInstrumentInvestment`
carries a position id, so no close quote is constructible from this module's inputs, and
the one substitution available would under-state a cost bound by an order of magnitude —
the single direction a cost bound must never be wrong in.

A rebalance that can only buy is half an allocator. What unblocks it: position ids
threaded from `broker_positions`, plus a close-side floor rule — and the floor half is
**unknown from the source**, since the portal documents both minimums for OPENING only.

## Source rule — the account-risk age bound, and two wrong derivations

There is no producer cadence to derive from: the snapshot is a live read stamped at
receipt (`_parse_account_risk_snapshot` takes `observed_at` as a parameter; the payload
carries no broker valuation stamp). So `strategy_core_preflight._freshness_bound`, which
derives from a producer's nominal PERIOD, does not apply and is not reused.

The bound is fixed **by construction** at **34 s** = one write-lane throttle wait (3.5 s,
`_ETORO_WRITE_INTERVAL_S`) + one nominal HTTP round trip (30.0 s, `_ETORO_HTTP_TIMEOUT_S`),
rounded up. Both wrong drafts are recorded in the constant's docstring so neither is
re-attempted:

1. **A worst-case derivation is unsound.** Measured in the transport: `get_what_if_costs`
   posts on `_http_write` (3.5 s), *not* the 1.1 s read lane the first draft used; the
   throttle is paid once per **attempt** (`resilient_client.py:186`); and on a 429
   `Retry-After` **overrides** the backoff with no upper cap (`:259`, only a 0.1 s floor).
   The worst case is therefore unbounded, and a constant derived from it could never fire
   — decoration wearing a derivation.
2. **Testing the age once, on entry, checks it before the one call whose duration the
   bound exists to cover.** A what-if delayed by throttling or retries still returned an
   ADMITTED verdict on an arbitrarily old snapshot. The entry point therefore takes a
   `clock`, not a `now`; the first reading is a cheap pre-check that avoids spending a
   write-lane request, and **the reading after the cost call is the binding one**.

Both were caught by Codex (checkpoints 1 and 2). Neither is a thing a diff reviewer sees.

⚠ `httpx`'s `timeout=30.0` is applied to connect/read/write/pool **individually** — not a
total wall-clock cap. It is used as a single-phase proxy for the nominal round trip, which
is what "nominal" means, and is not claimed as a hard bound.

⚠ The bound catches a **stall**, not market movement. No second snapshot is taken after
the cost call. The sleeve-vs-cost coherence question is separately bounded, by
`decode_quoted_trade_cost` refusing `cost_quote_stale` against `CoreSleeveState.as_of`.

A coupling test asserts both derivation inputs still hold, so a provider retuning either
fails there rather than silently invalidating the bound.

## Design notes

- **The broker floor is applied inside the allocator**, by passing `effective_open_minimum`
  into `evaluate_core_rebalance`, which already owns the precedence between it and the
  mandate's own minimum and reports which one bound. A second comparison here would be a
  copy of that rule. So the floor biting surfaces as the allocator's own
  `below_min_rebalance_amount`.
- **`None` from `effective_open_minimum` fails closed** (`core_broker_open_minimum_unquoted`).
  It means the broker quoted no usable threshold, whereas `evaluate_core_rebalance`'s
  `broker_minimum=None` means the CALLER has none to supply. Passing the first through as
  the second would read an unanswered question as an answered one.
- **Non-USD eligibility refuses before `effective_open_minimum` can raise**, honouring that
  function's documented contract that "both callers refuse a mismatch first". #2603 scope
  item 4 is the change that revisits it.
- **A `hold` or `refused` decision raises rather than refusing.** Asking to preflight a
  non-trade is a caller defect, the distinction `StrategyCorePreflightError` and
  `CoreSleeveObservationError` both draw; folding it into the vocabulary would make a
  caller learn about its own bug by catching a code that means the broker said something.
- **The recorded decision is not trusted as a sizing input.** The rebalance is re-derived
  from the fresh sleeve, so a decision whose sleeve has moved is REFUSED
  (`core_sleeve_moved_since_decision`) rather than raising later out of
  `resolve_core_trade_size._assert_decision_describes`.

## Not carried — stated, not silent

Broker rejection and the uncertain-submission resume path (outcomes of submission);
`maxUnitsPerOrder` (quoted in units while this sizes in currency, so it needs the price
3b-1 holds); and any coherence guarantee across the five reads informing a submission —
the advisory lock serialises our actors, not the broker's. The ticket already owes
"eligibility read and submission in ONE transaction" to the submitter, and this does not
discharge it.

## Incidental

- `UNDERLYING_SETTLEMENT_TYPE` / `UNDERLYING_DIRECTION` / `UNLEVERAGED_LEVERAGE` gain
  `Final`. Load-bearing, not decoration: without it pyright widens to `str`, and a caller
  passing it to `BrokerWhatIfOrder.settlement_type` (a `Literal`) fails to typecheck —
  which pushes that caller into re-typing `"real"` inline, i.e. back into the second copy
  `broker_settlement_arms` exists to prevent.
- `etoro_broker`'s `timeout=30.0` hoisted to `_ETORO_HTTP_TIMEOUT_S` so the coupling test
  can import it. An unnamed literal makes the derivation unverifiable.

## Security model

No new authority and no new surface. Both broker calls are informational reads
(`/trading/info/…`) and are deliberately outside
`refuse_broker_mutation_if_unattended` — #2645's other half was that ruling informational
work out was itself the error. Nothing here mutates broker or DB state, and the module has
no caller, so no path runs from it to an order. The execution guard, kill switch and
sandbox boundary are untouched.

## Testing

- `tests/test_2603_core_broker_preflight.py` — 24 pure-logic tests, no DB, no network:
  one per refusal code; the age bound at, and one second past, the boundary; a future
  stamp beyond skew; the binding check running AFTER the cost call (with the request
  provably spent); the sell arm refusing before any broker call; the `get_what_if_costs`
  request shape asserted field-by-field against the decision, since the response echoes
  none of it; pass-through of the sizing and allocator codes; and the coupling test on the
  bound's two derivation inputs.
- `uv run ruff check .`, `ruff format --check .`, `uv run pyright` — clean.
- `uv run pytest -m "not db"` — exit 0. `uv run pytest tests/smoke` — exit 0.

DoD clauses 8-12 (ETL/parser/schema) do not apply: no migration, no parser, no ingest
path, no stored output changed.

Refs #2603. Refs #2437.
