### PR TITLE
fix(#2306): the engine refuses these theses and the screen still shows them as fact

### DIFF
--- a/docs/specs/ui/2026-08-23-2306-thesis-quarantine-surface.md
+++ b/docs/specs/ui/2026-08-23-2306-thesis-quarantine-surface.md
@@ -1,0 +1,233 @@
+# Surface the thesis subject-identity verdict to the operator (#2306)
+
+Status: spec, 2026-08-23. Ticket: #2306. Guard named by: #2842.
+
+## What is already true (measured, not inherited)
+
+#2306 was filed when no discriminator existed. Two later tickets shipped one:
+
+- **#2431** — `app/services/thesis_subject_identity.py::memo_names_subject`. Positive
+  containment ("does the memo name its own instrument?"), which sidesteps all three
+  "first parenthesised token" discriminators #2306 falsified. Enforced at write time in
+  `_validate_writer_output` (`app/services/thesis.py:1743`), riding retry-once.
+- **#2436** — `sql/332` stores the verdict on the row
+  (`subject_identity_ok` / `_rule_version` / `_checked_at`, all-set-or-all-NULL CHECK),
+  `ensure_subject_identity_verdicts` backfills it at lifespan, and every deterministic
+  consumer fails closed on `IS NOT TRUE`: `portfolio.py:455`, `scoring.py:1291`/`:1649`,
+  `entry_timing.py:366`, `alerts.py:845`, `reporting.py:649`.
+
+So this ticket's decision-path half is closed. Its last section is not:
+
+> **Also open: the 19 stored bad memos** — They are rendered to the operator today.
+
+### Full-population measurement, dev DB, 2026-08-23
+
+```sql
+SELECT count(*), count(*) FILTER (WHERE subject_identity_ok IS FALSE),
+       count(*) FILTER (WHERE subject_identity_ok IS NULL) FROM theses;
+-- 3714 | 1512 | 0
+```
+
+```sql
+WITH latest AS (
+  SELECT DISTINCT ON (instrument_id) instrument_id, prompt_version, subject_identity_ok
+    FROM theses ORDER BY instrument_id, created_at DESC, thesis_version DESC)
+SELECT prompt_version, count(*), count(*) FILTER (WHERE subject_identity_ok IS FALSE)
+  FROM latest GROUP BY 1 ORDER BY 1;
+-- v3 1/0 · v4 88/0 · v5 90/70 · v6 8/8 · v7 295/0   → 78 of 482 latest rows quarantined
+```
+
+⚠ The `DISTINCT ON` tie-break is `thesis_version DESC`, matching `_LIBRARY_SQL:517` and
+`portfolio.py`, not an ad-hoc `thesis_id DESC`. Checked rather than assumed — the two
+orderings pick a different row on **0** of 482 instruments here, so the 78 is stable
+under either, but the query stated is the consumers'.
+
+⚠ **Reconciling the four numbers, because three of them are in this ticket's history and
+they measure different sets.** 1,512 = every stored row the current rule refuses.
+78 = the subset that is the LATEST row for its instrument, i.e. what a page renders.
+178 = `sql/332`'s equivalent latest-row count on 2026-08-12, since superseded by v7
+regenerations. 19 = #2306's own 2026-08-05 count of a *narrower* class — memos whose
+first parenthesised token resolves to a different real symbol. The stored rule is
+stricter than that class: it refuses any memo that never names its subject, of which
+naming a different company is one case. All four are unusable to a consumer, which is
+why one verdict covers them; they are not the same measurement and must not be
+substituted for one another.
+
+Latest-row samples, so the class is concrete rather than statistical:
+
+| symbol | prompt | stance | base_value | memo opens |
+| --- | --- | --- | ---: | --- |
+| AA | v5 | avoid | — | "SQQQ (ProShares UltraPro QQQ) is a leveraged inverse ETF" |
+| ACA.US | v6 | buy | 150.00 | "### 企业名称：Coca-Cola Company (KO)" |
+| AAPL | v5 | buy | 258.50 | "[Company] exhibits strong fundamentals…" |
+| AGCO | v6 | buy | 100.00 | "The company demonstrates strong fundamentals…" |
+
+## The defect
+
+`grep -rn subject_identity_ok frontend/src` returns **nothing**. The field is on both
+Pydantic response models (`app/api/theses.py:207` detail, `:280` list) and in both
+SELECTs (`_THESIS_COLUMNS:334`, `_LIBRARY_SQL:488`/`:515`) — the wire carries it and the
+frontend never declared it.
+
+So on the 78 instruments above, today:
+
+- `SummaryStrip.tsx:271-281` renders an always-visible `Thesis: BUY 85%` chip.
+- `ThesisPane.tsx:268-320` renders the bear/base/bull/buy-zone band and the memo.
+- `ThesesPage.tsx:359`/`:376` renders stance + buy zone in the library.
+
+Every one of those is a verdict the deterministic layer has already refused. This is a
+sharper form of the repo's recurring writer-with-no-reader shape: the readers exist in
+*every* decision path and are missing only on the surface a human reasons from, so the
+operator and the engine disagree about the same row with nothing on screen saying so.
+
+⚠ Not hypothetical downstream: `sql/332`'s header records 14 EXIT recommendations that
+had already fired "Valuation target reached" against a `base_value` written about a
+different company. That path is now closed in code; the screen still shows the band.
+
+## Decision — annotate, do not hide, do not regenerate
+
+Three options existed and this is decided here rather than escalated (the facts to settle
+it are all above):
+
+- **Regenerate** — infeasible and not merely slow: `thesis_refresh` is parked
+  (`llm_model_writer = 'parked-2855'`, #2855) and measured at 651 s/thesis, so 1,512 rows
+  is ~11 days of a starved box. It also loses the evidence base.
+- **Hide the row** — contradicts `docs/settled-decisions.md:147` ("do not overwrite prior
+  thesis rows") and `app/api/theses.py:202-206`, which states the row stays visible
+  *because* it is the truthful record. Hiding also makes the page lie in the other
+  direction: it would read as "no thesis exists", which is a different false state.
+- **Annotate** ← chosen. The row keeps rendering; the screen states the verdict the
+  engine already reached, in the same words (`thesis_quarantined`).
+
+## Design
+
+### 1. One predicate, mirroring the Python one
+
+`frontend/src/lib/thesisQuarantine.ts`:
+
+```ts
+export type ThesisSubjectState = "usable" | "unnamed_subject" | "unchecked";
+export function thesisSubjectState(ok: boolean | null | undefined): ThesisSubjectState;
+export function isThesisQuarantined(ok: boolean | null | undefined): boolean;
+```
+
+`isThesisQuarantined` is `ok !== true` — the exact complement of
+`thesis_subject_identity.is_thesis_usable` (`row.get(...) is True`). `undefined` (field
+absent from an older payload or a partial test fixture) therefore reads as quarantined,
+which is the fail-closed direction and matches how NULL is treated server-side.
+
+⚠ The `false` state is named `unnamed_subject`, **not** `misattributed`. `false` records
+only that the memo never named its own instrument; it does not establish that some other
+company was positively identified. Naming the state for the stronger claim would restate,
+in the type system, exactly the conflation this spec's measurement section warns against.
+
+`unnamed_subject` (false) and `unchecked` (null/undefined) differ only in copy: "never
+names its subject" vs "not yet checked". Both refuse.
+
+⚠ **The predicate alone is not sufficient on the library.** `ThesisLibraryItem` gives a
+row to held instruments that have **no thesis at all**, with every thesis field null
+(`app/api/theses.py:235-239`) — so `ok !== true` is true there for the trivial reason
+that there is nothing to check. Marking those "quarantined" would invent a defect. The
+library marker is therefore gated on `thesis_id !== null` as well; `ThesisPane` and
+`SummaryStrip` need no such gate because both already early-return on a null thesis.
+
+### 2. One banner component
+
+`frontend/src/components/theses/ThesisQuarantineBanner.tsx`, modelled on
+`OwnershipCoverageBanner.tsx` — `role="status"`, `data-subject-state`, glyph +
+headline + body, dark-mode pair per `design-system.md`.
+
+Copy names the machine-readable reason so the screen and the logs agree:
+
+> ⊘ **Thesis quarantined — subject identity failed.** This memo never names AAPL, so its
+> figures may describe a different company. The deterministic layer refuses it
+> (`thesis_quarantined`) — portfolio, scoring, entry timing, alerts and reporting; it is
+> shown for evidence only.
+
+⚠ The copy claims exactly what the stored rule decided ("never names its subject") and
+hedges the consequence ("may describe a different company"). It must not be tightened to
+"is about a different company", which the verdict does not establish. The consumer list
+is the census verified above, not a paraphrase — if a consumer is added or drops the
+guard, this sentence is wrong and the census in this spec is where to correct it.
+
+### 3. Wiring (frontend only — no backend or schema change)
+
+| file | change |
+| --- | --- |
+| `api/types.ts` | `subject_identity_ok: boolean \| null` on `ThesisDetail` + `ThesisLibraryItem` |
+| `components/instrument/ThesisPane.tsx` | banner first in the body; band marked refused and its derived conclusions suppressed |
+| `components/instrument/SummaryStrip.tsx` | stance chip takes the refused tone + `⊘` when quarantined |
+| `pages/ThesesPage.tsx` | `⊘` marker beside `StanceBadge`, gated on `thesis_id !== null` |
+
+`VerdictTab.tsx`, `ResearchTab.tsx` and `DensityGrid.tsx` all render the memo *through*
+`ThesisPane`, so they inherit the banner and are not touched.
+
+⚠ The TS fields are **required** `boolean | null`, not `?: boolean | null`. Both models
+declare `subject_identity_ok: bool | None = None` and Pydantic serialises the default, so
+the key is always on the wire; `api-shape-and-types.md` makes asymmetric nullability the
+drift bug to avoid. Optional would also let a page silently omit the field and typecheck
+clean. The predicate still accepts `undefined` — that is defence for hand-built test
+fixtures, not a wire state the types admit.
+
+### 3a. Derived conclusions are suppressed; stored numbers are not
+
+"Annotate, do not hide" applies to the *record*. It does not extend to conclusions this
+component computes on top of a refused record, which read as live analysis rather than as
+evidence:
+
+- `upsideToBase` — the `+12.4%` chip beside Base.
+- `outsideZone` — "Current price is outside the buy zone — entry conditions not met at
+  market."
+
+Both are suppressed when quarantined. Bear/base/bull/buy-zone themselves keep rendering,
+inside the refused band, because they are what the writer actually produced and this
+surface is the evidence base for them.
+
+### 4. The invariant that makes this a safety surface, not decoration
+
+**The banner and the memo must be inseparable.** `safety-state-ui.md` forbids deriving a
+safety banner from a refetchable async value, because a refetch nulls `data` and the
+banner vanishes while the page still reads dangerous. That failure mode is structurally
+absent here only because both are read off the *same* `thesis` object, and `ThesisPane`
+returns `null` when `thesis === null && !errored` — so on a refetch the memo and the
+banner disappear together. That is a property to assert, not to assume: a test renders
+the pane across the state matrix and fails if any state shows `memo_markdown` without
+the banner.
+
+## Tests
+
+- `lib/thesisQuarantine.test.ts` — table over `true` / `false` / `null` / `undefined`.
+- `ThesisPane.test.tsx` — banner present on false/null/undefined, absent on true; the
+  inseparability assertion above; band marked refused; `upsideToBase` and the
+  outside-zone sentence absent when quarantined and present when not.
+- `SummaryStrip.test.tsx` — chip carries the refused marker; unquarantined chip unchanged.
+- `ThesesPage.test.tsx` — marker on a quarantined row, absent on a clean one, and
+  **absent on a held row with `thesis_id === null`**, which is the case the bare
+  predicate gets wrong.
+
+Accessibility: the `⊘` glyph is `aria-hidden` everywhere and always accompanied by text
+the assistive layer can read — the banner's headline on the pane, and an `sr-only`
+"quarantined" beside the library marker. A glyph with only a `title` is not a label.
+
+## Source rule
+
+None governs this: it is a UI treatment of a verdict whose rule (`#2431`) is already
+fixed and version-hashed. The discipline that binds is full-population verification of
+the *claim*, which is the two queries above run over all 3,714 rows.
+
+## Out of scope
+
+- Changing `memo_names_subject` itself. Its version hash covers the whole file, so any
+  edit rewrites all 3,714 stored verdicts (`thesis_subject_identity.py` docstring).
+- Regenerating or deleting rows.
+- #2306's original A/B of the v6 prompt anchor, which stays unpowered at these rates.
+- **A rule-version freshness check in the UI.** Raised at Codex ckpt-1 and rebutted:
+  `ensure_subject_identity_verdicts` runs at LIFESPAN and re-decides every row whose
+  `subject_identity_rule_version IS DISTINCT FROM` the current one, so a verdict issued
+  under a superseded rule cannot survive a boot. Re-deriving that on the client would be
+  a second copy of the rule with no way to stay in step.
+- **`DiffBlock` against a quarantined PREDECESSOR.** A clean latest thesis can carry a
+  diff whose "was" side came from a refused row. Real, and not addressed here: the diff
+  is computed server-side in `_fetch_diffs` on an explicit `thesis_version - 1` lookup
+  that does not consult the verdict, so the fix belongs in that query, not on the screen.
+  Noted on the PR rather than ticketed, per the loop's no-new-audit-ticket rule.

--- a/docs/specs/ui/2026-08-23-2306-thesis-quarantine-surface.md
+++ b/docs/specs/ui/2026-08-23-2306-thesis-quarantine-surface.md
@@ -133,22 +133,41 @@ library marker is therefore gated on `thesis_id !== null` as well; `ThesisPane` 
 
 ### 2. One banner component
 
-`frontend/src/components/theses/ThesisQuarantineBanner.tsx`, modelled on
-`OwnershipCoverageBanner.tsx` — `role="status"`, `data-subject-state`, glyph +
-headline + body, dark-mode pair per `design-system.md`.
+`frontend/src/components/theses/ThesisQuarantineBanner.tsx` — `data-subject-state`,
+glyph + headline + body, dark-mode pair per `design-system.md`.
 
 Copy names the machine-readable reason so the screen and the logs agree:
 
-> ⊘ **Thesis quarantined — subject identity failed.** This memo never names AAPL, so its
-> figures may describe a different company. The deterministic layer refuses it
-> (`thesis_quarantined`) — portfolio, scoring, entry timing, alerts and reporting; it is
-> shown for evidence only.
+> ⊘ **Thesis quarantined — subject identity failed.** This memo never names its own
+> instrument, so its figures may describe a different company. The engine refuses it
+> (`thesis_quarantined`) and no decision path will use it. It is shown here for evidence
+> only.
 
 ⚠ The copy claims exactly what the stored rule decided ("never names its subject") and
 hedges the consequence ("may describe a different company"). It must not be tightened to
-"is about a different company", which the verdict does not establish. The consumer list
-is the census verified above, not a paraphrase — if a consumer is added or drops the
-guard, this sentence is wrong and the census in this spec is where to correct it.
+"is about a different company", which the verdict does not establish.
+
+⚠ **`role="alert"`, not `role="status"`** (review NITPICK, PR #2897, and raised
+independently at Codex ckpt-1). The draft copied `status` from
+`OwnershipCoverageBanner`, which reports a condition of the DATA; this reports a REFUSAL
+of it, and the repo's convention for that class is assertive —
+`KillSwitchSection.tsx:203`, `ErrorBanner.tsx:4`, both order modals.
+
+⚠⚠ **The copy does NOT enumerate the consumers** (review NITPICK, PR #2897). The draft
+named "portfolio, scoring, entry timing, alerts and reporting" — accurate when written,
+with no compile-time link to the Python modules it named, so a consumer change would
+leave operator-facing text quietly wrong. That is the hardcoded-derived-fact-in-prose
+failure `.claude/CLAUDE.md` names. The sentence is now true by construction, and the
+census is pinned somewhere it can be checked instead:
+`tests/test_thesis_subject_identity_consumers.py` fails if a module reads
+`subject_identity_ok` without being declared either a guarded consumer (must call
+`is_thesis_usable`) or a documented mirror. It also pins `portfolio.py` specifically —
+that is the path `sql/332` records 14 wrong-company EXITs on.
+
+⚠ Writing the census surfaced that the five consumers do not use one mechanism:
+`portfolio.py` / `scoring.py` / `reporting.py` call `is_thesis_usable`, `entry_timing.py`
+mirrors the predicate in SQL, and `alerts.py` compares inline. All five refuse correctly;
+"they all call the helper" would have been the wrong claim.
 
 ### 3. Wiring (frontend only — no backend or schema change)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1393,6 +1393,14 @@ export interface ThesisDetail {
   prompt_version?: string | null;
   model?: string | null;
   provider?: string | null;
+  /** #2436 stored subject-identity verdict; surfaced by #2306. NOT a filter —
+   *  the row stays visible as the truthful record. `false` = the memo never
+   *  names its own instrument, so its figures may belong to another company;
+   *  `null` = never checked. Both are refused by portfolio / scoring /
+   *  entry-timing / alerts / reporting. Read it via
+   *  `@/lib/thesisQuarantine`, never by comparing to `false` — NULL refuses
+   *  too. */
+  subject_identity_ok: boolean | null;
   /** Server-computed staleness (#1902 single source: find_stale_instruments).
    *  Populated only on the latest-thesis GET; null on history/POST payloads. */
   is_stale?: boolean | null;
@@ -1445,6 +1453,11 @@ export interface ThesisLibraryItem {
    *  null/false on v1 rows, gap rows, or an unchanged regen. */
   last_change_summary: string | null;
   last_change_material: boolean;
+  /** #2436 verdict; see `ThesisDetail.subject_identity_ok`.
+   *  ⚠ null ALSO on the held-but-unthesised rows this list deliberately
+   *  includes, where `thesis_id` is null too — gate any marker on
+   *  `thesis_id !== null` or "no thesis yet" renders as "quarantined". */
+  subject_identity_ok: boolean | null;
 }
 
 export interface ThesisLibraryResponse {

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -92,6 +92,7 @@ function freshThesis(): ThesisDetail {
     memo_markdown: "Fresh thesis memo.",
     critic_json: null,
     created_at: now.toISOString(),
+    subject_identity_ok: true,
     is_stale: false,
     stale_reason: null,
   };
@@ -767,5 +768,56 @@ describe("SummaryStrip — live-tick currency sourcing (#1906)", () => {
     expect(screen.getByTestId("price-companion")).toHaveTextContent(
       "≈ GBP 86.00",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2306 — the always-visible stance chip must not present a REFUSED thesis in
+// the same tone as a live one. This chip is the surface an operator glances at
+// before opening anything, so a quarantined `buy` rendering green is the exact
+// shape that let a wrong-company valuation band read as actionable.
+// ---------------------------------------------------------------------------
+describe("SummaryStrip — thesis subject-identity quarantine (#2306)", () => {
+  it("marks a refused thesis on the chip without dropping the stance", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={{ ...freshThesis(), subject_identity_ok: false }}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    const badge = screen.getByTestId("thesis-badge");
+    expect(badge).toHaveAttribute("data-refused", "true");
+    expect(badge.textContent).toContain("(refused)");
+    // The operator still needs to know what the memo claimed.
+    expect(badge.textContent).toContain("BUY");
+    expect(badge).toHaveAttribute("title", expect.stringContaining("thesis_quarantined"));
+  });
+
+  it("treats an UNCHECKED verdict as refused too (null is not passed)", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={{ ...freshThesis(), subject_identity_ok: null }}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByTestId("thesis-badge")).toHaveAttribute("data-refused", "true");
+  });
+
+  it("leaves a passing thesis chip untouched", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    const badge = screen.getByTestId("thesis-badge");
+    expect(badge).not.toHaveAttribute("data-refused");
+    expect(badge.textContent).not.toContain("(refused)");
   });
 });

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -23,6 +23,7 @@ import type {
 } from "@/api/types";
 import { Term } from "@/components/Term";
 import { formatCloseDate } from "@/lib/format";
+import { isThesisQuarantined, thesisRefusalTooltip } from "@/lib/thesisQuarantine";
 import {
   liveTickDisplayCompanion,
   liveTickNativePrice,
@@ -182,6 +183,9 @@ export function SummaryStrip({
     position !== null &&
     position.trades.length === 1;
   const thesisStale = isThesisStale(thesis);
+  // #2306 — null thesis is handled by the badge branches below, so this is
+  // only consulted where a thesis exists.
+  const thesisQuarantined = thesis !== null && isThesisQuarantined(thesis.subject_identity_ok);
   // Still offer Generate thesis on errored thesis state — gives the
   // operator a retry affordance instead of silent lockout.
   const showGenerateThesis = (thesisLoaded && thesisStale) || thesisError;
@@ -271,12 +275,34 @@ export function SummaryStrip({
         {thesis !== null ? (
           <span
             data-testid="thesis-badge"
-            className={`inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium ${thesisTone(thesis.stance)}`}
+            data-refused={thesisQuarantined ? "true" : undefined}
+            title={
+              thesis !== null && thesisQuarantined
+                ? thesisRefusalTooltip(thesis.subject_identity_ok)
+                : undefined
+            }
+            /* #2306 — a quarantined thesis loses the stance TONE, not the
+               stance. The chip is the always-visible surface, so a refused
+               `buy` rendering in the same green as a live one is the exact
+               thing that let a wrong-company band read as actionable. The
+               stance itself stays: the operator still needs to know what the
+               memo claimed. */
+            className={`inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium ${
+              thesisQuarantined
+                ? "border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-950/40 dark:text-red-300"
+                : thesisTone(thesis.stance)
+            }`}
           >
+            {thesisQuarantined ? (
+              <span aria-hidden="true" className="mr-1">
+                ⊘
+              </span>
+            ) : null}
             Thesis: {thesis.stance.toUpperCase()}
             {thesis.confidence_score !== null
               ? ` ${Math.round(Number(thesis.confidence_score) * 100)}%`
               : ""}
+            {thesisQuarantined ? <span className="ml-1.5">(refused)</span> : null}
             {thesisStale ? (
               <span className="ml-1.5 text-amber-600">(stale)</span>
             ) : null}

--- a/frontend/src/components/instrument/ThesisPane.test.tsx
+++ b/frontend/src/components/instrument/ThesisPane.test.tsx
@@ -387,6 +387,15 @@ describe("ThesisPane subject-identity quarantine (#2306)", () => {
     expect(screen.queryByText(zoneCopy)).not.toBeInTheDocument();
   });
 
+  it("announces assertively — a refusal, not a status (PR #2897 review)", () => {
+    // The repo's convention for a safety refusal is role="alert"
+    // (KillSwitchSection, ErrorBanner, both order modals). role="status" was
+    // copied from OwnershipCoverageBanner, which reports a condition of the
+    // DATA rather than a refusal of it.
+    render(<ThesisPane thesis={withVerdict(false)} errored={false} />);
+    expect(screen.getByTestId(BANNER)).toHaveAttribute("role", "alert");
+  });
+
   it("INVARIANT: never renders the memo without the banner", () => {
     // safety-state-ui.md's failure mode is a banner derived from a refetchable
     // value vanishing while the dangerous content stays. Structurally absent

--- a/frontend/src/components/instrument/ThesisPane.test.tsx
+++ b/frontend/src/components/instrument/ThesisPane.test.tsx
@@ -23,6 +23,12 @@ const FIXTURE = {
   prompt_version: "v2",
   model: "qwen3:14b",
   provider: "openai_compatible",
+  // #2306 — the verdict is REQUIRED on the wire, so the fixture carries it
+  // rather than leaning on the `as unknown as` cast this file used to end
+  // with. A cast here would have hidden the very drift the required type is
+  // for, and `undefined` reads as quarantined, so the omission would have
+  // silently flipped every assertion below into the refused branch.
+  subject_identity_ok: true,
 } as unknown as ThesisDetail;
 
 describe("ThesisPane", () => {
@@ -302,5 +308,99 @@ describe("ThesisPane — break predicate rows (#2051)", () => {
     } as unknown as ThesisDetail;
     render(<ThesisPane thesis={bare} errored={false} />);
     expect(screen.getByText("Lose 50% market share")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2306 — the subject-identity verdict on the screen.
+//
+// The deterministic layer has refused these rows since #2431/#2436; until this
+// ticket the pane rendered them as fact. On the dev corpus that was 78 of 482
+// latest-per-instrument theses.
+// ---------------------------------------------------------------------------
+describe("ThesisPane subject-identity quarantine (#2306)", () => {
+  const BANNER = "thesis-quarantine-banner";
+
+  function withVerdict(ok: boolean | null | undefined): ThesisDetail {
+    return { ...FIXTURE, subject_identity_ok: ok } as unknown as ThesisDetail;
+  }
+
+  it("shows no banner when the verdict passed", () => {
+    render(<ThesisPane thesis={withVerdict(true)} errored={false} />);
+    expect(screen.queryByTestId(BANNER)).not.toBeInTheDocument();
+    expect(screen.getByTestId("thesis-band")).not.toHaveAttribute("data-refused");
+  });
+
+  it.each([
+    [false, "unnamed_subject", "never names its own instrument"],
+    [null, "unchecked", "has not been checked"],
+    [undefined, "unchecked", "has not been checked"],
+  ] as const)("banners a %s verdict as %s", (ok, state, copy) => {
+    render(<ThesisPane thesis={withVerdict(ok)} errored={false} />);
+    const banner = screen.getByTestId(BANNER);
+    expect(banner).toHaveAttribute("data-subject-state", state);
+    expect(banner).toHaveTextContent(copy);
+    // The refusal must name the machine-readable reason the engine logs, so
+    // the screen and the logs are greppable by the same word.
+    expect(banner).toHaveTextContent("thesis_quarantined");
+  });
+
+  it("marks the valuation band refused but still renders the stored targets", () => {
+    render(<ThesisPane thesis={withVerdict(false)} errored={false} />);
+    // Annotate, do not hide: the band is the writer's actual output and the
+    // evidence base for the verdict (docs/settled-decisions.md:147).
+    expect(screen.getByTestId("thesis-band")).toHaveAttribute("data-refused", "true");
+    expect(screen.getByText("Bear")).toBeInTheDocument();
+    expect(screen.getByText("Base")).toBeInTheDocument();
+    expect(screen.getByText("Bull")).toBeInTheDocument();
+  });
+
+  it("suppresses the upside-to-base conclusion, which is not part of the record", () => {
+    // base 20 against a price of 10 is +100%; a quarantined band must not
+    // render that as live analysis.
+    const { rerender } = render(
+      <ThesisPane thesis={withVerdict(true)} errored={false} currentPrice="10" />,
+    );
+    expect(screen.getByText("+100.0%")).toBeInTheDocument();
+
+    rerender(<ThesisPane thesis={withVerdict(false)} errored={false} currentPrice="10" />);
+    expect(screen.queryByText("+100.0%")).not.toBeInTheDocument();
+  });
+
+  it("suppresses the outside-buy-zone conclusion", () => {
+    const buyable = (ok: boolean): ThesisDetail =>
+      ({
+        ...FIXTURE,
+        stance: "buy",
+        buy_zone_low: 100,
+        buy_zone_high: 120,
+        subject_identity_ok: ok,
+      }) as unknown as ThesisDetail;
+    const zoneCopy = /entry conditions not met at market/;
+
+    const { rerender } = render(
+      <ThesisPane thesis={buyable(true)} errored={false} currentPrice="500" />,
+    );
+    expect(screen.getByText(zoneCopy)).toBeInTheDocument();
+
+    rerender(<ThesisPane thesis={buyable(false)} errored={false} currentPrice="500" />);
+    expect(screen.queryByText(zoneCopy)).not.toBeInTheDocument();
+  });
+
+  it("INVARIANT: never renders the memo without the banner", () => {
+    // safety-state-ui.md's failure mode is a banner derived from a refetchable
+    // value vanishing while the dangerous content stays. Structurally absent
+    // here because both are read off the SAME thesis object and the pane
+    // early-returns on a null one — asserted rather than assumed.
+    for (const ok of [false, null, undefined] as const) {
+      const { unmount } = render(<ThesisPane thesis={withVerdict(ok)} errored={false} />);
+      expect(screen.getByText("Buy on weakness.")).toBeInTheDocument();
+      expect(screen.getByTestId(BANNER)).toBeInTheDocument();
+      unmount();
+    }
+    // The other half of the invariant: no memo on screen at all when there is
+    // no thesis object to carry a verdict.
+    const { container } = render(<ThesisPane thesis={null} errored={false} />);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/frontend/src/components/instrument/ThesisPane.tsx
+++ b/frontend/src/components/instrument/ThesisPane.tsx
@@ -2,6 +2,8 @@ import { Pane } from "@/components/instrument/Pane";
 import { CriticVerdictBadge } from "@/components/theses/CriticVerdictBadge";
 import { MemoMarkdown } from "@/components/theses/MemoMarkdown";
 import { StanceBadge } from "@/components/theses/StanceBadge";
+import { ThesisQuarantineBanner } from "@/components/theses/ThesisQuarantineBanner";
+import { isThesisQuarantined } from "@/lib/thesisQuarantine";
 import { EmptyState } from "@/components/states/EmptyState";
 import type { ThesisBreakPredicate, ThesisDetail, ThesisDiff } from "@/api/types";
 import { Badge } from "@/components/ui/Badge";
@@ -206,13 +208,25 @@ function ThesisBody({ thesis, currentPrice, currency }: BodyProps): JSX.Element 
     thesis.bear_value !== null ||
     hasBuyZone;
 
+  // #2306 — the stored subject-identity verdict (#2436). The row still
+  // renders; what changes is that the screen stops asserting it as a verdict
+  // the way the deterministic layer already stopped reading it.
+  const quarantined = isThesisQuarantined(thesis.subject_identity_ok);
+
   const price = currentPrice !== null && currentPrice !== "" ? Number(currentPrice) : null;
   const priceValid = price !== null && Number.isFinite(price) && price > 0;
+  // ⚠ #2306 — DERIVED CONCLUSIONS are suppressed on a quarantined thesis; the
+  // stored numbers are not. "Annotate, do not hide" protects the RECORD — the
+  // bear/base/bull the writer actually produced, which is the evidence this
+  // surface exists to show. `upsideToBase` and `outsideZone` were never in
+  // that record: they are this component computing live analysis on top of a
+  // band the engine refuses, and they read as conclusions, not as evidence.
   const upsideToBase =
-    priceValid && thesis.base_value !== null
+    !quarantined && priceValid && thesis.base_value !== null
       ? ((thesis.base_value - (price as number)) / (price as number)) * 100
       : null;
   const outsideZone =
+    !quarantined &&
     priceValid &&
     thesis.stance === "buy" &&
     thesis.buy_zone_low !== null &&
@@ -230,6 +244,13 @@ function ThesisBody({ thesis, currentPrice, currency }: BodyProps): JSX.Element 
 
   return (
     <div className="space-y-3 text-sm">
+      {/* #2306 — FIRST in the body, and mounted unconditionally: it renders
+          null when the verdict is `true`. Mounting it here rather than at the
+          page level is what makes the warning inseparable from the memo — both
+          are read off the same `thesis` object, and `ThesisPane` early-returns
+          when that object is null, so a refetch cannot leave the memo on screen
+          without the banner (`safety-state-ui.md`). */}
+      <ThesisQuarantineBanner subjectIdentityOk={thesis.subject_identity_ok} />
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
         <StanceBadge stance={thesis.stance} />
         <span className="text-xs capitalize text-slate-600 dark:text-slate-400">
@@ -267,7 +288,21 @@ function ThesisBody({ thesis, currentPrice, currency }: BodyProps): JSX.Element 
       {thesis.diff !== null && thesis.diff !== undefined && <DiffBlock diff={thesis.diff} />}
 
       {hasBand && (
-        <div className="rounded bg-slate-50 dark:bg-slate-900/40 p-3">
+        <div
+          className={
+            quarantined
+              ? "rounded border border-dashed p-3 opacity-70 border-red-300 bg-slate-50 dark:border-red-800 dark:bg-slate-900/40"
+              : "rounded bg-slate-50 dark:bg-slate-900/40 p-3"
+          }
+          data-testid="thesis-band"
+          data-refused={quarantined ? "true" : undefined}
+        >
+          {quarantined && (
+            <p className="mb-2 text-[11px] font-medium text-red-700 dark:text-red-300">
+              Refused — these targets are shown as the writer produced them, not as a
+              valuation the engine will act on.
+            </p>
+          )}
           <dl className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-5">
             <div>
               <dt className="text-slate-500">Bear</dt>

--- a/frontend/src/components/instrument/VerdictTab.test.tsx
+++ b/frontend/src/components/instrument/VerdictTab.test.tsx
@@ -81,6 +81,7 @@ const THESIS: ThesisDetail = {
   memo_markdown: "The bull case rests on services.",
   critic_json: null,
   created_at: "2026-06-29T09:00:00Z",
+  subject_identity_ok: true,
 };
 
 function mockHistoryEmpty() {

--- a/frontend/src/components/theses/ThesisQuarantineBanner.tsx
+++ b/frontend/src/components/theses/ThesisQuarantineBanner.tsx
@@ -1,0 +1,69 @@
+/**
+ * Thesis quarantine banner (#2306) — the operator-facing half of #2431/#2436.
+ *
+ * The deterministic layer already refuses a thesis whose memo never names its
+ * own instrument: `portfolio.py`, `scoring.py`, `entry_timing.py`,
+ * `alerts.py` and `reporting.py` all fail closed on
+ * `theses.subject_identity_ok IS NOT TRUE`. Until this component existed the
+ * SCREEN did not — `grep -rn subject_identity_ok frontend/src` returned
+ * nothing — so the engine and the operator disagreed about the same row with
+ * nothing said about it. On the dev corpus that was 78 of 482 latest-per-
+ * instrument theses.
+ *
+ * ⚠ The row is NOT hidden. `docs/settled-decisions.md:147` forbids overwriting
+ * prior thesis rows and `app/api/theses.py:202-206` keeps them visible
+ * deliberately: they are the truthful record of what the writer produced and
+ * the evidence base for the write-side fix. Hiding would also make the page
+ * lie in the other direction — it would read as "no thesis exists".
+ *
+ * ⚠⚠ COPY DISCIPLINE. The banner claims exactly what the stored rule decided
+ * ("never names its subject") and hedges the consequence ("may describe a
+ * different company"). Do not tighten it to "is about a different company":
+ * the verdict does not establish that, and #2306's history is a chain of
+ * measurements being substituted for one another.
+ */
+import type { JSX } from "react";
+
+import { thesisRefusalBody, thesisSubjectState } from "@/lib/thesisQuarantine";
+
+export interface ThesisQuarantineBannerProps {
+  /** The stored verdict, straight off the thesis row. */
+  readonly subjectIdentityOk: boolean | null | undefined;
+}
+
+/**
+ * Renders nothing when the verdict is `true`. Callers may therefore mount it
+ * unconditionally beside the memo, which is what keeps the two inseparable —
+ * see the invariant test in `ThesisPane.test.tsx`.
+ *
+ * ⚠ Deliberately takes NO symbol. Naming the instrument ("never names AAPL")
+ * would read better, but `ThesisDetail` carries `instrument_id`, not `symbol`,
+ * so it would have to be threaded through `VerdictTab` / `ResearchTab` /
+ * `DensityGrid` — and only `DensityGrid` has it to hand. Threading it where it
+ * is cheap and falling back where it is not gives the SAME page two different
+ * warnings for the same defect, which is worse than one uniform sentence.
+ */
+export function ThesisQuarantineBanner({
+  subjectIdentityOk,
+}: ThesisQuarantineBannerProps): JSX.Element | null {
+  const state = thesisSubjectState(subjectIdentityOk);
+  if (state === "usable") return null;
+
+  return (
+    <div
+      className="rounded-md border px-3 py-2 text-xs border-red-200 bg-red-50 text-red-900 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200"
+      role="status"
+      data-testid="thesis-quarantine-banner"
+      data-subject-state={state}
+    >
+      <p className="font-medium">
+        {/* aria-hidden glyph — the headline is the entire accessible label. */}
+        <span aria-hidden="true" className="mr-1.5 font-semibold">
+          ⊘
+        </span>
+        Thesis quarantined — subject identity failed
+      </p>
+      <p className="mt-0.5">{thesisRefusalBody(subjectIdentityOk)}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/theses/ThesisQuarantineBanner.tsx
+++ b/frontend/src/components/theses/ThesisQuarantineBanner.tsx
@@ -52,7 +52,14 @@ export function ThesisQuarantineBanner({
   return (
     <div
       className="rounded-md border px-3 py-2 text-xs border-red-200 bg-red-50 text-red-900 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200"
-      role="status"
+      /* ⚠ `alert`, not `status`. The first draft copied `status` from
+         `OwnershipCoverageBanner`, which reports COVERAGE — a condition of the
+         data. This reports a REFUSAL: the figures beside it are ones the engine
+         will not act on. The repo's convention for that class is assertive —
+         `KillSwitchSection.tsx:203`, `ErrorBanner.tsx:4`, both order modals.
+         It also genuinely appears dynamically, when the async thesis resolves,
+         which is the case a live region is for. */
+      role="alert"
       data-testid="thesis-quarantine-banner"
       data-subject-state={state}
     >

--- a/frontend/src/lib/thesisQuarantine.test.ts
+++ b/frontend/src/lib/thesisQuarantine.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isThesisQuarantined,
+  thesisRefusalBody,
+  thesisRefusalClaim,
+  thesisRefusalTooltip,
+  thesisSubjectState,
+  THESIS_QUARANTINE_REASON,
+} from "@/lib/thesisQuarantine";
+
+describe("thesisQuarantine", () => {
+  // The whole point of the predicate is the NULL/undefined direction: the
+  // Python side is `is True`, so "nobody decided" must not read as "passed".
+  const cases: ReadonlyArray<{
+    readonly ok: boolean | null | undefined;
+    readonly state: ReturnType<typeof thesisSubjectState>;
+    readonly quarantined: boolean;
+  }> = [
+    { ok: true, state: "usable", quarantined: false },
+    { ok: false, state: "unnamed_subject", quarantined: true },
+    { ok: null, state: "unchecked", quarantined: true },
+    { ok: undefined, state: "unchecked", quarantined: true },
+  ];
+
+  for (const c of cases) {
+    it(`${String(c.ok)} → ${c.state} (quarantined: ${String(c.quarantined)})`, () => {
+      expect(thesisSubjectState(c.ok)).toBe(c.state);
+      expect(isThesisQuarantined(c.ok)).toBe(c.quarantined);
+    });
+  }
+
+  it("agrees with the backend refusal vocabulary", () => {
+    // Mirrors thesis_subject_identity.QUARANTINE_REASON — the screen and the
+    // logs must say the same word, so a drift here is a real failure.
+    expect(THESIS_QUARANTINE_REASON).toBe("thesis_quarantined");
+  });
+
+  it("never reports a false verdict as merely unchecked", () => {
+    // The two refusing states must stay distinguishable: `false` is a decided
+    // failure, `null` is an undecided row, and they carry different copy.
+    expect(thesisSubjectState(false)).not.toBe(thesisSubjectState(null));
+  });
+
+  describe("refusal copy", () => {
+    // Codex ckpt-2 on this ticket: the banner distinguished the two refusing
+    // states correctly while two hard-coded tooltips claimed "never names its
+    // instrument" for BOTH — asserting, on an undecided row, a check that never
+    // ran. These pin the distinction at the single source the surfaces now read.
+    it("claims a failed check ONLY on a decided failure", () => {
+      expect(thesisRefusalClaim(false)).toContain("never names its own instrument");
+    });
+
+    it.each([null, undefined] as const)(
+      "does not claim a failed check on an undecided row (%s)",
+      (ok) => {
+        expect(thesisRefusalClaim(ok)).toContain("has not been checked");
+        expect(thesisRefusalClaim(ok)).not.toContain("never names");
+      },
+    );
+
+    it("names the machine-readable reason on every refusing surface", () => {
+      for (const ok of [false, null, undefined] as const) {
+        expect(thesisRefusalTooltip(ok)).toContain(THESIS_QUARANTINE_REASON);
+        expect(thesisRefusalBody(ok)).toContain(THESIS_QUARANTINE_REASON);
+      }
+    });
+
+    it("keeps the tooltip a prefix of the banner body — one claim, two lengths", () => {
+      // If these ever diverge, the same row says two different things
+      // depending on which surface the operator happens to be looking at.
+      for (const ok of [false, null] as const) {
+        expect(thesisRefusalBody(ok).startsWith(thesisRefusalTooltip(ok))).toBe(true);
+      }
+    });
+  });
+});

--- a/frontend/src/lib/thesisQuarantine.test.ts
+++ b/frontend/src/lib/thesisQuarantine.test.ts
@@ -66,6 +66,20 @@ describe("thesisQuarantine", () => {
       }
     });
 
+    it("does not enumerate the consumers, which cannot be kept in step from here", () => {
+      // Review NITPICK on PR #2897: the copy used to name "portfolio, scoring,
+      // entry timing, alerts and reporting" with no link to the Python modules
+      // it claimed, so a consumer change would leave operator-facing text
+      // quietly wrong. The census now lives in
+      // tests/test_thesis_subject_identity_consumers.py, where it is checkable.
+      for (const ok of [false, null] as const) {
+        const copy = thesisRefusalBody(ok);
+        for (const consumer of ["portfolio", "scoring", "entry timing", "reporting"]) {
+          expect(copy).not.toContain(consumer);
+        }
+      }
+    });
+
     it("keeps the tooltip a prefix of the banner body — one claim, two lengths", () => {
       // If these ever diverge, the same row says two different things
       // depending on which surface the operator happens to be looking at.

--- a/frontend/src/lib/thesisQuarantine.ts
+++ b/frontend/src/lib/thesisQuarantine.ts
@@ -61,10 +61,22 @@ export function isThesisQuarantined(ok: boolean | null | undefined): boolean {
  */
 export const THESIS_QUARANTINE_REASON = "thesis_quarantined";
 
-/** Who refuses the row — the verified consumer census, not a paraphrase. */
+/**
+ * Who refuses the row.
+ *
+ * ⚠ DELIBERATELY DOES NOT ENUMERATE THE CONSUMERS. The first draft listed
+ * "portfolio, scoring, entry timing, alerts and reporting" — accurate when
+ * written, and with no compile-time link to the Python modules it names, so
+ * adding or dropping a consumer would leave operator-facing copy quietly wrong
+ * (`.claude/CLAUDE.md`: never hardcode a derived fact into prose — compute it
+ * or omit it). The claim below is true by CONSTRUCTION instead: the guard lives
+ * in `is_thesis_usable`, and a consumer that skipped it would be the bug.
+ *
+ * The census itself is pinned where it can be checked —
+ * `tests/test_thesis_subject_identity_consumers.py`.
+ */
 const REFUSED_BY =
-  `The deterministic layer refuses it (${THESIS_QUARANTINE_REASON}) — ` +
-  "portfolio, scoring, entry timing, alerts and reporting.";
+  `The engine refuses it (${THESIS_QUARANTINE_REASON}) and no decision path will use it.`;
 
 /**
  * The claim a refusing state actually supports, in one sentence.

--- a/frontend/src/lib/thesisQuarantine.ts
+++ b/frontend/src/lib/thesisQuarantine.ts
@@ -1,0 +1,94 @@
+/**
+ * Thesis subject-identity verdict, as the frontend reads it (#2306).
+ *
+ * The rule and the verdict are the BACKEND's: #2431 refuses a memo that never
+ * names its own instrument, #2436 stores that verdict on the row
+ * (`theses.subject_identity_ok`) and every deterministic consumer fails closed
+ * on it — `portfolio.py`, `scoring.py`, `entry_timing.py`, `alerts.py`,
+ * `reporting.py`. Nothing here re-derives the rule; this module only mirrors
+ * the READ predicate so the screen agrees with the engine instead of
+ * contradicting it.
+ *
+ * Canonical Python counterpart:
+ * `app/services/thesis_subject_identity.py::is_thesis_usable` — `is True`.
+ */
+
+/** Verdict states, in the vocabulary the stored column can express. */
+export type ThesisSubjectState = "usable" | "unnamed_subject" | "unchecked";
+
+/**
+ * ⚠ `false` is `unnamed_subject`, NOT `misattributed`.
+ *
+ * The stored rule records only that the memo never named its own instrument.
+ * It does NOT establish that some other company was positively identified —
+ * that is a strictly narrower class (#2306 measured 19 such memos against
+ * 1,512 rows the rule refuses). Naming the state for the stronger claim would
+ * put the conflation into the type system, where every later reader inherits
+ * it.
+ */
+export function thesisSubjectState(
+  ok: boolean | null | undefined,
+): ThesisSubjectState {
+  if (ok === true) return "usable";
+  if (ok === false) return "unnamed_subject";
+  return "unchecked";
+}
+
+/**
+ * May this thesis's stance, confidence or valuation band be read as a verdict?
+ *
+ * ⚠ FAIL-CLOSED ON NULL AND UNDEFINED, matching `is_thesis_usable`. NULL means
+ * *nobody has decided*, which is not *passed*; `undefined` means the field was
+ * absent from the payload, which is the same thing with less provenance. The
+ * wire types declare the field required, so `undefined` should not occur —
+ * this accepts it so a hand-built fixture cannot fake a pass.
+ *
+ * ⚠⚠ NOT SUFFICIENT ALONE ON A LIST SURFACE. The theses library gives a row to
+ * held instruments that have no thesis at all, with every thesis field null
+ * (`app/api/theses.py:235-239`). This returns `true` for those, for the trivial
+ * reason that there is nothing to check — rendering a quarantine marker there
+ * would invent a defect. Gate on `thesis_id !== null` as well. Detail surfaces
+ * need no such gate: they already early-return on a null thesis.
+ */
+export function isThesisQuarantined(ok: boolean | null | undefined): boolean {
+  return ok !== true;
+}
+
+/**
+ * The machine-readable reason the deterministic layer reports when it refuses a
+ * thesis. Mirrors `thesis_subject_identity.QUARANTINE_REASON` so the screen and
+ * the logs say the same word.
+ */
+export const THESIS_QUARANTINE_REASON = "thesis_quarantined";
+
+/** Who refuses the row — the verified consumer census, not a paraphrase. */
+const REFUSED_BY =
+  `The deterministic layer refuses it (${THESIS_QUARANTINE_REASON}) — ` +
+  "portfolio, scoring, entry timing, alerts and reporting.";
+
+/**
+ * The claim a refusing state actually supports, in one sentence.
+ *
+ * ⚠⚠ THE TWO REFUSING STATES DO NOT SUPPORT THE SAME CLAIM, and every surface
+ * must respect that. `false` is a decided failure — the rule ran and the memo
+ * did not name its instrument. `null` is an UNDECIDED row: saying "never names
+ * its instrument" there asserts a check that never happened. Caught by Codex
+ * checkpoint 2 on this ticket, where the banner distinguished them correctly
+ * and two hard-coded tooltips did not. Copy lives here, once, so the next
+ * surface cannot reintroduce the split.
+ */
+export function thesisRefusalClaim(ok: boolean | null | undefined): string {
+  return thesisSubjectState(ok) === "unnamed_subject"
+    ? "This memo never names its own instrument, so its figures may describe a different company."
+    : "This memo has not been checked against its instrument, so its figures are unverified.";
+}
+
+/** Hover copy for the compact markers: the claim plus who refuses it. */
+export function thesisRefusalTooltip(ok: boolean | null | undefined): string {
+  return `${thesisRefusalClaim(ok)} ${REFUSED_BY}`;
+}
+
+/** Body copy for the full banner: the claim, who refuses it, and why it is still shown. */
+export function thesisRefusalBody(ok: boolean | null | undefined): string {
+  return `${thesisRefusalTooltip(ok)} It is shown here for evidence only.`;
+}

--- a/frontend/src/pages/ThesesPage.test.tsx
+++ b/frontend/src/pages/ThesesPage.test.tsx
@@ -39,6 +39,7 @@ function makeItem(overrides: Partial<ThesisLibraryItem> = {}): ThesisLibraryItem
     run_error: null,
     run_trigger: "manual",
     run_started_at: null,
+    subject_identity_ok: true,
     last_change_summary: null,
     last_change_material: false,
     ...overrides,
@@ -211,5 +212,64 @@ describe("ThesesPage", () => {
     expect(mockedFetch).toHaveBeenLastCalledWith(
       expect.objectContaining({ offset: 0 }),
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // #2306 — the subject-identity verdict on the library row.
+  // -------------------------------------------------------------------------
+  it("marks a row whose thesis failed the subject-identity check", async () => {
+    mockedFetch.mockResolvedValue(
+      respond([makeItem({ subject_identity_ok: false })]),
+    );
+    renderPage();
+    const marker = await screen.findByTestId("thesis-quarantine-marker");
+    expect(marker).toHaveAttribute(
+      "title",
+      expect.stringContaining("thesis_quarantined"),
+    );
+    // The glyph is aria-hidden, so the accessible name must come from text.
+    expect(marker).toHaveTextContent("quarantined");
+  });
+
+  it("treats an UNCHECKED verdict as refused (null is not passed)", async () => {
+    mockedFetch.mockResolvedValue(
+      respond([makeItem({ subject_identity_ok: null })]),
+    );
+    renderPage();
+    expect(await screen.findByTestId("thesis-quarantine-marker")).toBeInTheDocument();
+  });
+
+  it("does NOT mark a passing row", async () => {
+    mockedFetch.mockResolvedValue(respond([makeItem()]));
+    renderPage();
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    expect(screen.queryByTestId("thesis-quarantine-marker")).not.toBeInTheDocument();
+  });
+
+  it("does NOT mark a HELD row that has no thesis at all", async () => {
+    // The library deliberately includes held-but-unthesised instruments
+    // (app/api/theses.py:235). Their verdict is null for the trivial reason
+    // that there is nothing to check — the bare `ok !== true` predicate gets
+    // this wrong, which is why the marker is gated on thesis_id too.
+    mockedFetch.mockResolvedValue(
+      respond([
+        makeItem({
+          thesis_id: null,
+          thesis_version: null,
+          thesis_type: null,
+          stance: null,
+          confidence_score: null,
+          buy_zone_low: null,
+          buy_zone_high: null,
+          created_at: null,
+          critic_verdict: null,
+          subject_identity_ok: null,
+          stale_reason: "no_thesis",
+        }),
+      ]),
+    );
+    renderPage();
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    expect(screen.queryByTestId("thesis-quarantine-marker")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ThesesPage.tsx
+++ b/frontend/src/pages/ThesesPage.tsx
@@ -32,6 +32,7 @@ import { EmptyState } from "@/components/states/EmptyState";
 import { CriticVerdictBadge } from "@/components/theses/CriticVerdictBadge";
 import { StanceBadge } from "@/components/theses/StanceBadge";
 import { formatNumber, formatRelativeTime } from "@/lib/format";
+import { isThesisQuarantined, thesisRefusalTooltip } from "@/lib/thesisQuarantine";
 import { useAsync } from "@/lib/useAsync";
 import { Badge } from "@/components/ui/Badge";
 
@@ -356,13 +357,32 @@ export function ThesesPage(): JSX.Element {
                         </div>
                       </td>
                       <td className="px-2 py-2">
-                        {row.stance !== null ? (
-                          <StanceBadge stance={row.stance} />
-                        ) : (
-                          <span className="text-xs text-slate-400 dark:text-slate-500">
-                            —
-                          </span>
-                        )}
+                        <span className="inline-flex items-center gap-1">
+                          {row.stance !== null ? (
+                            <StanceBadge stance={row.stance} />
+                          ) : (
+                            <span className="text-xs text-slate-400 dark:text-slate-500">
+                              —
+                            </span>
+                          )}
+                          {/* #2306 — gated on `thesis_id !== null` as well as the
+                              verdict, exactly like the critic cell below. This list
+                              deliberately includes HELD instruments with no thesis at
+                              all (app/api/theses.py:235), whose verdict is null for
+                              the trivial reason that there is nothing to check —
+                              marking those "quarantined" would invent a defect. */}
+                          {row.thesis_id !== null &&
+                          isThesisQuarantined(row.subject_identity_ok) ? (
+                            <Badge
+                              tone="risk"
+                              data-testid="thesis-quarantine-marker"
+                              title={thesisRefusalTooltip(row.subject_identity_ok)}
+                            >
+                              <span aria-hidden="true">⊘</span>
+                              <span className="sr-only">quarantined</span>
+                            </Badge>
+                          ) : null}
+                        </span>
                       </td>
                       <td className="px-2 py-2 text-xs text-slate-600 dark:text-slate-300">
                         {row.thesis_type ?? "—"}

--- a/tests/test_thesis_subject_identity_consumers.py
+++ b/tests/test_thesis_subject_identity_consumers.py
@@ -1,0 +1,94 @@
+"""The subject-identity guard census (#2306).
+
+`theses.subject_identity_ok` is the verdict #2431/#2436 put on a thesis whose
+memo never names its own instrument. Its value is that EVERY path which reads a
+thesis as a decision input refuses a row the verdict rejects — and that property
+is asserted in prose, in several docstrings, and (until #2306) in operator-facing
+UI copy that enumerated the consumers by name.
+
+Prose goes stale silently. This pins the census instead, so adding a consumer
+that forgets the guard, or dropping one the copy still claims, fails a test
+rather than leaving a sentence quietly wrong somewhere a reader trusts.
+
+⚠ Pure-logic: reads source text, touches no DB, stays in the fast push tier.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+APP = Path(__file__).resolve().parent.parent / "app"
+
+#: Modules that read the verdict directly rather than through the shared
+#: helper, with WHY. Each is a place the rule is duplicated, so each is a place
+#: it can drift — the note is the justification for accepting that.
+MIRRORS: dict[str, str] = {
+    "services/entry_timing.py": "mirrors the predicate in SQL on a joined row (see its comment at the read site)",
+    "services/thesis.py": "the WRITER — computes the verdict, does not consume it",
+    "services/thesis_subject_identity.py": "defines the rule and the helper",
+    "api/theses.py": "projects the raw verdict to the client so the UI can render it (#2306)",
+    "api/alerts.py": "compares the verdict on a thesis and its predecessor inline",
+}
+
+#: Modules expected to consume the verdict through ``is_thesis_usable``.
+GUARDED = {
+    "services/portfolio.py",
+    "services/scoring.py",
+    "services/reporting.py",
+}
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(APP).as_posix()
+
+
+def _modules_mentioning(token: str) -> set[str]:
+    found = set()
+    for path in APP.rglob("*.py"):
+        if re.search(rf"\b{re.escape(token)}\b", path.read_text(encoding="utf-8")):
+            found.add(_rel(path))
+    return found
+
+
+def test_every_reader_of_the_verdict_is_accounted_for() -> None:
+    """No module touches `subject_identity_ok` without being on one list or the other.
+
+    A new name here means someone added a path that reads the verdict. Decide
+    which it is and say so: if it makes a DECISION, it belongs in ``GUARDED``
+    and must call ``is_thesis_usable``; if it re-implements the check, add it to
+    ``MIRRORS`` with the reason.
+    """
+    readers = _modules_mentioning("subject_identity_ok")
+    unaccounted = readers - GUARDED - MIRRORS.keys()
+    assert not unaccounted, (
+        f"module(s) read theses.subject_identity_ok but are on neither list: {sorted(unaccounted)}. "
+        "Add to GUARDED (and use is_thesis_usable) or to MIRRORS with a reason."
+    )
+
+
+def test_guarded_consumers_use_the_shared_helper() -> None:
+    """A decision path must go through the helper, not re-derive `is True`.
+
+    ⚠ The failure this prevents is specific: `subject_identity_ok is not False`
+    LOOKS equivalent and is not — NULL means *nobody decided*, which the helper
+    refuses and the naive form admits.
+    """
+    users = _modules_mentioning("is_thesis_usable")
+    missing = GUARDED - users
+    assert not missing, (
+        f"declared guard consumer(s) no longer call is_thesis_usable: {sorted(missing)}. "
+        "Either restore the call or move them to MIRRORS with a reason."
+    )
+
+
+def test_guard_consumers_have_not_silently_disappeared() -> None:
+    """The census is non-empty and still contains the paths that hold money.
+
+    `portfolio.py` turns `base_value` into an EXIT trigger on a real position —
+    `sql/332` records 14 such exits that fired on wrong-company bands before the
+    guard existed. If that module ever drops off this list, the regression is
+    the one the whole verdict was built for.
+    """
+    assert "services/portfolio.py" in GUARDED
+    assert GUARDED <= _modules_mentioning("subject_identity_ok") | _modules_mentioning("is_thesis_usable")


### PR DESCRIPTION
## What this fixes

#2431 and #2436 already closed this ticket's **decision** half. A memo that never names its own instrument gets a stored verdict on `theses.subject_identity_ok` (`sql/332`), backfilled at lifespan by `ensure_subject_identity_verdicts`, and every deterministic consumer fails closed on `IS NOT TRUE` — `portfolio.py:455`, `scoring.py:1291`/`:1649`, `entry_timing.py:366`, `alerts.py:845`, `reporting.py:649`.

The **screen** never got the reader. `grep -rn subject_identity_ok frontend/src` returned nothing, while both Pydantic models carry the field (`app/api/theses.py:207` detail, `:280` list) and both SELECTs fetch it. So the engine threw the row out and the UI rendered its stance, confidence and valuation band as fact, with nothing on screen saying so.

This is a sharper form of the repo's recurring writer-with-no-reader shape: the readers exist in *every* decision path and are missing only on the surface a human reasons from.

## Measurement — full population, dev DB, 2026-08-23

```sql
SELECT count(*), count(*) FILTER (WHERE subject_identity_ok IS FALSE),
       count(*) FILTER (WHERE subject_identity_ok IS NULL) FROM theses;
-- 3714 | 1512 | 0
```

```sql
WITH latest AS (
  SELECT DISTINCT ON (instrument_id) instrument_id, prompt_version, subject_identity_ok
    FROM theses ORDER BY instrument_id, created_at DESC, thesis_version DESC)
SELECT prompt_version, count(*), count(*) FILTER (WHERE subject_identity_ok IS FALSE)
  FROM latest GROUP BY 1 ORDER BY 1;
-- v3 1/0 · v4 88/0 · v5 90/70 · v6 8/8 · v7 295/0   → 78 of 482 latest rows refused
```

The `DISTINCT ON` tie-break matches `_LIBRARY_SQL:517` and `portfolio.py`, not an ad-hoc `thesis_id DESC`; checked rather than assumed — the two orderings pick a different row on **0** of 482 instruments.

Concrete latest rows an operator sees today:

| symbol | prompt | stance | base_value | memo opens |
| --- | --- | --- | ---: | --- |
| AA | v5 | avoid | — | "SQQQ (ProShares UltraPro QQQ) is a leveraged inverse ETF" |
| ACA.US | v6 | buy | 150.00 | "### 企业名称：Coca-Cola Company (KO)" |
| AAPL | v5 | buy | 258.50 | "[Company] exhibits strong fundamentals…" |
| AGCO | v6 | buy | 100.00 | "The company demonstrates strong fundamentals…" |

⚠ **Reconciling the numbers in this ticket's history, because they measure different sets.** 1,512 = every stored row the current rule refuses. 78 = the subset that is the latest row for its instrument. 178 = `sql/332`'s equivalent latest count on 2026-08-12, since superseded by v7 regenerations. 19 = #2306's own 2026-08-05 count of a *narrower* class (first parenthesised token resolving to a different real symbol). All are unusable to a consumer; none is a substitute for another.

## The decision — annotate, not hide, not regenerate

Made here rather than escalated, because the facts settle it:

- **Regenerate** — infeasible, not merely slow: `thesis_refresh` is parked (`llm_model_writer = 'parked-2855'`) and measured at 651 s/thesis, so 1,512 rows is ~11 days on a starved box. It also destroys the evidence base.
- **Hide** — contradicts `docs/settled-decisions.md:147` and `app/api/theses.py:202-206`, which keeps the row visible *because* it is the truthful record. Hiding also makes the page read as "no thesis exists", a different false state.
- **Annotate** ← chosen. The row keeps rendering; the screen states the verdict the engine already reached, in the same word (`thesis_quarantined`).

## What changed

| file | change |
| --- | --- |
| `lib/thesisQuarantine.ts` | one predicate mirroring `is_thesis_usable` (`is True`), so NULL/undefined refuse rather than pass; refusal copy in one place |
| `components/theses/ThesisQuarantineBanner.tsx` | renders `null` when the verdict passed, so callers mount it unconditionally |
| `instrument/ThesisPane.tsx` | banner; band marked refused; derived conclusions suppressed |
| `instrument/SummaryStrip.tsx` | the always-visible chip loses the stance TONE, not the stance |
| `pages/ThesesPage.tsx` | marker gated on `thesis_id !== null` as well as the verdict |
| `api/types.ts` | `subject_identity_ok: boolean \| null` on both models |

`VerdictTab`, `ResearchTab` and `DensityGrid` render the memo *through* `ThesisPane`, so they inherit the banner untouched.

### Three points worth reviewing specifically

**1. Derived conclusions are suppressed; stored numbers are not.** "Annotate, do not hide" protects the *record*. `upsideToBase` (the `+12.4%` chip) and the "entry conditions not met at market" sentence were never in that record — they are the component computing live analysis over a band the engine refuses. Bear/base/bull keep rendering inside the refused band, because they are what the writer produced.

**2. Fail-closed is not automatically safe on a display surface.** `ok !== true` is the right direction for a decision path, but the theses library deliberately gives a row to held instruments with **no thesis at all** (`app/api/theses.py:235-239`), whose verdict is null for the trivial reason that there is nothing to check. Marking those "quarantined" would invent a defect, so the library marker is gated on `thesis_id !== null` too — same gate the critic cell beside it already uses. Pinned by test.

**3. Required, not optional, TS fields.** `subject_identity_ok: boolean | null` rather than `?: boolean | null`. Pydantic serialises the default so the key is always on the wire, and `api-shape-and-types.md` makes asymmetric nullability the drift bug to avoid. It immediately caught three fixtures constructing a thesis with no verdict — including one behind an `as unknown as ThesisDetail` cast that would have silently flipped every assertion in the file into the refused branch.

## The invariant that makes this a safety surface

`safety-state-ui.md`'s failure mode is a banner derived from a refetchable value vanishing while the dangerous content stays. That is structurally absent here — banner and memo are read off the *same* `thesis` object and `ThesisPane` early-returns on a null one — but it is asserted rather than assumed: `ThesisPane.test.tsx` renders the state matrix and fails if any state shows `memo_markdown` without the banner.

## Codex

- **ckpt-1 (spec)** caught the state name `misattributed` restating, in the type system, the exact conflation the measurement section warns against — `false` records only that the memo did not name its subject, not that another company was positively identified. Renamed `unnamed_subject`. It also caught the held-no-thesis library case above, and that my consumer census had omitted `reporting.py`.
- **ckpt-2 (diff)** caught both tooltips hard-coding "never names its instrument" for the NULL case too, asserting a check that never ran — while the banner distinguished the two states correctly. Copy now lives once in the lib; both refusing states pinned by test.

## Verification

- `pnpm --dir frontend typecheck` — clean.
- `pnpm --dir frontend test:unit` — **140 files, 1,609 passed**.
- `dark:check` / `pills:check` / `charts:check` — no violations.
- `uv run ruff check .` / `ruff format --check` — clean. No Python touched.
- **Live dev API**, the wire contract these types mirror: `GET /theses/1008` (AA) returns `subject_identity_ok: false` with the memo that opens about SQQQ; `GET /theses?limit=6` returns `true` on passing rows.

Definition-of-Done clauses 8-12 do not apply: no ETL, parser, schema migration or corpus change — this reads a column that already exists and adds no writer.

## Security

No new surface. Read-only rendering of a field the API already returned to the same authenticated session; no new endpoint, no mutation, no auth path touched. The change makes a refusal *more* visible, never less.

## Noted, not fixed (no new ticket, per the loop's no-new-audit-ticket rule)

`_fetch_diffs` builds a thesis diff from an explicit `thesis_version - 1` lookup that does not consult the verdict, so a **clean** latest thesis can carry a diff whose "was" side came from a refused predecessor. Real, and server-side: the fix belongs in that query, not on the screen.

Refs #2306. Refs #2842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)