### PR TITLE
fix(#2891): seed the validated-universe anchor so the currency-refusal test can reach its branch

### DIFF
--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -81,6 +81,7 @@ from app.services.strategy_result_universe import (
 )
 from app.services.strategy_statistics import periods_per_year
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
+from tests.fixtures.ebull_test_db import seed_universe_anchor
 from tests.test_result_ledger import (
     BOOTSTRAP_BLOCK,
     build_control,
@@ -1536,6 +1537,11 @@ def test_the_deployment_currency_refusal_and_its_constraint_agree(
     # to reach it from a test, because the state it refuses is unrepresentable
     # at rest by the very constraint just asserted.
     monkeypatch.setattr("app.api.strategies.SUPPORTED_DEPLOYMENT_CURRENCIES", frozenset({"CHF"}))
+    # #2891 — the overview reaches ``load_validated_universe``, which since #2809
+    # refuses on a missing §4.0 anchor before any refusal this test is about can
+    # be computed. Seeding it is what lets the assertion below read the branch
+    # rather than the fixture's empty ``etoro_instrument_types``.
+    seed_universe_anchor(conn)
     overview = get_strategy_overview(conn)
     assert overview.strategies, "no strategies in the overview — the assertion below would be vacuous"
     assert all(DEPLOYMENT_CURRENCY_UNSUPPORTED in row.allocation_refusals for row in overview.strategies)


### PR DESCRIPTION
## What was wrong

`tests/test_strategy_control_plane.py::test_the_deployment_currency_refusal_and_its_constraint_agree` failed **deterministically on `main`**, both parametrisations:

```
E   RuntimeError: etoro_instrument_types.description = 'Stocks' resolved to 0 rows, expected exactly 1
    — the §4.0 validated-universe definition has no anchor
```

Call path: the test calls `get_strategy_overview` → `app/api/strategies.py:2059` `_corpus_frontier` → `:1438` `load_validated_universe` → `validated_universe.py:105` `resolve_stocks_type_id`. Since #2809 that refuses on zero rows. `etoro_instrument_types` is created empty by `sql/070` and only filled by the nightly eToro universe sync, so a test DB never has it.

The refusal is correct behaviour. The defect is that the test drives the full overview path without supplying the anchor that path requires — so it raised before any refusal it asserts on could be computed.

## Fix

One call to `tests/fixtures/ebull_test_db.py::seed_universe_anchor`, the helper added in #2859 for exactly this case and already used by the sibling tests in `test_api_strategies.py` (7 call sites) and `test_strategy_monitoring.py` (9). Its `conn.commit()` is load-bearing — `update_strategy_paper_pool` calls `conn.rollback()` before opening its own transaction, so an uncommitted anchor is discarded and the overview raises again. A bare inline `INSERT` would reproduce the bug in a subtler form.

The existing `assert overview.strategies` guard means the fix cannot make the test pass vacuously.

## Why it sat on `main` unnoticed

The `db` marker is module-scoped (`tests/conftest.py::pytest_collection_modifyitems`), so this module is off the `-m "not db"` push gate entirely, and CI runs no pytest. Nothing on the push path ever ran it.

## Verification

| check | command | result |
| --- | --- | --- |
| reproduced on `main` before the fix | `uv run pytest -m db -q tests/test_strategy_control_plane.py -k deployment_currency_refusal` | 2 FAILED |
| fixed | same command at `2cc4e393` | exit 0 |
| no regression in the module | `uv run pytest -m db -q tests/test_strategy_control_plane.py` | exit 0 |
| scope — every other test file reaching `get_strategy_overview` / `load_validated_universe` / `_corpus_frontier` | `uv run pytest -m db -q tests/test_2803_scan_card_version_basis.py tests/test_2809_scan_freshness_basis.py tests/test_api_strategies.py tests/test_insider_purchase_outcomes.py tests/test_validated_universe.py` | exit 0 |
| same, monitoring | `uv run pytest -m db -q tests/test_strategy_monitoring.py` | exit 0 |
| lint / format / typecheck | `ruff check` · `ruff format --check` · `pyright` | 0 / 0 / 0 |

The issue's scope claim ("only this test") was re-verified here rather than inherited: I grepped for every test file reaching that path and ran all of them.

## Security model

Not applicable — test-only change, one file, no production code, no schema, no data path.

## Review intensity

Narrow mechanical diff, no data semantics → the ladder's first rung: self-review + pre-push hook + review bot. No Codex checkpoint 2.

Fixes #2891