### PR TITLE
fix(#2414): count bar REVISIONS separately from new bars — the measurement #2414 gates its own fix on

### DIFF
--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -279,6 +279,18 @@ class MarketRefreshSummary:
     # close mismatch (split/adjustment event) and were healed with an
     # in-run full-history re-fetch.
     adjustment_refetches: int = 0
+    # #2414 — the subset of ``candle_rows_upserted`` that OVERWROTE an
+    # existing bar's OHLCV with a different value, as opposed to appending a
+    # new one. Not a second count of the same thing: an insert extends the
+    # series, a revision destroys a value some ``strategy_signals`` row may
+    # already have decided on, and ``price_daily`` keeps no prior value or
+    # audit column, so this counter is the ONLY place a revision is ever
+    # visible. #2414 asked "how often is a bar revised, and by how much"; the
+    # honest answer before this field was that stored state cannot say,
+    # because the overwrite and the evidence of it happen in one statement.
+    # This makes the rate measurable going forward — it does NOT recover the
+    # history, and it does not fix the ledger collision #2414 is really about.
+    candle_rows_revised: int = 0
 
 
 @dataclass(frozen=True)
@@ -554,6 +566,7 @@ def refresh_market_data(
         )
 
     candle_rows_upserted = 0
+    candle_rows_revised = 0
     features_computed = 0
     quotes_updated = 0
     quotes_skipped = 0
@@ -595,6 +608,7 @@ def refresh_market_data(
         else:
             fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days, today=freshness_target)
         upserted = 0
+        revised = 0
         computed = 0
         adjustment_detected = False
         try:
@@ -642,7 +656,8 @@ def refresh_market_data(
                         # only a heal if the series was actually rewritten.
                         adjustment_detected = bool(bars)
                 if bars:
-                    upserted = _upsert_candles(conn, instrument_id, bars)
+                    inserted, revised = _upsert_candles(conn, instrument_id, bars)
+                    upserted = inserted + revised
                     computed = _compute_and_store_features(conn, instrument_id)
             # Accumulate the running totals ONLY after the transaction has
             # committed cleanly (#1293 / Codex): incrementing inside the
@@ -650,6 +665,7 @@ def refresh_market_data(
             # feature-compute or commit later raised and rolled the write back
             # — and that same instrument is also counted in ``candles_failed``.
             candle_rows_upserted += upserted
+            candle_rows_revised += revised
             features_computed += computed
             # Counted only after a clean commit (same #1293 rule as the row
             # totals) — a heal whose re-fetch or write failed did NOT happen.
@@ -732,6 +748,7 @@ def refresh_market_data(
     return MarketRefreshSummary(
         instruments_refreshed=len(instruments),
         candle_rows_upserted=candle_rows_upserted,
+        candle_rows_revised=candle_rows_revised,
         features_computed=features_computed,
         quotes_updated=quotes_updated,
         quotes_skipped=quotes_skipped,
@@ -918,15 +935,44 @@ def _upsert_candles(
     conn: psycopg.Connection,  # type: ignore[type-arg]
     instrument_id: int,
     bars: list[OHLCVBar],
-) -> int:
+) -> tuple[int, int]:
     """
     Upsert OHLCV bars into price_daily. Idempotent — re-running with the same
     data produces no changes (ON CONFLICT DO UPDATE with WHERE clause).
-    Returns the number of rows written (insert or update).
+    Returns ``(inserted, revised)`` — NEW bars and bars whose stored OHLCV was
+    OVERWRITTEN by a different value. Their sum is the old scalar return.
+
+    ⚠⚠ The split exists because these two are not the same event and the
+    caller could not tell them apart (#2414). A new bar extends the series; a
+    revision **destroys the value a strategy already made a decision on**, in
+    place, with no prior value retained anywhere — ``price_daily`` has no
+    audit column, so after this statement nothing can establish that the bar
+    ever held a different number. ``strategy_signals`` rows key on
+    ``(strategy_id, strategy_version, instrument_id, signal_bar_date,
+    signal_kind)`` and carry no corpus stamp, so a revised bar silently
+    invalidates any signal written against it and the corrected verdict cannot
+    even be re-recorded (it collides on that key). Same reasoning as #1293's
+    ``candles_skipped`` / ``candles_failed``: a caller that cannot distinguish
+    two very different outcomes reports both as one number.
+
+    ⚠ The revision surface is NOT the 3-bar correction buffer. ``_candles_fetch_count``
+    falls back to ``lookback_days`` (1000) whenever ``gap_days >
+    _INCREMENTAL_FETCH_BARS``, so any instrument stale by more than 3 days
+    re-observes — and may rewrite — roughly four years of its history in one
+    pass. Measured 2026-08-23: 1,183 of 12,230 instruments (9.7%) were in that
+    state, holding 544,799 bars. A multi-day jobs outage puts the whole
+    universe over that threshold at once.
+
+    ⚠ ``xmax = 0`` distinguishes the INSERT path from the DO UPDATE path;
+    verified empirically against this cluster rather than assumed (insert →
+    ``xmax = 0``; update → non-zero). A row blocked by the ``IS DISTINCT FROM``
+    guard returns NO row at all, so a genuine no-op counts as neither — which
+    is the same thing the previous ``rowcount`` accounting did.
     """
-    written = 0
+    inserted = 0
+    revised = 0
     for bar in bars:
-        result = conn.execute(
+        row = conn.execute(
             """
             INSERT INTO price_daily (
                 instrument_id, price_date, open, high, low, close, volume
@@ -948,6 +994,7 @@ def _upsert_candles(
                 price_daily.close  IS DISTINCT FROM EXCLUDED.close  OR
                 price_daily.volume IS DISTINCT FROM EXCLUDED.volume
             )
+            RETURNING (xmax = 0) AS was_insert
             """,
             {
                 "instrument_id": instrument_id,
@@ -958,9 +1005,14 @@ def _upsert_candles(
                 "close": bar.close,
                 "volume": bar.volume,
             },
-        )
-        written += result.rowcount
-    return written
+        ).fetchone()
+        if row is None:
+            continue
+        if row[0]:
+            inserted += 1
+        else:
+            revised += 1
+    return inserted, revised
 
 
 def _compute_and_store_features(

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -3216,15 +3216,25 @@ def daily_candle_refresh() -> None:
                 context={
                     **watermark_context,
                     "population_status": "partial" if summary.candles_failed or unavailable else "complete",
+                    # #2414 — bars whose stored OHLCV this run OVERWROTE with a
+                    # different value, as opposed to appended. Persisted here
+                    # rather than left in the summary because the counter is
+                    # transient and ``price_daily`` keeps no prior value: once
+                    # this function returns, nothing anywhere can establish that
+                    # a bar was ever revised. ⚠ In ``context`` and not
+                    # ``outcomes`` deliberately — every key there counts
+                    # INSTRUMENTS, and this counts BARS.
+                    "bars_revised": summary.candle_rows_revised,
                 },
             )
         tracker.row_count = summary.candle_rows_upserted
 
     logger.info(
-        "Market refresh complete: instruments=%d candles=%d features=%d quotes=%d "
+        "Market refresh complete: instruments=%d candles=%d bars_revised=%d features=%d quotes=%d "
         "quotes_skipped=%d spread_flags=%d candles_fresh_skipped=%d candles_failed=%d",
         summary.instruments_refreshed,
         summary.candle_rows_upserted,
+        summary.candle_rows_revised,
         summary.features_computed,
         summary.quotes_updated,
         summary.quotes_skipped,

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1245,7 +1245,8 @@ class TestRefreshMarketDataForceBackfill:
             patch("app.services.market_data._candles_are_fresh", return_value=False),
             patch("app.services.market_data._candles_fetch_count", return_value=3),
             patch("app.services.market_data._last_bar", return_value=None),
-            patch("app.services.market_data._upsert_candles", return_value=1) as upsert,
+            # (inserted, revised) since #2414 — a bare int unpacks to nothing.
+            patch("app.services.market_data._upsert_candles", return_value=(1, 0)) as upsert,
             patch("app.services.market_data._compute_and_store_features", return_value=0),
             patch("app.services.market_data._record_supply_outcome"),
         ):
@@ -1307,12 +1308,17 @@ class TestRefreshMarketDataForceBackfill:
         provider.get_daily_candles.return_value = [MagicMock()]  # non-empty bars
 
         with (
-            _patch.object(market_data, "_upsert_candles", return_value=5),
+            # (inserted, revised) since #2414. Deliberately BOTH non-zero: the
+            # #1293 accumulate-only-after-a-clean-commit rule binds the revision
+            # counter exactly as it binds the row total, and a (5, 0) fixture
+            # would leave that half of it unpinned.
+            _patch.object(market_data, "_upsert_candles", return_value=(3, 2)),
             _patch.object(market_data, "_compute_and_store_features", side_effect=RuntimeError("feature boom")),
         ):
             summary = refresh_market_data(provider, conn, instruments=[(42, "AAPL")], skip_quotes=True)
 
-        assert summary.candle_rows_upserted == 0  # the 5 rolled back — not counted
+        assert summary.candle_rows_upserted == 0  # the 3 inserts rolled back — not counted
+        assert summary.candle_rows_revised == 0  # ...and neither are the 2 revisions
         assert summary.candles_failed == 1
 
 

--- a/tests/test_market_data_bar_revision_counter_db.py
+++ b/tests/test_market_data_bar_revision_counter_db.py
@@ -1,0 +1,179 @@
+"""Integration test for the #2414 insert-vs-revision split (one DB-tier file
+for the genuinely-new SQL mechanism, house rule).
+
+Pins the three-way outcome of ``_upsert_candles``' ``RETURNING (xmax = 0)``:
+a NEW bar counts as an insert, a bar whose OHLCV comes back DIFFERENT counts
+as a revision, and a bar that comes back IDENTICAL counts as neither because
+the ``IS DISTINCT FROM`` guard returns no row at all.
+
+⚠ Why this needs a real DB rather than a mocked cursor: ``xmax`` is a system
+column whose value is produced by the ON CONFLICT machinery itself. A mock
+returns whatever it was told to, so a mocked version of this test would pass
+against an upsert that never distinguished the two paths — which is the exact
+defect the counter exists to detect.
+
+⚠ Why the counter matters at all (#2414): ``price_daily`` has no audit column,
+so the overwrite and the evidence of it happen in one statement. Before this
+split, ``candle_rows_upserted`` reported a new bar and a destroyed one as the
+same number, and a revision silently invalidates any ``strategy_signals`` row
+written against that bar — 57,139 of them existed when this was written.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.providers.market_data import OHLCVBar
+from app.services.market_data import (
+    MarketRefreshSummary,
+    most_recent_trading_day,
+    refresh_market_data,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+_IID = 920_414
+
+
+def _weekdays_back(end: date, n: int) -> list[date]:
+    """The n weekdays ending at ``end`` (inclusive), oldest-first."""
+    out: list[date] = []
+    d = end
+    while len(out) < n:
+        if d.weekday() < 5:
+            out.append(d)
+        d -= timedelta(days=1)
+    return list(reversed(out))
+
+
+def _bar(price_date: date, close: str) -> OHLCVBar:
+    c = Decimal(close)
+    return OHLCVBar(price_date=price_date, open=c, high=c, low=c, close=c, volume=1000)
+
+
+def _seed(conn: psycopg.Connection[tuple], days: list[date], close: str) -> None:
+    for d in days:
+        conn.execute(
+            "INSERT INTO price_daily (instrument_id, price_date, open, high, low, close, volume) "
+            "VALUES (%s, %s, %s, %s, %s, %s, 1000) ON CONFLICT DO NOTHING",
+            (_IID, d, Decimal(close), Decimal(close), Decimal(close), Decimal(close)),
+        )
+
+
+def _run(conn: psycopg.Connection[tuple], bars: list[OHLCVBar]) -> MarketRefreshSummary:
+    provider = MagicMock()
+    provider.get_daily_candles.side_effect = [bars]
+    return refresh_market_data(
+        provider,
+        conn,
+        instruments=[(_IID, "REVN")],
+        lookback_days=1000,
+        skip_quotes=True,
+    )
+
+
+def test_new_revised_and_identical_bars_are_counted_separately(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'REVN', 'Revision Test Co', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (_IID,),
+    )
+
+    # Four weekdays ending at the most recent trading day. The last is left
+    # unseeded so the freshness skip does not fire and the run enters
+    # incremental mode (gap of 1 trading day <= the 3-bar window).
+    days = _weekdays_back(most_recent_trading_day(date.today()), 4)
+    _seed(conn, days[:-1], "100")
+
+    # The 3-bar incremental window returns:
+    #   days[-3] — stored at 100, returned at 100  -> IDENTICAL, counts as neither
+    #   days[-2] — stored at 100, returned at 111  -> REVISION
+    #   days[-1] — not stored at all               -> INSERT
+    summary = _run(
+        conn,
+        [_bar(days[-3], "100"), _bar(days[-2], "111"), _bar(days[-1], "123")],
+    )
+
+    assert summary.candles_failed == 0
+    # One overwrite, and it is reported as such rather than folded into the total.
+    assert summary.candle_rows_revised == 1
+    # The identical bar is in neither count — the IS DISTINCT FROM guard
+    # returns no row, so it is not a write at all.
+    assert summary.candle_rows_upserted == 2
+
+    # The revision really did land, so the counter is describing a real
+    # overwrite and not merely a code path.
+    stored = dict(
+        conn.execute(
+            "SELECT price_date, close FROM price_daily WHERE instrument_id = %s",
+            (_IID,),
+        ).fetchall()
+    )
+    assert stored[days[-2]] == Decimal("111")
+    assert stored[days[-1]] == Decimal("123")
+
+
+def test_a_pure_backfill_reports_no_revisions(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The counter must not fire on the ordinary case, or it is noise.
+
+    A revision count that is non-zero on a first-time backfill would make the
+    #2414 measurement useless in exactly the situation it is meant to bound —
+    a >3-day-stale instrument re-observing ~1000 bars.
+    """
+    conn = ebull_test_conn
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'REVN', 'Revision Test Co', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (_IID,),
+    )
+    days = _weekdays_back(most_recent_trading_day(date.today()), 4)
+
+    summary = _run(conn, [_bar(d, "100") for d in days])
+
+    assert summary.candles_failed == 0
+    assert summary.candle_rows_revised == 0
+    assert summary.candle_rows_upserted == len(days)
+
+
+def test_re_running_identical_bars_reports_neither(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Idempotence is preserved: a repeat of the same data is not a revision.
+
+    Without this, the counter would report the whole re-observed window as
+    revised on every stale-instrument refetch and overstate the rate by orders
+    of magnitude — the measurement would confirm itself.
+    """
+    conn = ebull_test_conn
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'REVN', 'Revision Test Co', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (_IID,),
+    )
+    days = _weekdays_back(most_recent_trading_day(date.today()), 4)
+    _seed(conn, days, "100")
+
+    # Every bar is already stored at exactly this value, and the last stored
+    # date is the most recent trading day — so the freshness skip fires and
+    # the provider is never called. Nothing is written either way.
+    summary = _run(conn, [_bar(d, "100") for d in days])
+
+    assert summary.candle_rows_revised == 0
+    assert summary.candle_rows_upserted == 0


### PR DESCRIPTION
#2414 states its own prerequisite: *"How often a `price_daily` bar is actually revised after first write, and by how much… That measurement should come before the fix is chosen — a revision rate of zero would change the priority."* Measured first (working-order 3b). The answer changes the ticket.

## What the measurement found

**1. The revision rate is not recoverable from stored state.** `price_daily` has 27 columns — instrument, date, OHLCV, indicators — and **no `created_at`/`updated_at`**, no audit table. `_upsert_candles` overwrites in place (`market_data.py`, `ON CONFLICT … DO UPDATE … WHERE (… IS DISTINCT FROM …)`), so the overwrite and the evidence of it happen in the same statement. `job_runs.row_count` conflates insert with update. Nothing anywhere can establish that a bar ever held a different number.

**2. ⚠⚠ The revision surface is NOT the 3-bar correction buffer the ticket assumed.** `_candles_fetch_count` falls back to `lookback_days` (**1000**) whenever `gap_days > _INCREMENTAL_FETCH_BARS` (3). So an instrument stale by more than 3 days re-observes — and may rewrite — roughly **four years** of its history in a single pass.

Measured on dev, 2026-08-23 (frontier `2026-08-21`):

| bucket | instruments | bars held | max bars, one instrument |
| --- | ---: | ---: | ---: |
| **>3d stale → 1000-bar refetch** | **1,183** (9.7%) | **544,799** | 1,050 |
| fresh → 3-bar window | 11,047 | 6,288,815 | 1,075 |

A multi-day jobs outage puts the *whole* universe over that threshold at once — and one such outage is already on record (#2833: SIGKILLed jobs child, scheduler down with every health signal green).

**3. It is no longer academic.** `strategy_signals` held **0** rows when #2414 was filed (2026-08-08) and holds **57,139** now, `signal_bar_date` spanning 2026-07-28 → 2026-08-20.

### What that means for the fix choice — evidence, not a pick

The ticket anticipated "frequent but tiny" or "zero". It is neither: the shape is **rare but massive**. That favours candidate 1 (corpus version in the key — a mass rewrite produces new rows beside the old, as `strategy_outcomes` already does) over candidate 2 (supersede-and-record, which would have to mark tens of thousands of rows in one event). **Not decided here** — that is still #2414's call, and it now has evidence rather than a guess.

## What this PR ships

Only the instrumentation the measurement showed was missing:

- `_upsert_candles` returns `(inserted, revised)` instead of one total, via `RETURNING (xmax = 0)`.
- Surfaced as `MarketRefreshSummary.candle_rows_revised`.
- Persisted by `daily_candle_refresh` into `job_runs.progress_json` as `bars_revised`.

⚠ This does **not** fix the ledger collision #2414 is really about, and does not recover any history. It makes the rate measurable **going forward**, which is the ticket's own stated prerequisite. Deliberately narrow.

⚠ `xmax = 0` was **verified empirically against this cluster**, not assumed from memory — insert → `xmax = 0`; update → non-zero; a row blocked by the `IS DISTINCT FROM` guard returns **no row at all**, so a genuine no-op counts as neither. That last case preserves exactly the accounting `rowcount` gave.

## Codex ckpt-2 caught a writer with no reader

The first draft left `candle_rows_revised` discarded by the scheduler — `app/workers/scheduler.py` recorded only `candle_rows_upserted`. Since the counter is transient and `price_daily` retains nothing, revisions from normal scheduled runs would have stayed unobservable the moment the function returned. That is this repo's **recurring writer-with-no-reader shape** — the same defect #2602 just documented for `broker_positions.total_fees`. Fixed before push.

`bars_revised` goes in `JobProgress.context`, not `outcomes`: every key in `outcomes` counts **instruments**, and this counts **bars**.

## Tests

New DB-tier file `tests/test_market_data_bar_revision_counter_db.py` (house rule: one DB file per genuinely-new SQL mechanism), pinning the three-way split — insert / revision / identical-counts-as-neither.

⚠ It needs a real DB rather than a mocked cursor: `xmax` is a system column produced by the ON CONFLICT machinery itself, so a mocked version of this test would pass against an upsert that never distinguished the two paths — the exact defect the counter exists to detect.

⚠ New file, **not** added to `tests/test_market_data.py`: the `db` marker is per-MODULE, so a DB test there would evict that whole pure-tier module from the `-m "not db"` push gate.

**Revert probe.** Forcing `revised` to never increment fails `test_new_revised_and_identical_bars_are_counted_separately`, while the two "must not fire on the ordinary case" guards correctly stay green (they assert `revised == 0`, which the injected defect also satisfies — that is the intended asymmetry). Restored via `cp` backup and the suite re-run green afterwards, per the probe-restore rule.

`test_market_data.py`'s rollback test now patches `(3, 2)` rather than `5` and asserts `candle_rows_revised == 0`, so #1293's accumulate-only-after-a-clean-commit rule is pinned for the revision counter too — a `(5, 0)` fixture would have left that half unpinned.

## Security model

Not applicable. No auth surface, no user input, no new external call, no schema change. The one SQL change adds a `RETURNING` clause to an existing parameterised statement.

## Verification

| gate | result |
| --- | --- |
| `ruff check .` / `ruff format --check .` | pass |
| `pyright` (full, exit code not piped) | 0 errors |
| `pytest -m "not db"` | exit 0 |
| `pytest tests/smoke -n 0` | exit 0 |
| `pytest -m db` on `test_daily_candle_refresh.py`, `test_market_data_split_adjustment_db.py`, new file | exit 0 |
| Codex ckpt-2 (`review --base origin/main`, staged) | clean after the scheduler fix |
| pre-push hook | green |

No migration, no backfill, no `sec_rebuild` — this alters no stored output, only whether a revision leaves a trace. **Jobs daemon restart IS required** on merge (scheduler change).

Refs #2414. Refs #2394.