### PR TITLE
fix(#2859): bound min_net_expectancy_pct, and refuse a non-finite limit as a named error

### DIFF
--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -910,6 +910,33 @@ def configure_execution_policy(
     """
     for value, field in ((changed_by, "changed_by"), (reason, "reason")):
         _require_text(value, field)
+    # #2859 — every ordered comparison below is unsafe on a non-finite Decimal:
+    # ``Decimal("NaN") <= 0`` raises ``InvalidOperation``, so a NaN limit escaped
+    # this function as an unhandled exception (a 500) instead of one named
+    # refusal, and it escaped from whichever comparison happened to reach it
+    # first. Sweeping finiteness up front is what makes the checks that follow
+    # total. ⚠ Must stay ABOVE them — moving it down restores the crash.
+    #
+    # ⚠⚠ The database cannot be relied on as the backstop here. Measured against
+    # Postgres: ``'NaN'::numeric >= 0`` is TRUE and ``NaN = NaN`` is TRUE, so a
+    # one-sided CHECK admits NaN; only the two-sided sibling CHECKs exclude it,
+    # and then only by accident of their upper bound. ``NUMERIC(12,8)`` does
+    # reject Infinity (field overflow), so NaN is the whole non-finite risk at
+    # rest — but the refusal belongs here, where it can be named.
+    for value, field in (
+        (ticket_fraction, "ticket_fraction"),
+        (fixed_ticket_amount, "fixed_ticket_amount"),
+        (max_ticket_amount, "max_ticket_amount"),
+        (stop_loss_pct, "stop_loss_pct"),
+        (take_profit_pct, "take_profit_pct"),
+        (max_instrument_exposure_pct, "max_instrument_exposure_pct"),
+        (max_portfolio_exposure_pct, "max_portfolio_exposure_pct"),
+        (max_drawdown_pct, "max_drawdown_pct"),
+        (min_net_expectancy_pct, "min_net_expectancy_pct"),
+        (cost_stress_multiplier, "cost_stress_multiplier"),
+    ):
+        if value is not None and not value.is_finite():
+            raise StrategyControlError(f"{field} must be finite")
     if ticket_sizing_mode == "percent":
         if ticket_fraction is None or not (Decimal("0") < ticket_fraction <= Decimal("1")):
             raise StrategyControlError("percent ticket_fraction must be in (0, 1]")
@@ -943,6 +970,18 @@ def configure_execution_policy(
         raise StrategyControlError("max_drawdown_pct must be in (0, 100)")
     if cost_stress_multiplier < 1:
         raise StrategyControlError("cost_stress_multiplier must be at least 1")
+    # #2859 — the one limit on this table that had neither a bound here nor a
+    # schema CHECK, while every numeric sibling has both. It is not decoration:
+    # `strategy_paper_executor` refuses a signal on
+    # ``net_expectancy < intent.min_net_expectancy_pct``, so a NEGATIVE floor
+    # turns the gate that stops a losing paper order into one that admits it,
+    # silently and with no refusal row to read afterwards.
+    #
+    # Zero stays admissible on purpose. An operator who wants strictly-positive
+    # expectancy expresses it as a positive floor; that is the whole point of
+    # the value being a policy rather than the hardcoded ``<= 0`` it replaced.
+    if min_net_expectancy_pct < 0:
+        raise StrategyControlError("min_net_expectancy_pct must be non-negative")
 
     deployment = conn.execute(
         "SELECT mode FROM strategy_deployments WHERE deployment_id = %s FOR UPDATE",

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -449,6 +449,20 @@ def _require_text(value: str, field: str) -> None:
         raise StrategyControlError(f"{field} must be non-empty")
 
 
+def _is_finite_decimal(value: object) -> bool:
+    """True only for a real, comparable ``Decimal``.
+
+    #2859 — the type check is not redundant with the annotation. Every caller of
+    ``configure_execution_policy`` supplies an execution limit that decides
+    whether a paper order is authorised, and the failure mode being closed here
+    is that a value which is not an ordered finite number reaches an ordered
+    comparison: ``None`` raises ``TypeError``, a ``str`` raises ``TypeError``,
+    and ``Decimal("NaN")`` raises ``InvalidOperation``. All three are a 500 with
+    no refusal recorded, where the contract is one named ``StrategyControlError``.
+    """
+    return isinstance(value, Decimal) and value.is_finite()
+
+
 def _lock_strategy(conn: psycopg.Connection[Any], strategy_id: str, strategy_version: str) -> None:
     conn.execute(
         "SELECT pg_advisory_xact_lock(%s, hashtext(%s))",
@@ -923,9 +937,22 @@ def configure_execution_policy(
     # and then only by accident of their upper bound. ``NUMERIC(12,8)`` does
     # reject Infinity (field overflow), so NaN is the whole non-finite risk at
     # rest — but the refusal belongs here, where it can be named.
-    for value, field in (
+    #
+    # ⚠ The two lists are split by whether the limit is OPTIONAL, not for tidiness.
+    # `ticket_fraction` and `fixed_ticket_amount` are genuinely `Decimal | None` —
+    # exactly one of them is `None` in each `ticket_sizing_mode` arm — so a `None`
+    # escape is correct for those two and only those two. Every other limit is a
+    # required `Decimal`, and asserting that here rather than trusting the
+    # annotation is what keeps a dynamic caller's `None` (or a `float`, or a
+    # `str`) a NAMED refusal instead of the `TypeError` / `AttributeError` it
+    # would otherwise become at the first comparison.
+    for optional_value, field in (
         (ticket_fraction, "ticket_fraction"),
         (fixed_ticket_amount, "fixed_ticket_amount"),
+    ):
+        if optional_value is not None and not _is_finite_decimal(optional_value):
+            raise StrategyControlError(f"{field} must be a finite number")
+    for value, field in (
         (max_ticket_amount, "max_ticket_amount"),
         (stop_loss_pct, "stop_loss_pct"),
         (take_profit_pct, "take_profit_pct"),
@@ -935,8 +962,8 @@ def configure_execution_policy(
         (min_net_expectancy_pct, "min_net_expectancy_pct"),
         (cost_stress_multiplier, "cost_stress_multiplier"),
     ):
-        if value is not None and not value.is_finite():
-            raise StrategyControlError(f"{field} must be finite")
+        if not _is_finite_decimal(value):
+            raise StrategyControlError(f"{field} must be a finite number")
     if ticket_sizing_mode == "percent":
         if ticket_fraction is None or not (Decimal("0") < ticket_fraction <= Decimal("1")):
             raise StrategyControlError("percent ticket_fraction must be in (0, 1]")

--- a/sql/368_execution_policy_min_net_expectancy_bound.sql
+++ b/sql/368_execution_policy_min_net_expectancy_bound.sql
@@ -36,7 +36,15 @@
 --     select count(*) from strategy_execution_policies;                        -- 0
 --     select count(*) from strategy_execution_policies
 --      where min_net_expectancy_pct < 0
---         or min_net_expectancy_pct <> min_net_expectancy_pct;                 -- 0
+--         or min_net_expectancy_pct = 'NaN'::numeric;                          -- 0
+--
+-- ⚠ The NaN half of that query is written as `= 'NaN'::numeric` and NOT as the
+-- IEEE self-inequality `col <> col`, which is the natural thing to reach for and
+-- is WRONG here for the same reason this CHECK needs its own clause: Postgres
+-- makes `NaN = NaN` TRUE, so `col <> col` is FALSE for a NaN row and the query
+-- would report zero offending rows while NaNs sat in the table. Caught by a
+-- second-opinion pass, after the correct semantics had already been measured
+-- three lines above -- knowing the rule is not the same as applying it.
 --
 -- ⚠ No CHECK on `strategy_execution_policy_events`, matching that table's
 -- existing shape: it is the append-only revision log and carries no numeric
@@ -51,7 +59,10 @@ ALTER TABLE strategy_execution_policies
     CHECK (min_net_expectancy_pct >= 0 AND min_net_expectancy_pct <> 'NaN'::numeric);
 
 COMMENT ON COLUMN strategy_execution_policies.min_net_expectancy_pct IS
-    'Minimum stress-adjusted net expectancy, in percent, a fired signal must clear '
-    'before strategy_paper_executor will submit it. Non-negative and never NaN. '
-    'Zero is admissible: it means "refuse anything negative", and an operator who '
-    'wants strictly-positive expectancy sets a positive floor.';
+    'Inclusive floor on stress-adjusted net expectancy, in percent. '
+    'strategy_paper_executor refuses a fired signal on '
+    '"net_expectancy < min_net_expectancy_pct", so a signal EQUAL to the floor is '
+    'admitted -- the comparison is strict, and the floor is a minimum rather than '
+    'a threshold to exceed. Non-negative and never NaN. Zero is admissible and '
+    'means "refuse anything negative"; an operator wanting strictly-positive '
+    'expectancy sets a positive floor.';

--- a/sql/368_execution_policy_min_net_expectancy_bound.sql
+++ b/sql/368_execution_policy_min_net_expectancy_bound.sql
@@ -1,0 +1,57 @@
+-- #2859 -- bound `min_net_expectancy_pct`, the one numeric limit on
+-- `strategy_execution_policies` that carried NO constraint of any kind.
+--
+-- Every numeric sibling on this table is bounded both in
+-- `strategy_control_plane.configure_execution_policy` and by a CHECK here:
+--
+--     max_instrument_exposure_pct  > 0 AND <= 100
+--     max_portfolio_exposure_pct   > 0 AND <= 100
+--     max_drawdown_pct             > 0 AND <  100
+--     cost_stress_multiplier       >= 1
+--
+-- `min_net_expectancy_pct` had neither.  It is read by
+-- `app/services/strategy_paper_executor.py` as
+-- `net_expectancy < intent.min_net_expectancy_pct` -> refuse, so a NEGATIVE
+-- floor inverts the gate: a paper order whose stressed cost exceeds its
+-- forecast expectancy is admitted, and the refusal row that would have
+-- recorded the fact is never written.  The service-side bound lands in the
+-- same change; this is the copy that survives a future caller which does not
+-- go through it.
+--
+-- ⚠⚠ The bound is deliberately two-sided-by-construction, not a bare `>= 0`.
+-- Measured against this Postgres, NOT reasoned from IEEE semantics:
+--
+--     select 'NaN'::numeric >= 0;              -- t
+--     select 'NaN'::numeric = 'NaN'::numeric;  -- t
+--     select 'Infinity'::numeric(12,8);        -- ERROR: numeric field overflow
+--
+-- so `>= 0` alone ADMITS NaN (Postgres sorts NaN above every non-NaN value),
+-- while the two-sided sibling CHECKs above exclude it only as an accident of
+-- their upper bound.  `<> 'NaN'` is the explicit exclusion: `NaN <> NaN` is
+-- FALSE here, and a CHECK rejects on FALSE.  Infinity needs no clause -- the
+-- NUMERIC(12,8) declaration already refuses it.
+--
+-- Verification of existing rows before adding the constraint:
+--
+--     select count(*) from strategy_execution_policies;                        -- 0
+--     select count(*) from strategy_execution_policies
+--      where min_net_expectancy_pct < 0
+--         or min_net_expectancy_pct <> min_net_expectancy_pct;                 -- 0
+--
+-- ⚠ No CHECK on `strategy_execution_policy_events`, matching that table's
+-- existing shape: it is the append-only revision log and carries no numeric
+-- CHECKs at all, because it must be able to record whatever the policy table
+-- accepted rather than re-adjudicate it.
+
+ALTER TABLE strategy_execution_policies
+    DROP CONSTRAINT IF EXISTS strategy_execution_policies_min_net_expectancy_bounded;
+
+ALTER TABLE strategy_execution_policies
+    ADD CONSTRAINT strategy_execution_policies_min_net_expectancy_bounded
+    CHECK (min_net_expectancy_pct >= 0 AND min_net_expectancy_pct <> 'NaN'::numeric);
+
+COMMENT ON COLUMN strategy_execution_policies.min_net_expectancy_pct IS
+    'Minimum stress-adjusted net expectancy, in percent, a fired signal must clear '
+    'before strategy_paper_executor will submit it. Non-negative and never NaN. '
+    'Zero is admissible: it means "refuse anything negative", and an operator who '
+    'wants strictly-positive expectancy sets a positive floor.';

--- a/tests/test_execution_policy_limits.py
+++ b/tests/test_execution_policy_limits.py
@@ -82,7 +82,7 @@ def test_a_non_finite_limit_is_one_named_refusal_and_never_an_invalid_operation(
     per field is what pins the sweep to the full set rather than to the one case
     a regression test happened to use.
     """
-    with pytest.raises(StrategyControlError, match=f"{field} must be finite"):
+    with pytest.raises(StrategyControlError, match=f"{field} must be a finite number"):
         _configure(**{field: Decimal("NaN")})
 
 
@@ -92,12 +92,31 @@ def test_a_non_finite_fixed_ticket_amount_is_still_refused_under_fixed_sizing() 
     ``fixed_ticket_amount`` is ``None`` under percent sizing, so the sweep skips
     it there; this is the arm where it carries a value.
     """
-    with pytest.raises(StrategyControlError, match="fixed_ticket_amount must be finite"):
+    with pytest.raises(StrategyControlError, match="fixed_ticket_amount must be a finite number"):
         _configure(
             ticket_sizing_mode="fixed",
             ticket_fraction=None,
             fixed_ticket_amount=Decimal("NaN"),
         )
+
+
+@pytest.mark.parametrize("bad", [None, "0.5", 0.5], ids=["none", "str", "float"])
+def test_a_required_limit_that_is_not_a_decimal_is_also_one_named_refusal(bad: object) -> None:
+    """The annotation is not the enforcement, and the failure it hides is a 500.
+
+    Raised at review: the finiteness sweep guards ``is not None`` for the two
+    genuinely optional limits, so a reader reasonably asks what happens when a
+    REQUIRED one arrives as ``None``. Before this, ``None < 0`` raised
+    ``TypeError`` and a ``str`` raised ``TypeError`` at the first comparison —
+    both unhandled, both a 500 with no refusal recorded, which is the same
+    contract break as the NaN case and not a different one.
+
+    ⚠ A ``float`` is included deliberately and is the one that would slip past a
+    ``None``-only guard: ``0.5 < 0`` is perfectly legal, so it reaches the
+    database and stores a limit that never went through ``Decimal``.
+    """
+    with pytest.raises(StrategyControlError, match="min_net_expectancy_pct must be a finite number"):
+        _configure(min_net_expectancy_pct=bad)
 
 
 def test_a_negative_net_expectancy_floor_is_refused() -> None:

--- a/tests/test_execution_policy_limits.py
+++ b/tests/test_execution_policy_limits.py
@@ -1,0 +1,124 @@
+"""#2859 — ``configure_execution_policy`` bounds its limits before touching the DB.
+
+Recovered from ``feature/2770-operator-promotion``, which the 08-21 rebuild lost.
+Classified as a REAL GAP by the #2859 audit rather than ported blind: main had a
+finiteness check on ``fixed_ticket_amount`` alone and no bound at all on
+``min_net_expectancy_pct``, the one numeric limit on
+``strategy_execution_policies`` with neither a service bound nor a schema CHECK.
+
+⚠ These are deliberately PURE tests, where the branch's originals passed a real
+connection and a ``deployment_id`` that did not exist. That version cannot
+distinguish "refused by the bound" from "refused because the deployment is
+missing", so it does not actually test the property its name claims. Passing a
+connection that raises on ANY attribute access does, and it keeps the module on
+the fast pre-push gate.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, cast
+
+import pytest
+
+from app.services.strategy_control_plane import StrategyControlError, configure_execution_policy
+
+
+class _ExplodingConn:
+    """A connection stand-in that fails the test if anything reaches the DB."""
+
+    def __getattr__(self, name: str) -> Any:
+        raise AssertionError(f"database was accessed via conn.{name} before the limits were validated")
+
+
+def _configure(**overrides: Any) -> None:
+    """Call the real chokepoint with one field overridden and no DB available."""
+    kwargs: dict[str, Any] = {
+        "deployment_id": 1,
+        "ticket_sizing_mode": "percent",
+        "ticket_fraction": Decimal("0.1"),
+        "fixed_ticket_amount": None,
+        "max_ticket_amount": Decimal("10"),
+        "stop_loss_pct": Decimal("5"),
+        "take_profit_pct": Decimal("10"),
+        "max_quote_age_seconds": 30,
+        "max_scan_age_seconds": 300,
+        "max_halt_feed_age_seconds": 300,
+        "max_cost_age_seconds": 3600,
+        "max_reconciliation_age_seconds": 60,
+        "max_instrument_exposure_pct": Decimal("20"),
+        "max_portfolio_exposure_pct": Decimal("50"),
+        "max_drawdown_pct": Decimal("10"),
+        "min_net_expectancy_pct": Decimal("0.5"),
+        "cost_stress_multiplier": Decimal("2"),
+        "changed_by": "operator",
+        "reason": "limits test",
+    }
+    kwargs.update(overrides)
+    configure_execution_policy(cast(Any, _ExplodingConn()), **kwargs)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "ticket_fraction",
+        "max_ticket_amount",
+        "stop_loss_pct",
+        "take_profit_pct",
+        "max_instrument_exposure_pct",
+        "max_portfolio_exposure_pct",
+        "max_drawdown_pct",
+        "min_net_expectancy_pct",
+        "cost_stress_multiplier",
+    ],
+)
+def test_a_non_finite_limit_is_one_named_refusal_and_never_an_invalid_operation(field: str) -> None:
+    """Every limit, not just the one that happened to be checked.
+
+    ⚠ The failure this replaces is not a wrong answer, it is an exception class:
+    ``Decimal("NaN") <= 0`` raises ``InvalidOperation``, so before the sweep a NaN
+    limit surfaced as a 500 from whichever comparison reached it first, and which
+    comparison that was depended on the field. Asserting ``StrategyControlError``
+    per field is what pins the sweep to the full set rather than to the one case
+    a regression test happened to use.
+    """
+    with pytest.raises(StrategyControlError, match=f"{field} must be finite"):
+        _configure(**{field: Decimal("NaN")})
+
+
+def test_a_non_finite_fixed_ticket_amount_is_still_refused_under_fixed_sizing() -> None:
+    """The pre-existing check kept its meaning — the sweep did not displace it.
+
+    ``fixed_ticket_amount`` is ``None`` under percent sizing, so the sweep skips
+    it there; this is the arm where it carries a value.
+    """
+    with pytest.raises(StrategyControlError, match="fixed_ticket_amount must be finite"):
+        _configure(
+            ticket_sizing_mode="fixed",
+            ticket_fraction=None,
+            fixed_ticket_amount=Decimal("NaN"),
+        )
+
+
+def test_a_negative_net_expectancy_floor_is_refused() -> None:
+    """A negative floor inverts the paper executor's own gate.
+
+    ``strategy_paper_executor`` refuses on
+    ``net_expectancy < intent.min_net_expectancy_pct``, so ``-0.01`` admits a
+    signal whose stressed cost exceeds its forecast expectancy — and writes no
+    refusal row, because nothing refused.
+    """
+    with pytest.raises(StrategyControlError, match="min_net_expectancy_pct must be non-negative"):
+        _configure(min_net_expectancy_pct=Decimal("-0.01"))
+
+
+def test_a_zero_net_expectancy_floor_reaches_the_database() -> None:
+    """Zero is admissible, and the boundary is load-bearing.
+
+    The value replaced a hardcoded ``net_expectancy <= 0`` refusal; expressing
+    "strictly positive" is now the operator's to do with a positive floor. So the
+    bound must be ``< 0``, not ``<= 0`` — and the proof that zero passed
+    validation is that the call goes on to touch the connection.
+    """
+    with pytest.raises(AssertionError, match="database was accessed"):
+        _configure(min_net_expectancy_pct=Decimal("0"))

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -1483,6 +1483,46 @@ def test_an_unsupported_currency_is_unrepresentable_at_rest(
     assert excinfo.value.diag.constraint_name == constraint
 
 
+def test_the_net_expectancy_floor_check_excludes_nan_and_not_only_negatives(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """#2859/sql/368 — the NaN clause is the half a "tidy-up" would delete.
+
+    ⚠ Asserted against the server, not against the migration text: a bare
+    ``min_net_expectancy_pct >= 0`` looks complete and is not. Measured on this
+    Postgres, ``'NaN'::numeric >= 0`` is TRUE — NaN sorts above every non-NaN
+    value — so the one-sided bound admits the exact value the service-side
+    finiteness sweep exists to refuse, and ``NUMERIC(12,8)`` stores it happily
+    (only Infinity overflows the declaration).
+
+    The two-sided sibling CHECKs on this table exclude NaN as an accident of
+    their upper bound. This column has no upper bound, so the exclusion has to
+    be written down.
+    """
+    conn = ebull_test_conn
+    row = conn.execute(
+        """
+        SELECT pg_get_constraintdef(c.oid)
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        WHERE t.relname = 'strategy_execution_policies'
+          AND c.conname = 'strategy_execution_policies_min_net_expectancy_bounded'
+        """
+    ).fetchone()
+    assert row is not None, "sql/368 did not apply"
+
+    definition = str(row[0])
+    assert ">= (0)" in definition.replace("::numeric", ""), definition
+    assert "NaN" in definition, (
+        f"{definition} bounds the floor below but not against NaN; "
+        "'NaN'::numeric >= 0 is TRUE in Postgres, so this admits NaN"
+    )
+
+    # And the server agrees with the reading above, rather than only the text.
+    assert conn.execute("SELECT 'NaN'::numeric >= 0").fetchone() == (True,)
+    assert conn.execute("SELECT 'NaN'::numeric <> 'NaN'::numeric").fetchone() == (False,)
+
+
 @pytest.mark.parametrize(
     ("table", "constraint"),
     [


### PR DESCRIPTION
Second half of #2859 — the `feature/2770-operator-promotion` audit. The ticket stays open; see "What this leaves" below.

## The audit, before any porting

Same method as the first half (`dd537255`), because it is the method that paid: classify each absent behaviour before writing a line. Branch tests with no name-equivalent on `main`: **70**.

| class | n | disposition |
| --- | ---: | --- |
| **MT-1** (`test_strategy_mt1_runner`, `test_strategy_mt1_store`, `test_2769_mt1_result_ledger_db`, `test_run_2769_mt1_in_sample`, `test_2769_mt1_auditors`, `test_2437_mt1_declarations`) | 38 | **Dead.** The MT-1 line was cut by the operator on 2026-08-22 (#2437 R5b, #2769 CLOSED). Porting them would re-land a cut line. |
| **Superseded by main's promotion shape** (`test_strategy_operator_promotion.py`) | 18 | Not ported — see below. |
| **Already resolved** by `dd537255` or superseded there | 9 | The #2766 eleven; two of those were deliberately never ported. |
| **Real gaps** | 3 | Two fixed here; one recorded below. |

### Why the 18 are superseded, measured rather than assumed

The branch's `strategy_operator_promotion.py` and main's share **zero symbols**. The branch validated caller-supplied `result_ids` individually; main's module *owns the denominator* — 6 `RECENT_EVIDENCE_WINDOWS` × 4 ambiguity×quarantine arms = 24 rows, bound to `current_identity_pins()` for cross-row coherence — which is the same defect closed one level up. Each branch behaviour maps onto a main symbol, and main tests them:

| branch behaviour | main equivalent | test files on main referencing it |
| --- | --- | ---: |
| incomplete / duplicate denominator | `load_authoritative_recent_evidence(...).refusals` | 1 |
| later stage must preserve the historical pin | `weakening_refusals` | 1 |
| prospective window wholly post-forward | `select_prospective_assessment(..., forward_started_at=)` | 1 |
| no live / arbitrary stage in the vocabulary | `OperatorAction` Literal + `_NON_OPERATOR_STAGES` + `allowed_operator_action` | 1 |
| registration ordered / idempotent / concurrent | `lock_strategy_control` then `current_stage` (lock first, by design) | 2 |

Main additionally refuses any evidence action on a strategy whose `registered_strategy_purpose` is not `capital_candidate`, which the branch had no equivalent for. Porting the branch tests would have asserted the weaker shape.

## The two real gaps this fixes

### 1. `min_net_expectancy_pct` had no bound anywhere

Every numeric field on `strategy_execution_policies` is bounded twice — once in `configure_execution_policy`, once by a schema CHECK:

```
max_instrument_exposure_pct  > 0 AND <= 100
max_portfolio_exposure_pct   > 0 AND <= 100
max_drawdown_pct             > 0 AND <  100
cost_stress_multiplier       >= 1
min_net_expectancy_pct       (nothing, either side)
```

`app/services/strategy_paper_executor.py:1225` reads it as `net_expectancy < intent.min_net_expectancy_pct` → refuse. So a **negative** floor turns the gate that stops a losing paper order into one that admits it — silently, with no `strategy_funding_decisions` refusal row afterwards, because nothing refused.

### 2. A non-finite limit was a 500, not a refusal

`Decimal("NaN") <= 0` raises `InvalidOperation`. Main checked `.is_finite()` on `fixed_ticket_amount` only, so a NaN in any other field escaped as an unhandled exception from whichever comparison happened to reach it first — and *which* comparison that was depended on the field. A finiteness sweep now runs above all of them.

### Why the CHECK is not a bare `>= 0`

Measured against this Postgres, not reasoned from IEEE:

```sql
select 'NaN'::numeric >= 0;              -- t
select 'NaN'::numeric = 'NaN'::numeric;  -- t
select 'Infinity'::numeric(12,8);        -- ERROR: numeric field overflow
```

Postgres sorts NaN **above** every non-NaN value, so `>= 0` alone admits NaN. The two-sided sibling CHECKs exclude it only as an accident of their upper bound; this column has no upper bound, so the exclusion is written down (`<> 'NaN'::numeric` — `NaN <> NaN` is FALSE, and a CHECK rejects on FALSE). Infinity needs no clause: `NUMERIC(12,8)` already refuses it.

### Zero stays admissible, deliberately

The branch's hardcoded `net_expectancy <= 0` refusal was replaced on main by a policy value. "Strictly positive" is now the operator's to express as a positive floor, so the bound is `< 0` and not `<= 0`. A test pins the boundary.

## Tests

`tests/test_execution_policy_limits.py` is new and **pure** — 12 cases on the fast pre-push gate. The branch's originals passed a real connection and `deployment_id=1`, which cannot distinguish "refused by the bound" from "refused because the deployment does not exist"; these pass a connection that raises on any attribute access, so "before database access" is actually asserted. The zero case asserts the call *reaches* the connection, which is how it proves validation let zero through.

One DB test (`tests/test_strategy_control_plane.py`) pins the CHECK definition **and** the two Postgres semantics it depends on, so a later "tidy-up" to `>= 0` fails loudly.

## Verification

| check | command | result |
| --- | --- | --- |
| new pure tests | `uv run pytest -m "not db" tests/test_execution_policy_limits.py` | exit 0, 12 collected on the fast tier |
| touched modules, db tier | `uv run pytest -m db -q tests/test_strategy_control_plane.py tests/test_strategy_paper_executor.py` | exit 0 |
| migration applied to dev DB | `uv run python scripts/migrate.py` | `Applied 1 migration(s): ['368_…']` — it was the only pending file |
| constraint present on dev | `pg_get_constraintdef` | `CHECK (((min_net_expectancy_pct >= (0)::numeric) AND (min_net_expectancy_pct <> 'NaN'::numeric)))` |
| **CHECK behaviourally probed on dev**, each in a rolled-back transaction | insert a policy row with each value | `-0.01` → REJECTED by `strategy_execution_policies_min_net_expectancy_bounded`; `NaN` → REJECTED by the same; `0` → ACCEPTED. `strategy_execution_policies` and `strategy_deployments` both back to 0 rows after. |
| existing rows at risk | `select count(*) from strategy_execution_policies` | **0** — nothing to backfill or repair |
| lint / format / typecheck | `ruff check` · `ruff format --check` · `pyright` | 0 / 0 / 0 errors |
| Codex ckpt-2 (schema-migration rung, files staged) | `codex exec review --base origin/main` | no findings |

No jobs-daemon restart: no job, scheduler, ingest or parser code is touched. No `sec_rebuild`: no stored output changes.

## Security model

The change only ever *narrows* what can be stored. `min_net_expectancy_pct` is an authority limit on the paper-execution path, and both new refusals fail closed — an unbounded or non-finite value is now rejected where it was previously stored or crashed. No execution-guard rule, kill switch, sandbox boundary or broker path is touched, and nothing here can authorise a trade that could not already be authorised.

## What this leaves — the third real gap, recorded not fixed

**`main` has no path that creates the first paper deployment *and* execution policy.** `configure_execution_policy` has exactly one `INSERT`, reachable only from `PUT /strategies/{id}/sizing`, which first `SELECT`s the existing policy and raises `paper execution policy is unavailable` if there is none. Circular. The branch's `create_strategy_paper_setup` + `StrategyInitialPaperSetupRequest` are absent from main, and the dev DB measures `strategy_deployments = 0`, `strategy_execution_policies = 0`.

Out of scope here (a new authenticated route that creates a deployment and an explicit policy atomically is a feature, not an audit fix), and left on #2859 with this evidence rather than opened as a new ticket, per the loop's no-new-audit-ticket rule.

⚠ Incidental, one line as required: `cost_stress_multiplier`'s CHECK is the other one-sided bound on this table (`>= 1`), so it admits NaN at rest for the same reason — unreachable in practice now that the service sweep refuses non-finite input, and not widened here.

Refs #2859