### PR TITLE
feat(#2603): expose evidence-gated core sleeve state

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -76,6 +76,10 @@ from app.services.strategy_core_mandate import (
     configure_core_mandate,
     load_core_mandate,
 )
+from app.services.strategy_core_selection import (
+    CoreSelectionError,
+    load_core_selection,
+)
 from app.services.strategy_live_gate import (
     REQUIRED_KILL_DRILLS,
     LiveGateReport,
@@ -960,6 +964,47 @@ class CoreMandateResponse(BaseModel):
     rebalance_band_pct: Decimal | None = None
     min_rebalance_amount: Decimal | None = None
     policy_version: str | None = None
+
+
+class CoreCandidateCoverageResponse(BaseModel):
+    instrument_id: int
+    symbol: str
+    observed_trading_days: int
+    first_observed_date: date | None
+    last_observed_date: date | None
+
+
+class CoreSleeveBlockerResponse(BaseModel):
+    code: Literal[
+        "core_evidence_collecting",
+        "core_candidates_missing",
+        "core_selection_invalid",
+        "core_mandate_unconfigured",
+        "core_mandate_disabled",
+        "core_submitter_unavailable",
+    ]
+    detail: str
+
+
+class CoreSleeveResponse(BaseModel):
+    state: Literal["evidence_collecting", "ready", "unavailable"]
+    selected_instrument_id: int | None
+    selected_symbol: str | None
+    evidence_ref: str | None
+    required_trading_days: int
+    observed_trading_days: int
+    max_cost_bps: int
+    candidates: list[CoreCandidateCoverageResponse]
+    mandate: CoreMandateResponse
+    can_configure: bool
+    can_rebalance: bool
+    blockers: list[CoreSleeveBlockerResponse]
+    environment: Literal["demo"] = "demo"
+    buy_only: bool = True
+    alpha_input_used: bool = False
+    household_tax_caveat: str = (
+        "A UK ISA at another broker tax-dominates this engine sleeve for eligible household capital."
+    )
 
 
 def _core_mandate_response(mandate: CoreMandate | None) -> CoreMandateResponse:
@@ -3393,6 +3438,91 @@ def read_core_mandate(
     return _core_mandate_response(load_core_mandate(conn))
 
 
+@router.get("/core-sleeve", response_model=CoreSleeveResponse, status_code=status.HTTP_200_OK)
+def read_core_sleeve(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CoreSleeveResponse:
+    """Canonical operator state for the deterministic fallback sleeve."""
+    selection = load_core_selection(conn)
+    mandate = load_core_mandate(conn)
+    blockers: list[CoreSleeveBlockerResponse] = []
+    if not selection.ready:
+        if selection.configuration_error is not None:
+            blockers.append(
+                CoreSleeveBlockerResponse(
+                    code="core_selection_invalid",
+                    detail=selection.configuration_error,
+                )
+            )
+        elif selection.missing_candidate_ids:
+            blockers.append(
+                CoreSleeveBlockerResponse(
+                    code="core_candidates_missing",
+                    detail=(
+                        "#2833 cannot collect evidence because candidate instrument ids are missing: "
+                        + ", ".join(str(value) for value in selection.missing_candidate_ids)
+                        + "."
+                    ),
+                )
+            )
+        else:
+            blockers.append(
+                CoreSleeveBlockerResponse(
+                    code="core_evidence_collecting",
+                    detail=(
+                        f"#2833 has {selection.observed_trading_days} of "
+                        f"{selection.required_trading_days} required trading days; cash remains the fallback."
+                    ),
+                )
+            )
+    if mandate is None:
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_mandate_unconfigured",
+                detail="No core/cash mandate has been configured.",
+            )
+        )
+    elif not mandate.enabled:
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_mandate_disabled",
+                detail="The current core/cash mandate is disabled.",
+            )
+        )
+    # This first product slice intentionally exposes no acting endpoint. Keeping
+    # this explicit prevents a ready mandate being presented as executable while
+    # the idempotent submitter remains under construction.
+    blockers.append(
+        CoreSleeveBlockerResponse(
+            code="core_submitter_unavailable",
+            detail="Attended demo rebalance submission is not deployed yet.",
+        )
+    )
+    return CoreSleeveResponse(
+        state=selection.state,
+        selected_instrument_id=selection.selected_instrument_id,
+        selected_symbol=selection.selected_symbol,
+        evidence_ref=selection.evidence_ref,
+        required_trading_days=selection.required_trading_days,
+        observed_trading_days=selection.observed_trading_days,
+        max_cost_bps=selection.max_cost_bps,
+        candidates=[
+            CoreCandidateCoverageResponse(
+                instrument_id=candidate.instrument_id,
+                symbol=candidate.symbol,
+                observed_trading_days=candidate.observed_trading_days,
+                first_observed_date=candidate.first_observed_date,
+                last_observed_date=candidate.last_observed_date,
+            )
+            for candidate in selection.candidates
+        ],
+        mandate=_core_mandate_response(mandate),
+        can_configure=selection.ready,
+        can_rebalance=False,
+        blockers=blockers,
+    )
+
+
 @router.put("/core-mandate", response_model=CoreMandateResponse, status_code=status.HTTP_200_OK)
 def update_core_mandate(
     body: CoreMandateUpdateRequest,
@@ -3455,7 +3585,7 @@ def update_core_mandate(
                 provider=provider,
                 environment=environment,
             )
-    except (CoreMandateError, CoreEligibilityError) as exc:
+    except (CoreMandateError, CoreEligibilityError, CoreSelectionError) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return _core_mandate_response(mandate)
 

--- a/app/services/strategy_core_mandate.py
+++ b/app/services/strategy_core_mandate.py
@@ -30,6 +30,7 @@ from uuid import UUID
 import psycopg
 
 from app.services.strategy_core_eligibility import require_core_eligibility
+from app.services.strategy_core_selection import require_selected_core_instrument
 
 # v2 as of #2670, which made both band triggers REACHABLE rather than merely in
 # range.  Bumped even though the table held 0 rows: a version denotes a rule set,
@@ -374,6 +375,7 @@ def configure_core_mandate(
         # authorisation must not be removable by an interpreter flag.
         if values.core_instrument_id is None:
             raise CoreMandateError("an enabled core mandate must name a core instrument")
+        require_selected_core_instrument(conn, instrument_id=values.core_instrument_id)
         require_core_eligibility(
             conn,
             instrument_id=values.core_instrument_id,

--- a/app/services/strategy_core_selection.py
+++ b/app/services/strategy_core_selection.py
@@ -1,0 +1,150 @@
+"""Evidence-approved instrument for the deterministic core/cash sleeve (#2833)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Final, Literal
+
+import psycopg
+
+CORE_SELECTION_CANDIDATE_IDS: Final = (3417, 3434, 3075)
+CORE_SELECTION_REQUIRED_TRADING_DAYS: Final = 5
+CORE_SELECTION_MAX_COST_BPS: Final = 60
+
+# Populated only by the reviewed #2833 verdict. Choosing here before the
+# prospective five-day gate completes would be adoption before measurement.
+SELECTED_CORE_INSTRUMENT_ID: Final[int | None] = None
+SELECTED_CORE_EVIDENCE_REF: Final[str | None] = None
+
+CoreSelectionState = Literal["evidence_collecting", "ready", "unavailable"]
+
+
+class CoreSelectionError(RuntimeError):
+    """An enabled mandate does not match an evidence-approved core sleeve."""
+
+
+@dataclass(frozen=True)
+class CoreCandidateCoverage:
+    instrument_id: int
+    symbol: str
+    observed_trading_days: int
+    first_observed_date: date | None
+    last_observed_date: date | None
+
+
+@dataclass(frozen=True)
+class CoreSelection:
+    state: CoreSelectionState
+    selected_instrument_id: int | None
+    selected_symbol: str | None
+    evidence_ref: str | None
+    required_trading_days: int
+    observed_trading_days: int
+    max_cost_bps: int
+    candidates: tuple[CoreCandidateCoverage, ...]
+    missing_candidate_ids: tuple[int, ...]
+    configuration_error: str | None
+
+    @property
+    def ready(self) -> bool:
+        return self.state == "ready"
+
+
+_COVERAGE_SQL: Final = """
+SELECT i.instrument_id, i.symbol,
+       count(DISTINCT (o.observed_at AT TIME ZONE 'UTC')::date)
+           FILTER (WHERE o.observation_status = 'observed') AS observed_days,
+       min((o.observed_at AT TIME ZONE 'UTC')::date)
+           FILTER (WHERE o.observation_status = 'observed') AS first_observed_date,
+       max((o.observed_at AT TIME ZONE 'UTC')::date)
+           FILTER (WHERE o.observation_status = 'observed') AS last_observed_date
+FROM instruments i
+LEFT JOIN strategy_core_quote_observations o ON o.instrument_id = i.instrument_id
+WHERE i.instrument_id = ANY(%s)
+GROUP BY i.instrument_id, i.symbol
+ORDER BY array_position(%s::bigint[], i.instrument_id)
+"""
+
+
+def load_core_selection(conn: psycopg.Connection[Any]) -> CoreSelection:
+    """Return reviewed selection and descriptive coverage, never infer a verdict."""
+    rows = conn.execute(
+        _COVERAGE_SQL,
+        (list(CORE_SELECTION_CANDIDATE_IDS), list(CORE_SELECTION_CANDIDATE_IDS)),
+    ).fetchall()
+    candidates = tuple(
+        CoreCandidateCoverage(
+            instrument_id=int(row[0]),
+            symbol=str(row[1]),
+            observed_trading_days=int(row[2]),
+            first_observed_date=row[3],
+            last_observed_date=row[4],
+        )
+        for row in rows
+    )
+    coverage_by_id = {candidate.instrument_id: candidate for candidate in candidates}
+    missing_candidate_ids = tuple(
+        instrument_id for instrument_id in CORE_SELECTION_CANDIDATE_IDS if instrument_id not in coverage_by_id
+    )
+    observed_days = min(
+        coverage_by_id[instrument_id].observed_trading_days if instrument_id in coverage_by_id else 0
+        for instrument_id in CORE_SELECTION_CANDIDATE_IDS
+    )
+    selected = SELECTED_CORE_INSTRUMENT_ID
+    selected_candidate = None if selected is None else coverage_by_id.get(selected)
+    evidence_ref = SELECTED_CORE_EVIDENCE_REF
+    selection_declared = selected is not None or evidence_ref is not None
+    selection_complete = (
+        selected in CORE_SELECTION_CANDIDATE_IDS
+        and selected_candidate is not None
+        and evidence_ref is not None
+        and bool(evidence_ref.strip())
+    )
+    configuration_error = None
+    if selection_declared and not selection_complete:
+        configuration_error = "the reviewed core selection must name a declared candidate and a non-blank evidence ref"
+    return CoreSelection(
+        state=(
+            "unavailable"
+            if missing_candidate_ids or configuration_error is not None
+            else "ready"
+            if selection_complete
+            else "evidence_collecting"
+        ),
+        selected_instrument_id=selected if selection_complete else None,
+        selected_symbol=selected_candidate.symbol if selection_complete and selected_candidate is not None else None,
+        evidence_ref=evidence_ref if selection_complete else None,
+        required_trading_days=CORE_SELECTION_REQUIRED_TRADING_DAYS,
+        observed_trading_days=observed_days,
+        max_cost_bps=CORE_SELECTION_MAX_COST_BPS,
+        candidates=candidates,
+        missing_candidate_ids=missing_candidate_ids,
+        configuration_error=configuration_error,
+    )
+
+
+def require_selected_core_instrument(conn: psycopg.Connection[Any], *, instrument_id: int) -> CoreSelection:
+    """Require the reviewed sleeve selection below every mandate writer."""
+    selection = load_core_selection(conn)
+    if not selection.ready or selection.selected_instrument_id is None:
+        raise CoreSelectionError(
+            "the core sleeve cannot be enabled until #2833 completes its five-trading-day cost verdict"
+        )
+    if instrument_id != selection.selected_instrument_id:
+        raise CoreSelectionError(
+            f"instrument {instrument_id} is not the evidence-approved core sleeve ({selection.selected_instrument_id})"
+        )
+    return selection
+
+
+__all__ = [
+    "CORE_SELECTION_CANDIDATE_IDS",
+    "CORE_SELECTION_MAX_COST_BPS",
+    "CORE_SELECTION_REQUIRED_TRADING_DAYS",
+    "CoreCandidateCoverage",
+    "CoreSelection",
+    "CoreSelectionError",
+    "load_core_selection",
+    "require_selected_core_instrument",
+]

--- a/docs/proposals/ta/2026-08-24-core-cash-operator.md
+++ b/docs/proposals/ta/2026-08-24-core-cash-operator.md
@@ -1,0 +1,155 @@
+# Core/cash operator surface and attended submitter (#2603)
+
+Status: proposed, 2026-08-24.
+
+## Outcome
+
+`/strategies` must remain useful when no alpha strategy has earned capital. It must show
+the programme's honest fallback — cash until the cap-weighted core sleeve passes its
+preregistered cost gate — and, after that gate passes, let a named operator configure
+the mandate and request one guarded demo rebalance.
+
+This does **not** adopt a sleeve before #2833 has a verdict. On 2026-08-24 the dev store
+contains one trading day of observations and #2833 requires five; the earliest honest
+decision is 2026-08-28. Until a selected instrument is frozen in code from that verdict,
+the server reports `evidence_collecting`, offers no instrument and refuses enablement.
+
+## Existing contracts retained
+
+- The mandate, allocator, immutable intent, trade arc, submission gate, DB/clock
+  preflight and broker preflight remain the decision spine.
+- The core path reads mandate plus current account holdings; it never reads alpha
+  signals or treats an alpha candidate as approved.
+- Demo only, underlying long, leverage 1, USD order currency. The global kill switch,
+  runtime auto-trading flag, execution block, market session, halt feed, fresh quote,
+  fresh account snapshot, fresh eligibility proof and cost quote all remain binding.
+- One server-side selection invariant is called by mandate configuration **and** by the
+  acting path while the mandate lock is held. A legacy enabled mandate naming any other
+  instrument is refused; checking only the endpoint would be a bypass.
+- `core_submission_lock` spans the DB decision phase: record -> admit -> DB preflight ->
+  durable order authority. The request UUID is committed before mutating broker I/O and
+  reused after uncertainty. No second request identity is generated.
+- Broker mutation remains refused from linked worktrees. The UI calls the main-checkout
+  dev API; tests use broker doubles. A real demo acceptance is an attended post-merge
+  check only after #2833 passes and the operator has deliberately cleared every gate.
+- Sell remains refused as `core_close_side_cost_quote_unavailable`; the page says the
+  allocator is buy-only rather than presenting a complete rebalance loop.
+
+## Server API
+
+### `GET /strategies/core-sleeve`
+
+One canonical operator view, assembled server-side:
+
+- selection: `evidence_collecting | ready | unavailable`, selected instrument identity
+  when frozen, evidence window/trading-day coverage and the #2833 threshold;
+- current mandate revision (the existing `CoreMandateResponse` fields);
+- latest intent plus the independently selected blocking non-terminal core trade/order
+  (which can belong to an older intent) and its reconciliation state;
+- `can_configure`, `can_rebalance` and ordered blocker codes with server-authored detail;
+- explicit limitations: demo-only, buy-only, no alpha input, and ISA household caveat.
+
+The first slice freezes no selected instrument. A later evidence-verdict change is a
+small, reviewed constant update carrying the #2833 evidence reference and chosen
+instrument; it is not an operator-selectable numeric id.
+
+### `PUT /strategies/core-mandate`
+
+Keep the existing authenticated append-only writer, but put the invariant in
+`configure_core_mandate`: an enabled request must name the server-selected instrument
+and the selection must be `ready`. This closes every caller, not only HTTP. Disabling
+remains available regardless of selection state; a legacy enabled/non-selected mandate
+must still be disableable from the page.
+
+### `POST /strategies/core-sleeve/rebalance`
+
+Authenticated, attended request; no amount or instrument in the body. The server:
+
+1. requires global demo configuration and loads the session operator's current demo
+   credential ids and secrets. Those exact ids remain attached to the broker handle;
+2. outside a DB transaction, loads the fresh broker account snapshot and informational
+   cost quote inputs. No database lock is held across retryable network I/O;
+3. opens `core_submission_lock` and one short transaction, re-loads the mandate, checks
+   the server selection invariant, observes the already-fetched sleeve and records one
+   immutable intent;
+4. admits that exact intent, runs DB/clock preflight, and verifies the admission proof's
+   credential ids equal the already-loaded pair. The `FOR SHARE` lock prevents a swap
+   until this transaction commits; the broker handle then continues with the exact
+   proved secrets rather than re-resolving labels after commit;
+5. applies broker cost sizing from the fresh observations. `maxUnitsPerOrder` is retained
+   as broker rejection evidence, not converted into an invented amount bound: a
+   market-by-amount order has no source-backed pre-trade conversion that guarantees its
+   eventual units. The broker remains the authoritative enforcer and an explicit reject
+   is terminal evidence;
+6. for a hold/refusal, commits the evidence and returns without broker mutation;
+7. for an admitted buy, inserts the core `strategy_trade`, strategy-origin `orders` row,
+   link and reconciliation authority, assigns the durable request UUID, and stores the
+   exact eligibility proof id on the trade as account provenance;
+8. commits before mutating broker I/O and submits through a dedicated demo-only method;
+   on acceptance, persists the normalized order id, reference id and response digest
+   before advancing order/trade status. The response token and raw body are not retained,
+   following the settled #471 eToro retention contract;
+9. on explicit rejection sets order `rejected`, trade `failed`, reconciliation
+   `rejected`; on transport,
+   server or response ambiguity leaves the durable authority `reconcile_required` and
+   resolves only by lookup using the same UUID.
+
+Reconciliation resolves the core trade's proof id to the exact credential ids used at
+submission. If those credentials have been revoked and the same account cannot be
+proved, reconciliation fails closed with a named account-provenance blocker; it never
+looks up the request UUID through the sole operator's newly-current account.
+
+The endpoint returns `held | refused | submitted | submission_uncertain`, the intent,
+trade/order identities, amount, reason and policy versions. A 409 is reserved for a
+control-plane refusal before an intent can be evaluated; allocator/preflight refusals
+are successful evidence-bearing responses.
+
+## Broker contract
+
+Add `BrokerCoreOrder` and `place_demo_core_order`. It hardcodes the v2 demo endpoint,
+`open/buy/real/mkt/x1/usd`, accepts a caller-owned UUID, and deliberately sends no
+stop-loss or take-profit. It has the same exact reference check and uncertainty
+classification as `place_demo_strategy_order`, calls the unattended mutation guard
+before I/O, and never falls back to `place_order`.
+
+The accepted result returns normalized order/reference identity plus a canonical response
+digest. Those fields are durably written before the order/trade status transition. The
+raw body and response token are not retained: the repository's #471 coverage audit
+settled eToro persistence on normalized decision-bearing facts plus a fingerprint.
+
+## Page
+
+Add a `Core & cash` panel above alpha automation. It owns one async source and renders
+loading/error/empty explicitly. In today's state it shows cash as the active fallback,
+the server-derived trading-day coverage and earliest possible decision date, and a
+disabled setup action with the server reason. It does not ask for an instrument id.
+
+When selection is ready it exposes mandate fields (core target, liquidity reserve,
+rebalance band, minimum rebalance amount and required audit reason), an enable checkbox,
+Save, and a separate
+`Rebalance demo now` button. The mutation button opens a confirmation modal naming the
+instrument, maximum mandate exposure, demo environment and buy-only limitation. It is
+disabled with visible reasons whenever the server says `can_rebalance=false`. A
+`submitted` result is labelled broker-accepted/pending reconciliation, never filled.
+
+Alpha Automation remains separate and disabled when no strategy passed. Core holdings
+continue through the existing positions/P&L panels under the `Core / cash mandate`
+presentation identity.
+
+## Tests and verification
+
+- Pure and DB tests for selection refusal, mandate bypass closure (including a legacy
+  enabled eligible-but-unselected mandate), orchestration order,
+  every early refusal, hold, accepted buy, explicit rejection, uncertainty, duplicate
+  request/reconcile, credential replacement, exact proof provenance, older blocking
+  trades and lock/transaction boundaries.
+- Provider tests for exact core request shape, demo-only refusal, reference mismatch,
+  raw payload and unattended guard inventory.
+- API tests for auth, honest collecting state, enable refusal and response shapes.
+- Frontend tests for loading/error/collecting, server-derived progression, editable ready
+  state, legacy disable, audit reason, blocker rendering, confirmation, post-mutation
+  refetch and each mutation outcome including accepted-versus-filled wording.
+- Before first push: repository Codex review, scoped backend/frontend tests, mandatory
+  gates. After merge: main-checkout page smoke. A broker-accepted demo order is attempted
+  only once #2833 is complete and a mandate is deliberately enabled; until then the
+  verified lifecycle ends at the expected evidence refusal.

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -2,6 +2,7 @@ import { apiFetch } from "@/api/client";
 import type {
   AllocationUpdateRequest,
   AllocationUpdateResponse,
+  CoreSleeveResponse,
   FiredSignalsResponse,
   StrategyAdvanceResponse,
   StrategyOperatorAction,
@@ -16,6 +17,10 @@ import type {
 
 export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
   return apiFetch("/strategies/overview");
+}
+
+export function fetchCoreSleeve(): Promise<CoreSleeveResponse> {
+  return apiFetch("/strategies/core-sleeve");
 }
 
 export function requestStrategyEvidenceRefresh(): Promise<StrategyEvidenceRefreshResponse> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2974,8 +2974,8 @@ export interface CoreSleeveResponse {
     detail: string;
   }>;
   environment: "demo";
-  buy_only: true;
-  alpha_input_used: false;
+  buy_only: boolean;
+  alpha_input_used: boolean;
   household_tax_caveat: string;
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2936,6 +2936,49 @@ export interface StrategyPaperPool {
   available_mandates: StrategyPortfolioMandate[];
 }
 
+export interface CoreMandate {
+  configured: boolean;
+  event_id: number | null;
+  revision: number | null;
+  enabled: boolean | null;
+  base_currency: string | null;
+  core_instrument_id: number | null;
+  core_target_pct: string | null;
+  cash_target_pct: string | null;
+  liquidity_reserve_pct: string | null;
+  rebalance_band_pct: string | null;
+  min_rebalance_amount: string | null;
+  policy_version: string | null;
+}
+
+export interface CoreSleeveResponse {
+  state: "evidence_collecting" | "ready" | "unavailable";
+  selected_instrument_id: number | null;
+  selected_symbol: string | null;
+  evidence_ref: string | null;
+  required_trading_days: number;
+  observed_trading_days: number;
+  max_cost_bps: number;
+  candidates: Array<{
+    instrument_id: number;
+    symbol: string;
+    observed_trading_days: number;
+    first_observed_date: string | null;
+    last_observed_date: string | null;
+  }>;
+  mandate: CoreMandate;
+  can_configure: boolean;
+  can_rebalance: boolean;
+  blockers: Array<{
+    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_submitter_unavailable";
+    detail: string;
+  }>;
+  environment: "demo";
+  buy_only: true;
+  alpha_input_used: false;
+  household_tax_caveat: string;
+}
+
 export interface StrategyPortfolioMandate {
   configured: boolean;
   policy_version: string;

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -95,6 +95,29 @@ const BLOCKED = {
   strategies: [],
 } as unknown as StrategyOverviewResponse;
 
+const CORE_COLLECTING = {
+  state: "evidence_collecting",
+  selected_instrument_id: null,
+  selected_symbol: null,
+  evidence_ref: null,
+  required_trading_days: 5,
+  observed_trading_days: 1,
+  max_cost_bps: 60,
+  candidates: [],
+  mandate: { configured: false },
+  can_configure: false,
+  can_rebalance: false,
+  blockers: [
+    { code: "core_evidence_collecting", detail: "#2833 has 1 of 5 required trading days; cash remains the fallback." },
+    { code: "core_mandate_unconfigured", detail: "No core/cash mandate has been configured." },
+    { code: "core_submitter_unavailable", detail: "Attended demo rebalance submission is not deployed yet." },
+  ],
+  environment: "demo",
+  buy_only: true,
+  alpha_input_used: false,
+  household_tax_caveat: "A UK ISA at another broker tax-dominates this engine sleeve for eligible household capital.",
+} as const;
+
 function renderLens() {
   return render(
     <MemoryRouter>
@@ -107,11 +130,21 @@ describe("StrategyPortfolioLens", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue(BLOCKED);
+    vi.spyOn(strategiesApi, "fetchCoreSleeve").mockResolvedValue(CORE_COLLECTING as never);
     vi.spyOn(strategiesApi, "fetchStrategyOwnedPositions").mockResolvedValue({
       positions: [],
       live_quote_instrument_ids: [],
     } as never);
     vi.spyOn(strategiesApi, "fetchStrategyPnlHistory").mockResolvedValue({ points: [] } as never);
+  });
+
+  it("shows cash as the evidence-gated fallback instead of an approved strategy", async () => {
+    renderLens();
+    expect(await screen.findByRole("heading", { name: "Core & cash" })).toBeInTheDocument();
+    expect(screen.getByText("1 / 5")).toBeInTheDocument();
+    expect(screen.getByText("No sleeve adopted")).toBeInTheDocument();
+    expect(screen.getByText(/cash remains the fallback/i)).toBeInTheDocument();
+    expect(screen.getByText(/UK ISA at another broker tax-dominates/i)).toBeInTheDocument();
   });
 
   it("states what is blocking as facts, and offers the control for the one that has one", async () => {

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { postKillSwitch } from "@/api/config";
 import {
   closeStrategyOwnedPosition,
+  fetchCoreSleeve,
   fetchStrategyOverview,
   fetchStrategyOwnedPositions,
   fetchStrategyPnlHistory,
@@ -70,6 +71,7 @@ function BlockerRow({
 
 export function StrategyPortfolioLens() {
   const overview = useAsync(fetchStrategyOverview, []);
+  const coreSleeve = useAsync(fetchCoreSleeve, []);
   const ownedPositions = useAsync(fetchStrategyOwnedPositions, []);
   const pnlHistory = useAsync(fetchStrategyPnlHistory, []);
   const [closeFor, setCloseFor] = useState<StrategyOwnedPosition | null>(null);
@@ -213,7 +215,54 @@ export function StrategyPortfolioLens() {
         <h2 id="pot-setup" className="sr-only">
           Setup
         </h2>
-        <AutomationControl overview={data} onUpdated={overview.refetch} />
+        <div className="space-y-4">
+          {coreSleeve.loading ? <SectionSkeleton rows={3} /> : null}
+          {coreSleeve.error ? <SectionError onRetry={coreSleeve.refetch} /> : null}
+          {coreSleeve.data ? (
+            <section className="border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold">Core &amp; cash</h2>
+                  <p className="mt-1 text-xs text-slate-500">
+                    Deterministic fallback when no strategy has earned capital.
+                  </p>
+                </div>
+                <Badge tone={coreSleeve.data.state === "ready" ? "ok" : "warn"}>
+                  {coreSleeve.data.state === "ready" ? "Ready" : "Cash"}
+                </Badge>
+              </div>
+              <div className="mt-5 grid grid-cols-2 gap-x-6 sm:grid-cols-3">
+                <StatTile
+                  size="md"
+                  label="Evidence"
+                  value={`${coreSleeve.data.observed_trading_days} / ${coreSleeve.data.required_trading_days}`}
+                  hint="Trading days"
+                />
+                <StatTile
+                  size="md"
+                  label="Instrument"
+                  value={coreSleeve.data.selected_symbol ?? "Cash"}
+                  hint={coreSleeve.data.selected_symbol ? "Evidence-selected" : "No sleeve adopted"}
+                />
+                <StatTile
+                  size="md"
+                  label="Cost ceiling"
+                  value={`${(coreSleeve.data.max_cost_bps / 100).toFixed(2)}%`}
+                  hint="Preregistered #2833 bar"
+                />
+              </div>
+              <div className="mt-4">
+                {coreSleeve.data.blockers.map((blocker) => (
+                  <BlockerRow key={blocker.code} tone="warn" label={blocker.detail} />
+                ))}
+              </div>
+              <p className="mt-4 border-t border-slate-200 pt-3 text-xs text-slate-500 dark:border-slate-800">
+                Demo only · buy only · no alpha signal. {coreSleeve.data.household_tax_caveat}
+              </p>
+            </section>
+          ) : null}
+          <AutomationControl overview={data} onUpdated={overview.refetch} />
+        </div>
       </section>
 
       <section aria-labelledby="pot-performance">

--- a/tests/test_2603_core_eligibility_db.py
+++ b/tests/test_2603_core_eligibility_db.py
@@ -30,6 +30,16 @@ from app.services.strategy_core_mandate import CoreMandateError, configure_core_
 INSTRUMENT_ID = 920604
 DIGEST = "a" * 64
 
+
+@pytest.fixture(autouse=True)
+def _approved_instrument_for_eligibility_consumer_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep this module's consumer tests focused on account eligibility."""
+    monkeypatch.setattr(
+        "app.services.strategy_core_mandate.require_selected_core_instrument",
+        lambda _conn, *, instrument_id: instrument_id,
+    )
+
+
 _INSERT = """
 INSERT INTO strategy_core_eligibility_proofs (
     instrument_id, operator_id, provider, environment,

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import inspect
 from decimal import Decimal
+from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.params import Depends as DependsParam
@@ -26,6 +28,7 @@ from fastapi.routing import APIRoute
 from app.api.strategies import (
     CoreMandateUpdateRequest,
     _core_mandate_response,
+    read_core_sleeve,
     router,
     update_core_mandate,
 )
@@ -35,8 +38,10 @@ from app.services.broker_credentials import (
     normalise_provider,
 )
 from app.services.strategy_core_mandate import CoreMandate
+from app.services.strategy_core_selection import CoreCandidateCoverage, CoreSelection
 
 CORE_MANDATE_PATH = "/strategies/core-mandate"
+CORE_SLEEVE_PATH = "/strategies/core-sleeve"
 
 
 def _routes() -> list[APIRoute]:
@@ -89,6 +94,43 @@ class TestTheRouteTable:
         before writing to it."""
         methods = {method for route in _routes() if route.path == CORE_MANDATE_PATH for method in route.methods}
         assert {"GET", "PUT"} <= methods
+
+    def test_the_operator_sleeve_view_is_registered_before_strategy_id_routes(self) -> None:
+        paths = [route.path for route in _routes()]
+        first_param_route = next(index for index, path in enumerate(paths) if "{strategy_id}" in path)
+        assert paths.index(CORE_SLEEVE_PATH) < first_param_route
+
+
+def test_collecting_state_reports_cash_and_server_derived_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
+    selection = CoreSelection(
+        state="evidence_collecting",
+        selected_instrument_id=None,
+        selected_symbol=None,
+        evidence_ref=None,
+        required_trading_days=5,
+        observed_trading_days=1,
+        max_cost_bps=60,
+        candidates=(
+            CoreCandidateCoverage(3417, "SPY.RTH", 1, None, None),
+            CoreCandidateCoverage(3434, "CSPX.L", 1, None, None),
+            CoreCandidateCoverage(3075, "IUSA.L", 1, None, None),
+        ),
+        missing_candidate_ids=(),
+        configuration_error=None,
+    )
+    monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
+    monkeypatch.setattr("app.api.strategies.load_core_mandate", lambda _conn: None)
+    response = read_core_sleeve(cast(Any, MagicMock()))
+    assert response.state == "evidence_collecting"
+    assert response.selected_instrument_id is None
+    assert response.observed_trading_days == 1
+    assert response.can_configure is False
+    assert response.can_rebalance is False
+    assert [blocker.code for blocker in response.blockers] == [
+        "core_evidence_collecting",
+        "core_mandate_unconfigured",
+        "core_submitter_unavailable",
+    ]
 
 
 class TestTheAuthDependency:

--- a/tests/test_2603_core_mandate_db.py
+++ b/tests/test_2603_core_mandate_db.py
@@ -58,6 +58,15 @@ _VALID_ROW: dict[str, Any] = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _approved_instrument_for_pre_2833_writer_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """These tests isolate mandate/eligibility behavior, not #2833 selection."""
+    monkeypatch.setattr(
+        "app.services.strategy_core_mandate.require_selected_core_instrument",
+        lambda _conn, *, instrument_id: instrument_id,
+    )
+
+
 def _migration_precondition_block() -> LiteralString:
     """sql/344's superseded-version guard, read from the SHIPPED file.
 

--- a/tests/test_2603_core_selection.py
+++ b/tests/test_2603_core_selection.py
@@ -1,0 +1,58 @@
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.services.strategy_core_selection import (
+    CoreSelectionError,
+    load_core_selection,
+    require_selected_core_instrument,
+)
+
+
+def _empty_connection() -> psycopg.Connection[Any]:
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = []
+    return cast(psycopg.Connection[Any], conn)
+
+
+def _candidate_connection() -> psycopg.Connection[Any]:
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = [
+        (3417, "SPY.RTH", 5, None, None),
+        (3434, "CSPX.L", 5, None, None),
+        (3075, "IUSA.L", 5, None, None),
+    ]
+    return cast(psycopg.Connection[Any], conn)
+
+
+def test_missing_candidates_are_unavailable_not_perpetually_collecting() -> None:
+    selection = load_core_selection(_empty_connection())
+    assert selection.state == "unavailable"
+    assert selection.selected_instrument_id is None
+    assert selection.observed_trading_days == 0
+    assert selection.missing_candidate_ids == (3417, 3434, 3075)
+    assert selection.configuration_error is None
+
+
+def test_mandate_enablement_refuses_before_2833_verdict() -> None:
+    with pytest.raises(CoreSelectionError, match="five-trading-day cost verdict"):
+        require_selected_core_instrument(_empty_connection(), instrument_id=3417)
+
+
+@pytest.mark.parametrize(
+    ("instrument_id", "evidence_ref"),
+    [(3417, None), (999999, "#2833 verdict")],
+)
+def test_partial_or_foreign_verdict_constants_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    instrument_id: int,
+    evidence_ref: str | None,
+) -> None:
+    monkeypatch.setattr("app.services.strategy_core_selection.SELECTED_CORE_INSTRUMENT_ID", instrument_id)
+    monkeypatch.setattr("app.services.strategy_core_selection.SELECTED_CORE_EVIDENCE_REF", evidence_ref)
+    selection = load_core_selection(_candidate_connection())
+    assert selection.state == "unavailable"
+    assert selection.selected_instrument_id is None
+    assert selection.configuration_error is not None


### PR DESCRIPTION
## Outcome

Makes `/strategies` tell the truth about the deterministic core/cash fallback while #2833's prospective instrument evidence is still collecting. This is the first product slice of #2603; it deliberately does not close the ticket or expose an acting endpoint yet.

## What changes

- adds canonical `GET /strategies/core-sleeve` operator state
- reports each #2833 candidate's immutable quote-day coverage, selection evidence, mandate state, and explicit blockers
- prevents any enabled core mandate from naming an instrument until a reviewed #2833 verdict is declared
- renders the core/cash state, 60 bps cost bar, demo/buy-only/no-alpha posture, and UK ISA caveat on Portfolio
- records the staged design for the attended demo-only submitter and durable provenance

## Current measured state

Dev DB on 2026-08-24: SPY.RTH (3417), CSPX.L (3434), and IUSA.L (3075) each have 1 of 5 required trading days. Therefore the only honest current sleeve is cash and configuration remains refused. The code cannot silently infer a winner from partial observations.

## Verification

- staged Codex review: no correctness findings
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m 'not db'` — 9,779 passed, 14 skipped
- `uv run pytest tests/smoke` — 161 passed, 3 skipped
- scoped DB-backed core tests — 71 passed
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend test:unit` — 1,612 passed
- full repository pre-push hook green

## Review findings already resolved

- FIXED: missing candidate instrument rows now fail unavailable instead of appearing to collect forever
- FIXED: partial/foreign selection constants now fail unavailable instead of marking the sleeve ready

Refs #2603
Refs #2833