### PR TITLE
feature(#2859): the paper lane has no way in — add the first-setup route

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -1152,6 +1152,56 @@ class AllocationUpdateResponse(BaseModel):
     revision: int
 
 
+class StrategyInitialPaperSetupRequest(BaseModel):
+    """#2859 — every limit on the first paper policy, supplied explicitly.
+
+    ⚠ No defaults, deliberately, matching ``configure_execution_policy``'s own
+    rule: every number here can authorise or refuse capital, so it has to be an
+    operator decision that appears in the audit stream rather than a constant
+    nobody chose. That is why this model is long.
+    """
+
+    strategy_version: str = Field(min_length=1, max_length=200)
+    capital_limit: Decimal = Field(gt=0, max_digits=18, decimal_places=6)
+    ticket_sizing_mode: Literal["percent", "fixed"]
+    ticket_value: Decimal = Field(gt=0, max_digits=18, decimal_places=6)
+    max_ticket_amount: Decimal = Field(gt=0, max_digits=18, decimal_places=6)
+    stop_loss_pct: Decimal = Field(gt=0, lt=100)
+    take_profit_pct: Decimal = Field(gt=0)
+    max_quote_age_seconds: int = Field(gt=0)
+    max_scan_age_seconds: int = Field(gt=0)
+    max_halt_feed_age_seconds: int = Field(gt=0)
+    max_cost_age_seconds: int = Field(gt=0)
+    max_reconciliation_age_seconds: int = Field(gt=0)
+    max_instrument_exposure_pct: Decimal = Field(gt=0, le=100)
+    max_portfolio_exposure_pct: Decimal = Field(gt=0, le=100)
+    max_drawdown_pct: Decimal = Field(gt=0, lt=100)
+    min_net_expectancy_pct: Decimal = Field(ge=0)
+    cost_stress_multiplier: Decimal = Field(ge=1)
+    reason: str = Field(min_length=1, max_length=1000)
+
+    @model_validator(mode="after")
+    def valid_ticket_shape(self) -> StrategyInitialPaperSetupRequest:
+        if self.ticket_sizing_mode == "percent" and self.ticket_value > 100:
+            raise ValueError("percent ticket value must be in (0, 100]")
+        if self.ticket_sizing_mode == "fixed" and self.ticket_value > self.max_ticket_amount:
+            raise ValueError("fixed ticket value cannot exceed its hard maximum")
+        if self.max_ticket_amount > self.capital_limit:
+            raise ValueError("hard ticket maximum cannot exceed the strategy capital limit")
+        return self
+
+
+class StrategyInitialPaperSetupResponse(BaseModel):
+    strategy_id: str
+    strategy_version: str
+    deployment_id: int
+    deployment_revision: int
+    policy_revision: int
+    capital_limit: Decimal
+    #: Never anything else. Setup is not an enable — see the route's docstring.
+    enabled: Literal[False]
+
+
 class StrategySizingUpdateRequest(BaseModel):
     strategy_version: str = Field(min_length=1, max_length=200)
     ticket_sizing_mode: Literal["percent", "fixed"]
@@ -3408,6 +3458,114 @@ def update_core_mandate(
     except (CoreMandateError, CoreEligibilityError) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return _core_mandate_response(mandate)
+
+
+@router.post(
+    "/{strategy_id}/paper-setup",
+    response_model=StrategyInitialPaperSetupResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_strategy_paper_setup(
+    strategy_id: str,
+    body: StrategyInitialPaperSetupRequest,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategyInitialPaperSetupResponse:
+    """Create the first disabled paper deployment and its explicit risk policy.
+
+    #2859 — recovered from ``feature/2770-operator-promotion``, which the 08-21
+    rebuild lost. Without it the paper lane is unreachable, and not merely
+    awkward: ``configure_execution_policy`` holds the only INSERT into
+    ``strategy_execution_policies``, its sole caller ``PUT /{id}/sizing`` first
+    SELECTs the policy it is about to revise, and ``PUT /{id}/allocation``
+    refuses unless ``allocation_ready``, which is ``not allocation_refusals`` and
+    so is false while ``execution_policy_missing`` is one of them. Each route
+    requires the other's output. This is the only way in.
+
+    ⚠⚠ Setup is NOT an enable, and the ``enabled=False`` is the load-bearing
+    part rather than a conservative default. Enabling paper automation is
+    ``PUT /strategies/paper-pool``, which carries the demo-environment and
+    live-trading exclusivity guards added in #2859's first half — both taken
+    under ``PAPER_ALLOCATOR_ADVISORY_LOCK``. A setup route that could enable
+    would be a second door into the same authority with none of those checks on
+    it, which is exactly the "one-sided guard is decorative" shape that half
+    already had to fix once.
+
+    ⚠ The pool-ceiling comparison below is an EARLY refusal, not the
+    authoritative one. ``strategy_paper_executor`` reads ``pool.capital_limit``
+    as the hard cap at execution time and that stays the enforcement; refusing
+    here only means an operator finds out at setup instead of at the first
+    fired signal.
+    """
+    _require_current_strategy_version(strategy_id, body.strategy_version)
+    try:
+        with conn.transaction():
+            # Lock first, then read — the other order decides against a stage a
+            # concurrent request may already have moved, the same ordering
+            # `advance_strategy` documents.
+            lock_strategy_control(conn, strategy_id, body.strategy_version)
+            if current_stage(conn, strategy_id, body.strategy_version) != "paper_enabled":
+                raise StrategyControlError("strategy must be paper-approved before initial setup")
+            overview = get_strategy_overview(conn)
+            strategy = next((item for item in overview.strategies if item.strategy_id == strategy_id), None)
+            if strategy is None:
+                raise StrategyControlError("strategy overview changed; refresh required")
+            if strategy.allocation.policy_configured:
+                raise StrategyControlError("paper execution policy is already configured")
+            # `execution_policy_missing` is the refusal this route exists to
+            # clear, so it is the one code that must not block it. Every other
+            # refusal is a real prerequisite and still applies.
+            blocking = [code for code in strategy.allocation_refusals if code != "execution_policy_missing"]
+            if blocking:
+                raise StrategyControlError(f"paper setup prerequisites failed: {', '.join(blocking)}")
+            pool = load_paper_pool(conn)
+            if pool.capital_limit <= 0:
+                raise StrategyControlError("paper pool capital limit must be configured first")
+            if body.capital_limit > pool.capital_limit:
+                raise StrategyControlError("strategy capital limit cannot exceed the paper pool limit")
+            deployment = configure_deployment(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=body.strategy_version,
+                mode="paper",
+                capital_limit=body.capital_limit,
+                enabled=False,
+                changed_by=session.username,
+                reason=body.reason,
+            )
+            policy = configure_execution_policy(
+                conn,
+                deployment_id=deployment.deployment_id,
+                ticket_sizing_mode=body.ticket_sizing_mode,
+                ticket_fraction=(body.ticket_value / Decimal("100") if body.ticket_sizing_mode == "percent" else None),
+                fixed_ticket_amount=(body.ticket_value if body.ticket_sizing_mode == "fixed" else None),
+                max_ticket_amount=body.max_ticket_amount,
+                stop_loss_pct=body.stop_loss_pct,
+                take_profit_pct=body.take_profit_pct,
+                max_quote_age_seconds=body.max_quote_age_seconds,
+                max_scan_age_seconds=body.max_scan_age_seconds,
+                max_halt_feed_age_seconds=body.max_halt_feed_age_seconds,
+                max_cost_age_seconds=body.max_cost_age_seconds,
+                max_reconciliation_age_seconds=body.max_reconciliation_age_seconds,
+                max_instrument_exposure_pct=body.max_instrument_exposure_pct,
+                max_portfolio_exposure_pct=body.max_portfolio_exposure_pct,
+                max_drawdown_pct=body.max_drawdown_pct,
+                min_net_expectancy_pct=body.min_net_expectancy_pct,
+                cost_stress_multiplier=body.cost_stress_multiplier,
+                changed_by=session.username,
+                reason=body.reason,
+            )
+    except StrategyControlError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return StrategyInitialPaperSetupResponse(
+        strategy_id=strategy_id,
+        strategy_version=body.strategy_version,
+        deployment_id=deployment.deployment_id,
+        deployment_revision=deployment.revision,
+        policy_revision=policy.revision,
+        capital_limit=deployment.capital_limit,
+        enabled=False,
+    )
 
 
 @router.put(

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -3495,7 +3495,10 @@ def create_strategy_paper_setup(
     authoritative one. ``strategy_paper_executor`` reads ``pool.capital_limit``
     as the hard cap at execution time and that stays the enforcement; refusing
     here only means an operator finds out at setup instead of at the first
-    fired signal.
+    fired signal. The same caveat applies to the whole pre-flight: the control
+    lock is per strategy-version, so the overview and the pool it reads are not
+    frozen against a concurrent ``configure_paper_pool``. Nothing here is the
+    last line of defence, and none of it is written as if it were.
     """
     _require_current_strategy_version(strategy_id, body.strategy_version)
     try:
@@ -3512,6 +3515,20 @@ def create_strategy_paper_setup(
                 raise StrategyControlError("strategy overview changed; refresh required")
             if strategy.allocation.policy_configured:
                 raise StrategyControlError("paper execution policy is already configured")
+            # ⚠⚠ FIRST setup, asserted rather than assumed. `configure_deployment`
+            # UPSERTs on (strategy_id, strategy_version, mode), so without this an
+            # existing deployment that happens to have no policy would be silently
+            # revised here — taking `body.capital_limit` with it. That is a bypass,
+            # not a cosmetic one: `PUT /{id}/allocation` requires `allocation_ready`
+            # (no refusals at all) to move a ceiling, whereas this route deliberately
+            # tolerates `execution_policy_missing`. A strategy in exactly that state
+            # could therefore have its capital ceiling RAISED through the setup door
+            # with the allocation gate never consulted. Refusing keeps the route's
+            # name true and leaves ceiling changes to the route that gates them.
+            if strategy.allocation.deployment_id is not None:
+                raise StrategyControlError(
+                    "a paper deployment already exists; revise it via the allocation and sizing routes"
+                )
             # `execution_policy_missing` is the refusal this route exists to
             # clear, so it is the one code that must not block it. Every other
             # refusal is a real prerequisite and still applies.

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -4,15 +4,23 @@ from __future__ import annotations
 
 import re
 from dataclasses import replace
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any, cast
+from uuid import uuid4
 
 import psycopg
 import psycopg.sql
 import pytest
+from fastapi import HTTPException
 
-from app.api.strategies import get_strategy_overview
+from app.api.strategies import (
+    StrategyInitialPaperSetupRequest,
+    create_strategy_paper_setup,
+    get_strategy_overview,
+)
+from app.security.sessions import SessionRow
 from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
 from app.services.result_ledger import (
@@ -1481,6 +1489,243 @@ def test_an_unsupported_currency_is_unrepresentable_at_rest(
                 (deployment.deployment_id,),
             )
     assert excinfo.value.diag.constraint_name == constraint
+
+
+def _operator_session() -> SessionRow:
+    now = datetime.now(UTC)
+    return SessionRow("paper-setup-session", uuid4(), "operator", now + timedelta(hours=1), now)
+
+
+def _setup_request(**overrides: Any) -> StrategyInitialPaperSetupRequest:
+    fields: dict[str, Any] = {
+        "strategy_version": "v1",
+        "capital_limit": Decimal("100"),
+        "ticket_sizing_mode": "percent",
+        "ticket_value": Decimal("10"),
+        "max_ticket_amount": Decimal("25"),
+        "stop_loss_pct": Decimal("5"),
+        "take_profit_pct": Decimal("10"),
+        "max_quote_age_seconds": 30,
+        "max_scan_age_seconds": 300,
+        "max_halt_feed_age_seconds": 300,
+        "max_cost_age_seconds": 3600,
+        "max_reconciliation_age_seconds": 60,
+        "max_instrument_exposure_pct": Decimal("20"),
+        "max_portfolio_exposure_pct": Decimal("50"),
+        "max_drawdown_pct": Decimal("10"),
+        "min_net_expectancy_pct": Decimal("0"),
+        "cost_stress_multiplier": Decimal("2"),
+        "reason": "explicit first paper limits",
+    }
+    fields.update(overrides)
+    return StrategyInitialPaperSetupRequest(**fields)
+
+
+def _stub_overview(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    refusals: list[str],
+    policy_configured: bool = False,
+) -> None:
+    """Stand in for the real overview so the route's OWN rules are what is tested.
+
+    ⚠ Stated rather than hidden: assembling a genuinely allocation-ready overview
+    needs the full 24-cell evidence matrix, which is `strategy_operator_promotion`'s
+    subject and is tested there. Stubbing it here keeps this test about the two
+    things only this route decides — which refusal codes block setup, and whether
+    the deployment and the policy land together.
+    """
+    monkeypatch.setattr("app.api.strategies._current_versions", lambda: {"S-OWN": "v1"})
+    monkeypatch.setattr(
+        "app.api.strategies.get_strategy_overview",
+        lambda _conn: SimpleNamespace(
+            strategies=[
+                SimpleNamespace(
+                    strategy_id="S-OWN",
+                    allocation=SimpleNamespace(policy_configured=policy_configured),
+                    allocation_refusals=refusals,
+                )
+            ]
+        ),
+    )
+
+
+def test_first_paper_setup_creates_a_disabled_deployment_and_its_policy_atomically(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#2859 — the only way into the paper lane, and it must not enable anything.
+
+    Before this route, `configure_execution_policy` held the repo's one INSERT
+    into `strategy_execution_policies`, reachable only from `PUT /{id}/sizing`,
+    which SELECTs the policy it is about to revise; and `PUT /{id}/allocation`
+    refuses unless `allocation_ready`, which is false while
+    `execution_policy_missing` is a refusal. Each route needed the other's
+    output, so neither row could ever be created.
+    """
+    conn = ebull_test_conn
+    seed_universe_anchor(conn)
+    _paper_stage(conn)
+    configure_paper_pool(
+        conn,
+        enabled=False,
+        capital_limit=Decimal("1000"),
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="bound the demo pool",
+    )
+    _stub_overview(monkeypatch, refusals=["execution_policy_missing"])
+
+    response = create_strategy_paper_setup("S-OWN", _setup_request(), _operator_session(), conn)
+
+    assert response.enabled is False, "setup is not an enable — that is PUT /strategies/paper-pool"
+    assert response.capital_limit == Decimal("100")
+    assert conn.execute(
+        "SELECT capital_limit, enabled FROM strategy_deployments WHERE deployment_id = %s",
+        (response.deployment_id,),
+    ).fetchone() == (Decimal("100"), False)
+    # 10% expressed as a fraction, and the hard maximum carried through unscaled.
+    assert conn.execute(
+        "SELECT ticket_fraction, max_ticket_amount, cost_stress_multiplier "
+        "FROM strategy_execution_policies WHERE deployment_id = %s",
+        (response.deployment_id,),
+    ).fetchone() == (Decimal("0.1"), Decimal("25"), Decimal("2"))
+
+
+def test_a_refused_policy_leaves_no_orphan_deployment_behind(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "Atomically" is the load-bearing word in the route's name.
+
+    The deployment is written first, so a policy refused after it must take the
+    deployment with it. A half-completed setup is worse than none: the strategy
+    would show an allocation with no limits, and `PUT /{id}/sizing` would then
+    happily revise a policy that was never authorised.
+
+    ⚠ Driven by making ``configure_execution_policy`` itself raise, rather than
+    by a bad limit value. A bad value cannot reach it: every bound on the
+    request model mirrors the service's own, so pydantic refuses first and the
+    route is never entered — which is correct behaviour and useless for testing
+    a rollback. What is under test is the transaction boundary, not which
+    validation fires.
+    """
+    conn = ebull_test_conn
+    seed_universe_anchor(conn)
+    _paper_stage(conn)
+    configure_paper_pool(
+        conn,
+        enabled=False,
+        capital_limit=Decimal("1000"),
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="bound the demo pool",
+    )
+    _stub_overview(monkeypatch, refusals=["execution_policy_missing"])
+    before = conn.execute("SELECT count(*) FROM strategy_deployments").fetchone()
+
+    def _refuse(*_args: Any, **_kwargs: Any) -> None:
+        raise StrategyControlError("policy refused after the deployment landed")
+
+    monkeypatch.setattr("app.api.strategies.configure_execution_policy", _refuse)
+
+    with pytest.raises(HTTPException) as excinfo:
+        create_strategy_paper_setup("S-OWN", _setup_request(), _operator_session(), conn)
+
+    assert excinfo.value.status_code == 409
+    assert "policy refused after the deployment landed" in str(excinfo.value.detail)
+    assert conn.execute("SELECT count(*) FROM strategy_deployments").fetchone() == before
+    assert conn.execute("SELECT count(*) FROM strategy_execution_policies").fetchone() == (0,)
+
+
+def test_setup_clears_only_the_missing_policy_refusal_and_no_other(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`execution_policy_missing` is the one code this route exists to clear.
+
+    Every other refusal is a real prerequisite, and a setup route that ignored
+    them would be a way to give a strategy an allocation its evidence does not
+    support — quietly, because nothing downstream re-checks at setup time.
+    """
+    conn = ebull_test_conn
+    seed_universe_anchor(conn)
+    _paper_stage(conn)
+    configure_paper_pool(
+        conn,
+        enabled=False,
+        capital_limit=Decimal("1000"),
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="bound the demo pool",
+    )
+    _stub_overview(monkeypatch, refusals=["execution_policy_missing", "recent_evidence_incomplete"])
+
+    with pytest.raises(HTTPException) as excinfo:
+        create_strategy_paper_setup("S-OWN", _setup_request(), _operator_session(), conn)
+
+    assert excinfo.value.status_code == 409
+    assert "recent_evidence_incomplete" in str(excinfo.value.detail)
+    assert conn.execute("SELECT count(*) FROM strategy_execution_policies").fetchone() == (0,)
+
+
+def test_setup_refuses_a_capital_limit_above_the_shared_paper_pool(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An early refusal, not the enforcement — and worth having anyway.
+
+    ``strategy_paper_executor`` reads ``pool.capital_limit`` as the hard cap at
+    execution time and that remains the authority. Refusing here only moves the
+    discovery from the first fired signal to the setup call.
+    """
+    conn = ebull_test_conn
+    seed_universe_anchor(conn)
+    _paper_stage(conn)
+    configure_paper_pool(
+        conn,
+        enabled=False,
+        capital_limit=Decimal("50"),
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="bound the demo pool small",
+    )
+    _stub_overview(monkeypatch, refusals=["execution_policy_missing"])
+
+    with pytest.raises(HTTPException) as excinfo:
+        create_strategy_paper_setup("S-OWN", _setup_request(), _operator_session(), conn)
+
+    assert excinfo.value.status_code == 409
+    assert "cannot exceed the paper pool limit" in str(excinfo.value.detail)
+
+
+def test_setup_refuses_before_the_strategy_is_paper_approved(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No promotion chain seeded, so the stage is not ``paper_enabled``.
+
+    ⚠ The stage is read AFTER ``lock_strategy_control``, deliberately: the other
+    order decides against a stage a concurrent request may already have moved.
+    """
+    conn = ebull_test_conn
+    seed_universe_anchor(conn)
+    configure_paper_pool(
+        conn,
+        enabled=False,
+        capital_limit=Decimal("1000"),
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="bound the demo pool",
+    )
+    _stub_overview(monkeypatch, refusals=["execution_policy_missing"])
+
+    with pytest.raises(HTTPException) as excinfo:
+        create_strategy_paper_setup("S-OWN", _setup_request(), _operator_session(), conn)
+
+    assert excinfo.value.status_code == 409
+    assert "must be paper-approved" in str(excinfo.value.detail)
+    assert conn.execute("SELECT count(*) FROM strategy_deployments").fetchone() == (0,)
 
 
 def test_the_net_expectancy_floor_check_excludes_nan_and_not_only_negatives(

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -1526,6 +1526,7 @@ def _stub_overview(
     *,
     refusals: list[str],
     policy_configured: bool = False,
+    deployment_id: int | None = None,
 ) -> None:
     """Stand in for the real overview so the route's OWN rules are what is tested.
 
@@ -1542,7 +1543,10 @@ def _stub_overview(
             strategies=[
                 SimpleNamespace(
                     strategy_id="S-OWN",
-                    allocation=SimpleNamespace(policy_configured=policy_configured),
+                    allocation=SimpleNamespace(
+                        policy_configured=policy_configured,
+                        deployment_id=deployment_id,
+                    ),
                     allocation_refusals=refusals,
                 )
             ]
@@ -1666,6 +1670,64 @@ def test_setup_clears_only_the_missing_policy_refusal_and_no_other(
 
     assert excinfo.value.status_code == 409
     assert "recent_evidence_incomplete" in str(excinfo.value.detail)
+    assert conn.execute("SELECT count(*) FROM strategy_execution_policies").fetchone() == (0,)
+
+
+def test_setup_refuses_when_a_deployment_already_exists_even_without_a_policy(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FIRST setup, asserted rather than assumed — and the bypass it closes is real.
+
+    ``configure_deployment`` UPSERTs on ``(strategy_id, strategy_version, mode)``,
+    so a deployment that exists without a policy would otherwise be silently
+    revised here, carrying ``body.capital_limit`` with it. ``PUT /{id}/allocation``
+    requires ``allocation_ready`` — no refusals at all — to move a ceiling, while
+    this route deliberately tolerates ``execution_policy_missing``. A strategy in
+    exactly that state could have had its ceiling RAISED through the setup door
+    with the allocation gate never consulted.
+
+    ⚠ Found by Codex checkpoint 3, on a round the review bot had already
+    APPROVED — and it was a false claim of mine ("no path writes one without the
+    other") rather than a flagged line, which is why neither diff review saw it.
+    """
+    conn = ebull_test_conn
+    seed_universe_anchor(conn)
+    _paper_stage(conn)
+    configure_paper_pool(
+        conn,
+        enabled=False,
+        capital_limit=Decimal("1000"),
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="bound the demo pool",
+    )
+    existing = configure_deployment(
+        conn,
+        strategy_id="S-OWN",
+        strategy_version="v1",
+        mode="paper",
+        capital_limit=Decimal("10"),
+        enabled=False,
+        changed_by="operator",
+        reason="a deployment that never got a policy",
+    )
+    _stub_overview(
+        monkeypatch,
+        refusals=["execution_policy_missing"],
+        deployment_id=existing.deployment_id,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        create_strategy_paper_setup("S-OWN", _setup_request(capital_limit=Decimal("900")), _operator_session(), conn)
+
+    assert excinfo.value.status_code == 409
+    assert "already exists" in str(excinfo.value.detail)
+    # The ceiling is untouched — the whole point of the refusal.
+    assert conn.execute(
+        "SELECT capital_limit FROM strategy_deployments WHERE deployment_id = %s",
+        (existing.deployment_id,),
+    ).fetchone() == (Decimal("10"),)
     assert conn.execute("SELECT count(*) FROM strategy_execution_policies").fetchone() == (0,)
 
 


### PR DESCRIPTION
Third and last real gap from the `feature/2770-operator-promotion` audit (#2859). The audit's classification and its other two gaps merged as `461398e1` (PR #2893); this is the one that needed a route rather than a bound.

## `main` cannot create a paper deployment or an execution policy. At all.

Not "awkwardly", not "only via a script" — there is no path:

| step | what stops it |
| --- | --- |
| create a policy | `configure_execution_policy` (`strategy_control_plane.py:984`) holds the repo's **only** `INSERT INTO strategy_execution_policies`. Its sole caller is `PUT /strategies/{id}/sizing`, which first `SELECT`s the policy it is about to revise and raises `paper execution policy is unavailable`. |
| create a deployment first, then the policy | `PUT /strategies/{id}/allocation` refuses unless `row.allocation_ready`, which is literally `not allocation_refusals` (`app/api/strategies.py:2434`) — and `execution_policy_missing` is appended whenever `not control.policy_configured` (`:2305-2306`). The `risk_reducing` escape needs `row.allocation.deployment_id is not None`, which is `None` when no deployment exists. |

Each route requires the other's output. Measured on the dev DB:

```sql
select count(*) from strategy_deployments;          -- 0
select count(*) from strategy_execution_policies;   -- 0
```

So `strategy_paper_executor` refuses every fired signal with `execution_policy_missing` and nothing in the application can change that. This route is the only way in.

## What it does

`POST /strategies/{strategy_id}/paper-setup` → 201. One transaction, under `lock_strategy_control`:

1. `_require_current_strategy_version` (404 / 409, the existing helper);
2. lock, **then** read the stage — the same ordering `advance_strategy` documents, because the other order decides against a stage a concurrent request may already have moved. Stage must be `paper_enabled`;
3. refuse if a policy is already configured;
4. refuse on any `allocation_refusals` code **other than** `execution_policy_missing` — that one is what setup clears, every other one is a real prerequisite;
5. refuse an unconfigured or exceeded paper-pool ceiling;
6. `configure_deployment(mode='paper', enabled=False)` then `configure_execution_policy(...)`.

### ⚠⚠ `enabled=False` is load-bearing, not a conservative default

Enabling paper automation is `PUT /strategies/paper-pool`, which carries the demo-environment guard and the live-trading exclusivity guard added in this ticket's first half (`dd537255`) — both taken under `PAPER_ALLOCATOR_ADVISORY_LOCK`, paired with the inverse check in `PATCH /config`. A setup route that could also enable would be a **second door into the same authority with none of those checks on it**, which is precisely the "a one-sided guard is decorative" shape that half already had to fix once. The response type is `Literal[False]`, so it cannot drift.

### The pool ceiling here is an early refusal, and the code says so

`strategy_paper_executor.py:247` reads `pool.capital_limit` as the hard cap at execution time and that remains the authority. Refusing at setup only moves the discovery from the first fired signal to the setup call. It is not a second copy of the rule.

## Ported onto `main`'s vocabulary, not verbatim

The branch's version sat on `validate_paper_promotion_evidence`, which `main` deliberately superseded with `evidence_refusals` / `load_promotion_evidences` under `GOVERNANCE_GATE_VERSION = "strategy-governance-v2+edge-evidence"`. This uses `main`'s stage machinery and `allocation_refusals` shape. The branch's request/response models port cleanly and are kept, including the deliberate absence of defaults — `configure_execution_policy`'s own rule is that every number can authorise or refuse capital and so must be an operator decision visible in the audit stream.

## Tests — 5 new, in `tests/test_strategy_control_plane.py`

| test | property |
| --- | --- |
| `..._creates_a_disabled_deployment_and_its_policy_atomically` | both rows land; `enabled` is `False`; 10% arrives as `ticket_fraction = 0.1` and `max_ticket_amount` is carried through unscaled |
| `test_a_refused_policy_leaves_no_orphan_deployment_behind` | the deployment is written **first**, so a policy refused after it must take the deployment with it. Half-completed setup is worse than none: the strategy would show an allocation with no limits, and `PUT /{id}/sizing` would then revise a policy nobody authorised |
| `test_setup_clears_only_the_missing_policy_refusal_and_no_other` | a second refusal blocks; no policy row is written |
| `test_setup_refuses_a_capital_limit_above_the_shared_paper_pool` | early refusal fires |
| `test_setup_refuses_before_the_strategy_is_paper_approved` | no promotion chain → 409, no deployment row |

⚠ Two things stated in the tests rather than hidden:

- The overview is **stubbed** on the happy path. Assembling a genuinely allocation-ready overview needs the full 24-cell evidence matrix, which is `strategy_operator_promotion`'s subject and is tested there. Stubbing keeps these tests about the two things only this route decides.
- The rollback test drives the failure by making `configure_execution_policy` raise, **not** by passing a bad limit. A bad limit cannot reach it: every bound on the request model mirrors the service's own, so pydantic refuses first and the route is never entered. (Found by writing the test with `min_net_expectancy_pct=-0.01` and watching pydantic reject it — correct behaviour, useless for testing a rollback.) What is under test is the transaction boundary, not which validation fires.

## Verification

| check | result |
| --- | --- |
| new tests | `uv run pytest -m db -q tests/test_strategy_control_plane.py -k "paper_setup or refused_policy or setup_clears or setup_refuses"` → exit 0 |
| whole module | `uv run pytest -m db -q tests/test_strategy_control_plane.py` → exit 0 |
| neighbours | `uv run pytest -m db -q tests/test_api_strategies.py tests/test_strategy_paper_executor.py` → exit 0 |
| **route actually registered** (the tests call the function, not the route) | `app.routes` → `['POST'] /strategies/{strategy_id}/paper-setup`; `app.openapi()['paths']` contains it → `True` |
| lint / format / typecheck | `ruff check` · `ruff format --check` · `pyright` → 0 / 0 / 0 |
| Codex ckpt-2 (behavioural rung, files staged) | no findings |

**Dev-verify limitation, stated plainly:** the happy path cannot be exercised end-to-end on dev, because it needs a strategy at stage `paper_enabled` with an otherwise-clean overview, and dev currently has `capital_candidate` count 0 and no promotion chains. What *is* verified against the real app object is that the route and its schema are registered. The first real end-to-end run belongs to whoever brings a strategy to `paper_enabled` — which this route is the prerequisite for.

## Security model

This route creates an authority record; it does not exercise one. It is session-authenticated, creates the deployment **disabled**, cannot enable automation (the response type forbids it), and every existing evidence refusal except the one it clears still blocks it. No broker call, no order path, no execution-guard rule, no kill switch, no sandbox boundary. Both writes are in one transaction under the per-version control lock, so a partial setup cannot be observed.

No jobs-daemon restart and no `sec_rebuild`: no job, scheduler, ingest or parser code is touched, and no stored output changes. No migration.

Refs #2859