### PR TITLE
fix(#2900): fail closed without point-in-time evidence

### DIFF
--- a/app/services/research_point_in_time.py
+++ b/app/services/research_point_in_time.py
@@ -262,7 +262,7 @@ class R6RankingRequest:
     def __post_init__(self) -> None:
         if not isinstance(self.identity, R6RankingIdentity):
             raise ValueError(f"unknown R6 ranking identity: {self.identity!r}")
-        if not isinstance(self.decision_session, date):
+        if type(self.decision_session) is not date:
             raise ValueError("decision_session must be a date")
 
 

--- a/app/services/research_point_in_time.py
+++ b/app/services/research_point_in_time.py
@@ -1,0 +1,317 @@
+"""Fail-closed point-in-time authorization for R6 historical rankings (#2900).
+
+There is deliberately no ranking reader in this module.  The frozen #2900
+inventory found no current input family satisfying all four admissibility
+conditions, so making a SQL callback injectable here would turn the guard into
+an honour system.  A future reader must live in the private dispatch table
+beside an identity whose evidence matrix has moved to eligible.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Final, Literal
+
+from app.services.market_calendar import us_market_status
+from app.services.universe_selection import INTRADER_CAPTURE_DATE
+
+
+class RankingFamily(StrEnum):
+    RESEARCH_PRICES = "research_prices"
+    FUNDAMENTAL_FACTS = "fundamental_facts"
+    DERIVED_FUNDAMENTALS = "derived_fundamentals"
+    DIMENSIONAL_XBRL = "dimensional_xbrl"
+    OWNERSHIP_OBSERVATIONS = "ownership_observations"
+    FILING_RED_FLAGS = "filing_red_flags"
+    FINRA_SHORT_INTEREST = "finra_short_interest"
+    LIVE_ETORO_STATE = "live_etoro_state"
+    HISTORICAL_POPULATION = "historical_population"
+
+
+class R6RankingIdentity(StrEnum):
+    DILUTION_RED_FLAGS = "2908-dilution-red-flags"
+    SHORT_INTEREST = "2913-short-interest"
+    QUALITY = "2901-quality"
+    SHAREHOLDER_YIELD = "2917-shareholder-yield"
+    MOMENTUM = "2916-momentum"
+    DEFENSIVE = "2910-defensive"
+    VALUATION = "2902-valuation"
+    OWNERSHIP = "2903-ownership"
+    COMBINATION = "2904-combination"
+    MACHINE_LEARNING = "2911-machine-learning"
+
+
+Condition = Literal["public_clock", "system_versions", "historical_population", "causal_transform"]
+Outcome = Literal["pass", "fail"]
+
+
+@dataclass(frozen=True)
+class ConditionEvidence:
+    outcome: Outcome
+    probes: tuple[str, ...]
+    qualification: str | None = None
+
+
+@dataclass(frozen=True)
+class FieldVerdict:
+    status: Literal["refused"]
+    reason: str
+
+
+def _cell(outcome: Outcome, *probes: str, qualification: str | None = None) -> ConditionEvidence:
+    if not probes:
+        raise ValueError("condition evidence requires at least one probe")
+    return ConditionEvidence(outcome=outcome, probes=tuple(probes), qualification=qualification)
+
+
+PROBE_MATRIX: Final[Mapping[RankingFamily, Mapping[Condition, ConditionEvidence]]] = MappingProxyType(
+    {
+        RankingFamily.RESEARCH_PRICES: MappingProxyType(
+            {
+                "public_clock": _cell("fail", "P1"),
+                "system_versions": _cell("fail", "P1"),
+                "historical_population": _cell("fail", "P2", "P5"),
+                "causal_transform": _cell("fail", "P3", "P4"),
+            }
+        ),
+        RankingFamily.FUNDAMENTAL_FACTS: MappingProxyType(
+            {
+                "public_clock": _cell("pass", "F0"),
+                "system_versions": _cell("fail", "F1", "F2"),
+                "historical_population": _cell("fail", "P2", "P5"),
+                "causal_transform": _cell("pass", "F0"),
+            }
+        ),
+        RankingFamily.DERIVED_FUNDAMENTALS: MappingProxyType(
+            {
+                condition: _cell("fail", "D1")
+                for condition in (
+                    "public_clock",
+                    "system_versions",
+                    "historical_population",
+                    "causal_transform",
+                )
+            }
+        ),
+        RankingFamily.DIMENSIONAL_XBRL: MappingProxyType(
+            {
+                condition: _cell("fail", "X1")
+                for condition in (
+                    "public_clock",
+                    "system_versions",
+                    "historical_population",
+                    "causal_transform",
+                )
+            }
+        ),
+        RankingFamily.OWNERSHIP_OBSERVATIONS: MappingProxyType(
+            {
+                "public_clock": _cell("fail", "O2"),
+                "system_versions": _cell("fail", "O1", "O2", "O3"),
+                "historical_population": _cell("fail", "H2", "H3"),
+                "causal_transform": _cell("fail", "O3"),
+            }
+        ),
+        RankingFamily.FILING_RED_FLAGS: MappingProxyType(
+            {
+                "public_clock": _cell("pass", "R0"),
+                "system_versions": _cell("fail", "R1"),
+                "historical_population": _cell("fail", "H2", "H3"),
+                "causal_transform": _cell("fail", "R1"),
+            }
+        ),
+        RankingFamily.FINRA_SHORT_INTEREST: MappingProxyType(
+            {
+                "public_clock": _cell("fail", "N1"),
+                "system_versions": _cell("fail", "N1"),
+                "historical_population": _cell("fail", "N2", "H2", "H3"),
+                "causal_transform": _cell("pass", "N0"),
+            }
+        ),
+        RankingFamily.LIVE_ETORO_STATE: MappingProxyType(
+            {
+                "public_clock": _cell("fail", "L1"),
+                "system_versions": _cell("fail", "L1"),
+                "historical_population": _cell("fail", "L1", "H1"),
+                "causal_transform": _cell("fail", "L1"),
+            }
+        ),
+        RankingFamily.HISTORICAL_POPULATION: MappingProxyType(
+            {
+                "public_clock": _cell("fail", "H1"),
+                "system_versions": _cell("pass", "H2", qualification="prospective coverage only"),
+                "historical_population": _cell("fail", "H1", "H2", "H3"),
+                "causal_transform": _cell("pass", "H2", qualification="prospective coverage only"),
+            }
+        ),
+    }
+)
+
+
+_REASONS: Final[Mapping[RankingFamily, str]] = MappingProxyType(
+    {
+        RankingFamily.RESEARCH_PRICES: "no publication vintage; current/eventual population and non-causal transforms",
+        RankingFamily.FUNDAMENTAL_FACTS: "same-accession updates and destructive filing retention",
+        RankingFamily.DERIVED_FUNDAMENTALS: "rebuilt/current winner state lacks a historical public version",
+        RankingFamily.DIMENSIONAL_XBRL: "stored facts omit the dimension/member identity",
+        RankingFamily.OWNERSHIP_OBSERVATIONS: "writers overwrite or supersede without retaining prior payload versions",
+        RankingFamily.FILING_RED_FLAGS: "mutable event/classifier state has no historical scorer version",
+        RankingFamily.FINRA_SHORT_INTEREST: "settlement is mislabelled as publication and revisions overwrite",
+        RankingFamily.LIVE_ETORO_STATE: "live broker state is not historical evidence",
+        RankingFamily.HISTORICAL_POPULATION: (
+            "forward membership begins after the frozen archive and has unknown imports"
+        ),
+    }
+)
+
+FIELD_REGISTRY: Final[Mapping[RankingFamily, FieldVerdict]] = MappingProxyType(
+    {family: FieldVerdict(status="refused", reason=_REASONS[family]) for family in RankingFamily}
+)
+
+_ALL_FAMILIES = frozenset(RankingFamily)
+IDENTITY_FAMILIES: Final[Mapping[R6RankingIdentity, frozenset[RankingFamily]]] = MappingProxyType(
+    {
+        R6RankingIdentity.DILUTION_RED_FLAGS: frozenset(
+            {
+                RankingFamily.FUNDAMENTAL_FACTS,
+                RankingFamily.DERIVED_FUNDAMENTALS,
+                RankingFamily.DIMENSIONAL_XBRL,
+                RankingFamily.FILING_RED_FLAGS,
+                RankingFamily.HISTORICAL_POPULATION,
+            }
+        ),
+        R6RankingIdentity.SHORT_INTEREST: frozenset(
+            {
+                RankingFamily.FINRA_SHORT_INTEREST,
+                RankingFamily.FUNDAMENTAL_FACTS,
+                RankingFamily.HISTORICAL_POPULATION,
+            }
+        ),
+        R6RankingIdentity.QUALITY: frozenset(
+            {
+                RankingFamily.FUNDAMENTAL_FACTS,
+                RankingFamily.DERIVED_FUNDAMENTALS,
+                RankingFamily.HISTORICAL_POPULATION,
+            }
+        ),
+        R6RankingIdentity.SHAREHOLDER_YIELD: frozenset(
+            {
+                RankingFamily.FUNDAMENTAL_FACTS,
+                RankingFamily.DERIVED_FUNDAMENTALS,
+                RankingFamily.HISTORICAL_POPULATION,
+            }
+        ),
+        R6RankingIdentity.MOMENTUM: frozenset({RankingFamily.RESEARCH_PRICES, RankingFamily.HISTORICAL_POPULATION}),
+        R6RankingIdentity.DEFENSIVE: frozenset({RankingFamily.RESEARCH_PRICES, RankingFamily.HISTORICAL_POPULATION}),
+        R6RankingIdentity.VALUATION: frozenset(
+            {
+                RankingFamily.FUNDAMENTAL_FACTS,
+                RankingFamily.DERIVED_FUNDAMENTALS,
+                RankingFamily.DIMENSIONAL_XBRL,
+                RankingFamily.LIVE_ETORO_STATE,
+                RankingFamily.HISTORICAL_POPULATION,
+            }
+        ),
+        R6RankingIdentity.OWNERSHIP: frozenset(
+            {RankingFamily.OWNERSHIP_OBSERVATIONS, RankingFamily.HISTORICAL_POPULATION}
+        ),
+        R6RankingIdentity.COMBINATION: _ALL_FAMILIES,
+        R6RankingIdentity.MACHINE_LEARNING: _ALL_FAMILIES,
+    }
+)
+
+
+def _registry_payload() -> dict[str, object]:
+    return {
+        "families": {
+            family.value: {
+                "reason": FIELD_REGISTRY[family].reason,
+                "status": FIELD_REGISTRY[family].status,
+                "conditions": {
+                    condition: {
+                        "outcome": evidence.outcome,
+                        "probes": list(evidence.probes),
+                        "qualification": evidence.qualification,
+                    }
+                    for condition, evidence in sorted(PROBE_MATRIX[family].items())
+                },
+            }
+            for family in sorted(RankingFamily, key=lambda item: item.value)
+        },
+        "identities": {
+            identity.value: sorted(family.value for family in IDENTITY_FAMILIES[identity])
+            for identity in sorted(R6RankingIdentity, key=lambda item: item.value)
+        },
+    }
+
+
+REGISTRY_VERSION: Final = (
+    "r6-pit-registry-v1+"
+    + hashlib.sha256(json.dumps(_registry_payload(), sort_keys=True, separators=(",", ":")).encode()).hexdigest()[:12]
+)
+
+
+@dataclass(frozen=True)
+class R6RankingRequest:
+    identity: R6RankingIdentity
+    decision_session: date
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.identity, R6RankingIdentity):
+            raise ValueError(f"unknown R6 ranking identity: {self.identity!r}")
+        if not isinstance(self.decision_session, date):
+            raise ValueError("decision_session must be a date")
+
+
+class PointInTimeUnavailableError(RuntimeError):
+    """The requested historical ranking has no admissible PIT input path."""
+
+
+def source_date_is_public(source_public_date: date, *, decision_session: date) -> bool:
+    """Date-resolution sources are usable only strictly before the decision."""
+    return source_public_date < decision_session
+
+
+def execute_r6_ranking(request: R6RankingRequest | None) -> None:
+    """Authorize and dispatch one R6 ranking, or refuse before SQL is possible."""
+    if request is None:
+        raise PointInTimeUnavailableError("R6 ranking requires a non-empty typed request")
+    if not isinstance(request, R6RankingRequest):
+        raise PointInTimeUnavailableError("R6 ranking requires a non-empty typed request")
+    if us_market_status(request.decision_session) == "closed":
+        raise PointInTimeUnavailableError(f"decision_session {request.decision_session} is a closed NYSE date")
+
+    families = IDENTITY_FAMILIES[request.identity]
+    if RankingFamily.RESEARCH_PRICES in families and request.decision_session > INTRADER_CAPTURE_DATE:
+        raise PointInTimeUnavailableError(
+            f"decision_session {request.decision_session} is after research-price capture {INTRADER_CAPTURE_DATE}"
+        )
+
+    refusals = "; ".join(
+        f"{family.value}: {FIELD_REGISTRY[family].reason}" for family in sorted(families, key=lambda item: item.value)
+    )
+    raise PointInTimeUnavailableError(
+        f"{request.identity.value}: no admissible historical read path under {REGISTRY_VERSION}; {refusals}"
+    )
+
+
+__all__ = [
+    "FIELD_REGISTRY",
+    "IDENTITY_FAMILIES",
+    "PROBE_MATRIX",
+    "REGISTRY_VERSION",
+    "ConditionEvidence",
+    "FieldVerdict",
+    "PointInTimeUnavailableError",
+    "R6RankingIdentity",
+    "R6RankingRequest",
+    "RankingFamily",
+    "execute_r6_ranking",
+    "source_date_is_public",
+]

--- a/app/services/research_point_in_time.py
+++ b/app/services/research_point_in_time.py
@@ -92,19 +92,16 @@ PROBE_MATRIX: Final[Mapping[RankingFamily, Mapping[Condition, ConditionEvidence]
             {
                 "public_clock": _cell("pass", "D0"),
                 "system_versions": _cell("fail", "D1"),
-                "historical_population": _cell("fail", "D1"),
+                "historical_population": _cell("fail", "P2", "P5"),
                 "causal_transform": _cell("fail", "D1"),
             }
         ),
         RankingFamily.DIMENSIONAL_XBRL: MappingProxyType(
             {
-                condition: _cell("fail", "X1")
-                for condition in (
-                    "public_clock",
-                    "system_versions",
-                    "historical_population",
-                    "causal_transform",
-                )
+                "public_clock": _cell("fail", "X1"),
+                "system_versions": _cell("fail", "X1"),
+                "historical_population": _cell("fail", "P2", "P5"),
+                "causal_transform": _cell("fail", "X1"),
             }
         ),
         RankingFamily.OWNERSHIP_OBSERVATIONS: MappingProxyType(

--- a/app/services/research_point_in_time.py
+++ b/app/services/research_point_in_time.py
@@ -74,7 +74,7 @@ PROBE_MATRIX: Final[Mapping[RankingFamily, Mapping[Condition, ConditionEvidence]
     {
         RankingFamily.RESEARCH_PRICES: MappingProxyType(
             {
-                "public_clock": _cell("fail", "P1"),
+                "public_clock": _cell("pass", "P0"),
                 "system_versions": _cell("fail", "P1"),
                 "historical_population": _cell("fail", "P2", "P5"),
                 "causal_transform": _cell("fail", "P3", "P4"),
@@ -90,13 +90,10 @@ PROBE_MATRIX: Final[Mapping[RankingFamily, Mapping[Condition, ConditionEvidence]
         ),
         RankingFamily.DERIVED_FUNDAMENTALS: MappingProxyType(
             {
-                condition: _cell("fail", "D1")
-                for condition in (
-                    "public_clock",
-                    "system_versions",
-                    "historical_population",
-                    "causal_transform",
-                )
+                "public_clock": _cell("pass", "D0"),
+                "system_versions": _cell("fail", "D1"),
+                "historical_population": _cell("fail", "D1"),
+                "causal_transform": _cell("fail", "D1"),
             }
         ),
         RankingFamily.DIMENSIONAL_XBRL: MappingProxyType(
@@ -112,7 +109,7 @@ PROBE_MATRIX: Final[Mapping[RankingFamily, Mapping[Condition, ConditionEvidence]
         ),
         RankingFamily.OWNERSHIP_OBSERVATIONS: MappingProxyType(
             {
-                "public_clock": _cell("fail", "O2"),
+                "public_clock": _cell("pass", "O0", qualification="filing-based families; DEF 14A fails O2"),
                 "system_versions": _cell("fail", "O1", "O2", "O3"),
                 "historical_population": _cell("fail", "H2", "H3"),
                 "causal_transform": _cell("fail", "O3"),
@@ -144,7 +141,7 @@ PROBE_MATRIX: Final[Mapping[RankingFamily, Mapping[Condition, ConditionEvidence]
         ),
         RankingFamily.HISTORICAL_POPULATION: MappingProxyType(
             {
-                "public_clock": _cell("fail", "H1"),
+                "public_clock": _cell("pass", "H2", qualification="prospective coverage only"),
                 "system_versions": _cell("pass", "H2", qualification="prospective coverage only"),
                 "historical_population": _cell("fail", "H1", "H2", "H3"),
                 "causal_transform": _cell("pass", "H2", qualification="prospective coverage only"),

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-1.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-1.md
@@ -1,0 +1,19 @@
+# R6 point-in-time spine correction 1: sentinel accession syntax (#2900)
+
+Status: **FROZEN BEFORE A VALID LEAK TEST**.
+
+The first focused database test never reached a baseline or leak result. The
+schema rejected the declaration's synthetic `source_accession` value
+`R6-2900-PIT-SENTINEL` under
+`chk_institutions_obs_source_accession`, which requires the SEC accession shape
+`^[0-9]{10}-[0-9]{2}-[0-9]{6}$`.
+
+The corrected fixed identity uses `0000002900-20-002900` for both
+`source_document_id` and `source_accession`; the post-decision control uses
+`0000002900-20-002901`. Filer CIK, decision date, period end, values, writer,
+natural-key overwrite, tuple columns, comparison and verdict rules are
+unchanged.
+
+The source probe for FINRA `settlement_date DATE NOT NULL` expects two anchors,
+because migration 152 declares that column on both observations and current
+tables. This changes no evidence condition; it corrects the non-vacuity count.

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-2.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-2.md
@@ -1,0 +1,30 @@
+# R6 point-in-time spine correction 2: do not overstate failed conditions (#2900)
+
+Status: **FROZEN BEFORE THE FINAL VERDICT RUN**.
+
+The first valid verifier run confirmed the decisive system-version overwrite,
+but its matrix overstated three independent conditions. A family is refused
+when any required condition fails; it is neither necessary nor accurate to
+label every condition failed.
+
+This correction supersedes these declaration matrix cells:
+
+- `research_prices/public_clock` becomes `PASS[P0]`: a completed prior-session
+  `bar_date < D` has a causal daily public clock. The family remains refused by
+  missing source vintages, future-adjusted values, non-causal quarantine and
+  non-PIT population.
+- `derived_fundamentals/public_clock` becomes `PASS[D0]`: derived period rows
+  carry `filed_date`. They remain refused because the tables are rebuilt and
+  select today's normalization/restatement winner.
+- `ownership_observations/public_clock` becomes `PASS[O0]` for filing-based
+  families such as 13F, qualified that DEF 14A still fails `O2`. All ownership
+  record writers remain refused because same-key rewashes discard prior
+  payload versions; the arm cannot reconstruct an old research state.
+- `historical_population/public_clock` becomes `PASS[H2]`, prospectively only.
+  The append-only membership record has effective dates, but begins in 2026
+  with unknown imported starts and cannot populate the archive window.
+
+New probes `P0`, `D0` and `O0` bind those positive claims. No registry status,
+decision date, mutation, comparison, threshold or overall verdict rule changes.
+The earlier valid run is diagnostic only; the final result must be regenerated
+after this correction and its implementation are committed cleanly.

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-3.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-3.md
@@ -1,0 +1,20 @@
+# R6 point-in-time spine correction 3: bind probe semantics (#2900)
+
+Status: **FROZEN BEFORE THE NEXT VERDICT RUN**.
+
+The latest independent review identified two evidence-attribution defects. The
+verdict remains unchanged, but the final run must not proceed with either:
+
+- `derived_fundamentals/historical_population` and
+  `dimensional_xbrl/historical_population` must cite `P2,P5`, as frozen in the
+  declaration. `D1` proves destructive derived-table rebuilds and `X1` proves
+  missing XBRL dimension identity; neither examines the historical population.
+- Source anchors must be checked in parsed executable Python or uncommented
+  DDL, not raw file substrings. Python modules must resolve and parse; comments,
+  docstrings and statically dead `if False` bodies cannot satisfy a probe.
+  Positive and negative schema claims must also bind to the live schema.
+
+No registry status, decision date, mutation, comparison, threshold or overall
+verdict rule changes. The previous runs are diagnostic only; the next result
+must be generated after this correction and implementation are committed
+cleanly.

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-declaration.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-declaration.md
@@ -1,0 +1,207 @@
+# R6 point-in-time spine failure-test declaration (#2900)
+
+Status: **FROZEN BEFORE LEAK TEST**. This is a
+data-admissibility declaration, not a strategy arm. It creates no return,
+haircut, benchmark or investability evidence.
+
+## Question and pass bar
+
+Can any field needed by the ordered R6 arms be ranked for a historical New
+York decision session using only the state public at that decision, with the
+same rank surviving a later ingest?
+
+A field is admissible only if all four conditions hold:
+
+1. **Public clock:** the stored source publication instant is known. Period end,
+   settlement date and price-bar date are not substitutes for publication.
+2. **System-version clock:** every correction, reparse and identifier change is
+   retained append-only. An in-place `UPSERT` cannot reconstruct its predecessor.
+3. **Point-in-time population:** membership and identity use no current
+   tradability, eventual survival, later termination or timeless symbol list.
+4. **Causal transform:** every input used to classify the final pre-decision
+   observation is itself public before the decision. A next-bar quarantine is
+   non-causal at the boundary.
+
+Unknown fields and fields failing any condition are refused before SQL is
+issued. A hash of today's mutable output is not a missing system-version clock:
+it can detect drift, but it cannot reconstruct the state that produced the old
+decision.
+
+`D` is the opening auction of an actual New York exchange session. All
+date-resolution source values must have `source_public_date < D`; same-date
+values are excluded because the repository does not uniformly retain intraday
+publication time. Weekend and holiday dates are refused. Research-price reads
+also refuse `D > 2024-09-27`, the pinned archive capture date.
+
+## Source rules
+
+- SEC Companyfacts `filed` governs public availability; `start`/`end` describe
+  the fact's period. See `.claude/skills/data-sources/sec-edgar.md` §§1, 2 and
+  5 and the SEC's [EDGAR API contract](https://www.sec.gov/search-filings/edgar-application-programming-interfaces).
+- Form 13F reports quarter-end holdings later. Public availability is the
+  filing date, not period end. Amendments, confidential-treatment releases,
+  PUT/CALL rows and PRN units prevent a raw sum from being an ownership state.
+  See the same skill §§2.1 and 7.1–7.2 and the
+  [SEC Form 13F FAQ](https://www.sec.gov/rules-regulations/staff-guidance/division-investment-management-frequently-asked-questions/frequently-asked-questions-about-form-13f).
+- Forms 3, 4 and 5 are initial ownership, changes and deferred/annual reporting,
+  not interchangeable snapshots. Filing time governs knowability. See the
+  skill §2.3 and the [SEC forms index](https://www.sec.gov/submit-filings/forms-index).
+- Schedule 13D/G beneficial, voting and dispositive amounts overlap under Rule
+  13d-3 and group reporting under Rule 13d-5; they are not additive. Machine
+  coverage has a 2024-12-18 structured-XML floor. See the skill §§2.4 and 2.6.
+- DEF 14A Item 403's stated `as of` date describes the ownership snapshot; the
+  filing date says when it became public. The current observation writer sets
+  `filed_at` to current wall-clock time for every row, whether or not the parsed
+  `as_of_date` exists; only `period_end` branches on that date. The SEC public
+  clock is therefore absent from every current DEF 14A observation row.
+- FINRA short interest describes a designated settlement date and is provided
+  for publication on the seventh business day after it. The current table
+  stamps settlement-date midnight into `filed_at` and overwrites revisions.
+  See [FINRA's data description](https://www.finra.org/finra-data/browse-catalog/equity-short-interest)
+  and [reporting schedule](https://www.finra.org/filing-reporting/regulatory-filing-systems/short-interest).
+
+## Frozen field inventory
+
+The implementation registry must contain every input family named by the
+current ordered arms and downstream gates. The allowed states are `eligible`
+and `refused`; no implicit/default admission exists. This issue matrix is the
+completeness authority:
+
+| Issue | Required registry families |
+|---|---|
+| #2908 dilution/red flags | `fundamental_facts`, `derived_fundamentals`, `dimensional_xbrl`, `filing_red_flags`, `historical_population` |
+| #2913 short interest | `finra_short_interest`, `fundamental_facts` (float), `historical_population` |
+| #2901 quality | `fundamental_facts`, `derived_fundamentals`, `historical_population` |
+| #2917 shareholder yield | `fundamental_facts`, `derived_fundamentals`, `historical_population` |
+| #2916 momentum | `research_prices`, `historical_population` |
+| #2910 low beta/volatility | `research_prices`, `historical_population` |
+| #2902 valuation | `fundamental_facts`, `derived_fundamentals`, `dimensional_xbrl`, `live_etoro_state`, `historical_population` |
+| #2903 ownership | `ownership_observations`, `historical_population` |
+| #2904 combination / #2911 ML | union of every surviving upstream family; with none admissible, both are blocked |
+
+The verifier derives the verdict from this non-vacuous probe matrix. `FAIL[x]`
+means probe `x` proves that condition absent; `PASS[x]` means it is structurally
+present but does not rescue another failed condition. Every probe must match
+exactly one runtime/schema anchor unless its definition explicitly names more.
+
+| Registry family | Public clock | System versions | PIT population/identity | Causal transform |
+|---|---|---|---|---|
+| `research_prices` | `FAIL[P1]` | `FAIL[P1]` | `FAIL[P2,P5]` | `FAIL[P3,P4]` |
+| `fundamental_facts` | `PASS[F0]` | `FAIL[F1,F2]` | `FAIL[P2,P5]` | `PASS[F0]` |
+| `derived_fundamentals` | `FAIL[D1]` | `FAIL[D1]` | `FAIL[P2,P5]` | `FAIL[D1]` |
+| `dimensional_xbrl` | `FAIL[X1]` | `FAIL[X1]` | `FAIL[P2,P5]` | `FAIL[X1]` |
+| `ownership_observations` | `FAIL[O2]` | `FAIL[O1,O2,O3]` | `FAIL[H2,H3]` | `FAIL[O3]` |
+| `filing_red_flags` | `PASS[R0]` | `FAIL[R1]` | `FAIL[H2,H3]` | `FAIL[R1]` |
+| `finra_short_interest` | `FAIL[N1]` | `FAIL[N1]` | `FAIL[N2,H2,H3]` | `PASS[N0]` |
+| `live_etoro_state` | `FAIL[L1]` | `FAIL[L1]` | `FAIL[L1,H1]` | `FAIL[L1]` |
+| `historical_population` | `FAIL[H1]` | `PASS[H2]` only prospectively | `FAIL[H1,H2,H3]` | `PASS[H2]` only prospectively |
+
+| Intended input family | Frozen verdict | Governing reason |
+|---|---|---|
+| Research price OHLCV, adjusted close, momentum, beta, volatility and price-derived size proxies | **REFUSED** | The selection admits linked names using today's eToro `is_tradable`/type/exchange, admits unlinked names according to eventual termination at the 2024 capture, and applies a 2026 exchange-test symbol list timelessly. Stored B4 quarantine uses the next bar. Historical prices are retrospectively split-adjusted, changing the historical `$1` eligibility gate after a future split. No vendor publication/version history exists. |
+| Direct `price_daily` or current eToro data | **REFUSED** | Current identity, tradability and quote state are execution facts, not a historical population. |
+| Revenue, cost, profit, income, balance-sheet, cash-flow, capex, dividends, buybacks, debt and share-count concepts in `financial_facts_raw` | **REFUSED** | Same-accession values are updated in place and the daily retention sweep deletes older 10-K/Q accessions as new filings arrive. `filed_date < D` cannot reproduce the former rows. Only tracked concepts are retained. |
+| `fundamentals_snapshot`, `financial_periods_raw`, `financial_periods`, `financial_periods_ttm`, current dilution and market-cap summaries | **REFUSED** | Snapshot `as_of_date` is statement period end, not publication; periods-raw is rebuilt from the mutable retained facts; canonical/current rows select today's normalization/restatement winner. |
+| Per-share-class, segment or other dimensional XBRL facts | **REFUSED** | Companyfacts JSON as stored lacks the dimension/member needed to identify the security-class fact. |
+| Institutional, insider, blockholder, DEF 14A, treasury, fund and ESOP observations or changes | **REFUSED** | Writers use `ON CONFLICT DO UPDATE`, advance only the latest `ingested_at`, and discard the prior payload. Rewash can rename, supersede, revive or change historical rows. Current identifier resolution and overlapping legal measures cannot reconstruct a historical owner state. |
+| Filing red-flag score | **REFUSED** | Filing rows and scorer classifications are mutable/current-version inputs; the accession-deduped historical event state is not frozen. |
+| FINRA short interest, ADV and days-to-cover | **REFUSED** | Stored `filed_at` is settlement date rather than publication; schedule history is absent; revisions overwrite values and publication time; symbol resolution is current. |
+| Current eToro tradability, type, venue, ISA eligibility and symbol mapping | **REFUSED for historical ranks** | Live execution/mandate gates do not establish historical membership. They still apply before any live order. |
+| `instrument_universe_membership` and dated symbol/identifier histories | **REFUSED for the frozen historical archive; prospectively usable only within observed coverage** | Membership is append-only and structurally PIT from its first observation, but migration 271 explicitly forbids a backfill: imported starts are unknown and coverage begins after the research-price archive ends. Dated symbol/identifier records do not supply the missing pre-observation membership population. |
+
+These refusals govern historical R6 evidence under the current table contracts.
+Reopening a field requires an append-only source-versioned store, overlapping
+historical identity and population, and the causal source-specific state
+builder. Forward-only membership may become usable prospectively once a full
+window has accumulated; it cannot repair the frozen archive. Adding a lag
+constant, copying today's rows, or pinning an output hash is insufficient.
+
+## Fail-closed read-path contract
+
+`app.services.research_point_in_time` will expose the registry and one query
+boundary, `execute_r6_ranking`. It accepts a non-empty typed `R6RankingRequest`
+containing the ranking identity, explicit NYSE `decision_session`, and the
+inseparable registry-family set declared by that ranking identity. Callers
+cannot supply a callback or override/under-declare the family set. The service
+validates the session with `market_calendar.us_market_status`, refuses price
+requests after the archive capture, and dispatches only to an internal reader
+registered beside the identity. Empty, unknown and refused requests raise
+`PointInTimeUnavailableError` before a connection or SQL is available. There
+are no internal readers under this declaration, so every request refuses.
+
+The registry is a closed mapping from the issue-level input families to their
+status, source clock, system-version status, population status, causal status
+and reason. Tests pin its exact key set. An unknown key raises separately.
+
+## Frozen adversarial test
+
+Decision date: `2020-01-15`. Exact counts and values remain unknown until this
+declaration is frozen.
+
+The dev-only verifier runs in rollback-only transactions and records:
+
+1. Select the lowest existing `instrument_id`, then seed a deterministic 13F
+   equity specimen through `record_institution_observation` with a unique
+   declaration-fixed filer/document identity and `filed_at < D`. This makes the
+   test independent of retained production depth. The compared tuple is exactly
+   `(instrument_id, filer_cik, filer_name, filer_type, ownership_nature, source,
+   source_document_id, source_accession, source_field, source_url, filed_at,
+   period_start, period_end, known_from, known_to, ingest_run_id, shares,
+   market_value_usd, voting_authority, exposure_kind, ingested_at)`, ordered by
+   `(instrument_id, filer_cik, ownership_nature, period_end,
+   source_document_id, exposure_kind)` using bytewise Python tuple order after
+   retrieval. Datetimes are UTC ISO-8601, decimals are fixed-point strings and
+   null is JSON null; canonical JSON uses sorted keys and compact separators.
+2. A new observation with `filed_at > D`. The sequence must remain unchanged;
+   this is the easy public-clock control.
+3. Call the same production writer on the specimen's pre-D natural key,
+   changing shares without changing `filed_at`. The sequence must change and a
+   full-tuple comparator must raise. Querying `ingested_at <=` the original
+   vintage must not recover the overwritten predecessor. This is the decisive
+   system-version failure.
+4. Executable probes, with source SHA-256s reported, bind these IDs:
+   `F0` Companyfacts `filed_date`; `F1` facts conflict update; `F2` 10-K/Q
+   delete sweep; `D1` destructive periods rebuild plus latest-winner derivation;
+   `X1` raw schema/parser absence of dimension/member; `O1` every ownership
+   record writer's conflict update; `O2` DEF 14A's unconditional wall clock;
+   `O3` retention/supersession and current identifier resolution; `R0` filing
+   event filed clock; `R1` mutable score/lookup without historical scorer
+   version; `N0` settlement-date presence; `N1` settlement-derived `filed_at`
+   plus conflict update; `N2` current symbol resolution; `L1` current-only eToro
+   state; `H1` current validated-universe query plus eventual-termination
+   admission; `H2` forward membership's no-backfill/imported-start contract and
+   measured coverage non-overlap; `H3` symbol/external-identifier historical
+   coverage; `P1` research bars lack observation/publication versions; `P2`
+   current/eventual selection; `P3` B4 successor read; `P4` retrospective
+   split-adjustment semantics; `P5` timeless 2026 exchange-test list.
+5. `execute_r6_ranking` refuses every ranking identity plus unknown/empty
+   requests; an AST guard fails if any `app/services/r6_*.py` ranking module
+   reads a governed table outside `research_point_in_time.py`.
+6. The sentinel identity is fixed as filer CIK `0000002900`, document/accession
+   `R6-2900-PIT-SENTINEL`, nature `economic`, exposure `EQUITY`, period end
+   `2019-12-31`. The verifier acquires transaction advisory lock
+   `hashtextextended('r6-2900-pit-verifier', 0)`, selects the lowest existing
+   instrument only after the lock, and refuses if the full natural key exists.
+   Every comparison is sentinel-key scoped. One explicit outer transaction is
+   unconditionally rolled back in `finally`; a newly opened connection proves
+   the sentinel is absent. Any pre-state collision or missing instrument is a
+   refusal, not cleanup.
+
+The test **passes** only if the guard fails closed and all contamination is
+detected. #2900's evidence verdict is nevertheless **FAIL / NO ADMISSIBLE
+HISTORICAL FIELD** if no family satisfies the four-part bar. Detection is not
+reconstruction, and a passing refusal test must not be reported as a usable PIT
+spine.
+
+## Reporting boundary
+
+The result states declaration SHA-256 and commit, command, decision date,
+complete registry, measured source census, before/after hashes, first unequal
+tuple, source-code contract hashes, and rollback proof. The frozen census is:
+row and distinct-instrument counts plus min/max public/period/system dates for
+`financial_facts_raw`, every ownership observation table, FINRA short interest,
+research price series/bars/quarantine coverage, universe membership, symbol
+history and external identifiers; zero rows print explicit zero/null strata.
+It must say explicitly
+that Tier 2 is blocked rather than manufacture an arm result. No performance,
+haircut, cost or benchmark output may be inferred from this diagnostic.

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
@@ -6,15 +6,15 @@ Declaration SHA-256: `369b397e17694f2a54b07897b4d68a8728bf0624e35d00ced8a6ce833b
 Correction-1 SHA-256: `b101123c59183b8204a70b98a9c40b25e350a4fc58a9c114d8ea76735157cff6` at commit `fe67f100e565fd52db8201ac6ad8f1758c2b163f`.
 Correction-2 SHA-256: `a330ed170d39da3c201e2bd8e1ce5f80566209a356faa75bb899090e5e2b4f32` at commit `055056a5c3b1aa3bc5971de4a6085b0f7bd72206`.
 Correction-3 SHA-256: `3186b8573a2bd66dbe04eb0cf378e520dad8e9deaccae4dc92800c696708445d` at commit `4fc9c397dd5c31835856d948137fc0cab3318841`.
-Execution commit: `9f4aa232c0274a2fd1409568aa6a0e863a9fc034`. Registry: `r6-pit-registry-v1+bc337f13bf00`.
+Execution commit: `76397c281f6cc57046f326462a90e514041f0ec0`. Registry: `r6-pit-registry-v1+bc337f13bf00`.
 Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown`
 
 ## Adversarial leak test
 
 - Decision date: `2020-01-15` (NYSE session).
-- Baseline hash: `74f00d3be202356fad69c1b18afa9a4fe8b12f6cd367c96aac633b5e48121dbb`.
-- Post-decision insert hash: `74f00d3be202356fad69c1b18afa9a4fe8b12f6cd367c96aac633b5e48121dbb` (unchanged).
-- Same-key pre-decision overwrite hash: `ece1c09a47bd6be448bdb15597bcf5e8dad5d4ddf9711ed8d683d97cf2313072` (changed).
+- Baseline hash: `f1d7469066740918f5102df79e374cdeb3c40f15f73bc97656bbecf0e10cec7d`.
+- Post-decision insert hash: `f1d7469066740918f5102df79e374cdeb3c40f15f73bc97656bbecf0e10cec7d` (unchanged).
+- Same-key pre-decision overwrite hash: `6eb77456146f2514e8bf800e034aee5477028e1f40ad3e329fcb8ed275875d50` (changed).
 - First unequal field: `ingest_run_id`: `00000000-0000-0000-0000-000000002900` → `00000000-0000-0000-0000-000000002902`.
 - Rows recoverable at the old `ingested_at` after overwrite: 0.
 - Rollback proved on a new connection: `true`.

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
@@ -6,15 +6,15 @@ Declaration SHA-256: `369b397e17694f2a54b07897b4d68a8728bf0624e35d00ced8a6ce833b
 Correction-1 SHA-256: `b101123c59183b8204a70b98a9c40b25e350a4fc58a9c114d8ea76735157cff6` at commit `fe67f100e565fd52db8201ac6ad8f1758c2b163f`.
 Correction-2 SHA-256: `a330ed170d39da3c201e2bd8e1ce5f80566209a356faa75bb899090e5e2b4f32` at commit `055056a5c3b1aa3bc5971de4a6085b0f7bd72206`.
 Correction-3 SHA-256: `3186b8573a2bd66dbe04eb0cf378e520dad8e9deaccae4dc92800c696708445d` at commit `4fc9c397dd5c31835856d948137fc0cab3318841`.
-Execution commit: `04b0978bbd0be9d00d5cc89c8b153d0b894171de`. Registry: `r6-pit-registry-v1+bc337f13bf00`.
+Execution commit: `9f4aa232c0274a2fd1409568aa6a0e863a9fc034`. Registry: `r6-pit-registry-v1+bc337f13bf00`.
 Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown`
 
 ## Adversarial leak test
 
 - Decision date: `2020-01-15` (NYSE session).
-- Baseline hash: `1fba6dc7c6e83168b6ce1291697bd7d9459ee1788f00a8bf38b1a326dd9657b7`.
-- Post-decision insert hash: `1fba6dc7c6e83168b6ce1291697bd7d9459ee1788f00a8bf38b1a326dd9657b7` (unchanged).
-- Same-key pre-decision overwrite hash: `7a3eb5e44d0a6315754385204b85ca557a552a62f78cc9f1438d307b0a462b12` (changed).
+- Baseline hash: `74f00d3be202356fad69c1b18afa9a4fe8b12f6cd367c96aac633b5e48121dbb`.
+- Post-decision insert hash: `74f00d3be202356fad69c1b18afa9a4fe8b12f6cd367c96aac633b5e48121dbb` (unchanged).
+- Same-key pre-decision overwrite hash: `ece1c09a47bd6be448bdb15597bcf5e8dad5d4ddf9711ed8d683d97cf2313072` (changed).
 - First unequal field: `ingest_run_id`: `00000000-0000-0000-0000-000000002900` → `00000000-0000-0000-0000-000000002902`.
 - Rows recoverable at the old `ingested_at` after overwrite: 0.
 - Rollback proved on a new connection: `true`.

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
@@ -5,15 +5,15 @@ Verdict: **FAIL — NO ADMISSIBLE HISTORICAL FIELD**
 Declaration SHA-256: `369b397e17694f2a54b07897b4d68a8728bf0624e35d00ced8a6ce833bb4da20` at commit `51e55d58823a5ebe98e5eea6473895b9d05abc1d`.
 Correction-1 SHA-256: `b101123c59183b8204a70b98a9c40b25e350a4fc58a9c114d8ea76735157cff6` at commit `fe67f100e565fd52db8201ac6ad8f1758c2b163f`.
 Correction-2 SHA-256: `a330ed170d39da3c201e2bd8e1ce5f80566209a356faa75bb899090e5e2b4f32` at commit `055056a5c3b1aa3bc5971de4a6085b0f7bd72206`.
-Execution commit: `9a5e905e3455cbaa426f1cc2a0c38815959b7270`. Registry: `r6-pit-registry-v1+73aa1335b55e`.
+Execution commit: `0a47d341a410fc9053f83183223d822d5f7efd1f`. Registry: `r6-pit-registry-v1+73aa1335b55e`.
 Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown`
 
 ## Adversarial leak test
 
 - Decision date: `2020-01-15` (NYSE session).
-- Baseline hash: `ec6ad54aba777248a10fad18358cba48eb5bcf2bb8c53cfc1241c51c384c9a41`.
-- Post-decision insert hash: `ec6ad54aba777248a10fad18358cba48eb5bcf2bb8c53cfc1241c51c384c9a41` (unchanged).
-- Same-key pre-decision overwrite hash: `567bb6682861b4afd8952c70cad353030a2ef49d9cc63616c12b52aebb8e03f5` (changed).
+- Baseline hash: `b62d107f6af98a224f4f663c8f9ee1ca3ed6cb85ae0150f974e139c7b8b766d1`.
+- Post-decision insert hash: `b62d107f6af98a224f4f663c8f9ee1ca3ed6cb85ae0150f974e139c7b8b766d1` (unchanged).
+- Same-key pre-decision overwrite hash: `40bd40394974d4b1391bb6d8a6263e963b963da4fc691d7c6369088de9686e5a` (changed).
 - First unequal field: `ingest_run_id`: `00000000-0000-0000-0000-000000002900` → `00000000-0000-0000-0000-000000002902`.
 - Rows recoverable at the old `ingested_at` after overwrite: 0.
 - Rollback proved on a new connection: `true`.
@@ -27,21 +27,21 @@ Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --fo
 
 ## Population census
 
-- `financial_facts_raw`: 4,603,674 rows, 5,252 instruments
-- `ownership_insiders_observations`: 5,578,431 rows, 4,995 instruments
-- `ownership_institutions_observations`: 10,840,219 rows, 4,561 instruments
-- `ownership_blockholders_observations`: 44,767 rows, 4,943 instruments
-- `ownership_treasury_observations`: 60,804 rows, 1,859 instruments
-- `ownership_def14a_observations`: 125,804 rows, 3,635 instruments
-- `ownership_funds_observations`: 3,714,118 rows, 4,101 instruments
-- `ownership_esop_observations`: 91 rows, 41 instruments
-- `finra_short_interest_observations`: 186,983 rows, 6,185 instruments
-- `research_price_series`: 30,591 rows, 5,892 instruments
-- `research_price_daily`: 75,972,649 rows
-- `research_price_quarantine_coverage`: 30,572 rows
-- `instrument_universe_membership`: 12,732 rows, 12,732 instruments
-- `instrument_symbol_history`: 12,862 rows, 12,741 instruments
-- `external_identifiers`: 25,031 rows, 6,069 instruments
+- `financial_facts_raw`: `row_count`=4603674, `distinct_instruments`=5252, `min_filed_date`=2009-05-07, `max_filed_date`=2026-08-21, `min_period_end`=2006-06-30, `max_period_end`=2034-06-30
+- `ownership_insiders_observations`: `row_count`=5578431, `distinct_instruments`=4995, `min_filed_at`=2006-01-03T00:00:00+00:00, `max_filed_at`=2026-08-22T01:38:40+00:00, `min_period_end`=0001-01-01, `max_period_end`=2047-05-24, `min_ingested_at`=2026-06-03T21:47:34.700519+00:00, `max_ingested_at`=2026-08-23T05:34:31.691900+00:00, `min_known_from`=2026-06-03T19:16:27.134703+00:00, `max_known_from`=2026-08-23T05:20:37.841309+00:00, `min_known_to`=2026-06-24T03:23:52.998553+00:00, `max_known_to`=2026-07-22T16:52:21.983223+00:00
+- `ownership_institutions_observations`: `row_count`=10840219, `distinct_instruments`=4561, `min_filed_at`=2006-08-05T00:00:00+00:00, `max_filed_at`=2026-08-21T00:00:00+00:00, `min_period_end`=2024-06-30, `max_period_end`=2026-06-30, `min_ingested_at`=2026-06-03T18:58:08.029620+00:00, `max_ingested_at`=2026-08-23T06:50:16.877605+00:00, `min_known_from`=2026-06-03T18:57:15.047265+00:00, `max_known_from`=2026-08-22T07:06:06.777149+00:00, `min_known_to`=None, `max_known_to`=None
+- `ownership_blockholders_observations`: `row_count`=44767, `distinct_instruments`=4943, `min_filed_at`=2024-12-18T00:00:00+00:00, `max_filed_at`=2026-08-22T01:44:20+00:00, `min_period_end`=2024-12-18, `max_period_end`=2026-08-22, `min_ingested_at`=2026-06-14T15:30:10.273379+00:00, `max_ingested_at`=2026-08-23T06:51:44.780049+00:00, `min_known_from`=2026-06-14T14:20:08.744706+00:00, `max_known_from`=2026-08-23T02:35:43.656959+00:00, `min_known_to`=2026-06-15T00:07:39.414654+00:00, `max_known_to`=2026-06-15T00:07:39.440312+00:00
+- `ownership_treasury_observations`: `row_count`=60804, `distinct_instruments`=1859, `min_filed_at`=2009-04-23T00:00:00+00:00, `max_filed_at`=2026-08-21T00:00:00+00:00, `min_period_end`=2009-03-31, `max_period_end`=2026-12-31, `min_ingested_at`=2026-06-21T03:04:53.110601+00:00, `max_ingested_at`=2026-08-23T06:52:01.846275+00:00, `min_known_from`=2026-06-03T19:22:16.736325+00:00, `max_known_from`=2026-08-23T02:35:30.268216+00:00, `min_known_to`=None, `max_known_to`=None
+- `ownership_def14a_observations`: `row_count`=125804, `distinct_instruments`=3635, `min_filed_at`=2026-06-04T16:10:00.071067+00:00, `max_filed_at`=2026-08-23T02:30:17.087192+00:00, `min_period_end`=1990-10-31, `max_period_end`=2026-12-31, `min_ingested_at`=2026-06-21T03:05:04.453991+00:00, `max_ingested_at`=2026-08-23T06:52:34.939864+00:00, `min_known_from`=2026-06-04T03:45:00.074895+00:00, `max_known_from`=2026-08-23T02:30:17.087192+00:00, `min_known_to`=2026-07-24T22:36:21.016735+00:00, `max_known_to`=2026-08-07T17:20:01.957715+00:00
+- `ownership_funds_observations`: `row_count`=3714118, `distinct_instruments`=4101, `min_filed_at`=2024-03-28T20:10:19+00:00, `max_filed_at`=2026-07-28T20:55:43+00:00, `min_period_end`=2024-07-31, `max_period_end`=2026-11-30, `min_ingested_at`=2026-06-03T21:10:00.048023+00:00, `max_ingested_at`=2026-07-28T21:05:04.258198+00:00, `min_known_from`=2026-06-03T18:57:15.046982+00:00, `max_known_from`=2026-07-28T21:05:04.258198+00:00, `min_known_to`=None, `max_known_to`=None
+- `ownership_esop_observations`: `row_count`=91, `distinct_instruments`=41, `min_filed_at`=2026-06-14T02:51:59.497312+00:00, `max_filed_at`=2026-07-30T18:25:06.121739+00:00, `min_period_end`=2016-04-20, `max_period_end`=2026-07-30, `min_ingested_at`=2026-06-21T03:05:07.205460+00:00, `max_ingested_at`=2026-08-23T06:52:34.628429+00:00, `min_known_from`=2026-06-14T02:39:03.202685+00:00, `max_known_from`=2026-07-30T18:09:16.199090+00:00, `min_known_to`=2026-07-25T13:58:55.931404+00:00, `max_known_to`=2026-07-30T17:39:10.695219+00:00
+- `finra_short_interest_observations`: `row_count`=186983, `distinct_instruments`=6185, `min_filed_at`=2024-01-12T00:00:00+00:00, `max_filed_at`=2026-07-31T00:00:00+00:00, `min_period_end`=2024-01-12, `max_period_end`=2026-07-31, `min_known_from`=2026-06-04T12:00:04.028357+00:00, `max_known_from`=2026-08-23T12:00:01.079207+00:00, `min_settlement_date`=2024-01-12, `max_settlement_date`=2026-07-31
+- `research_price_series`: `row_count`=30591, `distinct_instruments`=5892, `min_first_bar`=1962-01-02, `max_first_bar`=2026-07-06, `min_last_bar`=2013-06-21, `max_last_bar`=2026-08-21, `min_created_at`=2026-08-05T08:59:09.414883+00:00, `max_created_at`=2026-08-12T17:23:20.271864+00:00
+- `research_price_daily`: `row_count`=75972649, `min_bar_date`=1962-01-02, `max_bar_date`=2026-08-21
+- `research_price_quarantine_coverage`: `row_count`=30572, `min_first_bar`=1962-01-02, `max_first_bar`=2026-07-06, `min_last_bar`=2013-06-21, `max_last_bar`=2026-07-08, `min_evaluated_at`=2026-08-05T09:03:36.068897+00:00, `max_evaluated_at`=2026-08-14T11:08:21.119140+00:00
+- `instrument_universe_membership`: `row_count`=12732, `distinct_instruments`=12732, `min_effective_from`=2026-08-10, `max_effective_from`=2026-08-21, `min_effective_to`=2026-08-10, `max_effective_to`=2026-08-13
+- `instrument_symbol_history`: `row_count`=12862, `distinct_instruments`=12741, `min_effective_from`=2026-06-03, `max_effective_from`=2026-08-21, `min_effective_to`=2026-06-12, `max_effective_to`=2026-08-21
+- `external_identifiers`: `row_count`=25031, `distinct_instruments`=6069, `min_created_at`=2026-06-03T18:56:10.213323+00:00, `max_created_at`=2026-08-23T05:12:07.883776+00:00, `min_last_verified_at`=2026-06-03T18:56:56.241482+00:00, `max_last_verified_at`=2026-08-23T02:30:00.249466+00:00
 
 ## Consequence
 

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
@@ -5,15 +5,16 @@ Verdict: **FAIL — NO ADMISSIBLE HISTORICAL FIELD**
 Declaration SHA-256: `369b397e17694f2a54b07897b4d68a8728bf0624e35d00ced8a6ce833bb4da20` at commit `51e55d58823a5ebe98e5eea6473895b9d05abc1d`.
 Correction-1 SHA-256: `b101123c59183b8204a70b98a9c40b25e350a4fc58a9c114d8ea76735157cff6` at commit `fe67f100e565fd52db8201ac6ad8f1758c2b163f`.
 Correction-2 SHA-256: `a330ed170d39da3c201e2bd8e1ce5f80566209a356faa75bb899090e5e2b4f32` at commit `055056a5c3b1aa3bc5971de4a6085b0f7bd72206`.
-Execution commit: `0a47d341a410fc9053f83183223d822d5f7efd1f`. Registry: `r6-pit-registry-v1+73aa1335b55e`.
+Correction-3 SHA-256: `3186b8573a2bd66dbe04eb0cf378e520dad8e9deaccae4dc92800c696708445d` at commit `4fc9c397dd5c31835856d948137fc0cab3318841`.
+Execution commit: `04b0978bbd0be9d00d5cc89c8b153d0b894171de`. Registry: `r6-pit-registry-v1+bc337f13bf00`.
 Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown`
 
 ## Adversarial leak test
 
 - Decision date: `2020-01-15` (NYSE session).
-- Baseline hash: `b62d107f6af98a224f4f663c8f9ee1ca3ed6cb85ae0150f974e139c7b8b766d1`.
-- Post-decision insert hash: `b62d107f6af98a224f4f663c8f9ee1ca3ed6cb85ae0150f974e139c7b8b766d1` (unchanged).
-- Same-key pre-decision overwrite hash: `40bd40394974d4b1391bb6d8a6263e963b963da4fc691d7c6369088de9686e5a` (changed).
+- Baseline hash: `1fba6dc7c6e83168b6ce1291697bd7d9459ee1788f00a8bf38b1a326dd9657b7`.
+- Post-decision insert hash: `1fba6dc7c6e83168b6ce1291697bd7d9459ee1788f00a8bf38b1a326dd9657b7` (unchanged).
+- Same-key pre-decision overwrite hash: `7a3eb5e44d0a6315754385204b85ca557a552a62f78cc9f1438d307b0a462b12` (changed).
 - First unequal field: `ingest_run_id`: `00000000-0000-0000-0000-000000002900` → `00000000-0000-0000-0000-000000002902`.
 - Rows recoverable at the old `ingested_at` after overwrite: 0.
 - Rollback proved on a new connection: `true`.

--- a/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
+++ b/docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md
@@ -1,0 +1,50 @@
+# R6 point-in-time spine result (#2900)
+
+Verdict: **FAIL — NO ADMISSIBLE HISTORICAL FIELD**
+
+Declaration SHA-256: `369b397e17694f2a54b07897b4d68a8728bf0624e35d00ced8a6ce833bb4da20` at commit `51e55d58823a5ebe98e5eea6473895b9d05abc1d`.
+Correction-1 SHA-256: `b101123c59183b8204a70b98a9c40b25e350a4fc58a9c114d8ea76735157cff6` at commit `fe67f100e565fd52db8201ac6ad8f1758c2b163f`.
+Correction-2 SHA-256: `a330ed170d39da3c201e2bd8e1ce5f80566209a356faa75bb899090e5e2b4f32` at commit `055056a5c3b1aa3bc5971de4a6085b0f7bd72206`.
+Execution commit: `9a5e905e3455cbaa426f1cc2a0c38815959b7270`. Registry: `r6-pit-registry-v1+73aa1335b55e`.
+Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown`
+
+## Adversarial leak test
+
+- Decision date: `2020-01-15` (NYSE session).
+- Baseline hash: `ec6ad54aba777248a10fad18358cba48eb5bcf2bb8c53cfc1241c51c384c9a41`.
+- Post-decision insert hash: `ec6ad54aba777248a10fad18358cba48eb5bcf2bb8c53cfc1241c51c384c9a41` (unchanged).
+- Same-key pre-decision overwrite hash: `567bb6682861b4afd8952c70cad353030a2ef49d9cc63616c12b52aebb8e03f5` (changed).
+- First unequal field: `ingest_run_id`: `00000000-0000-0000-0000-000000002900` → `00000000-0000-0000-0000-000000002902`.
+- Rows recoverable at the old `ingested_at` after overwrite: 0.
+- Rollback proved on a new connection: `true`.
+
+## Contract evidence
+
+- Successful non-vacuous probes: D0, D1, F0, F1, F2, H1, H2, H3, L1, N0, N1, N2, O0, O1, O2, O3, P0, P1, P2, P3, P4, P5, R0, R1, X1.
+- Refused registry families: derived_fundamentals, dimensional_xbrl, filing_red_flags, finra_short_interest, fundamental_facts, historical_population, live_etoro_state, ownership_observations, research_prices.
+- Exact census tables: financial_facts_raw, ownership_insiders_observations, ownership_institutions_observations, ownership_blockholders_observations, ownership_treasury_observations, ownership_def14a_observations, ownership_funds_observations, ownership_esop_observations, finra_short_interest_observations, research_price_series, research_price_daily, research_price_quarantine_coverage, instrument_universe_membership, instrument_symbol_history, external_identifiers.
+- Full probe anchors, source hashes, registry matrix and census values are emitted by `--format json`.
+
+## Population census
+
+- `financial_facts_raw`: 4,603,674 rows, 5,252 instruments
+- `ownership_insiders_observations`: 5,578,431 rows, 4,995 instruments
+- `ownership_institutions_observations`: 10,840,219 rows, 4,561 instruments
+- `ownership_blockholders_observations`: 44,767 rows, 4,943 instruments
+- `ownership_treasury_observations`: 60,804 rows, 1,859 instruments
+- `ownership_def14a_observations`: 125,804 rows, 3,635 instruments
+- `ownership_funds_observations`: 3,714,118 rows, 4,101 instruments
+- `ownership_esop_observations`: 91 rows, 41 instruments
+- `finra_short_interest_observations`: 186,983 rows, 6,185 instruments
+- `research_price_series`: 30,591 rows, 5,892 instruments
+- `research_price_daily`: 75,972,649 rows
+- `research_price_quarantine_coverage`: 30,572 rows
+- `instrument_universe_membership`: 12,732 rows, 12,732 instruments
+- `instrument_symbol_history`: 12,862 rows, 12,741 instruments
+- `external_identifiers`: 25,031 rows, 6,069 instruments
+
+## Consequence
+
+The public-date filter correctly ignores a genuinely later filing, but the production writer overwrites a pre-decision natural key and the prior bytes cannot be recovered. The other source families fail at least one independently probed public-clock, system-version, population/identity or causal-transform condition.
+
+There is no admissible historical ranking field under the current contracts. Tier 2 arms are blocked and remain unmeasured; no return, haircut, cost or benchmark claim was produced.

--- a/docs/superpowers/plans/2026-08-23-r6-point-in-time-spine.md
+++ b/docs/superpowers/plans/2026-08-23-r6-point-in-time-spine.md
@@ -1,0 +1,75 @@
+# R6 point-in-time spine implementation plan (#2900)
+
+Status: draft. The declaration in
+`docs/proposals/ta/2026-08-23-r6-point-in-time-spine-declaration.md` governs;
+this plan cannot weaken it.
+
+1. **Freeze the question before implementation.** Change the declaration status
+   to `FROZEN BEFORE LEAK TEST`, compute its SHA-256, and commit only the
+   declaration and this plan. Record that commit; do not run the verifier.
+
+2. **Implement the red fail-closed contract.** Add
+   `tests/test_research_point_in_time.py` first. It imports the not-yet-existing
+   `RankingFamily`, `R6RankingIdentity`, `R6RankingRequest`, `FIELD_REGISTRY`,
+   `PROBE_MATRIX`, `REGISTRY_VERSION`, `PointInTimeUnavailableError`, and
+   `execute_r6_ranking`; pins the exact issue/family and probe sets; asserts
+   every current identity refuses; and covers empty/unknown/under-declared,
+   weekend (`2020-01-18`), holiday (`2020-01-20`), same-date policy, and
+   post-capture price requests. Run and expect collection failure:
+   `uv run pytest tests/test_research_point_in_time.py`.
+
+3. **Make the pure contract green.** Add
+   `app/services/research_point_in_time.py`. `R6RankingIdentity` owns its
+   immutable, non-empty family set and optional price-corpus bound; no callback
+   or caller family override exists. Validate NYSE sessions through
+   `app.services.market_calendar.us_market_status`; keep the internal reader map
+   empty; canonicalize registry/probe content using sorted-key compact JSON and
+   SHA-256. Add an AST test that scans `app/services/r6_*.py` and fails on
+   governed table literals outside this module. Run:
+   `uv run pytest tests/test_research_point_in_time.py`.
+
+4. **Implement non-vacuous probes and the rollback test.** Add
+   `tests/test_2900_point_in_time_db.py` with an isolated test-DB behavioral
+   version of the fixed sentinel insert/post-D control/same-key overwrite and
+   rollback. Add `scripts/verify_2900_point_in_time.py` with the same functions.
+   Each declared probe ID has one function that asserts its runtime symbol is
+   importable, its schema columns through `information_schema`, and either an
+   exact AST construct or behavioral mutation. Anchor counts are declared per
+   probe and zero/unexpected multiples fail. `derive_verdict` fails unless every
+   matrix cell cites successful probes and at least one condition fails per
+   family. Run:
+   `uv run pytest tests/test_2900_point_in_time_db.py`.
+
+5. **Pin isolation and output.** The dev verifier calls
+   `scripts._dev_guard.assert_dev_environment`, verifies the declaration hash,
+   requires `git status --porcelain` empty, acquires the declared advisory lock,
+   refuses a pre-existing sentinel, and scopes all tuple hashes to it. It uses
+   one outer transaction with `finally: conn.rollback()` and then a new
+   connection for absence proof. It emits one canonical JSON document to
+   stdout containing schema version, execution commit, declaration commit/hash,
+   decision date, registry/probe matrices, per-probe anchor counts and source
+   hashes, exact censuses, before/control/overwrite hashes, first unequal tuple,
+   rollback proof and derived verdict. `--format markdown` renders the result
+   document from the same typed evidence object. Tests pin both schemas.
+
+6. **Commit executable evidence before looking.** Put the frozen declaration
+   hash/commit constants into the verifier, run Ruff format on the new Python
+   files, run the two focused test commands above, and commit implementation and
+   tests. Require a clean worktree. Only now run:
+   `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format json`
+   and then the identical command with `--format markdown`. Add the verbatim
+   markdown output as
+   `docs/proposals/ta/2026-08-23-r6-point-in-time-spine-result.md` without
+   changing the declaration, implementation or test commits.
+
+7. **Run repository gates and review.** Run, separately and without pipelines:
+   `uv run ruff check .`; `uv run ruff format --check .`; `uv run pyright`;
+   `uv run pytest -m "not db"`; `uv run pytest tests/smoke`. Run
+   `codex exec review --base origin/main` before the first push. Commit any
+   correction and rerun affected focused/full gates.
+
+8. **Land and report.** Push, open the #2900 PR, resolve every review comment as
+   FIXED/DEFERRED/REBUTTED plus prevention under `.claude/CLAUDE.md`, and merge
+   only on latest-commit approval and green CI. Post the derived FAIL verdict on
+   #2900 and update #2899: dependent Tier 2 arms remain unmeasured. Continue
+   only independent Tier 1 kill-checks; never substitute current/restated rows.

--- a/scripts/verify_2900_point_in_time.py
+++ b/scripts/verify_2900_point_in_time.py
@@ -457,6 +457,7 @@ _DATE_COLUMNS: Final = (
     "period_end_date",
     "ingested_at",
     "known_from",
+    "known_to",
     "settlement_date",
     "bar_date",
     "first_bar",

--- a/scripts/verify_2900_point_in_time.py
+++ b/scripts/verify_2900_point_in_time.py
@@ -9,9 +9,14 @@ Run only after the implementation commit is clean:
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
+import importlib.util
+import io
 import json
+import re
 import subprocess
+import tokenize
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from datetime import UTC, date, datetime
@@ -38,6 +43,9 @@ CORRECTION_COMMIT: Final = "fe67f100e565fd52db8201ac6ad8f1758c2b163f"
 CORRECTION_2_PATH: Final = Path("docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-2.md")
 CORRECTION_2_SHA256: Final = "a330ed170d39da3c201e2bd8e1ce5f80566209a356faa75bb899090e5e2b4f32"
 CORRECTION_2_COMMIT: Final = "055056a5c3b1aa3bc5971de4a6085b0f7bd72206"
+CORRECTION_3_PATH: Final = Path("docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-3.md")
+CORRECTION_3_SHA256: Final = "3186b8573a2bd66dbe04eb0cf378e520dad8e9deaccae4dc92800c696708445d"
+CORRECTION_3_COMMIT: Final = "4fc9c397dd5c31835856d948137fc0cab3318841"
 DECISION_DATE: Final = date(2020, 1, 15)
 SENTINEL_CIK: Final = "0000002900"
 SENTINEL_DOCUMENT: Final = "0000002900-20-002900"
@@ -111,6 +119,8 @@ class Evidence:
     correction_sha256: str
     correction_2_commit: str
     correction_2_sha256: str
+    correction_3_commit: str
+    correction_3_sha256: str
     decision_date: str
     registry_version: str
     registry: Mapping[str, object]
@@ -200,11 +210,15 @@ _PROBE_ANCHORS: Final[Mapping[str, tuple[SourceAnchor, ...]]] = {
         SourceAnchor("app/services/universe_selection.py", "if alive:", maximum=1),
     ),
     "H2": (
-        SourceAnchor("sql/271_instrument_universe_membership.sql", "NO BACKFILL", maximum=1),
-        SourceAnchor("sql/271_instrument_universe_membership.sql", "'imported'", minimum=2),
+        SourceAnchor(
+            "sql/271_instrument_universe_membership.sql",
+            "source_event IN ('imported', 'listing', 'relisting')",
+            maximum=1,
+        ),
+        SourceAnchor("sql/271_instrument_universe_membership.sql", "true start unknown and truncated here", maximum=1),
     ),
     "H3": (
-        SourceAnchor("sql/103_instrument_symbol_history.sql", "only the current symbol is seeded", maximum=1),
+        SourceAnchor("sql/103_instrument_symbol_history.sql", "Synthetic backfill from former_names", maximum=1),
         SourceAnchor("sql/003_external_identifiers.sql", "last_verified_at", maximum=1),
     ),
     "P0": (SourceAnchor("sql/249_research_price_corpus.sql", "bar_date    DATE NOT NULL", maximum=1),),
@@ -221,17 +235,58 @@ _PROBE_ANCHORS: Final[Mapping[str, tuple[SourceAnchor, ...]]] = {
     ),
     "P4": (
         SourceAnchor("app/services/research_corpus_ingest.py", 'ADJUSTMENT_BASIS = "split_adjusted"', maximum=1),
-        SourceAnchor("app/services/backtest_run.py", "has no point-in-time split", maximum=1),
+        SourceAnchor("app/services/backtest_run.py", 'price_basis="split_adjusted"', minimum=2, maximum=2),
     ),
     "P5": (
-        SourceAnchor("app/services/universe_selection.py", "capture 2026-08-23", maximum=1),
-        SourceAnchor("app/services/universe_selection.py", "EXCHANGE_TEST_ISSUE_SYMBOLS", minimum=3),
+        SourceAnchor(
+            "app/services/universe_selection.py",
+            "INTRADER_CAPTURE_DATE: Final = date(2024, 9, 27)",
+            maximum=1,
+        ),
+        SourceAnchor("app/services/universe_selection.py", "EXCHANGE_TEST_ISSUE_SYMBOLS", minimum=3, maximum=3),
     ),
 }
 
 
 def _file_sha(path: str) -> str:
     return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def _python_semantic_text(path: str) -> str:
+    source = Path(path).read_text()
+    tree = ast.parse(source, filename=path)
+    path_obj = Path(path)
+    if not path_obj.is_absolute():
+        module_name = path.removesuffix(".py").replace("/", ".")
+        if importlib.util.find_spec(module_name) is None:
+            raise RuntimeError(f"Python probe module does not resolve: {module_name}")
+
+    excluded: set[int] = set()
+    owners = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    for node in ast.walk(tree):
+        if isinstance(node, owners) and node.body:
+            first = node.body[0]
+            if (
+                isinstance(first, ast.Expr)
+                and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)
+            ):
+                excluded.update(range(first.lineno, (first.end_lineno or first.lineno) + 1))
+        if isinstance(node, ast.If) and isinstance(node.test, ast.Constant) and not bool(node.test.value):
+            for child in node.body:
+                excluded.update(range(child.lineno, (child.end_lineno or child.lineno) + 1))
+
+    masked = "".join("\n" if number in excluded else line for number, line in enumerate(source.splitlines(True), 1))
+    tokens = tokenize.generate_tokens(io.StringIO(masked).readline)
+    return tokenize.untokenize(token for token in tokens if token.type != tokenize.COMMENT)
+
+
+def _semantic_text(path: str) -> str:
+    if path.endswith(".py"):
+        return _python_semantic_text(path)
+    source = Path(path).read_text()
+    without_blocks = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    return re.sub(r"--[^\n]*", "", without_blocks)
 
 
 def run_source_probes(conn: psycopg.Connection[Any]) -> tuple[ProbeResult, ...]:
@@ -245,7 +300,7 @@ def run_source_probes(conn: psycopg.Connection[Any]) -> tuple[ProbeResult, ...]:
         counts: dict[str, int] = {}
         hashes: dict[str, str] = {}
         for index, anchor in enumerate(_PROBE_ANCHORS[probe_id]):
-            text = Path(anchor.path).read_text()
+            text = _semantic_text(anchor.path)
             count = text.count(anchor.needle)
             key = f"{anchor.path}:{index}"
             counts[key] = count
@@ -258,17 +313,33 @@ def run_source_probes(conn: psycopg.Connection[Any]) -> tuple[ProbeResult, ...]:
                 )
         results.append(ProbeResult(probe_id, True, counts, hashes, "source anchors non-vacuous"))
 
-    # X1 and P1 are absence claims: bind them to the live schema as well as DDL text.
-    for table, forbidden, probe_id in (
-        ("financial_facts_raw", {"dimension", "member", "dimensions"}, "X1"),
-        ("research_price_daily", {"observed_at", "published_at", "source_public_at", "source_version"}, "P1"),
+    # Bind positive and negative DDL claims to the live schema.
+    for table, required, forbidden, probe_id in (
+        ("financial_periods_raw", {"filed_date"}, set(), "D0"),
+        ("financial_facts_raw", {"filed_date"}, {"dimension", "member", "dimensions"}, "F0/X1"),
+        (
+            "ownership_institutions_observations",
+            {"filed_at", "ingested_at", "known_from", "known_to"},
+            set(),
+            "O0/O1",
+        ),
+        (
+            "research_price_daily",
+            {"bar_date"},
+            {"observed_at", "published_at", "source_public_at", "source_version"},
+            "P0/P1",
+        ),
+        ("finra_short_interest_observations", {"settlement_date", "filed_at", "known_from"}, set(), "N0/N1"),
+        ("instrument_universe_membership", {"effective_from", "effective_to"}, set(), "H2"),
+        ("instrument_symbol_history", {"effective_from", "effective_to"}, set(), "H3"),
+        ("external_identifiers", {"last_verified_at"}, set(), "H3"),
     ):
         rows = conn.execute(
             "SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=%s",
             (table,),
         ).fetchall()
         columns = {str(row[0]) for row in rows}
-        if not columns or columns & forbidden:
+        if not required <= columns or columns & forbidden:
             raise RuntimeError(f"probe {probe_id} schema failure for {table}: columns={sorted(columns)}")
 
     return tuple(results)
@@ -534,6 +605,9 @@ def collect_evidence() -> Evidence:
     measured_correction_2 = hashlib.sha256(CORRECTION_2_PATH.read_bytes()).hexdigest()
     if measured_correction_2 != CORRECTION_2_SHA256:
         raise RuntimeError(f"correction-2 hash moved: expected {CORRECTION_2_SHA256}, measured {measured_correction_2}")
+    measured_correction_3 = hashlib.sha256(CORRECTION_3_PATH.read_bytes()).hexdigest()
+    if measured_correction_3 != CORRECTION_3_SHA256:
+        raise RuntimeError(f"correction-3 hash moved: expected {CORRECTION_3_SHA256}, measured {measured_correction_3}")
     if _git("status", "--porcelain"):
         raise RuntimeError("verifier requires a clean worktree")
     execution_commit = _git("rev-parse", "HEAD")
@@ -572,6 +646,8 @@ def collect_evidence() -> Evidence:
         correction_sha256=CORRECTION_SHA256,
         correction_2_commit=CORRECTION_2_COMMIT,
         correction_2_sha256=CORRECTION_2_SHA256,
+        correction_3_commit=CORRECTION_3_COMMIT,
+        correction_3_sha256=CORRECTION_3_SHA256,
         decision_date=DECISION_DATE.isoformat(),
         registry_version=REGISTRY_VERSION,
         registry=_registry_json(),
@@ -607,6 +683,7 @@ def render_markdown(evidence: Evidence) -> str:
             f"Declaration SHA-256: `{evidence.declaration_sha256}` at commit `{evidence.declaration_commit}`.",
             f"Correction-1 SHA-256: `{evidence.correction_sha256}` at commit `{evidence.correction_commit}`.",
             f"Correction-2 SHA-256: `{evidence.correction_2_sha256}` at commit `{evidence.correction_2_commit}`.",
+            f"Correction-3 SHA-256: `{evidence.correction_3_sha256}` at commit `{evidence.correction_3_commit}`.",
             f"Execution commit: `{evidence.execution_commit}`. Registry: `{evidence.registry_version}`.",
             "Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown`",
             "",

--- a/scripts/verify_2900_point_in_time.py
+++ b/scripts/verify_2900_point_in_time.py
@@ -289,6 +289,13 @@ def _semantic_text(path: str) -> str:
     return re.sub(r"--[^\n]*", "", without_blocks)
 
 
+def _semantic_anchor_count(text: str, needle: str) -> int:
+    """Count an executable anchor without coupling it to source formatting."""
+    normalized_text = re.sub(r"\s+", " ", text)
+    normalized_needle = re.sub(r"\s+", " ", needle)
+    return normalized_text.count(normalized_needle)
+
+
 def run_source_probes(conn: psycopg.Connection[Any]) -> tuple[ProbeResult, ...]:
     """Execute every declared source/schema probe; fail on vacuous anchors."""
     declared = {probe for cells in PROBE_MATRIX.values() for cell in cells.values() for probe in cell.probes}
@@ -301,7 +308,7 @@ def run_source_probes(conn: psycopg.Connection[Any]) -> tuple[ProbeResult, ...]:
         hashes: dict[str, str] = {}
         for index, anchor in enumerate(_PROBE_ANCHORS[probe_id]):
             text = _semantic_text(anchor.path)
-            count = text.count(anchor.needle)
+            count = _semantic_anchor_count(text, anchor.needle)
             key = f"{anchor.path}:{index}"
             counts[key] = count
             hashes[anchor.path] = _file_sha(anchor.path)

--- a/scripts/verify_2900_point_in_time.py
+++ b/scripts/verify_2900_point_in_time.py
@@ -291,8 +291,13 @@ def _semantic_text(path: str) -> str:
 
 def _semantic_anchor_count(text: str, needle: str) -> int:
     """Count an executable anchor without coupling it to source formatting."""
-    normalized_text = re.sub(r"\s+", " ", text)
-    normalized_needle = re.sub(r"\s+", " ", needle)
+
+    def normalize(value: str) -> str:
+        lines = (re.sub(r"[^\S\n]+", " ", line).strip() for line in value.splitlines())
+        return "\n".join(line for line in lines if line)
+
+    normalized_text = normalize(text)
+    normalized_needle = normalize(needle)
     return normalized_text.count(normalized_needle)
 
 

--- a/scripts/verify_2900_point_in_time.py
+++ b/scripts/verify_2900_point_in_time.py
@@ -35,6 +35,9 @@ DECLARATION_COMMIT: Final = "51e55d58823a5ebe98e5eea6473895b9d05abc1d"
 CORRECTION_PATH: Final = Path("docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-1.md")
 CORRECTION_SHA256: Final = "b101123c59183b8204a70b98a9c40b25e350a4fc58a9c114d8ea76735157cff6"
 CORRECTION_COMMIT: Final = "fe67f100e565fd52db8201ac6ad8f1758c2b163f"
+CORRECTION_2_PATH: Final = Path("docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-2.md")
+CORRECTION_2_SHA256: Final = "a330ed170d39da3c201e2bd8e1ce5f80566209a356faa75bb899090e5e2b4f32"
+CORRECTION_2_COMMIT: Final = "055056a5c3b1aa3bc5971de4a6085b0f7bd72206"
 DECISION_DATE: Final = date(2020, 1, 15)
 SENTINEL_CIK: Final = "0000002900"
 SENTINEL_DOCUMENT: Final = "0000002900-20-002900"
@@ -106,6 +109,8 @@ class Evidence:
     declaration_sha256: str
     correction_commit: str
     correction_sha256: str
+    correction_2_commit: str
+    correction_2_sha256: str
     decision_date: str
     registry_version: str
     registry: Mapping[str, object]
@@ -116,6 +121,7 @@ class Evidence:
 
 
 _PROBE_ANCHORS: Final[Mapping[str, tuple[SourceAnchor, ...]]] = {
+    "D0": (SourceAnchor("sql/032_financial_data_enrichment_p1.sql", "filed_date           DATE,", minimum=2),),
     "F0": (
         SourceAnchor("app/services/fundamentals/__init__.py", '"filed_date",', minimum=1),
         SourceAnchor("sql/032_financial_data_enrichment_p1.sql", "filed_date           DATE NOT NULL", maximum=1),
@@ -144,6 +150,11 @@ _PROBE_ANCHORS: Final[Mapping[str, tuple[SourceAnchor, ...]]] = {
         SourceAnchor("app/services/ownership_observations.py", "def record_", minimum=7),
         SourceAnchor("app/services/ownership_observations.py", "ON CONFLICT (", minimum=22, maximum=22),
         SourceAnchor("app/services/ownership_observations.py", "ingested_at = clock_timestamp()", minimum=7),
+    ),
+    "O0": (
+        SourceAnchor(
+            "sql/114_ownership_institutions_observations.sql", "filed_at                TIMESTAMPTZ NOT NULL", minimum=2
+        ),
     ),
     "O2": (
         SourceAnchor("app/services/def14a_ingest.py", "fetched_at = datetime.now(tz=UTC)", minimum=2),
@@ -196,6 +207,7 @@ _PROBE_ANCHORS: Final[Mapping[str, tuple[SourceAnchor, ...]]] = {
         SourceAnchor("sql/103_instrument_symbol_history.sql", "only the current symbol is seeded", maximum=1),
         SourceAnchor("sql/003_external_identifiers.sql", "last_verified_at", maximum=1),
     ),
+    "P0": (SourceAnchor("sql/249_research_price_corpus.sql", "bar_date    DATE NOT NULL", maximum=1),),
     "P1": (
         SourceAnchor("sql/249_research_price_corpus.sql", "CREATE TABLE IF NOT EXISTS research_price_daily", maximum=1),
     ),
@@ -518,6 +530,9 @@ def collect_evidence() -> Evidence:
     measured_correction = hashlib.sha256(CORRECTION_PATH.read_bytes()).hexdigest()
     if measured_correction != CORRECTION_SHA256:
         raise RuntimeError(f"correction hash moved: expected {CORRECTION_SHA256}, measured {measured_correction}")
+    measured_correction_2 = hashlib.sha256(CORRECTION_2_PATH.read_bytes()).hexdigest()
+    if measured_correction_2 != CORRECTION_2_SHA256:
+        raise RuntimeError(f"correction-2 hash moved: expected {CORRECTION_2_SHA256}, measured {measured_correction_2}")
     if _git("status", "--porcelain"):
         raise RuntimeError("verifier requires a clean worktree")
     execution_commit = _git("rev-parse", "HEAD")
@@ -554,6 +569,8 @@ def collect_evidence() -> Evidence:
         declaration_sha256=DECLARATION_SHA256,
         correction_commit=CORRECTION_COMMIT,
         correction_sha256=CORRECTION_SHA256,
+        correction_2_commit=CORRECTION_2_COMMIT,
+        correction_2_sha256=CORRECTION_2_SHA256,
         decision_date=DECISION_DATE.isoformat(),
         registry_version=REGISTRY_VERSION,
         registry=_registry_json(),
@@ -574,6 +591,16 @@ def _lines(items: Iterable[str]) -> str:
 
 def render_markdown(evidence: Evidence) -> str:
     mutation = evidence.mutation
+    census_lines: list[str] = []
+    for table, raw_values in evidence.censuses.items():
+        if not isinstance(raw_values, Mapping):
+            raise TypeError(f"census {table} is not a mapping")
+        row_count = raw_values.get("row_count")
+        instruments = raw_values.get("distinct_instruments")
+        line = f"- `{table}`: {row_count} rows"
+        if instruments is not None:
+            line += f", {instruments} instruments"
+        census_lines.append(line)
     return _lines(
         (
             "# R6 point-in-time spine result (#2900)",
@@ -582,6 +609,7 @@ def render_markdown(evidence: Evidence) -> str:
             "",
             f"Declaration SHA-256: `{evidence.declaration_sha256}` at commit `{evidence.declaration_commit}`.",
             f"Correction-1 SHA-256: `{evidence.correction_sha256}` at commit `{evidence.correction_commit}`.",
+            f"Correction-2 SHA-256: `{evidence.correction_2_sha256}` at commit `{evidence.correction_2_commit}`.",
             f"Execution commit: `{evidence.execution_commit}`. Registry: `{evidence.registry_version}`.",
             "Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown`",
             "",
@@ -603,6 +631,10 @@ def render_markdown(evidence: Evidence) -> str:
             f"- Refused registry families: {', '.join(sorted(evidence.registry))}.",
             f"- Exact census tables: {', '.join(evidence.censuses)}.",
             "- Full probe anchors, source hashes, registry matrix and census values are emitted by `--format json`.",
+            "",
+            "## Population census",
+            "",
+            *census_lines,
             "",
             "## Consequence",
             "",

--- a/scripts/verify_2900_point_in_time.py
+++ b/scripts/verify_2900_point_in_time.py
@@ -596,12 +596,8 @@ def render_markdown(evidence: Evidence) -> str:
     for table, raw_values in evidence.censuses.items():
         if not isinstance(raw_values, Mapping):
             raise TypeError(f"census {table} is not a mapping")
-        row_count = raw_values.get("row_count")
-        instruments = raw_values.get("distinct_instruments")
-        line = f"- `{table}`: {row_count} rows"
-        if instruments is not None:
-            line += f", {instruments} instruments"
-        census_lines.append(line)
+        details = ", ".join(f"`{key}`={value}" for key, value in raw_values.items())
+        census_lines.append(f"- `{table}`: {details}")
     return _lines(
         (
             "# R6 point-in-time spine result (#2900)",

--- a/scripts/verify_2900_point_in_time.py
+++ b/scripts/verify_2900_point_in_time.py
@@ -1,0 +1,630 @@
+"""Reproduce the frozen #2900 point-in-time admissibility verdict.
+
+Run only after the implementation commit is clean:
+
+    PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format json
+    PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Final
+from uuid import UUID
+
+import psycopg
+from psycopg import sql
+from psycopg.rows import dict_row
+
+from app.config import settings
+from app.services.ownership_observations import record_institution_observation
+from app.services.research_point_in_time import FIELD_REGISTRY, PROBE_MATRIX, REGISTRY_VERSION, RankingFamily
+from scripts._dev_guard import assert_dev_environment
+
+DECLARATION_PATH: Final = Path("docs/proposals/ta/2026-08-23-r6-point-in-time-spine-declaration.md")
+DECLARATION_SHA256: Final = "369b397e17694f2a54b07897b4d68a8728bf0624e35d00ced8a6ce833bb4da20"
+DECLARATION_COMMIT: Final = "51e55d58823a5ebe98e5eea6473895b9d05abc1d"
+CORRECTION_PATH: Final = Path("docs/proposals/ta/2026-08-23-r6-point-in-time-spine-correction-1.md")
+CORRECTION_SHA256: Final = "b101123c59183b8204a70b98a9c40b25e350a4fc58a9c114d8ea76735157cff6"
+CORRECTION_COMMIT: Final = "fe67f100e565fd52db8201ac6ad8f1758c2b163f"
+DECISION_DATE: Final = date(2020, 1, 15)
+SENTINEL_CIK: Final = "0000002900"
+SENTINEL_DOCUMENT: Final = "0000002900-20-002900"
+SENTINEL_PERIOD_END: Final = date(2019, 12, 31)
+SENTINEL_RUN: Final = UUID("00000000-0000-0000-0000-000000002900")
+POST_DOCUMENT: Final = "0000002900-20-002901"
+SCHEMA_VERSION: Final = "r6-2900-evidence-v1"
+
+_TUPLE_COLUMNS: Final = (
+    "instrument_id",
+    "filer_cik",
+    "filer_name",
+    "filer_type",
+    "ownership_nature",
+    "source",
+    "source_document_id",
+    "source_accession",
+    "source_field",
+    "source_url",
+    "filed_at",
+    "period_start",
+    "period_end",
+    "known_from",
+    "known_to",
+    "ingest_run_id",
+    "shares",
+    "market_value_usd",
+    "voting_authority",
+    "exposure_kind",
+    "ingested_at",
+)
+
+
+@dataclass(frozen=True)
+class SourceAnchor:
+    path: str
+    needle: str
+    minimum: int = 1
+    maximum: int | None = None
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    probe_id: str
+    passed: bool
+    anchor_counts: Mapping[str, int]
+    source_sha256: Mapping[str, str]
+    detail: str
+
+
+@dataclass(frozen=True)
+class MutationEvidence:
+    instrument_id: int
+    before_sha256: str
+    postdated_control_sha256: str
+    overwritten_sha256: str
+    old_vintage_rows_after_overwrite: int
+    first_unequal_column: str
+    before_value: object
+    overwritten_value: object
+    rollback_proved: bool
+
+
+@dataclass(frozen=True)
+class Evidence:
+    schema_version: str
+    execution_commit: str
+    declaration_commit: str
+    declaration_sha256: str
+    correction_commit: str
+    correction_sha256: str
+    decision_date: str
+    registry_version: str
+    registry: Mapping[str, object]
+    probes: Sequence[ProbeResult]
+    censuses: Mapping[str, object]
+    mutation: MutationEvidence
+    verdict: str
+
+
+_PROBE_ANCHORS: Final[Mapping[str, tuple[SourceAnchor, ...]]] = {
+    "F0": (
+        SourceAnchor("app/services/fundamentals/__init__.py", '"filed_date",', minimum=1),
+        SourceAnchor("sql/032_financial_data_enrichment_p1.sql", "filed_date           DATE NOT NULL", maximum=1),
+    ),
+    "F1": (SourceAnchor("app/services/fundamentals/__init__.py", "DO UPDATE SET\n    val = EXCLUDED.val", maximum=1),),
+    "F2": (SourceAnchor("app/services/financial_facts_retention.py", "DELETE FROM financial_facts_raw", maximum=1),),
+    "D1": (
+        SourceAnchor(
+            "app/services/fundamentals/__init__.py",
+            "DELETE FROM financial_periods_raw WHERE instrument_id = %(iid)s AND source = 'sec_edgar'",
+            maximum=1,
+        ),
+        SourceAnchor(
+            "app/services/fundamentals/__init__.py",
+            "SELECT DISTINCT ON (fiscal_year, fiscal_quarter, period_type)",
+            minimum=2,
+        ),
+    ),
+    "X1": (
+        SourceAnchor("app/providers/implementations/sec_fundamentals.py", "companyfacts", minimum=1),
+        SourceAnchor(
+            "sql/032_financial_data_enrichment_p1.sql", "CREATE TABLE IF NOT EXISTS financial_facts_raw", maximum=1
+        ),
+    ),
+    "O1": (
+        SourceAnchor("app/services/ownership_observations.py", "def record_", minimum=7),
+        SourceAnchor("app/services/ownership_observations.py", "ON CONFLICT (", minimum=22, maximum=22),
+        SourceAnchor("app/services/ownership_observations.py", "ingested_at = clock_timestamp()", minimum=7),
+    ),
+    "O2": (
+        SourceAnchor("app/services/def14a_ingest.py", "fetched_at = datetime.now(tz=UTC)", minimum=2),
+        SourceAnchor("app/services/def14a_ingest.py", "filed_at = fetched_at", minimum=2),
+    ),
+    "O3": (
+        SourceAnchor("app/services/ownership_observations_sync.py", "retention_cutoff", minimum=3),
+        SourceAnchor("app/services/rewash_filings.py", "DELETE FROM", minimum=1),
+        SourceAnchor("app/services/ownership_observations.py", "SET known_to = NOW()", minimum=1),
+    ),
+    "R0": (SourceAnchor("sql/001_init.sql", "filing_date DATE NOT NULL", maximum=1),),
+    "R1": (
+        SourceAnchor("app/services/sec_filing_items.py", "SET items = %s, red_flag_score = %s", maximum=1),
+        SourceAnchor("app/services/filings_risk.py", "SELECT code, severity FROM sec_8k_item_codes", maximum=1),
+    ),
+    "N0": (
+        SourceAnchor(
+            "sql/152_finra_short_interest.sql", "settlement_date         DATE   NOT NULL", minimum=2, maximum=2
+        ),
+    ),
+    "N1": (
+        SourceAnchor(
+            "app/services/finra_short_interest_ingest.py",
+            "filed_at = datetime.combine(settlement_date, datetime.min.time(), tzinfo=UTC)",
+            maximum=1,
+        ),
+        SourceAnchor(
+            "app/services/finra_short_interest_ingest.py",
+            "current_short_interest = EXCLUDED.current_short_interest",
+            minimum=2,
+        ),
+    ),
+    "N2": (
+        SourceAnchor(
+            "app/services/finra_short_interest_ingest.py",
+            "SELECT instrument_id, symbol FROM instruments WHERE is_tradable = TRUE",
+            maximum=1,
+        ),
+    ),
+    "L1": (SourceAnchor("app/services/strategies/validated_universe.py", "WHERE i.is_tradable", maximum=1),),
+    "H1": (
+        SourceAnchor("app/services/strategies/validated_universe.py", "WHERE i.is_tradable", maximum=1),
+        SourceAnchor("app/services/universe_selection.py", "if alive:", maximum=1),
+    ),
+    "H2": (
+        SourceAnchor("sql/271_instrument_universe_membership.sql", "NO BACKFILL", maximum=1),
+        SourceAnchor("sql/271_instrument_universe_membership.sql", "'imported'", minimum=2),
+    ),
+    "H3": (
+        SourceAnchor("sql/103_instrument_symbol_history.sql", "only the current symbol is seeded", maximum=1),
+        SourceAnchor("sql/003_external_identifiers.sql", "last_verified_at", maximum=1),
+    ),
+    "P1": (
+        SourceAnchor("sql/249_research_price_corpus.sql", "CREATE TABLE IF NOT EXISTS research_price_daily", maximum=1),
+    ),
+    "P2": (
+        SourceAnchor("app/services/universe_selection.py", "validated_ids", minimum=4),
+        SourceAnchor("app/services/universe_selection.py", "if alive:", maximum=1),
+    ),
+    "P3": (
+        SourceAnchor("app/services/price_quarantine.py", "def rule_b4(prev: Bar, bar: Bar, nxt: Bar", maximum=1),
+        SourceAnchor("app/services/price_quarantine.py", "next_close / close", maximum=1),
+    ),
+    "P4": (
+        SourceAnchor("app/services/research_corpus_ingest.py", 'ADJUSTMENT_BASIS = "split_adjusted"', maximum=1),
+        SourceAnchor("app/services/backtest_run.py", "has no point-in-time split", maximum=1),
+    ),
+    "P5": (
+        SourceAnchor("app/services/universe_selection.py", "capture 2026-08-23", maximum=1),
+        SourceAnchor("app/services/universe_selection.py", "EXCHANGE_TEST_ISSUE_SYMBOLS", minimum=3),
+    ),
+}
+
+
+def _file_sha(path: str) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def run_source_probes(conn: psycopg.Connection[Any]) -> tuple[ProbeResult, ...]:
+    """Execute every declared source/schema probe; fail on vacuous anchors."""
+    declared = {probe for cells in PROBE_MATRIX.values() for cell in cells.values() for probe in cell.probes}
+    if declared != set(_PROBE_ANCHORS):
+        raise RuntimeError(f"probe definition mismatch: declared={sorted(declared)} defined={sorted(_PROBE_ANCHORS)}")
+
+    results: list[ProbeResult] = []
+    for probe_id in sorted(_PROBE_ANCHORS):
+        counts: dict[str, int] = {}
+        hashes: dict[str, str] = {}
+        for index, anchor in enumerate(_PROBE_ANCHORS[probe_id]):
+            text = Path(anchor.path).read_text()
+            count = text.count(anchor.needle)
+            key = f"{anchor.path}:{index}"
+            counts[key] = count
+            hashes[anchor.path] = _file_sha(anchor.path)
+            maximum = anchor.maximum
+            if count < anchor.minimum or (maximum is not None and count > maximum):
+                expected = f"{anchor.minimum}..{maximum}" if maximum is not None else f">={anchor.minimum}"
+                raise RuntimeError(
+                    f"probe {probe_id} anchor {anchor.needle!r} in {anchor.path} matched {count}; expected {expected}"
+                )
+        results.append(ProbeResult(probe_id, True, counts, hashes, "source anchors non-vacuous"))
+
+    # X1 and P1 are absence claims: bind them to the live schema as well as DDL text.
+    for table, forbidden, probe_id in (
+        ("financial_facts_raw", {"dimension", "member", "dimensions"}, "X1"),
+        ("research_price_daily", {"observed_at", "published_at", "source_public_at", "source_version"}, "P1"),
+    ):
+        rows = conn.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=%s",
+            (table,),
+        ).fetchall()
+        columns = {str(row[0]) for row in rows}
+        if not columns or columns & forbidden:
+            raise RuntimeError(f"probe {probe_id} schema failure for {table}: columns={sorted(columns)}")
+
+    return tuple(results)
+
+
+def derive_verdict(probes: Sequence[ProbeResult]) -> str:
+    passed = {probe.probe_id for probe in probes if probe.passed}
+    for family, cells in PROBE_MATRIX.items():
+        if not any(cell.outcome == "fail" for cell in cells.values()):
+            raise RuntimeError(f"family {family.value} has no failed admissibility condition")
+        for condition, cell in cells.items():
+            missing = set(cell.probes) - passed
+            if missing:
+                raise RuntimeError(f"family {family.value}/{condition} lacks probes {sorted(missing)}")
+    return "FAIL — NO ADMISSIBLE HISTORICAL FIELD"
+
+
+def _canonical(value: object) -> object:
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    return value
+
+
+def _load_sentinel_rows(
+    conn: psycopg.Connection[Any], *, iid: int, ingested_through: datetime | None = None
+) -> list[dict[str, object]]:
+    through = "AND ingested_at <= %(through)s" if ingested_through is not None else ""
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            f"""
+            SELECT {", ".join(_TUPLE_COLUMNS)}
+            FROM ownership_institutions_observations
+            WHERE instrument_id = %(iid)s
+              AND filer_cik = %(cik)s
+              AND filed_at < %(decision)s
+              {through}
+            ORDER BY instrument_id, filer_cik, ownership_nature, period_end,
+                     source_document_id, exposure_kind
+            """,
+            {"iid": iid, "cik": SENTINEL_CIK, "decision": DECISION_DATE, "through": ingested_through},
+        )
+        return [{key: _canonical(value) for key, value in row.items()} for row in cur.fetchall()]
+
+
+def _rows_sha(rows: Sequence[Mapping[str, object]]) -> str:
+    payload = "".join(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n" for row in rows)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _record_specimen(
+    conn: psycopg.Connection[Any],
+    *,
+    iid: int,
+    document: str,
+    filed_at: datetime,
+    period_end: date,
+    shares: Decimal,
+    run_id: UUID,
+) -> None:
+    record_institution_observation(
+        conn,
+        instrument_id=iid,
+        filer_cik=SENTINEL_CIK,
+        filer_name="R6 PIT Sentinel",
+        filer_type="OTHER",
+        ownership_nature="economic",
+        source="13f",
+        source_document_id=document,
+        source_accession=document,
+        source_field="shares",
+        source_url="https://example.invalid/r6-2900",
+        filed_at=filed_at,
+        period_start=None,
+        period_end=period_end,
+        ingest_run_id=run_id,
+        shares=shares,
+        market_value_usd=Decimal("1000.00"),
+        voting_authority="SOLE",
+        exposure_kind="EQUITY",
+    )
+
+
+def run_mutation_test(conn: psycopg.Connection[Any]) -> MutationEvidence:
+    conn.execute("SELECT pg_advisory_xact_lock(hashtextextended('r6-2900-pit-verifier', 0))")
+    row = conn.execute("SELECT min(instrument_id) FROM instruments").fetchone()
+    iid = int(row[0]) if row and row[0] is not None else None
+    if iid is None:
+        raise RuntimeError("no instrument exists for the rollback-only sentinel")
+    collision = conn.execute(
+        """
+        SELECT 1 FROM ownership_institutions_observations
+        WHERE instrument_id=%s AND filer_cik=%s AND ownership_nature='economic'
+          AND period_end=%s AND source_document_id=%s AND exposure_kind='EQUITY'
+        """,
+        (iid, SENTINEL_CIK, SENTINEL_PERIOD_END, SENTINEL_DOCUMENT),
+    ).fetchone()
+    if collision:
+        raise RuntimeError("fixed #2900 sentinel already exists; refusing to overwrite it")
+
+    _record_specimen(
+        conn,
+        iid=iid,
+        document=SENTINEL_DOCUMENT,
+        filed_at=datetime(2020, 1, 14, tzinfo=UTC),
+        period_end=SENTINEL_PERIOD_END,
+        shares=Decimal("100"),
+        run_id=SENTINEL_RUN,
+    )
+    before = _load_sentinel_rows(conn, iid=iid)
+    if len(before) != 1:
+        raise RuntimeError(f"sentinel baseline expected one row, got {len(before)}")
+    baseline_ingested_at = datetime.fromisoformat(str(before[0]["ingested_at"]))
+    before_sha = _rows_sha(before)
+
+    _record_specimen(
+        conn,
+        iid=iid,
+        document=POST_DOCUMENT,
+        filed_at=datetime(2020, 1, 16, tzinfo=UTC),
+        period_end=date(2020, 1, 31),
+        shares=Decimal("999"),
+        run_id=UUID("00000000-0000-0000-0000-000000002901"),
+    )
+    control_sha = _rows_sha(_load_sentinel_rows(conn, iid=iid))
+    if control_sha != before_sha:
+        raise RuntimeError("post-decision observation changed the public-clock control")
+
+    _record_specimen(
+        conn,
+        iid=iid,
+        document=SENTINEL_DOCUMENT,
+        filed_at=datetime(2020, 1, 14, tzinfo=UTC),
+        period_end=SENTINEL_PERIOD_END,
+        shares=Decimal("101"),
+        run_id=UUID("00000000-0000-0000-0000-000000002902"),
+    )
+    overwritten = _load_sentinel_rows(conn, iid=iid)
+    overwritten_sha = _rows_sha(overwritten)
+    if overwritten_sha == before_sha:
+        raise RuntimeError("same-key historical overwrite was not detected")
+    old_rows = _load_sentinel_rows(conn, iid=iid, ingested_through=baseline_ingested_at)
+    if old_rows:
+        raise RuntimeError("system-time predicate unexpectedly recovered an overwritten predecessor")
+
+    differing = next(column for column in _TUPLE_COLUMNS if before[0][column] != overwritten[0][column])
+    return MutationEvidence(
+        instrument_id=iid,
+        before_sha256=before_sha,
+        postdated_control_sha256=control_sha,
+        overwritten_sha256=overwritten_sha,
+        old_vintage_rows_after_overwrite=len(old_rows),
+        first_unequal_column=differing,
+        before_value=before[0][differing],
+        overwritten_value=overwritten[0][differing],
+        rollback_proved=False,
+    )
+
+
+_CENSUS_TABLES: Final = (
+    "financial_facts_raw",
+    "ownership_insiders_observations",
+    "ownership_institutions_observations",
+    "ownership_blockholders_observations",
+    "ownership_treasury_observations",
+    "ownership_def14a_observations",
+    "ownership_funds_observations",
+    "ownership_esop_observations",
+    "finra_short_interest_observations",
+    "research_price_series",
+    "research_price_daily",
+    "research_price_quarantine_coverage",
+    "instrument_universe_membership",
+    "instrument_symbol_history",
+    "external_identifiers",
+)
+_DATE_COLUMNS: Final = (
+    "filed_date",
+    "filed_at",
+    "period_end",
+    "period_end_date",
+    "ingested_at",
+    "known_from",
+    "settlement_date",
+    "bar_date",
+    "first_bar",
+    "last_bar",
+    "evaluated_at",
+    "effective_from",
+    "effective_to",
+    "created_at",
+    "last_verified_at",
+)
+
+
+def collect_censuses(conn: psycopg.Connection[Any]) -> dict[str, object]:
+    censuses: dict[str, object] = {}
+    for table in _CENSUS_TABLES:
+        rows = conn.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=%s",
+            (table,),
+        ).fetchall()
+        columns = {str(row[0]) for row in rows}
+        if not columns:
+            raise RuntimeError(f"census table {table} is absent")
+        select: list[sql.Composable] = [sql.SQL("count(*) AS row_count")]
+        if "instrument_id" in columns:
+            select.append(sql.SQL("count(DISTINCT instrument_id) AS distinct_instruments"))
+        for column in _DATE_COLUMNS:
+            if column in columns:
+                select.extend(
+                    (
+                        sql.SQL("min({column}) AS {alias}").format(
+                            column=sql.Identifier(column), alias=sql.Identifier(f"min_{column}")
+                        ),
+                        sql.SQL("max({column}) AS {alias}").format(
+                            column=sql.Identifier(column), alias=sql.Identifier(f"max_{column}")
+                        ),
+                    )
+                )
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                sql.SQL("SELECT {columns} FROM {table}").format(
+                    columns=sql.SQL(", ").join(select), table=sql.Identifier(table)
+                )
+            )
+            result = cur.fetchone()
+        if result is None:
+            raise RuntimeError(f"census for {table} returned no aggregate row")
+        censuses[table] = {key: _canonical(value) for key, value in result.items()}
+    return censuses
+
+
+def _registry_json() -> dict[str, object]:
+    return {
+        family.value: {
+            "status": FIELD_REGISTRY[family].status,
+            "reason": FIELD_REGISTRY[family].reason,
+            "conditions": {condition: asdict(cell) for condition, cell in sorted(PROBE_MATRIX[family].items())},
+        }
+        for family in sorted(RankingFamily, key=lambda item: item.value)
+    }
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(("git", *args), check=True, text=True, capture_output=True).stdout.strip()
+
+
+def collect_evidence() -> Evidence:
+    assert_dev_environment()
+    measured = hashlib.sha256(DECLARATION_PATH.read_bytes()).hexdigest()
+    if measured != DECLARATION_SHA256:
+        raise RuntimeError(f"declaration hash moved: expected {DECLARATION_SHA256}, measured {measured}")
+    measured_correction = hashlib.sha256(CORRECTION_PATH.read_bytes()).hexdigest()
+    if measured_correction != CORRECTION_SHA256:
+        raise RuntimeError(f"correction hash moved: expected {CORRECTION_SHA256}, measured {measured_correction}")
+    if _git("status", "--porcelain"):
+        raise RuntimeError("verifier requires a clean worktree")
+    execution_commit = _git("rev-parse", "HEAD")
+
+    mutation: MutationEvidence | None = None
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            conn.autocommit = False
+            try:
+                probes = run_source_probes(conn)
+                censuses = collect_censuses(conn)
+                mutation = run_mutation_test(conn)
+            finally:
+                conn.rollback()
+    finally:
+        if mutation is not None:
+            with psycopg.connect(settings.database_url) as check_conn:
+                remaining = check_conn.execute(
+                    "SELECT count(*) FROM ownership_institutions_observations WHERE filer_cik=%s "
+                    "AND source_document_id IN (%s, %s)",
+                    (SENTINEL_CIK, SENTINEL_DOCUMENT, POST_DOCUMENT),
+                ).fetchone()
+            if remaining is None or int(remaining[0]) != 0:
+                raise RuntimeError("rollback proof failed: #2900 sentinel remains")
+            mutation = MutationEvidence(**{**asdict(mutation), "rollback_proved": True})
+
+    if mutation is None:
+        raise RuntimeError("mutation test did not produce evidence")
+    verdict = derive_verdict(probes)
+    return Evidence(
+        schema_version=SCHEMA_VERSION,
+        execution_commit=execution_commit,
+        declaration_commit=DECLARATION_COMMIT,
+        declaration_sha256=DECLARATION_SHA256,
+        correction_commit=CORRECTION_COMMIT,
+        correction_sha256=CORRECTION_SHA256,
+        decision_date=DECISION_DATE.isoformat(),
+        registry_version=REGISTRY_VERSION,
+        registry=_registry_json(),
+        probes=probes,
+        censuses=censuses,
+        mutation=mutation,
+        verdict=verdict,
+    )
+
+
+def render_json(evidence: Evidence) -> str:
+    return json.dumps(asdict(evidence), sort_keys=True, separators=(",", ":"), default=_canonical)
+
+
+def _lines(items: Iterable[str]) -> str:
+    return "\n".join(items)
+
+
+def render_markdown(evidence: Evidence) -> str:
+    mutation = evidence.mutation
+    return _lines(
+        (
+            "# R6 point-in-time spine result (#2900)",
+            "",
+            f"Verdict: **{evidence.verdict}**",
+            "",
+            f"Declaration SHA-256: `{evidence.declaration_sha256}` at commit `{evidence.declaration_commit}`.",
+            f"Correction-1 SHA-256: `{evidence.correction_sha256}` at commit `{evidence.correction_commit}`.",
+            f"Execution commit: `{evidence.execution_commit}`. Registry: `{evidence.registry_version}`.",
+            "Reproduce: `PYTHONPATH=. uv run python -m scripts.verify_2900_point_in_time --format markdown`",
+            "",
+            "## Adversarial leak test",
+            "",
+            f"- Decision date: `{evidence.decision_date}` (NYSE session).",
+            f"- Baseline hash: `{mutation.before_sha256}`.",
+            f"- Post-decision insert hash: `{mutation.postdated_control_sha256}` (unchanged).",
+            f"- Same-key pre-decision overwrite hash: `{mutation.overwritten_sha256}` (changed).",
+            f"- First unequal field: `{mutation.first_unequal_column}`: "
+            f"`{mutation.before_value}` → `{mutation.overwritten_value}`.",
+            "- Rows recoverable at the old `ingested_at` after overwrite: "
+            f"{mutation.old_vintage_rows_after_overwrite}.",
+            f"- Rollback proved on a new connection: `{str(mutation.rollback_proved).lower()}`.",
+            "",
+            "## Contract evidence",
+            "",
+            f"- Successful non-vacuous probes: {', '.join(probe.probe_id for probe in evidence.probes)}.",
+            f"- Refused registry families: {', '.join(sorted(evidence.registry))}.",
+            f"- Exact census tables: {', '.join(evidence.censuses)}.",
+            "- Full probe anchors, source hashes, registry matrix and census values are emitted by `--format json`.",
+            "",
+            "## Consequence",
+            "",
+            "The public-date filter correctly ignores a genuinely later filing, but the production writer overwrites a "
+            "pre-decision natural key and the prior bytes cannot be recovered. The other source families fail at least "
+            "one independently probed public-clock, system-version, population/identity or causal-transform condition.",
+            "",
+            "There is no admissible historical ranking field under the current contracts. Tier 2 arms are blocked and "
+            "remain unmeasured; no return, haircut, cost or benchmark claim was produced.",
+            "",
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--format", choices=("json", "markdown"), required=True)
+    args = parser.parse_args()
+    evidence = collect_evidence()
+    print(render_json(evidence) if args.format == "json" else render_markdown(evidence))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_2900_point_in_time_db.py
+++ b/tests/test_2900_point_in_time_db.py
@@ -38,7 +38,8 @@ def test_source_probe_text_excludes_comments_docstrings_and_dead_blocks(tmp_path
     assert "COMMENT_NEEDLE" not in text
     assert "DEAD_NEEDLE" not in text
     assert "LIVE_NEEDLE" in text
-    assert _semantic_anchor_count(text, 'LIVE_NEEDLE   =\n"reachable"') == 1
+    assert _semantic_anchor_count(text, 'LIVE_NEEDLE   =   "reachable"') == 1
+    assert _semantic_anchor_count("LEFT_HALF = 1\nRIGHT_HALF = 2\n", "LEFT_HALF = 1 RIGHT_HALF") == 0
 
 
 def _seed_instrument(conn: psycopg.Connection[tuple]) -> None:

--- a/tests/test_2900_point_in_time_db.py
+++ b/tests/test_2900_point_in_time_db.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+
+import psycopg
+import pytest
+
+from scripts.verify_2900_point_in_time import (
+    POST_DOCUMENT,
+    SENTINEL_CIK,
+    SENTINEL_DOCUMENT,
+    derive_verdict,
+    render_json,
+    render_markdown,
+    run_mutation_test,
+    run_source_probes,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (2900001, 'R6PIT', 'R6 PIT Test', '4', 'USD', TRUE)
+        """
+    )
+
+
+def test_declared_probes_are_non_vacuous_and_derive_fail_verdict(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    probes = run_source_probes(ebull_test_conn)
+    assert len(probes) == 22
+    assert all(probe.passed and probe.anchor_counts and probe.source_sha256 for probe in probes)
+    assert derive_verdict(probes) == "FAIL — NO ADMISSIBLE HISTORICAL FIELD"
+
+
+def test_rollback_mutation_proves_public_clock_and_lost_system_version(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    _seed_instrument(ebull_test_conn)
+    evidence = run_mutation_test(ebull_test_conn)
+    assert evidence.instrument_id == 2900001
+    assert evidence.before_sha256 == evidence.postdated_control_sha256
+    assert evidence.overwritten_sha256 != evidence.before_sha256
+    assert evidence.old_vintage_rows_after_overwrite == 0
+    assert evidence.first_unequal_column in {"ingest_run_id", "shares", "ingested_at"}
+
+    ebull_test_conn.rollback()
+    remaining = ebull_test_conn.execute(
+        "SELECT count(*) FROM ownership_institutions_observations WHERE filer_cik=%s "
+        "AND source_document_id IN (%s, %s)",
+        (SENTINEL_CIK, SENTINEL_DOCUMENT, POST_DOCUMENT),
+    ).fetchone()
+    assert remaining is not None and int(remaining[0]) == 0
+
+
+def test_renderers_share_one_typed_evidence_schema() -> None:
+    from scripts.verify_2900_point_in_time import Evidence, MutationEvidence, ProbeResult
+
+    evidence = Evidence(
+        schema_version="test",
+        execution_commit="a" * 40,
+        declaration_commit="b" * 40,
+        declaration_sha256="c" * 64,
+        correction_commit="d" * 40,
+        correction_sha256="e" * 64,
+        decision_date="2020-01-15",
+        registry_version="test-registry",
+        registry={"family": {"status": "refused"}},
+        probes=(ProbeResult("X", True, {"a": 1}, {"a": "d" * 64}, "ok"),),
+        censuses={"table": {"row_count": 0}},
+        mutation=MutationEvidence(1, "f" * 64, "f" * 64, "0" * 64, 0, "shares", "100", "101", True),
+        verdict="FAIL — NO ADMISSIBLE HISTORICAL FIELD",
+    )
+    payload = json.loads(render_json(evidence))
+    assert payload["schema_version"] == "test"
+    markdown = render_markdown(evidence)
+    assert "FAIL — NO ADMISSIBLE HISTORICAL FIELD" in markdown
+    assert "`100` → `101`" in markdown

--- a/tests/test_2900_point_in_time_db.py
+++ b/tests/test_2900_point_in_time_db.py
@@ -33,7 +33,7 @@ def test_declared_probes_are_non_vacuous_and_derive_fail_verdict(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
 ) -> None:
     probes = run_source_probes(ebull_test_conn)
-    assert len(probes) == 22
+    assert len(probes) == 25
     assert all(probe.passed and probe.anchor_counts and probe.source_sha256 for probe in probes)
     assert derive_verdict(probes) == "FAIL — NO ADMISSIBLE HISTORICAL FIELD"
 
@@ -68,6 +68,8 @@ def test_renderers_share_one_typed_evidence_schema() -> None:
         declaration_sha256="c" * 64,
         correction_commit="d" * 40,
         correction_sha256="e" * 64,
+        correction_2_commit="1" * 40,
+        correction_2_sha256="2" * 64,
         decision_date="2020-01-15",
         registry_version="test-registry",
         registry={"family": {"status": "refused"}},

--- a/tests/test_2900_point_in_time_db.py
+++ b/tests/test_2900_point_in_time_db.py
@@ -10,6 +10,7 @@ from scripts.verify_2900_point_in_time import (
     POST_DOCUMENT,
     SENTINEL_CIK,
     SENTINEL_DOCUMENT,
+    _semantic_anchor_count,
     _semantic_text,
     derive_verdict,
     render_json,
@@ -37,6 +38,7 @@ def test_source_probe_text_excludes_comments_docstrings_and_dead_blocks(tmp_path
     assert "COMMENT_NEEDLE" not in text
     assert "DEAD_NEEDLE" not in text
     assert "LIVE_NEEDLE" in text
+    assert _semantic_anchor_count(text, 'LIVE_NEEDLE   =\n"reachable"') == 1
 
 
 def _seed_instrument(conn: psycopg.Connection[tuple]) -> None:

--- a/tests/test_2900_point_in_time_db.py
+++ b/tests/test_2900_point_in_time_db.py
@@ -10,6 +10,7 @@ from scripts.verify_2900_point_in_time import (
     POST_DOCUMENT,
     SENTINEL_CIK,
     SENTINEL_DOCUMENT,
+    _semantic_text,
     derive_verdict,
     render_json,
     render_markdown,
@@ -24,6 +25,18 @@ pytestmark = pytest.mark.integration
 def test_census_includes_both_system_version_bounds() -> None:
     assert "known_from" in _DATE_COLUMNS
     assert "known_to" in _DATE_COLUMNS
+
+
+def test_source_probe_text_excludes_comments_docstrings_and_dead_blocks(tmp_path) -> None:
+    specimen = tmp_path / "probe_specimen.py"
+    specimen.write_text(
+        '"""DOCSTRING_NEEDLE"""\n# COMMENT_NEEDLE\nif False:\n    DEAD_NEEDLE = True\nLIVE_NEEDLE = "reachable"\n'
+    )
+    text = _semantic_text(str(specimen))
+    assert "DOCSTRING_NEEDLE" not in text
+    assert "COMMENT_NEEDLE" not in text
+    assert "DEAD_NEEDLE" not in text
+    assert "LIVE_NEEDLE" in text
 
 
 def _seed_instrument(conn: psycopg.Connection[tuple]) -> None:
@@ -76,6 +89,8 @@ def test_renderers_share_one_typed_evidence_schema() -> None:
         correction_sha256="e" * 64,
         correction_2_commit="1" * 40,
         correction_2_sha256="2" * 64,
+        correction_3_commit="3" * 40,
+        correction_3_sha256="4" * 64,
         decision_date="2020-01-15",
         registry_version="test-registry",
         registry={"family": {"status": "refused"}},

--- a/tests/test_2900_point_in_time_db.py
+++ b/tests/test_2900_point_in_time_db.py
@@ -6,6 +6,7 @@ import psycopg
 import pytest
 
 from scripts.verify_2900_point_in_time import (
+    _DATE_COLUMNS,
     POST_DOCUMENT,
     SENTINEL_CIK,
     SENTINEL_DOCUMENT,
@@ -18,6 +19,11 @@ from scripts.verify_2900_point_in_time import (
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
 
 pytestmark = pytest.mark.integration
+
+
+def test_census_includes_both_system_version_bounds() -> None:
+    assert "known_from" in _DATE_COLUMNS
+    assert "known_to" in _DATE_COLUMNS
 
 
 def _seed_instrument(conn: psycopg.Connection[tuple]) -> None:

--- a/tests/test_2900_point_in_time_db.py
+++ b/tests/test_2900_point_in_time_db.py
@@ -80,7 +80,7 @@ def test_renderers_share_one_typed_evidence_schema() -> None:
         registry_version="test-registry",
         registry={"family": {"status": "refused"}},
         probes=(ProbeResult("X", True, {"a": 1}, {"a": "d" * 64}, "ok"),),
-        censuses={"table": {"row_count": 0}},
+        censuses={"table": {"row_count": 0, "min_known_to": None, "max_known_to": None}},
         mutation=MutationEvidence(1, "f" * 64, "f" * 64, "0" * 64, 0, "shares", "100", "101", True),
         verdict="FAIL — NO ADMISSIBLE HISTORICAL FIELD",
     )
@@ -89,3 +89,4 @@ def test_renderers_share_one_typed_evidence_schema() -> None:
     markdown = render_markdown(evidence)
     assert "FAIL — NO ADMISSIBLE HISTORICAL FIELD" in markdown
     assert "`100` → `101`" in markdown
+    assert "`min_known_to`=None" in markdown

--- a/tests/test_research_point_in_time.py
+++ b/tests/test_research_point_in_time.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from datetime import date
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from app.services.research_point_in_time import (
+    FIELD_REGISTRY,
+    IDENTITY_FAMILIES,
+    PROBE_MATRIX,
+    REGISTRY_VERSION,
+    PointInTimeUnavailableError,
+    R6RankingIdentity,
+    R6RankingRequest,
+    RankingFamily,
+    execute_r6_ranking,
+    source_date_is_public,
+)
+
+EXPECTED_FAMILIES = {
+    "research_prices",
+    "fundamental_facts",
+    "derived_fundamentals",
+    "dimensional_xbrl",
+    "ownership_observations",
+    "filing_red_flags",
+    "finra_short_interest",
+    "live_etoro_state",
+    "historical_population",
+}
+EXPECTED_PROBES = {
+    "F0",
+    "F1",
+    "F2",
+    "D1",
+    "X1",
+    "O1",
+    "O2",
+    "O3",
+    "R0",
+    "R1",
+    "N0",
+    "N1",
+    "N2",
+    "L1",
+    "H1",
+    "H2",
+    "H3",
+    "P1",
+    "P2",
+    "P3",
+    "P4",
+    "P5",
+}
+
+
+def test_registry_is_closed_complete_and_all_historical_families_refuse() -> None:
+    assert {family.value for family in RankingFamily} == EXPECTED_FAMILIES
+    assert {family.value for family in FIELD_REGISTRY} == EXPECTED_FAMILIES
+    assert {probe for cells in PROBE_MATRIX.values() for cell in cells.values() for probe in cell.probes} == (
+        EXPECTED_PROBES
+    )
+    assert all(verdict.status == "refused" for verdict in FIELD_REGISTRY.values())
+    assert REGISTRY_VERSION.startswith("r6-pit-registry-v1+")
+    assert len(REGISTRY_VERSION.rsplit("+", 1)[1]) == 12
+
+
+def test_every_identity_owns_a_nonempty_immutable_family_set() -> None:
+    assert set(IDENTITY_FAMILIES) == set(R6RankingIdentity)
+    for identity, families in IDENTITY_FAMILIES.items():
+        assert families, identity
+        assert isinstance(families, frozenset)
+        assert families <= set(RankingFamily)
+
+
+@pytest.mark.parametrize("identity", list(R6RankingIdentity))
+def test_every_current_r6_ranking_identity_refuses(identity: R6RankingIdentity) -> None:
+    with pytest.raises(PointInTimeUnavailableError, match="no admissible historical read path") as exc:
+        execute_r6_ranking(R6RankingRequest(identity=identity, decision_session=date(2020, 1, 15)))
+    assert identity.value in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("decision", "reason"),
+    [
+        (date(2020, 1, 18), "closed NYSE date"),
+        (date(2020, 1, 20), "closed NYSE date"),
+    ],
+)
+def test_closed_decision_dates_refuse_before_field_evaluation(decision: date, reason: str) -> None:
+    request = R6RankingRequest(identity=R6RankingIdentity.QUALITY, decision_session=decision)
+    with pytest.raises(PointInTimeUnavailableError, match=reason):
+        execute_r6_ranking(request)
+
+
+def test_price_identity_after_frozen_capture_refuses_specific_boundary() -> None:
+    request = R6RankingRequest(identity=R6RankingIdentity.MOMENTUM, decision_session=date(2024, 9, 30))
+    with pytest.raises(PointInTimeUnavailableError, match="after research-price capture"):
+        execute_r6_ranking(request)
+
+
+def test_empty_unknown_and_underdeclared_requests_are_not_representable() -> None:
+    with pytest.raises(PointInTimeUnavailableError, match="non-empty typed"):
+        execute_r6_ranking(None)
+    with pytest.raises(ValueError, match="unknown R6 ranking identity"):
+        R6RankingRequest(identity="not-an-arm", decision_session=date(2020, 1, 15))  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        cast(Any, R6RankingRequest)(
+            identity=R6RankingIdentity.QUALITY,
+            decision_session=date(2020, 1, 15),
+            families=frozenset(),
+        )
+
+
+def test_date_resolution_public_clock_excludes_same_date() -> None:
+    decision = date(2020, 1, 15)
+    assert source_date_is_public(date(2020, 1, 14), decision_session=decision)
+    assert not source_date_is_public(decision, decision_session=decision)
+    assert not source_date_is_public(date(2020, 1, 16), decision_session=decision)
+
+
+def test_query_boundary_exposes_no_connection_callback_or_direct_sql() -> None:
+    assert tuple(inspect.signature(execute_r6_ranking).parameters) == ("request",)
+    module_source = Path("app/services/research_point_in_time.py").read_text()
+    tree = ast.parse(module_source)
+    calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    assert not any(isinstance(call.func, ast.Attribute) and call.func.attr == "execute" for call in calls)
+
+    governed = {
+        "financial_facts_raw",
+        "financial_periods",
+        "ownership_institutions_observations",
+        "finra_short_interest_observations",
+        "research_price_daily",
+        "instruments",
+    }
+    for path in Path("app/services").glob("r6_*.py"):
+        literals = {
+            node.value
+            for node in ast.walk(ast.parse(path.read_text()))
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        assert not any(table in literal for table in governed for literal in literals), path

--- a/tests/test_research_point_in_time.py
+++ b/tests/test_research_point_in_time.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 import inspect
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -78,6 +78,14 @@ def test_every_identity_owns_a_nonempty_immutable_family_set() -> None:
         assert families, identity
         assert isinstance(families, frozenset)
         assert families <= set(RankingFamily)
+
+
+def test_request_rejects_datetime_subclass_as_a_decision_session() -> None:
+    with pytest.raises(ValueError, match="decision_session must be a date"):
+        R6RankingRequest(
+            identity=R6RankingIdentity.QUALITY,
+            decision_session=cast(Any, datetime(2020, 1, 15, tzinfo=UTC)),
+        )
 
 
 @pytest.mark.parametrize("identity", list(R6RankingIdentity))

--- a/tests/test_research_point_in_time.py
+++ b/tests/test_research_point_in_time.py
@@ -33,12 +33,14 @@ EXPECTED_FAMILIES = {
     "historical_population",
 }
 EXPECTED_PROBES = {
+    "D0",
     "F0",
     "F1",
     "F2",
     "D1",
     "X1",
     "O1",
+    "O0",
     "O2",
     "O3",
     "R0",
@@ -51,6 +53,7 @@ EXPECTED_PROBES = {
     "H2",
     "H3",
     "P1",
+    "P0",
     "P2",
     "P3",
     "P4",


### PR DESCRIPTION
## Summary

- freeze and implement the #2900 point-in-time admissibility declaration
- expose a typed fail-closed boundary for every current R6 ranking identity
- prove with a rollback-only production-writer mutation that later ingestion changes historical state and the prior bytes are unrecoverable
- record full source probes, live-schema bindings, population census, and the verdict: **FAIL — NO ADMISSIBLE HISTORICAL FIELD**

## Evidence

Declaration SHA-256: `369b397e17694f2a54b07897b4d68a8728bf0624e35d00ced8a6ce833bb4da20`.
Final execution commit: `04b0978bbd0be9d00d5cc89c8b153d0b894171de`.

The 2020-01-15 baseline hash survives a genuinely post-decision insert but changes after a same-key pre-decision overwrite; zero predecessor rows remain recoverable and rollback is proved on a new connection. Tier 2 remains unmeasured.

## Review resolution

- FIXED: reject `datetime` subclasses at the date-only ranking boundary. Prevention: dedicated constructor regression test.
- FIXED: include `known_to` in every applicable census and render all bounds. Prevention: allowlist and renderer regression assertions.
- FIXED: use `P2,P5` for derived/XBRL population cells. Prevention: exact closed probe-matrix test.
- FIXED: exclude comments, docstrings and statically dead bodies from source probes; require Python module resolution/parsing and bind positive/negative DDL claims to live schema. Prevention: semantic-source regression test plus database probe test.

## Gates

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not db"` — 9705 passed, 14 skipped
- `uv run pytest tests/smoke` — 161 passed, 3 skipped

Closes #2900
