### PR TITLE
fix(#2374): a closing keyword with a partitive qualifier closes the whole issue

### DIFF
--- a/scripts/check_pr_issue_link.sh
+++ b/scripts/check_pr_issue_link.sh
@@ -23,6 +23,25 @@ if printf '%s\n' "$body_clean" | perl -ne '
   exit 1
 fi
 
+# GitHub reads only the two tokens "KEYWORD #N" and stops. A partitive
+# qualifier after the reference ("Fixes #2176's class 4", "Closes #1233's PR8
+# milestone") means the author is shipping PART of the issue, but GitHub closes
+# the whole thing on merge. PR #2373 closed #2176 this way while its own body
+# said "Refs #2176" and "classes 1 and 3 are untouched"; PR #1244 closed #1233,
+# which needed two reopens. Measured over the last 1000 merged PRs, this pattern
+# fires exactly twice and both are those incidents.
+#
+# \xe2\x80\x99 is a curly apostrophe. perl runs without -C here, so the body is
+# bytes and the literal character would trip shellcheck SC1112 besides.
+if printf '%s\n' "$body_clean" | perl -ne '
+  $found = 1 if /(?:^|[^\w-])(?:close[sd]?|closing|fix(?:e[sd]|ing)?|resolve[sd]?|resolving)[ \t:]+#\d+(?![0-9])[ \t]*(?:'"'"'s|\xe2\x80\x99s|(?:item|items|step|steps|class|classes|part|parts|phase|clause|arm|leg|half)\b)/i;
+  END { exit(!$found) }
+'; then
+  echo "::error::PR body closes an issue but describes only PART of it. GitHub reads 'KEYWORD #N' and closes the whole issue, ignoring the qualifier that follows."
+  echo "Use 'Refs #N' or 'Part of #N' and describe the part in prose without a closing verb."
+  exit 1
+fi
+
 # Pull every #N out of the title. Empty title means no required issue link.
 title_nums=()
 while IFS= read -r issue_number; do

--- a/tests/test_pr_issue_link_gate.py
+++ b/tests/test_pr_issue_link_gate.py
@@ -51,6 +51,56 @@ def test_explicit_non_closing_and_closing_forms_pass() -> None:
     assert _run("fix(#2741): guard links", "Nothing unusual. Closes #2741.").returncode == 0
 
 
+def test_exact_2373_partial_close_incident_is_refused() -> None:
+    result = _run(
+        "fix(#2176): an Item 403 row must name a beneficial owner",
+        "## Issue reference\n\nRefs #2176.\n\n"
+        "Fixes #2176's class 4 (Total rows stored as beneficial owners) and the "
+        "residue of class 2. Classes 1 and 3 are untouched, so the issue stays open.",
+    )
+    assert result.returncode == 1
+    assert "describes only PART of it" in result.stdout
+
+
+def test_exact_1244_partial_close_incident_is_refused() -> None:
+    result = _run(
+        "feat(#1233): PR8 — N-CSR 730d retention cap",
+        "Per spec 6.3 no existing rows shift.\n\nCloses #1233's PR8 milestone.",
+    )
+    assert result.returncode == 1
+
+
+def test_partitive_qualifiers_after_a_closing_reference_are_refused() -> None:
+    for body in (
+        "Fixes #2741 item 3.",
+        "Closes #2741 step 2.",
+        "Resolves #2741 phase 1.",
+        "Fixes #2741 class 4.",
+        "Closes #2741 arm B.",
+        "Fixes #2741’s second half.",
+    ):
+        assert _run("fix(#2741): guard links", body).returncode == 1, body
+
+
+def test_partitive_guard_does_not_fire_across_a_line_break() -> None:
+    # PR #2875: "## What this fixes" heading, then "#2833 step 2's pass bar" on a
+    # later line. GitHub did not close #2833 and neither should the gate fire.
+    body = "## What this fixes\n\n#2833 step 2's pass bar moved.\n\nRefs #2833."
+    assert _run("fix(#2833): accumulate the spread sample", body).returncode == 0
+
+
+def test_partitive_guard_does_not_treat_a_hyphenated_word_as_a_keyword() -> None:
+    # PR #2361: "silently un-fixed #2169's own accession" is prose, not a link.
+    body = "Refs #2169.\n\nThe first draft silently un-fixed #2169's own accession."
+    assert _run("fix(#2169): block markup", body).returncode == 0
+
+
+def test_plain_closing_and_non_closing_forms_are_unaffected() -> None:
+    assert _run("fix(#2741): guard links", "Closes #2741.").returncode == 0
+    assert _run("fix(#2741): guard links", "Refs #2741. Part of #2832.").returncode == 0
+    assert _run("fix(#2741): guard links", "Closes #2741 and nothing else.").returncode == 0
+
+
 def test_missing_title_issue_reference_still_fails() -> None:
     result = _run("fix(#2741): guard links", "Refs #9999.")
     assert result.returncode == 1


### PR DESCRIPTION
## Issue reference

Closes #2374.

## The ticket's premise is falsified

#2374 says a `fix(#N):` **title** auto-closes `#N`. Measured over the last 1000 merged PRs, it does not.

378 have a title of the shape `fix(#N):` / `closes(#N):` / `resolves(#N):`. **86 of them left `#N` out of GitHub's own `closingIssuesReferences`** — `fix(#2603 step 3b-2)` (PR #2886, #2603 still open), `fix(#2859)` (PR #2878), `fix(#2602)` (PR #2851). The squash-commit path does not close them either: of those 86, five issues closed within 120 s of merge and every one has `commit_id = null`, i.e. a manual close by the author.

GitHub's parser reads the pull request **description** and commit messages, not the title. So this ticket's option 2 (drop the `#` from titles) would have changed nothing, and its preferred option 1 (title-vs-body contradiction check) guards a path that is not live.

## What actually closed #2176

PR #2373's body, verbatim:

```
Refs #2176.

Fixes #2176's class 4 (`Total` rows stored as beneficial owners) and the residue
of class 2. Classes 1 and 3 are untouched, so the issue stays open.
```

GitHub reads the two tokens `Fixes` `#2176` and stops. The qualifier that makes it a *partial* fix is invisible to the parser, so the issue closed and had to be reopened by hand. Same failure family as #2740's `does not close #2493`, which the negation guard in `scripts/check_pr_issue_link.sh` already covers — the author wrote a sentence, GitHub read a link.

The existing gate only asks whether *some* verb links each title-referenced `#N`. It never notices a closing verb and a non-closing verb on the same number.

## Source rule

GitHub's own `closingIssuesReferences` field on the PR is the authoritative parse — it is what the merge acts on. Every claim above is measured against that field rather than against a regex of my own, which matters because my first two candidate regexes disagreed with it.

## The rule was picked by its reject-side census, not by taste

Three candidates, each replayed over the same 1000 merged PRs:

| candidate rule | fires / 1000 | verdict |
| --- | ---: | --- |
| body carries both a closing and a non-closing verb for the same `#N` | 22 | over-matches GitHub's parser — PRs #2875, #2615, #2233 flagged where GitHub closed nothing |
| `closingIssuesReferences` ∩ body non-closing verbs | 19 | only 4 of 19 targets ever needed a reopen |
| **closing verb + `#N` + a partitive qualifier** | **2** | **both true positives** |

The shipped rule is the third: a closing keyword whose reference is followed by `'s` / `’s` or one of `item(s)`, `step(s)`, `class(es)`, `part(s)`, `phase`, `clause`, `arm`, `leg`, `half`.

Its two fires are PR #2373 → #2176 (reopened by hand; this ticket) and PR #1244 → #1233 (reopened twice).

Two boundary bugs were the entire gap between 4 fires and 2, and both are now covered by a test:

- `[\s:]+` crossed a newline, so a `## What this fixes` heading matched a `#2833` on a later line (PR #2875 — which GitHub did **not** close). Separator is now `[ \t:]+`.
- `un-fixed #2169's own accession` matched as the keyword `fixed` (PR #2361). Left boundary is now `[^\w-]`, so a hyphenated word is prose.

## Full-population verification

Replayed all 1000 merged PR bodies through **the shipped script**, not a Python model of it:

```
merged PRs replayed through the shipped script: 1000
partitive guard fires: 2
   PR 2373 | fix(#2176): an Item 403 row must name a beneficial owner, an
   PR 1244 | feat(#1233): PR8 — N-CSR 730d retention cap at every chokepo
```

Zero false positives. Re-run after the byte-escape change below: same two.

## Changes

- `scripts/check_pr_issue_link.sh` — new guard between the negation guard and the link check. Message names the failure and prescribes the rewrite (`Refs #N` plus prose).
- `tests/test_pr_issue_link_gate.py` — both incidents pinned verbatim, the partitive vocabulary table-tested, and the two boundary bugs pinned as **passing** cases so a future widening of the regex fails the suite.

⚠ The curly apostrophe is written `\xe2\x80\x99` rather than literally: `perl` runs without `-C` here so the body is bytes, and the literal character trips `shellcheck` SC1112. The `’s` case is exercised by a test, so the escape is verified rather than assumed.

## What this does not do

It does not catch a plain over-broad `Closes #N` on genuinely partial work — nothing in the body distinguishes that from a correct closure, and the 19-fire candidate above is what trying to catch it costs. This closes the one shape that is unambiguous: the author wrote the qualifier down.

## Security model

None. A CI gate reading two environment variables; no credentials, no network, no data path.

## Checks

- `shellcheck -S warning scripts/check_pr_issue_link.sh` — clean
- `uv run pytest tests/test_pr_issue_link_gate.py` — exit 0
- `uv run ruff check .` / `ruff format --check .` / `uv run pyright` — clean
- pre-push gate green (dev-DB size warning only, pre-existing)

Refs #2437.
