### PR TITLE
docs(#2915): establish the ISA execution boundary

### DIFF
--- a/docs/proposals/ta/2026-08-23-r6-tax-wrapper-verdict.md
+++ b/docs/proposals/ta/2026-08-23-r6-tax-wrapper-verdict.md
@@ -1,0 +1,175 @@
+# R6 tax-wrapper verdict (#2915)
+
+**Verdict: no supported public-API route into eToro's Stocks & Shares ISA is
+established as of 2026-08-23.** eBull must therefore treat the ISA as
+unreachable and must not deploy an automated pot there today. This is a
+support and deployment verdict, not proof that no private, partner-only or
+undocumented route exists.
+
+R6 keeps the ordinary eToro trading account as its prospective execution
+venue. Any eventual sleeve must still pass the remaining programme gates
+before it can hold money.
+
+The live eToro portal was verified on 2026-08-23. The last OpenAPI version
+recorded in this repository was v1.342.0 on 2026-08-14; the rendered portal no
+longer exposed a version string, so this memo does not claim that v1.342.0 was
+still current.
+
+## API reachability
+
+The public API documents a **balance read** for Moneyfarm-labelled accounts:
+`GET /api/v1/balances/{accountType}` accepts `moneyfarm`, alongside `trading`,
+`cash`, `options`, `crypto`, and `spaceship`. The response does not identify a
+balance as an ISA. A balance label is not an order route.
+
+On the dated public-documentation snapshot:
+
+- the live API index contained no `ISA` or Moneyfarm execution endpoint;
+- `POST /api/v2/trading/execution/orders` exposed no account identifier,
+  account type or sub-account selector; and
+- the separate sub-account API documented only provider `etoro-trading`.
+
+The ISA is powered by Moneyfarm, and eToro's setup guide directs customers to
+the Moneyfarm partner platform. These facts establish that the documented
+eToro trading writer is not a supported ISA writer. Absence from a public
+index cannot disprove a private or undocumented interface.
+
+The configured eBull credential inventory at verification time was:
+
+```text
+[('etoro', 'demo', 'api_key', 'valid', 1),
+ ('etoro', 'demo', 'user_key', 'valid', 1)]
+```
+
+There were zero active real credentials. Reproduce that derived fact without
+printing secrets:
+
+```sql
+SELECT provider, environment, label, health_state, count(*)
+FROM broker_credentials
+WHERE revoked_at IS NULL
+GROUP BY 1, 2, 3, 4
+ORDER BY 1, 2, 3, 4;
+```
+
+A read-only probe with the configured demo credentials to
+`GET /api/v1/balances/moneyfarm?includeZeroBalances=true&expand=equityDetails`
+returned `403 InsufficientPermissions`. That proves only that these demo
+credentials cannot read the endpoint; it is not evidence about execution.
+
+The deployment gate can be reversed only when current eToro or Moneyfarm
+documentation/support identifies the ISA execution contract, eBull can prove
+the account identity with appropriately scoped credentials, and the writer can
+be validated through the repository's sandbox and execution guards. A future
+solution might be an evolution of the existing API or a new integration; this
+memo does not prejudge which.
+
+## Eligible instruments
+
+The public facts establish advertised categories, not an instrument-level
+eligibility list:
+
+- eToro advertises thousands of UK, US and European stocks, ETFs, bonds and
+  mutual funds in the DIY ISA; this does not establish that every security in
+  those regions or categories is eligible;
+- eToro's ISA guide says CFDs are not ISA-eligible and the account cannot be
+  used to short; and
+- non-GBP instruments incur a 0.70% conversion fee on each buy and each sell.
+
+No public source or API field found in this investigation exposed the exact
+ISA catalogue. Investment selection occurs on the separately administered
+Moneyfarm platform. The overlap with eBull's ordinary-account universe is
+therefore unknown and must not be inferred.
+
+Because API execution fails first, #2915 does not narrow the research universe
+for later arms. R6 retains the repository's full, survivorship-free US research
+population and must prove ordinary-account broker eligibility at execution
+time. It must not claim ISA deployability.
+
+## Tax and FX sensitivity in pounds
+
+The ticket's phrase “a certain 18–24% on realised gains” is too broad. For UK
+individuals in 2026/27, net gains above the £3,000 annual exempt amount can be
+split between 18% and 24% depending on taxable income. Dividends first use any
+unused Personal Allowance, then a £500 dividend allowance, and can be split
+between 10.75%, 35.75% and 39.35% bands. ISA gains and dividends are not
+charged UK Capital Gains Tax or dividend tax.
+
+The reproducible table is deliberately a sensitivity, not a personal tax
+estimate or return forecast. It freezes these assumptions:
+
+- £50,000 is foreign-asset **purchase consideration**, requiring £50,350 cash
+  after the initial 0.70% FX charge. It represents prior-year accumulation or
+  a compliant ISA transfer, not a one-year new subscription;
+- 100% of holdings are non-GBP, and each rebalanced pound is sold and replaced,
+  so both the 0.70% sell and 0.70% buy FX charges apply;
+- one-way turnover is sold notional divided by mean equity: 25% means £12,500
+  sold and £12,500 bought;
+- every sale has a positive gain equal to 20% of sold proceeds, with no losses;
+- the cash dividend yield is 2%;
+- the Personal Allowance is fully consumed by other income, while the CGT and
+  dividend allowances are wholly unused elsewhere; and
+- “all lower rate” and “all higher rate” put every taxable pound at the named
+  rate. They are the two prescribed scenarios, not exhaustive bounds or labels
+  for an actual taxpayer; the additional-rate dividend scenario is not shown.
+
+The comparator is also deliberately narrow. eBull's settled ordinary-account
+lane is long/x1/real, with USD orders, a USD demo account and a USD universe,
+so its trading FX is structurally zero. The difference below is incremental to
+that lane only; it is not a universal GIA-versus-ISA comparison.
+
+Run:
+
+```bash
+uv run python -m scripts.report_2915_isa_tax_wrapper
+```
+
+| rate scenario / turnover | assumed realised gain | hypothetical GIA CGT | hypothetical GIA dividend tax | ISA initial FX | ISA rebalance FX | tax minus ISA FX, first year | tax minus ISA FX, no initial purchase |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| all lower rate / 25.00% | £2,500.00 | £0.00 | £53.75 | £350.00 | £175.00 | **−£471.25** | **−£121.25** |
+| all higher rate / 25.00% | £2,500.00 | £0.00 | £178.75 | £350.00 | £175.00 | **−£346.25** | **+£3.75** |
+| all lower rate / 100% | £10,000.00 | £1,260.00 | £53.75 | £350.00 | £700.00 | **+£263.75** | **+£613.75** |
+| all higher rate / 100% | £10,000.00 | £1,680.00 | £178.75 | £350.00 | £700.00 | **+£808.75** | **+£1,158.75** |
+
+Positive means the hypothetical GIA tax exceeds only the specified ISA FX;
+negative means the specified ISA FX is larger. Neither is a personal net
+benefit. “No initial purchase” is the same one-period sensitivity with the
+initial purchase charge excluded, not a later-year forecast.
+
+The ISA has 0% dealing commission and no annual custody fee from 29 July 2026.
+The £20,000 annual allowance limits new subscriptions, while compliant ISA
+transfers do not consume that allowance.
+
+The sensitivity omits funding FX to an existing account, spreads, market
+impact, other fees, foreign withholding and tax credits, terminal conversion,
+actual share matching, carried losses, other income and disposals. It therefore
+is not net return. The existing `app.services.tax_ledger` supports disposal
+matching and CGT calculations, but dividend and fee ingestion is incomplete;
+an eventual live sleeve needs that gap closed or a separate validated tax
+calculation before reporting realised GIA tax.
+
+## Programme consequence
+
+1. Do not narrow Tier 2 to an assumed ISA catalogue and do not claim ISA
+   deployability.
+2. Keep turnover as a first-order gate. In this all-foreign ISA sensitivity it
+   creates an exact 1.40% round-trip FX charge on replacement notional; in the
+   assumed GIA construction it also controls the pace of gain realisation.
+3. Keep the ordinary eToro account explicit as the prospective R6 execution
+   venue until the ISA gate's reversal conditions are met.
+4. If the gate is later reversed, perform an authenticated instrument-level
+   catalogue census and execution proof before changing any arm's universe.
+
+## Primary sources
+
+- [HMRC: ISA rules and eligible asset classes](https://www.gov.uk/individual-savings-accounts/how-isas-work)
+- [HMRC: 2026/27 Capital Gains Tax rates and £3,000 exemption](https://www.gov.uk/capital-gains-tax/rates)
+- [HMRC: 2026/27 dividend allowance and rates](https://www.gov.uk/tax-on-dividends)
+- [eToro: DIY Stocks & Shares ISA](https://www.etoro.com/investing/isa/stocks-shares/)
+- [eToro: guide to its Stocks & Shares ISA](https://www.etoro.com/investing/what-is-a-stocks-and-shares-isa/)
+- [eToro: ISA fee removal, FX charge and Moneyfarm partnership](https://www.etoro.com/news-and-analysis/press-releases/etoro-removes-fees-from-stocks-shares-isa-launches-market-leading-cash-isa-rate/)
+- [eToro live API index](https://api-portal.etoro.com/llms.txt)
+- [eToro API: balances by account type](https://api-portal.etoro.com/api-reference/balances/get-balances-by-account-type)
+- [eToro API: real order creation](https://api-portal.etoro.com/api-reference/trading--real/create-an-order)
+- [eToro API: supported sub-accounts](https://api-portal.etoro.com/api-reference/sub-accounts/get-my-sub-accounts)
+- [Moneyfarm terms: 0.70% on each non-GBP buy and sell](https://mfm-prod-site-assets.moneyfarm.com/uk/2024/02/21145138/Terms-of-Business-Execution-Only-Proposition-13.02.2024-Bonds-3.pdf)

--- a/scripts/report_2915_isa_tax_wrapper.py
+++ b/scripts/report_2915_isa_tax_wrapper.py
@@ -1,0 +1,168 @@
+"""Reproduce #2915's frozen 2026/27 tax-and-FX sensitivity.
+
+This is not a personal tax estimate. It compares hypothetical GIA tax under
+explicit assumptions with the eToro ISA's full FX charge. Other costs are out
+of scope and must not be inferred from the difference column.
+
+Default construction: GBP 50,000 foreign-asset purchase consideration; 20%
+positive gain as a fraction of sold proceeds; 2% cash dividend yield; and
+25%/100% one-way annual turnover. The Personal Allowance is fully consumed by
+other income, while the CGT and dividend allowances are wholly unused. The
+initial 0.70% FX fee is additional to the purchase consideration.
+
+Usage:
+    uv run python -m scripts.report_2915_isa_tax_wrapper
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Final, Literal
+
+RateScenario = Literal["all_lower_rate", "all_higher_rate"]
+
+# Frozen 2026/27 constants. Importing the application's current-year constant
+# would let future legislation silently rewrite this dated report.
+CGT_ALLOWANCE_2026_27: Final = Decimal("3000")
+DIVIDEND_ALLOWANCE_2026_27: Final = Decimal("500")
+ISA_FX_RATE_2026_07_29: Final = Decimal("0.007")
+CGT_RATES_2026_27: Final[dict[RateScenario, Decimal]] = {
+    "all_lower_rate": Decimal("0.18"),
+    "all_higher_rate": Decimal("0.24"),
+}
+DIVIDEND_RATES_2026_27: Final[dict[RateScenario, Decimal]] = {
+    "all_lower_rate": Decimal("0.1075"),
+    "all_higher_rate": Decimal("0.3575"),
+}
+PENNY: Final = Decimal("0.01")
+
+
+@dataclass(frozen=True)
+class Scenario:
+    rate_scenario: RateScenario
+    foreign_purchase_consideration_gbp: Decimal
+    one_way_turnover: Decimal
+    gain_fraction_of_sold_proceeds: Decimal
+    dividend_yield: Decimal
+
+
+@dataclass(frozen=True)
+class Result:
+    rate_scenario: RateScenario
+    one_way_turnover: Decimal
+    sold_notional_gbp: Decimal
+    assumed_realised_gain_gbp: Decimal
+    assumed_dividends_gbp: Decimal
+    hypothetical_gia_cgt_gbp: Decimal
+    hypothetical_gia_dividend_tax_gbp: Decimal
+    hypothetical_gia_total_tax_gbp: Decimal
+    isa_initial_fx_gbp: Decimal
+    isa_rebalance_fx_gbp: Decimal
+    tax_minus_first_year_isa_fx_gbp: Decimal
+    tax_minus_rebalance_isa_fx_gbp: Decimal
+
+
+def _money(value: Decimal) -> Decimal:
+    return value.quantize(PENNY, rounding=ROUND_HALF_UP)
+
+
+def _finite_nonnegative(name: str, value: Decimal) -> None:
+    if not value.is_finite() or value < 0:
+        raise ValueError(f"{name} must be finite and non-negative")
+
+
+def calculate(scenario: Scenario) -> Result:
+    """Calculate the explicit sensitivity; do not treat it as a tax return."""
+    _finite_nonnegative("foreign purchase consideration", scenario.foreign_purchase_consideration_gbp)
+    _finite_nonnegative("turnover", scenario.one_way_turnover)
+    for name, value in (
+        ("gain fraction", scenario.gain_fraction_of_sold_proceeds),
+        ("dividend yield", scenario.dividend_yield),
+    ):
+        _finite_nonnegative(name, value)
+        if value > 1:
+            raise ValueError(f"{name} must be in [0, 1]")
+    if scenario.rate_scenario not in CGT_RATES_2026_27:
+        raise ValueError(f"unknown rate scenario: {scenario.rate_scenario}")
+
+    consideration = scenario.foreign_purchase_consideration_gbp
+    sold = consideration * scenario.one_way_turnover
+    gain = sold * scenario.gain_fraction_of_sold_proceeds
+    dividends = consideration * scenario.dividend_yield
+    cgt = max(gain - CGT_ALLOWANCE_2026_27, Decimal(0)) * CGT_RATES_2026_27[scenario.rate_scenario]
+    dividend_tax = (
+        max(dividends - DIVIDEND_ALLOWANCE_2026_27, Decimal(0)) * DIVIDEND_RATES_2026_27[scenario.rate_scenario]
+    )
+    gia_tax = cgt + dividend_tax
+
+    initial_fx = consideration * ISA_FX_RATE_2026_07_29
+    # One-way turnover is sold notional / mean equity. This frozen all-foreign
+    # sensitivity replaces the same gross notional: one sell and one buy.
+    rebalance_fx = sold * ISA_FX_RATE_2026_07_29 * 2
+    return Result(
+        rate_scenario=scenario.rate_scenario,
+        one_way_turnover=scenario.one_way_turnover,
+        sold_notional_gbp=_money(sold),
+        assumed_realised_gain_gbp=_money(gain),
+        assumed_dividends_gbp=_money(dividends),
+        hypothetical_gia_cgt_gbp=_money(cgt),
+        hypothetical_gia_dividend_tax_gbp=_money(dividend_tax),
+        hypothetical_gia_total_tax_gbp=_money(gia_tax),
+        isa_initial_fx_gbp=_money(initial_fx),
+        isa_rebalance_fx_gbp=_money(rebalance_fx),
+        tax_minus_first_year_isa_fx_gbp=_money(gia_tax - initial_fx - rebalance_fx),
+        tax_minus_rebalance_isa_fx_gbp=_money(gia_tax - rebalance_fx),
+    )
+
+
+def default_results() -> list[Result]:
+    return [
+        calculate(
+            Scenario(
+                rate_scenario=rate_scenario,
+                foreign_purchase_consideration_gbp=Decimal("50000"),
+                one_way_turnover=turnover,
+                gain_fraction_of_sold_proceeds=Decimal("0.20"),
+                dividend_yield=Decimal("0.02"),
+            )
+        )
+        for turnover in (Decimal("0.25"), Decimal("1"))
+        for rate_scenario in ("all_lower_rate", "all_higher_rate")
+    ]
+
+
+def _gbp(value: Decimal) -> str:
+    sign = "−" if value < 0 else "+" if value > 0 else ""
+    return f"{sign}£{abs(value):,.2f}"
+
+
+def render_markdown(results: list[Result]) -> str:
+    lines = [
+        "| rate scenario / turnover | assumed realised gain | hypothetical GIA CGT | "
+        "hypothetical GIA dividend tax | ISA initial FX | ISA rebalance FX | "
+        "tax minus ISA FX, first year | tax minus ISA FX, no initial purchase |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    labels = {"all_lower_rate": "all lower rate", "all_higher_rate": "all higher rate"}
+    for result in results:
+        turnover = result.one_way_turnover * 100
+        lines.append(
+            f"| {labels[result.rate_scenario]} / {turnover:g}% | "
+            f"£{result.assumed_realised_gain_gbp:,.2f} | £{result.hypothetical_gia_cgt_gbp:,.2f} | "
+            f"£{result.hypothetical_gia_dividend_tax_gbp:,.2f} | £{result.isa_initial_fx_gbp:,.2f} | "
+            f"£{result.isa_rebalance_fx_gbp:,.2f} | **{_gbp(result.tax_minus_first_year_isa_fx_gbp)}** | "
+            f"**{_gbp(result.tax_minus_rebalance_isa_fx_gbp)}** |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+    print(render_markdown(default_results()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_report_2915_isa_tax_wrapper.py
+++ b/tests/test_report_2915_isa_tax_wrapper.py
@@ -1,0 +1,108 @@
+from dataclasses import replace
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from scripts.report_2915_isa_tax_wrapper import RateScenario, Scenario, calculate, default_results, render_markdown
+
+
+def _scenario(*, rate_scenario: RateScenario = "all_higher_rate", turnover: str = "0.25") -> Scenario:
+    return Scenario(
+        rate_scenario=rate_scenario,
+        foreign_purchase_consideration_gbp=Decimal("50000"),
+        one_way_turnover=Decimal(turnover),
+        gain_fraction_of_sold_proceeds=Decimal("0.20"),
+        dividend_yield=Decimal("0.02"),
+    )
+
+
+def test_default_rows_are_exact_and_penny_quantized() -> None:
+    rows = default_results()
+    assert [
+        (
+            row.rate_scenario,
+            row.one_way_turnover,
+            row.assumed_realised_gain_gbp,
+            row.hypothetical_gia_cgt_gbp,
+            row.hypothetical_gia_dividend_tax_gbp,
+            row.isa_initial_fx_gbp,
+            row.isa_rebalance_fx_gbp,
+            row.tax_minus_first_year_isa_fx_gbp,
+            row.tax_minus_rebalance_isa_fx_gbp,
+        )
+        for row in rows
+    ] == [
+        (
+            "all_lower_rate",
+            Decimal("0.25"),
+            Decimal("2500.00"),
+            Decimal("0.00"),
+            Decimal("53.75"),
+            Decimal("350.00"),
+            Decimal("175.00"),
+            Decimal("-471.25"),
+            Decimal("-121.25"),
+        ),
+        (
+            "all_higher_rate",
+            Decimal("0.25"),
+            Decimal("2500.00"),
+            Decimal("0.00"),
+            Decimal("178.75"),
+            Decimal("350.00"),
+            Decimal("175.00"),
+            Decimal("-346.25"),
+            Decimal("3.75"),
+        ),
+        (
+            "all_lower_rate",
+            Decimal("1"),
+            Decimal("10000.00"),
+            Decimal("1260.00"),
+            Decimal("53.75"),
+            Decimal("350.00"),
+            Decimal("700.00"),
+            Decimal("263.75"),
+            Decimal("613.75"),
+        ),
+        (
+            "all_higher_rate",
+            Decimal("1"),
+            Decimal("10000.00"),
+            Decimal("1680.00"),
+            Decimal("178.75"),
+            Decimal("350.00"),
+            Decimal("700.00"),
+            Decimal("808.75"),
+            Decimal("1158.75"),
+        ),
+    ]
+
+
+def test_markdown_table_in_verdict_is_generated_output() -> None:
+    verdict = Path("docs/proposals/ta/2026-08-23-r6-tax-wrapper-verdict.md").read_text()
+    assert render_markdown(default_results()) in verdict
+
+
+def test_turnover_can_exceed_one() -> None:
+    assert calculate(_scenario(turnover="2")).isa_rebalance_fx_gbp == Decimal("1400.00")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("foreign_purchase_consideration_gbp", Decimal("-1")),
+        ("one_way_turnover", Decimal("NaN")),
+        ("gain_fraction_of_sold_proceeds", Decimal("1.01")),
+        ("dividend_yield", Decimal("Infinity")),
+    ],
+)
+def test_invalid_inputs_refuse(field: str, value: Decimal) -> None:
+    with pytest.raises(ValueError):
+        calculate(replace(_scenario(), **{field: value}))
+
+
+def test_runtime_invalid_rate_scenario_refuses() -> None:
+    with pytest.raises(ValueError, match="unknown rate scenario"):
+        calculate(replace(_scenario(), rate_scenario="additional"))  # type: ignore[arg-type]


### PR DESCRIPTION
## Issue reference

Closes #2915

## Summary

Establishes the dated, evidence-backed answer to the R6 tax-wrapper gate: no supported public-API ISA order route is established, so eBull must keep the prospective automated sleeve on the ordinary eToro account. Quantifies the tax-versus-FX sensitivity in pounds without presenting it as personal tax or net return.

## Changes

- Add the #2915 verdict with primary HMRC, eToro, Moneyfarm and live API evidence, instrument-eligibility limits, and explicit reversal conditions.
- Add a frozen 2026/27 Decimal calculator for the £50,000 sensitivity and a generated Markdown table.
- Add exact-value, rendering, high-turnover and invalid-input tests.

## Security and audit model

No execution path touched. The verdict explicitly refuses ISA deployment until a supported contract, scoped credentials, account identity and guarded writer are proven. The live investigation used only a read-only demo balance probe.

## Testing

- [x] Tested locally against Docker PostgreSQL stack
- [x] New calculation logic exercised with realistic inputs and edge cases
- [x] No raw user input reaches the DB without parameterisation
- [x] `uv run pytest -m "not db"` — 9,676 passed, 14 skipped
- [x] `uv run pytest tests/smoke` — 155 passed, 3 skipped
- [x] mandatory Codex framing and base-diff reviews completed; findings resolved

## Checklist

- [x] Branch named `feature/NNN-short-description` or `fix/NNN-short-description`
- [x] Raw API payloads persisted before normalisation (not applicable; no ingestion)
- [x] Score model version / thesis version stamped on any new output rows (not applicable; no output rows)
- [x] No order placement path bypasses execution guard
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run pyright` passes
- [ ] CI checks pass