### PR TITLE
fix(#2342): decide test-template staleness from the template, not a machine-global file

### DIFF
--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -877,6 +877,39 @@ def _worker_lock_key() -> int:
     return int.from_bytes(digest, "big", signed=True)
 
 
+def _assert_holds_template_lock(admin: psycopg.Connection[Any]) -> None:
+    """Fail if this session does not hold ``EBULL_TEMPLATE_LOCK``.
+
+    The stamp check below is a read-then-act, so without the lock a sibling can
+    drop and rebuild the template between the read and the CREATE — the guard
+    would pass on a stamp that no longer describes the template being copied.
+    The precondition was documented but unenforced (review bot), which is worth
+    a query here specifically because the failure it admits is SILENT.
+
+    A bigint advisory key is stored split across ``classid`` (high 32 bits) and
+    ``objid`` (low 32). Verified against the cluster: the reconstruction below
+    returns EBULL_TEMPLATE_LOCK exactly while held, and no row after unlock.
+    """
+    with admin.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1 FROM pg_locks
+             WHERE locktype = 'advisory'
+               AND granted
+               AND pid = pg_backend_pid()
+               AND ((classid::bigint << 32) | objid::bigint) = %s
+            """,
+            (EBULL_TEMPLATE_LOCK,),
+        )
+        if cur.fetchone() is None:
+            raise RuntimeError(
+                "_assert_template_matches_this_worktree() ran without holding "
+                "EBULL_TEMPLATE_LOCK on this connection. The stamp it reads could "
+                "then be replaced before the template is copied, which is the "
+                "silent wrong-schema clone this check exists to prevent."
+            )
+
+
 class TemplateWorktreeMismatch(RuntimeError):
     """The template on the cluster was built from a different checkout's ``sql/``.
 
@@ -902,6 +935,7 @@ def _assert_template_matches_this_worktree(admin: psycopg.Connection[Any]) -> No
 
     Must be called while holding ``EBULL_TEMPLATE_LOCK``.
     """
+    _assert_holds_template_lock(admin)
     stamp = _read_template_stamp(admin)
     current = _migration_hash()
     if stamp is not None and stamp[0] == current:

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -877,6 +877,16 @@ def _worker_lock_key() -> int:
     return int.from_bytes(digest, "big", signed=True)
 
 
+class TemplateWorktreeMismatch(RuntimeError):
+    """The template on the cluster was built from a different checkout's ``sql/``.
+
+    A distinct type, not a bare ``RuntimeError``, because ``test_db_available``
+    catches ``Exception`` and converts it into a warning + skip. Swallowed there,
+    this condition would silently skip the whole db tier and let the run pass —
+    which is #2342's defect wearing a different hat. It is re-raised by name.
+    """
+
+
 def _assert_template_matches_this_worktree(admin: psycopg.Connection[Any]) -> None:
     """Refuse to clone a template built from a different checkout's ``sql/``.
 
@@ -897,7 +907,7 @@ def _assert_template_matches_this_worktree(admin: psycopg.Connection[Any]) -> No
     if stamp is not None and stamp[0] == current:
         return
     built_from = "an unknown checkout (no readable stamp)" if stamp is None else stamp[1]
-    raise RuntimeError(
+    raise TemplateWorktreeMismatch(
         f"{TEMPLATE_DB_NAME!r} was built from {built_from}, whose migrations differ "
         f"from this checkout's ({_REPO_ROOT}). Cloning it would run these tests "
         "against the wrong schema, which fails as if the migration under test were "
@@ -1023,6 +1033,13 @@ def test_db_available() -> bool:  # noqa: D401 — `test_*` here is the legacy p
                 cur.execute("SELECT 1")
         _TEST_DB_AVAILABLE.add(test_db_name())
         return True
+    except TemplateWorktreeMismatch:
+        # ⚠ NOT "unavailable". The cluster is fine and the template is fine —
+        # it just belongs to another checkout. Letting this fall into the skip
+        # path below would reinstate #2342's actual defect one layer up: the db
+        # tier would be silently skipped and the run would go GREEN having
+        # exercised no database at all. Must stay fatal (Codex checkpoint 2).
+        raise
     except Exception as exc:
         warnings.warn(
             f"ebull_test DB unavailable -- {type(exc).__name__}: {exc}. "
@@ -1511,6 +1528,7 @@ __all__ = [
     "EBULL_SMOKE_LIFESPAN_LOCK",
     "EBULL_TEMPLATE_LOCK",
     "TEMPLATE_DB_NAME",
+    "TemplateWorktreeMismatch",
     "_drop_orphan_workers_older_than",
     "_force_drop_invalid_test_dbs",
     "_worker_db_keepalive",

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -41,6 +41,7 @@ database, never ``ebull``.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import time
 import warnings
@@ -69,7 +70,12 @@ from app.db.dev_test_db_reaper import (
 )
 
 TEMPLATE_DB_NAME = "ebull_test_template"
-_SQL_DIR = Path(__file__).resolve().parents[2] / "sql"
+
+#: Repo root of the checkout that invoked pytest. Stamped into the template
+#: alongside the migration hash so a mismatch can NAME the sibling worktree that
+#: last rebuilt it, rather than reporting an anonymous schema drift (#2342).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SQL_DIR = _REPO_ROOT / "sql"
 
 #: The §4.0 validated-universe anchor. `etoro_instrument_types` is created empty
 #: by `sql/070` and filled by the nightly eToro universe sync, so a test DB never
@@ -156,19 +162,6 @@ _TEST_CLUSTER_PORT = os.environ.get("POSTGRES_TEST_PORT", "5433")
 # test_sync_orchestrator_dispatcher). Module import happens at collection time,
 # which always precedes per-test fixtures, so this captures the genuine dev URL.
 _DEV_DATABASE_URL: str = settings.database_url
-
-
-# Path to the migration-hash cache file. Lives under the user's cache
-# dir so the value survives across pytest invocations.
-def _hash_cache_path() -> Path:
-    try:
-        from platformdirs import user_cache_dir
-    except ImportError:  # pragma: no cover
-        cache_root = Path.home() / ".cache" / "ebull"
-    else:
-        cache_root = Path(user_cache_dir("ebull"))
-    cache_root.mkdir(parents=True, exist_ok=True)
-    return cache_root / "test_template_hash"
 
 
 # ROOTS of the per-test wipe set. The set actually emptied is this list plus
@@ -600,16 +593,52 @@ def _migration_hash() -> str:
     return h.hexdigest()
 
 
-def _read_stored_hash() -> str | None:
-    cache_path = _hash_cache_path()
+def _read_template_stamp(admin: psycopg.Connection[Any]) -> tuple[str, str] | None:
+    """``(migration_hash, built_from)`` recorded on the template, or ``None``.
+
+    The stamp lives in the template's DATABASE COMMENT, not in a file. That
+    matters for two measured reasons (#2342):
+
+    * A machine-global cache file under ``user_cache_dir("ebull")`` is shared by
+      every worktree on the box, so a sibling loop with different pending
+      migrations wrote ITS hash and the next run here saw a match and SKIPPED
+      the rebuild — testing against a schema without its own migration. The
+      failure is silent and directional: tests assert the OLD behaviour and fail,
+      which reads exactly like "your migration is wrong".
+    * ``pg_shdescription`` is a shared catalog keyed by database OID, so
+      ``CREATE DATABASE ... TEMPLATE`` does NOT copy the comment. Verified
+      against the test cluster before adopting it — every per-worker clone comes
+      out with a NULL stamp, so this leaves no residue in the DBs tests run on.
+    """
+    with admin.cursor() as cur:
+        cur.execute(
+            "SELECT shobj_description(oid, 'pg_database') FROM pg_database WHERE datname = %s",
+            (TEMPLATE_DB_NAME,),
+        )
+        row = cur.fetchone()
+    if row is None or row[0] is None:
+        return None
     try:
-        return cache_path.read_text(encoding="utf-8").strip()
-    except FileNotFoundError:
+        stamp = json.loads(row[0])
+        return str(stamp["migration_hash"]), str(stamp["built_from"])
+    except ValueError, KeyError, TypeError:
+        # A comment we did not write (or an older format) means "unknown", which
+        # forces a rebuild. Never treat an unparseable stamp as a match.
         return None
 
 
-def _write_stored_hash(value: str) -> None:
-    _hash_cache_path().write_text(value, encoding="utf-8")
+def _write_template_stamp(admin: psycopg.Connection[Any], migration_hash: str) -> None:
+    """Record this worktree's migration hash on the template we just built.
+
+    ``COMMENT ON DATABASE`` takes no bound parameters, so the value is rendered
+    as a ``sql.Literal``. It runs on the admin connection (a different database),
+    which is permitted and was verified against the cluster.
+    """
+    payload = json.dumps({"migration_hash": migration_hash, "built_from": str(_REPO_ROOT)})
+    with admin.cursor() as cur:
+        cur.execute(
+            sql.SQL("COMMENT ON DATABASE {} IS {}").format(sql.Identifier(TEMPLATE_DB_NAME), sql.Literal(payload))
+        )
 
 
 def _ensure_database(admin: psycopg.Connection[object], db_name: str) -> bool:
@@ -788,7 +817,6 @@ def build_template_if_stale() -> None:
         )
 
     current = _migration_hash()
-    cached = _read_stored_hash()
 
     with psycopg.connect(_admin_database_url(), autocommit=True) as admin:
         with admin.cursor() as cur:
@@ -809,8 +837,14 @@ def build_template_if_stale() -> None:
             _force_drop_invalid_test_dbs()
 
             template_exists = _ensure_database(admin, TEMPLATE_DB_NAME)
-            if template_exists and cached == current:
-                return
+            # Read the stamp INSIDE the lock and after the existence check: a
+            # sibling worktree may have rebuilt the template since this process
+            # started, and its hash is the only thing that says whose schema the
+            # template currently holds.
+            if template_exists:
+                stamp = _read_template_stamp(admin)
+                if stamp is not None and stamp[0] == current:
+                    return
 
             if template_exists:
                 _drop_database_force(admin, TEMPLATE_DB_NAME)
@@ -825,7 +859,7 @@ def build_template_if_stale() -> None:
                 with tpl_conn.cursor() as cur:
                     cur.execute("CREATE EXTENSION IF NOT EXISTS pgstattuple")
                 tpl_conn.commit()
-            _write_stored_hash(current)
+            _write_template_stamp(admin, current)
         finally:
             with admin.cursor() as cur:
                 cur.execute("SELECT pg_advisory_unlock(%s)", (EBULL_TEMPLATE_LOCK,))
@@ -841,6 +875,35 @@ def _worker_lock_key() -> int:
     payload = f"{_run_id()}:{_worker_id()}".encode()
     digest = hashlib.blake2b(payload, digest_size=8).digest()
     return int.from_bytes(digest, "big", signed=True)
+
+
+def _assert_template_matches_this_worktree(admin: psycopg.Connection[Any]) -> None:
+    """Refuse to clone a template built from a different checkout's ``sql/``.
+
+    ``build_template_if_stale`` runs in the controller and RELEASES the template
+    lock before the workers clone, so a sibling pytest controller in another
+    worktree can rebuild the template in that gap. This is the only window the
+    lock does not cover, and without this check it is silent: the clone succeeds
+    and the tests assert against the sibling's schema.
+
+    Deliberately raises rather than rebuilding — a worker must never rebuild the
+    template (it would invalidate the DBs sibling workers already cloned), which
+    ``build_template_if_stale`` enforces at its own entry.
+
+    Must be called while holding ``EBULL_TEMPLATE_LOCK``.
+    """
+    stamp = _read_template_stamp(admin)
+    current = _migration_hash()
+    if stamp is not None and stamp[0] == current:
+        return
+    built_from = "an unknown checkout (no readable stamp)" if stamp is None else stamp[1]
+    raise RuntimeError(
+        f"{TEMPLATE_DB_NAME!r} was built from {built_from}, whose migrations differ "
+        f"from this checkout's ({_REPO_ROOT}). Cloning it would run these tests "
+        "against the wrong schema, which fails as if the migration under test were "
+        "wrong. A sibling pytest run rebuilt the template after this one started — "
+        "re-run pytest, and avoid running the db tier in two worktrees at once."
+    )
 
 
 def ensure_worker_database() -> None:
@@ -881,6 +944,7 @@ def ensure_worker_database() -> None:
             with admin.cursor() as cur:
                 cur.execute("SELECT pg_advisory_lock(%s)", (EBULL_TEMPLATE_LOCK,))
             try:
+                _assert_template_matches_this_worktree(admin)
                 _create_database_from_template(admin, db_name, TEMPLATE_DB_NAME)
             finally:
                 # Unlock on a connection that may be in an error

--- a/tests/test_template_staleness_stamp.py
+++ b/tests/test_template_staleness_stamp.py
@@ -47,7 +47,11 @@ class _StubCursor:
         return False
 
     def execute(self, statement: object, *args: object, **kwargs: object) -> None:
-        self._row = (1,) if "pg_locks" in str(statement) else self._conn.stamp_row
+        if "pg_locks" in str(statement):
+            # The real query returns no row when this session holds no lock.
+            self._row = (1,) if self._conn.holds_lock else None
+        else:
+            self._row = self._conn.stamp_row
 
     def fetchone(self) -> tuple[Any, ...] | None:
         return self._row
@@ -62,20 +66,6 @@ class _StubConn:
 
     def cursor(self) -> _StubCursor:
         return _StubCursor(self)
-
-
-class _StubConnWithoutLock(_StubConn):
-    def cursor(self) -> _StubCursor:
-        cursor = _StubCursor(self)
-        original = cursor.execute
-
-        def execute(statement: object, *args: object, **kwargs: object) -> None:
-            original(statement, *args, **kwargs)
-            if "pg_locks" in str(statement):
-                cursor._row = None
-
-        cursor.execute = execute  # type: ignore[method-assign]
-        return cursor
 
 
 def _stamped(migration_hash: str, built_from: str = SIBLING) -> _StubConn:
@@ -127,7 +117,8 @@ def test_the_stamp_check_refuses_to_run_without_the_template_lock() -> None:
     # The check is a read-then-act. Without the lock a sibling can rebuild the
     # template between the read and the CREATE, so a stamp that matched no
     # longer describes what gets copied — silently.
-    conn = _StubConnWithoutLock((json.dumps({"migration_hash": _migration_hash(), "built_from": "x"}),))
+    payload = json.dumps({"migration_hash": _migration_hash(), "built_from": SIBLING})
+    conn = _StubConn((payload,), holds_lock=False)
     with pytest.raises(RuntimeError, match="EBULL_TEMPLATE_LOCK"):
         _assert_template_matches_this_worktree(conn)  # type: ignore[arg-type]
 

--- a/tests/test_template_staleness_stamp.py
+++ b/tests/test_template_staleness_stamp.py
@@ -13,11 +13,13 @@ and evict it from the pre-push gate.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 from tests.fixtures.ebull_test_db import (
+    TemplateWorktreeMismatch,
     _assert_template_matches_this_worktree,
     _migration_hash,
     _read_template_stamp,
@@ -87,12 +89,29 @@ def test_a_matching_stamp_lets_the_clone_proceed() -> None:
 
 def test_a_sibling_worktrees_stamp_refuses_the_clone_and_names_the_sibling() -> None:
     conn = _stamped("deadbeef" * 8, built_from=SIBLING)
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(TemplateWorktreeMismatch) as excinfo:
         _assert_template_matches_this_worktree(conn)  # type: ignore[arg-type]
     assert SIBLING in str(excinfo.value)
 
 
 def test_an_unstamped_template_refuses_rather_than_assuming_it_is_ours() -> None:
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(TemplateWorktreeMismatch) as excinfo:
         _assert_template_matches_this_worktree(_StubConn((None,)))  # type: ignore[arg-type]
     assert "unknown checkout" in str(excinfo.value)
+
+
+def test_the_mismatch_is_a_distinct_type_so_the_availability_probe_cannot_eat_it() -> None:
+    """The probe catches ``Exception`` and turns it into a warning + skip.
+
+    If this mismatch fell into that path the db tier would be silently skipped
+    and the run would go green having exercised no database — #2342's defect one
+    layer up. `test_db_available` re-raises this type by name, so it must stay a
+    distinct class and must NOT be widened to a bare RuntimeError.
+    """
+    assert issubclass(TemplateWorktreeMismatch, RuntimeError)
+    assert TemplateWorktreeMismatch is not RuntimeError
+
+    source = (Path(__file__).resolve().parents[0] / "fixtures" / "ebull_test_db.py").read_text(encoding="utf-8")
+    assert "except TemplateWorktreeMismatch:" in source, (
+        "test_db_available must re-raise the mismatch instead of skipping"
+    )

--- a/tests/test_template_staleness_stamp.py
+++ b/tests/test_template_staleness_stamp.py
@@ -1,0 +1,98 @@
+"""#2342 — template staleness is decided from the template, not a shared file.
+
+Pure-logic: the stamp reader and the clone-time refusal are exercised against a
+stub cursor, so this module stays in the fast tier. The mechanism itself (a
+DATABASE COMMENT surviving a rebuild and NOT being copied into a clone) was
+verified against the 5433 cluster before adoption; see the PR.
+
+⚠ Deliberately avoids the identifiers in ``tests/conftest.py::_DB_SOURCE_MARKERS``
+— naming one of them here would auto-apply the ``db`` marker to the whole module
+and evict it from the pre-push gate.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests.fixtures.ebull_test_db import (
+    _assert_template_matches_this_worktree,
+    _migration_hash,
+    _read_template_stamp,
+)
+
+SIBLING = "/Users/lukebradford/Dev/.ebull-ownership"
+
+
+class _StubCursor:
+    def __init__(self, row: tuple[Any, ...] | None) -> None:
+        self._row = row
+
+    def __enter__(self) -> _StubCursor:
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def execute(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._row
+
+
+class _StubConn:
+    """Just enough of a connection for the two functions under test."""
+
+    def __init__(self, row: tuple[Any, ...] | None) -> None:
+        self._row = row
+
+    def cursor(self) -> _StubCursor:
+        return _StubCursor(self._row)
+
+
+def _stamped(migration_hash: str, built_from: str = SIBLING) -> _StubConn:
+    payload = json.dumps({"migration_hash": migration_hash, "built_from": built_from})
+    return _StubConn((payload,))
+
+
+def test_a_well_formed_stamp_reads_back_as_hash_and_origin() -> None:
+    conn = _stamped("abc123", built_from=SIBLING)
+    assert _read_template_stamp(conn) == ("abc123", SIBLING)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        None,  # no such database
+        (None,),  # database exists, never stamped
+        ("not json",),  # a comment we did not write
+        ('{"migration_hash": "abc"}',),  # our shape, missing a key
+        ("[]",),  # valid JSON, wrong type
+    ],
+    ids=["no-row", "unstamped", "not-json", "missing-key", "wrong-type"],
+)
+def test_an_unreadable_stamp_is_unknown_and_never_a_match(row: tuple[Any, ...] | None) -> None:
+    # Reading "unknown" as "matches" is the failure this ticket is about: it
+    # skips the rebuild and runs the suite against another checkout's schema.
+    assert _read_template_stamp(_StubConn(row)) is None  # type: ignore[arg-type]
+
+
+def test_a_matching_stamp_lets_the_clone_proceed() -> None:
+    conn = _stamped(_migration_hash())
+    assert _assert_template_matches_this_worktree(conn) is None  # type: ignore[arg-type]
+
+
+def test_a_sibling_worktrees_stamp_refuses_the_clone_and_names_the_sibling() -> None:
+    conn = _stamped("deadbeef" * 8, built_from=SIBLING)
+    with pytest.raises(RuntimeError) as excinfo:
+        _assert_template_matches_this_worktree(conn)  # type: ignore[arg-type]
+    assert SIBLING in str(excinfo.value)
+
+
+def test_an_unstamped_template_refuses_rather_than_assuming_it_is_ours() -> None:
+    with pytest.raises(RuntimeError) as excinfo:
+        _assert_template_matches_this_worktree(_StubConn((None,)))  # type: ignore[arg-type]
+    assert "unknown checkout" in str(excinfo.value)

--- a/tests/test_template_staleness_stamp.py
+++ b/tests/test_template_staleness_stamp.py
@@ -29,8 +29,16 @@ SIBLING = "/Users/lukebradford/Dev/.ebull-ownership"
 
 
 class _StubCursor:
-    def __init__(self, row: tuple[Any, ...] | None) -> None:
-        self._row = row
+    """Answers the two queries these functions issue, told apart by their SQL.
+
+    Deliberately NOT one canned row for both: the lock probe and the stamp read
+    have opposite meanings, and a stub that returns the same thing for each
+    would pass whichever check ran first for the wrong reason.
+    """
+
+    def __init__(self, conn: _StubConn) -> None:
+        self._conn = conn
+        self._row: tuple[Any, ...] | None = None
 
     def __enter__(self) -> _StubCursor:
         return self
@@ -38,21 +46,36 @@ class _StubCursor:
     def __exit__(self, *exc: object) -> bool:
         return False
 
-    def execute(self, *args: object, **kwargs: object) -> None:
-        return None
+    def execute(self, statement: object, *args: object, **kwargs: object) -> None:
+        self._row = (1,) if "pg_locks" in str(statement) else self._conn.stamp_row
 
     def fetchone(self) -> tuple[Any, ...] | None:
         return self._row
 
 
 class _StubConn:
-    """Just enough of a connection for the two functions under test."""
+    """Just enough of a connection for the functions under test."""
 
-    def __init__(self, row: tuple[Any, ...] | None) -> None:
-        self._row = row
+    def __init__(self, stamp_row: tuple[Any, ...] | None, *, holds_lock: bool = True) -> None:
+        self.stamp_row = stamp_row
+        self.holds_lock = holds_lock
 
     def cursor(self) -> _StubCursor:
-        return _StubCursor(self._row)
+        return _StubCursor(self)
+
+
+class _StubConnWithoutLock(_StubConn):
+    def cursor(self) -> _StubCursor:
+        cursor = _StubCursor(self)
+        original = cursor.execute
+
+        def execute(statement: object, *args: object, **kwargs: object) -> None:
+            original(statement, *args, **kwargs)
+            if "pg_locks" in str(statement):
+                cursor._row = None
+
+        cursor.execute = execute  # type: ignore[method-assign]
+        return cursor
 
 
 def _stamped(migration_hash: str, built_from: str = SIBLING) -> _StubConn:
@@ -98,6 +121,15 @@ def test_an_unstamped_template_refuses_rather_than_assuming_it_is_ours() -> None
     with pytest.raises(TemplateWorktreeMismatch) as excinfo:
         _assert_template_matches_this_worktree(_StubConn((None,)))  # type: ignore[arg-type]
     assert "unknown checkout" in str(excinfo.value)
+
+
+def test_the_stamp_check_refuses_to_run_without_the_template_lock() -> None:
+    # The check is a read-then-act. Without the lock a sibling can rebuild the
+    # template between the read and the CREATE, so a stamp that matched no
+    # longer describes what gets copied — silently.
+    conn = _StubConnWithoutLock((json.dumps({"migration_hash": _migration_hash(), "built_from": "x"}),))
+    with pytest.raises(RuntimeError, match="EBULL_TEMPLATE_LOCK"):
+        _assert_template_matches_this_worktree(conn)  # type: ignore[arg-type]
 
 
 def test_the_mismatch_is_a_distinct_type_so_the_availability_probe_cannot_eat_it() -> None:


### PR DESCRIPTION
## Issue reference

Closes #2342.

## What was broken

`ebull_test_template` is **one** database on the shared `postgres-test` cluster (5433), and its staleness was keyed on **one** machine-global cache file — `platformdirs.user_cache_dir("ebull")/test_template_hash`. Every worktree on the box reads and writes that same file.

So when two headless loops run in different worktrees with different pending migrations, whichever invokes pytest last rebuilds the shared template from ITS `sql/` and writes ITS hash. The other worktree's next run then sees a matching hash and **skips the rebuild**, testing against a schema that does not contain its own migration. Measured at the point of failure on #2232:

```sql
select max(filename) from schema_migrations;  -- on ebull_test_template
-- 257_strategy_signals_input_rule_sets.sql
```

while the invoking worktree's `sql/` contained `259_share_count_views_positive_only.sql`.

⚠ The failure is **silent and directional**. Tests do not error on a missing table — they assert the OLD behaviour and fail, which reads exactly like *"your migration is wrong"*. The opposite direction is worse: a sibling whose `sql/` is a superset makes a migration's tests **pass** in a worktree where the migration is absent.

The existing advisory lock serialises concurrent template BUILDS. It does not make the template's content correct for more than one worktree at a time, which is a different problem.

## Approach — and why not the other two options

The issue offered three. Option 1 (namespace the template per worktree) is the only one that lets two loops run the db tier concurrently, but `app/db/dev_test_db_reaper.py::NEVER_DROP` is a literal frozenset containing `ebull_test_template`, while the orphan sweep matches `ebull_test_*`. A per-worktree name would match the sweep and be dropped, so option 1 drags a protection-rule rewrite into `app/` — a much larger blast radius than the bug.

This PR is option 2 + option 3, which together remove the silent property without touching the reaper:

- **The hash moves into the template.** No shared file, so no cross-worktree write.
- **The clone re-checks it under the lock.** Closes the one window the lock leaves open.

## Source rule / mechanism, verified before adoption

The stamp is the template's **DATABASE COMMENT**, holding `{"migration_hash", "built_from"}`. Two properties were measured against the real cluster, not assumed:

- `COMMENT ON DATABASE` executes fine from the admin connection to a *different* database. (It takes no bound parameters, so the value is rendered as a `sql.Literal`.)
- Comments on databases live in `pg_shdescription`, a **shared catalog keyed by database OID**, so `CREATE DATABASE ... TEMPLATE` does **not** copy them. Probed directly: a clone of a stamped template comes out with a NULL stamp. That is what makes this leave zero residue in the per-worker DBs tests actually run on — the reason a metadata *table* was rejected.

## Changes

- `_hash_cache_path` / `_read_stored_hash` / `_write_stored_hash` deleted.
- `_read_template_stamp(admin)` / `_write_template_stamp(admin, hash)` replace them.
- `build_template_if_stale` reads the stamp **inside** the template lock and after the existence check, so a sibling rebuild since process start is seen.
- `ensure_worker_database` calls `_assert_template_matches_this_worktree` while holding `EBULL_TEMPLATE_LOCK`, immediately before `CREATE DATABASE ... TEMPLATE`. The controller **releases** the lock between building and the workers cloning; that gap is the only window the lock does not cover, and it was silent.
- An unreadable, absent or wrong-shaped stamp is `None` — "unknown", which forces a rebuild. It is **never** read as a match, which is the defect itself.
- `_SQL_DIR` is now derived from `_REPO_ROOT` rather than repeating the `parents[2]` walk.

The guard **raises rather than rebuilding**: a worker must never rebuild the template — it would invalidate the DBs sibling workers have already cloned — which `build_template_if_stale` already enforces at its own entry. Refusing is the correct terminal state.

## ⚠ Codex checkpoint 2 found a P1, and it was the interesting one

The guard was correct and **its loudness was not**. `test_db_available` catches `Exception`, warns *"ebull_test DB unavailable"* and returns `False` so the test skips. A sibling-worktree mismatch would therefore have skipped the entire db tier and let the run go **green having exercised no database** — this ticket's defect one layer up, wearing a different symptom.

Fixed with a distinct `TemplateWorktreeMismatch(RuntimeError)` that `test_db_available` re-raises by name. Every other failure keeps the clean-skip path, because "no Postgres at all" is a genuinely different condition from "the cluster is fine and the template belongs to someone else". A type was required rather than a better message: `except Exception` cannot be taught to care about wording.

## Verification — run, not reasoned

Against the real 5433 cluster:

| probe | result |
| --- | --- |
| absent stamp → build | rebuilt in **6.4s**, stamped with this worktree's hash + `/Users/lukebradford/Dev/.ebull-autonomy` |
| second call | no-op in **0.0s** |
| bogus sibling stamp → controller | rebuilds (6.3s) and re-stamps correctly |
| bogus sibling stamp → clone check | raises, naming `/Users/lukebradford/Dev/.ebull-ownership` |
| unparseable comment (`"not json"`) | reads as `None` and refuses — never a false match |
| sibling stamp + worker DB dropped → `test_db_available()` | **raises `TemplateWorktreeMismatch`** instead of returning `False` |

Full db tier, 22 file-scoped batches over all 854 test files (`-m db`, gated on exit code): **all green except one batch**, whose two failures are `test_strategy_control_plane::test_the_deployment_currency_refusal_and_its_constraint_agree[...]`. Those reproduce identically **on `main`** with this branch checked out away — `RuntimeError: etoro_instrument_types.description = 'Stocks' resolved to 0 rows` — so they predate this change and are a missing validated-universe anchor in that test, not schema staleness. Noted here rather than fixed, to keep this diff to its own subject; filed separately.

Tests: 10 pure-logic cases in `tests/test_template_staleness_stamp.py`, deliberately avoiding every identifier in `conftest.py::_DB_SOURCE_MARKERS` so the module stays in the **fast tier** (confirmed by collecting under `-m "not db"`). They pin the five unreadable-stamp shapes, both refusal messages, and the re-raise clause — so widening the exception back to a bare `RuntimeError` fails the suite.

## Residue

The old `user_cache_dir("ebull")/test_template_hash` file is now unreferenced. Left in place deliberately: deleting a user cache file as a side effect of a test run is a worse habit than one stale byte-string, and nothing reads it.

## Security model

None. Test-fixture code on the 5433 test cluster; no credentials, no production path, no change to what any test may connect to. `assert_test_db`'s refusal to operate on the dev DB or the template is untouched.

## Checks

- `ruff check .` / `ruff format --check .` / `pyright` — clean
- `pytest tests/test_template_staleness_stamp.py` — exit 0
- `pytest -m db` in 22 file-scoped batches — see above
- `codex exec review --base origin/main` — one P1, fixed in `c8c74133`
- pre-push gate green

Refs #2437.
