### PR TITLE
fix(#2783): a stacked PR now gets every gate, and an inert closing reference is loud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+  # No ``branches:`` filter on pull_request. That filter matches the BASE, so a
+  # PR stacked on another branch used to get no CI at all and ``gh pr checks``
+  # reported "no checks reported" — indistinguishable from "not finished yet".
+  # See #2783.
   pull_request:
-    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,9 +1,12 @@
 name: Claude PR Review
 
 on:
+  # No ``branches:`` filter — see #2783. That filter matches the BASE, so a PR
+  # stacked on another branch never triggered this workflow, and safe_merge's
+  # ``bot_comment`` gate then waited forever for a comment that could not be
+  # posted. Four such PRs (#2773 #2776 #2777 #2782) were merged by hand.
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    branches: [main]
 
 jobs:
   review:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -6,8 +6,8 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"
+  # No ``branches:`` filter on pull_request — see #2783.
   pull_request:
-    branches: [main]
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -13,10 +13,14 @@ name: PR issue link
 #
 #   This workflow blocks that drift at the PR gate. See #935 / #942.
 
+#   A PR stacked on a non-default base gets no closing references at all
+#   (GitHub registers them only against the default branch), so ``Closes #N``
+#   is inert there and ``safe_merge``'s ``done_everywhere`` boards nothing.
+#   The gate must therefore run on EVERY base, not just main. See #2783.
+
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [main]
 
 permissions:
   contents: read
@@ -31,4 +35,6 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: bash scripts/check_pr_issue_link.sh

--- a/scripts/check_pr_issue_link.sh
+++ b/scripts/check_pr_issue_link.sh
@@ -8,6 +8,20 @@ pr_body=${PR_BODY:-}
 pr_base=${PR_BASE:-}
 default_branch=${DEFAULT_BRANCH:-}
 
+# Two closing-verb alternations, deliberately NOT the same one, exported so the
+# perl guards below read them as $ENV{...} rather than each carrying a copy.
+#
+#   GITHUB  — GitHub's actual closing keywords. Gerunds are NOT among them, so
+#             this is the list to use when asking "what will GitHub really close".
+#   PROSE   — the same plus gerunds, for guards that detect an author's SENTENCE
+#             ("without closing #N") rather than a link GitHub would act on.
+#
+# Widening GITHUB to match PROSE would make the inert-reference guard refuse
+# phrasings GitHub ignores. Narrowing PROSE to match GITHUB would let the
+# negation guard miss "land without closing #N". Keep them apart.
+export CLOSING_VERBS_GITHUB='close[sd]?|fix(?:e[sd])?|resolve[sd]?'
+export CLOSING_VERBS_PROSE='close[sd]?|closing|fix(?:e[sd]|ing)?|resolve[sd]?|resolving'
+
 # Strip HTML comments + fenced code blocks + inline code so examples cannot
 # satisfy the link gate or trigger the negation incident guard.
 body_clean=$(printf '%s' "$pr_body" | perl -0pe 's/<!--.*?-->//gs; s/```.*?```//gs; s/`[^`]*`//g')
@@ -17,7 +31,7 @@ body_clean=$(printf '%s' "$pr_body" | perl -0pe 's/<!--.*?-->//gs; s/```.*?```//
 # followed on the same line by a closing keyword reference; require an explicit
 # Refs/Part of/Umbrella form instead.
 if printf '%s\n' "$body_clean" | perl -ne '
-  $found = 1 if /(?:^|[^\w])(?:not|never|without|doesn.t|don.t|didn.t|won.t|wouldn.t|shouldn.t|mustn.t|can.t|cannot)(?!\w)[^#\r\n]{0,80}(?:^|[^\w])(?:close[sd]?|closing|fix(?:e[sd]|ing)?|resolve[sd]?|resolving)[\s:]+#\d+/i;
+  $found = 1 if /(?:^|[^\w])(?:not|never|without|doesn.t|don.t|didn.t|won.t|wouldn.t|shouldn.t|mustn.t|can.t|cannot)(?!\w)[^#\r\n]{0,80}(?:^|[^\w])(?:$ENV{CLOSING_VERBS_PROSE})[\s:]+#\d+/i;
   END { exit(!$found) }
 '; then
   echo "::error::PR body contains a negated closing-keyword reference. GitHub ignores negation and may close the issue on merge."
@@ -36,7 +50,7 @@ fi
 # \xe2\x80\x99 is a curly apostrophe. perl runs without -C here, so the body is
 # bytes and the literal character would trip shellcheck SC1112 besides.
 if printf '%s\n' "$body_clean" | perl -ne '
-  $found = 1 if /(?:^|[^\w-])(?:close[sd]?|closing|fix(?:e[sd]|ing)?|resolve[sd]?|resolving)[ \t:]+#\d+(?![0-9])[ \t]*(?:'"'"'s|\xe2\x80\x99s|(?:item|items|step|steps|class|classes|part|parts|phase|clause|arm|leg|half)\b)/i;
+  $found = 1 if /(?:^|[^\w-])(?:$ENV{CLOSING_VERBS_PROSE})[ \t:]+#\d+(?![0-9])[ \t]*(?:'"'"'s|\xe2\x80\x99s|(?:item|items|step|steps|class|classes|part|parts|phase|clause|arm|leg|half)\b)/i;
   END { exit(!$found) }
 '; then
   echo "::error::PR body closes an issue but describes only PART of it. GitHub reads 'KEYWORD #N' and closes the whole issue, ignoring the qualifier that follows."
@@ -54,7 +68,7 @@ fi
 # Both env vars absent (a local run) disables the check rather than guessing.
 if [ -n "$pr_base" ] && [ -n "$default_branch" ] && [ "$pr_base" != "$default_branch" ]; then
   inert=$(printf '%s\n' "$body_clean" | perl -ne '
-    while (/(?:^|[^\w-])(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[ \t:]+#(\d+)(?![0-9])/ig) {
+    while (/(?:^|[^\w-])(?:$ENV{CLOSING_VERBS_GITHUB})[ \t:]+#(\d+)(?![0-9])/ig) {
       print "$1\n";
     }
   ' | sort -un | paste -sd' ' -)

--- a/scripts/check_pr_issue_link.sh
+++ b/scripts/check_pr_issue_link.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 pr_title=${PR_TITLE:-}
 pr_body=${PR_BODY:-}
+pr_base=${PR_BASE:-}
+default_branch=${DEFAULT_BRANCH:-}
 
 # Strip HTML comments + fenced code blocks + inline code so examples cannot
 # satisfy the link gate or trigger the negation incident guard.
@@ -40,6 +42,27 @@ if printf '%s\n' "$body_clean" | perl -ne '
   echo "::error::PR body closes an issue but describes only PART of it. GitHub reads 'KEYWORD #N' and closes the whole issue, ignoring the qualifier that follows."
   echo "Use 'Refs #N' or 'Part of #N' and describe the part in prose without a closing verb."
   exit 1
+fi
+
+# GitHub registers closing references only for PRs targeting the DEFAULT branch.
+# On a stacked PR "Closes #N" is inert: closingIssuesReferences comes back empty,
+# so safe_merge's done_everywhere closes nothing and boards nothing, silently.
+# Measured over the last 1000 merged PRs: 4 had a non-main base, 2 of those
+# declared a closing keyword (#2782 -> #2779, #2773 -> #2775) and both were
+# registered as closing NOTHING. See #2783.
+#
+# Both env vars absent (a local run) disables the check rather than guessing.
+if [ -n "$pr_base" ] && [ -n "$default_branch" ] && [ "$pr_base" != "$default_branch" ]; then
+  inert=$(printf '%s\n' "$body_clean" | perl -ne '
+    while (/(?:^|[^\w-])(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[ \t:]+#(\d+)(?![0-9])/ig) {
+      print "$1\n";
+    }
+  ' | sort -un | paste -sd' ' -)
+  if [ -n "$inert" ]; then
+    echo "::error::PR base is '${pr_base}', not the default branch '${default_branch}'. GitHub registers closing references only against the default branch, so these are INERT and will close nothing on merge: ${inert}"
+    echo "Retarget the PR at '${default_branch}', or use 'Refs #N' and close the issue by hand once the stack lands."
+    exit 1
+  fi
 fi
 
 # Pull every #N out of the title. Empty title means no required issue link.

--- a/tests/test_pr_issue_link_gate.py
+++ b/tests/test_pr_issue_link_gate.py
@@ -143,6 +143,21 @@ def test_every_closing_verb_is_reported_inert_on_a_stacked_base() -> None:
     assert "2783" not in result.stdout
 
 
+def test_a_gerund_is_prose_to_github_so_the_inert_guard_ignores_it() -> None:
+    # GitHub's closing keywords are close/closes/closed, fix/fixes/fixed and
+    # resolve/resolves/resolved — no gerunds. So "Closing #N" registers nothing
+    # and is not inert. The negation guard DOES read gerunds (it matches an
+    # author's sentence), which is why the two alternations must stay distinct.
+    result = _run(
+        "fix(#2741): stacked",
+        "Closing #2741 is out of scope here.\n\nRefs #2741.",
+        base="fix/2697-metric-axis-integrity",
+        default_branch="main",
+    )
+    assert result.returncode == 0
+    assert _run("fix(#2741): guard links", "Land without closing #2741. Umbrella #2741.").returncode == 1
+
+
 def test_non_closing_references_on_a_stacked_base_pass() -> None:
     result = _run(
         "fix(#2779): stacked",

--- a/tests/test_pr_issue_link_gate.py
+++ b/tests/test_pr_issue_link_gate.py
@@ -8,8 +8,19 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "check_pr_issue_link.sh"
 
 
-def _run(title: str, body: str) -> subprocess.CompletedProcess[str]:
-    env = {**os.environ, "PR_TITLE": title, "PR_BODY": body}
+def _run(
+    title: str,
+    body: str,
+    base: str = "",
+    default_branch: str = "",
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "PR_TITLE": title,
+        "PR_BODY": body,
+        "PR_BASE": base,
+        "DEFAULT_BRANCH": default_branch,
+    }
     return subprocess.run(
         ["bash", str(SCRIPT)],
         cwd=ROOT,
@@ -105,6 +116,51 @@ def test_missing_title_issue_reference_still_fails() -> None:
     result = _run("fix(#2741): guard links", "Refs #9999.")
     assert result.returncode == 1
     assert "no Closes/Fixes/Resolves" in result.stdout
+
+
+def test_exact_2782_inert_closing_reference_on_a_stacked_base_is_refused() -> None:
+    result = _run(
+        "fix(#2779): metric-axis integrity follow-up",
+        "Closes #2779.",
+        base="fix/2697-metric-axis-integrity",
+        default_branch="main",
+    )
+    assert result.returncode == 1
+    assert "INERT" in result.stdout
+    assert "2779" in result.stdout
+
+
+def test_every_closing_verb_is_reported_inert_on_a_stacked_base() -> None:
+    result = _run(
+        "fix(#2779): stacked",
+        "Fixes #2779. Resolves #2775. Refs #2783.",
+        base="fix/2697-metric-axis-integrity",
+        default_branch="main",
+    )
+    assert result.returncode == 1
+    # Sorted, de-duplicated, and Refs is not a closing verb so #2783 is absent.
+    assert "2775 2779" in result.stdout
+    assert "2783" not in result.stdout
+
+
+def test_non_closing_references_on_a_stacked_base_pass() -> None:
+    result = _run(
+        "fix(#2779): stacked",
+        "Refs #2779. Part of #2783.",
+        base="fix/2697-metric-axis-integrity",
+        default_branch="main",
+    )
+    assert result.returncode == 0
+
+
+def test_closing_reference_on_the_default_base_is_unaffected() -> None:
+    result = _run("fix(#2779): direct", "Closes #2779.", base="main", default_branch="main")
+    assert result.returncode == 0
+
+
+def test_stacked_base_check_is_disabled_when_the_workflow_supplies_no_base() -> None:
+    # A local invocation has neither variable; the gate must not guess a base.
+    assert _run("fix(#2779): local", "Closes #2779.").returncode == 0
 
 
 def test_examples_inside_comments_and_code_do_not_trigger_or_satisfy() -> None:


### PR DESCRIPTION
## Issue reference

Closes #2783.

## What was broken

All four workflows filtered on `pull_request: branches: [main]`. **That filter matches the PR's base, not its head**, so a PR stacked on another branch got none of them:

| workflow | ran on a stacked PR? |
| --- | --- |
| `ci.yml` (lint, perf-claim-lint, supply-chain) | no |
| `frontend-ci.yml` | no |
| `claude-review.yml` | no |
| `pr-issue-link.yml` | no |

Three consequences, one root:

1. **The review bot never runs**, so `gh pr checks` reports *"no checks reported"* — indistinguishable from *"not finished yet"*.
2. **`safe_merge.sh` can never pass.** `.autonomy/config.yaml` sets `merge_gate.strategy: bot_comment`; the gate waits for a `Claude Code Review` comment from `github-actions` that by construction cannot be posted. The autonomy loop has no path off this.
3. **`Closes #N` is inert.** GitHub registers `closingIssuesReferences` only against the **default** branch, so `done_everywhere` closes nothing and boards nothing — silently, and with `check_pr_issue_link.sh` passing, because the body does contain a well-formed closing verb.

All four stacked PRs to date (#2773, #2776, #2777, #2782) were merged **by hand**, bypassing the gate, with nothing recording that it had been skipped.

## Source rule

GitHub links a pull request to an issue from a closing keyword in the **description**, and registers the link only for PRs targeting the repository's **default branch**. `closingIssuesReferences` on the PR is that registration, and it is what `safe_merge.sh::done_everywhere` reads (correctly — #301 made it the authority instead of a prose regex). So facet 3 is a property of the platform, not a bug in `done_everywhere`, and no `branches:` change can fix it.

## Full-population verification

Every merged PR (last 1000) queried for its real base:

```
merged PRs with base != main: 4
  PR 2782 base=fix/2697-metric-axis-integrity  body-closes=[2779]  gh-closes=[]
  PR 2777 base=fix/2697-metric-axis-integrity  body-closes=[]      gh-closes=[]
  PR 2776 base=fix/2697-metric-axis-integrity  body-closes=[]      gh-closes=[]
  PR 2773 base=fix/2697-metric-axis-integrity  body-closes=[2775]  gh-closes=[]
```

Two declared a closing keyword; GitHub registered **zero** for both. Facet 3 is measured, not inferred.

## Changes

**Facets 1 and 2 — drop the base filter.** `pull_request.branches: [main]` removed from all four workflows. `push.branches: [main]` is untouched (push-to-main is the correct scope for that trigger). Every PR now gets lint, review and the issue-link gate whatever it is stacked on, so `safe_merge` has a reachable terminal state on a stacked PR instead of an infinite wait.

**Facet 3 — make the inert reference loud.** `scripts/check_pr_issue_link.sh` gains a guard: when the PR's base is not the default branch and the body carries a closing verb, it refuses and lists the numbers.

```
::error::PR base is 'fix/2697-metric-axis-integrity', not the default branch 'main'.
GitHub registers closing references only against the default branch, so these are
INERT and will close nothing on merge: 2779
Retarget the PR at 'main', or use 'Refs #N' and close the issue by hand once the
stack lands.
```

This guard only works *because* of the filter change above — the gate did not run on a stacked base at all before. `PR_BASE` and `DEFAULT_BRANCH` are passed through `env:` (never interpolated into `run:`), matching the existing `PR_TITLE`/`PR_BODY` pattern. Both absent — a local invocation — disables the check rather than guessing a base.

## Reject-side census

Replayed all 1000 merged PR bodies through **the shipped script**, each with its own real `baseRefName`:

```
inert-closing-ref fires: [(2782, 'fix/2697-metric-axis-integrity'), (2773, 'fix/2697-metric-axis-integrity')]
partitive fires: [2373, 1244]
negation fires:  [2740, 2580, 2308, 1935, 1727, 1715, 1518, 1495, 1446, 1157]
missing-link fires: 0
```

The new guard fires on exactly the two PRs whose closing references GitHub dropped, and on none of the other 998. The pre-existing negation and partitive guards are unchanged.

## Residue

None. #2779 and #2775 are both already `CLOSED` — the author noticed and closed them by hand, which is the manual step this change removes the need for.

## Deliberately not done

The issue's fix direction 1 (document a stacked-PR terminal state in `.claude/CLAUDE.md`) is **moot after this change**: a stacked PR now gets a bot and CI, so there is no undocumented terminal state left to describe. Direction 2 (a distinct `safe_merge` refusal message) lives in the separate `autonomy-engine` repo and is no longer load-bearing — the gate it complains about can now be satisfied.

## Security model

`PR_BASE` and `DEFAULT_BRANCH` join `PR_TITLE`/`PR_BODY` as `env:` values consumed by a shell script; none is interpolated into a `run:` expression, so the workflow-injection surface is unchanged. Widening the trigger means the review workflow now runs on PRs to any base — this repo has a single author and no fork PRs, so no new principal gains the ability to trigger it.

## Checks

- `shellcheck -S warning scripts/check_pr_issue_link.sh` — clean
- `uv run pytest tests/test_pr_issue_link_gate.py` — exit 0 (5 new cases, including the exact #2782 shape and the local-invocation opt-out)
- all four workflow files re-parsed with `yaml.safe_load` and their resolved triggers printed
- `ruff check` / `ruff format --check` / `pyright` clean; pre-push gate green

Refs #2437.
