### PR TITLE
feat(#2603): add guarded core sleeve execution

### DIFF
--- a/app/api/broker_credentials.py
+++ b/app/api/broker_credentials.py
@@ -49,6 +49,7 @@ from app.security.sessions import SessionRow
 from app.services.broker_credentials import (
     CredentialAlreadyExists,
     CredentialDecryptError,
+    CredentialInUse,
     CredentialMetadata,
     CredentialNotFound,
     CredentialValidationError,
@@ -511,6 +512,8 @@ def delete(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="credential not found",
         ) from exc
+    except CredentialInUse as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -903,6 +906,12 @@ def replace(
     conn.commit()
 
     with conn.transaction():
+        # Lock order is core submission advisory lock -> credential row. The
+        # executor uses that same order; taking the row first would deadlock a
+        # replacement against eligibility's FOR SHARE credential proof.
+        from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
+
+        conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
                 """
@@ -983,11 +992,14 @@ def replace(
             )
 
         # Different secret. Revoke the existing row, then insert.
-        revoke_credential(
-            conn,
-            credential_id=existing["id"],
-            operator_id=session.operator_id,
-        )
+        try:
+            revoke_credential(
+                conn,
+                credential_id=existing["id"],
+                operator_id=session.operator_id,
+            )
+        except CredentialInUse as exc:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
         new_meta = store_credential(
             conn,
             operator_id=session.operator_id,

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -30,6 +30,7 @@ from app.services.broker_credentials import (
     CredentialNotFound,
     CredentialValidationError,
     load_credential_for_provider_use,
+    load_credential_with_id_for_provider_use,
     normalise_environment,
     normalise_provider,
 )
@@ -68,6 +69,13 @@ from app.services.strategy_control_plane import (
     resolve_approval_mode,
 )
 from app.services.strategy_core_eligibility import CoreEligibilityError
+from app.services.strategy_core_executor import (
+    CoreExecutionResult,
+    StrategyCoreExecutionError,
+    execute_core_rebalance,
+    load_core_resume_authority,
+    resume_core_submission,
+)
 from app.services.strategy_core_mandate import (
     CORE_MANDATE_SERIES_ID,
     CORE_MANDATE_SERIES_TITLE,
@@ -981,7 +989,9 @@ class CoreSleeveBlockerResponse(BaseModel):
         "core_selection_invalid",
         "core_mandate_unconfigured",
         "core_mandate_disabled",
-        "core_submitter_unavailable",
+        "core_mandate_selection_mismatch",
+        "core_demo_required",
+        "core_order_unresolved",
     ]
     detail: str
 
@@ -998,13 +1008,28 @@ class CoreSleeveResponse(BaseModel):
     mandate: CoreMandateResponse
     can_configure: bool
     can_rebalance: bool
+    can_resume: bool
+    pending_order_id: int | None
+    execution_action: Literal["blocked", "rebalance", "resume"]
     blockers: list[CoreSleeveBlockerResponse]
-    environment: Literal["demo"] = "demo"
+    environment: Literal["demo", "real"]
     buy_only: bool = True
     alpha_input_used: bool = False
     household_tax_caveat: str = (
         "A UK ISA at another broker tax-dominates this engine sleeve for eligible household capital."
     )
+
+
+class CoreRebalanceResponse(BaseModel):
+    state: Literal["held", "refused", "submitted", "submission_uncertain"]
+    reason_code: str
+    intent_id: int | None
+    trade_id: int | None
+    order_id: int | None
+    amount: Decimal
+    submission_policy_version: str
+    preflight_policy_version: str
+    broker_preflight_policy_version: str
 
 
 def _core_mandate_response(mandate: CoreMandate | None) -> CoreMandateResponse:
@@ -3445,6 +3470,7 @@ def read_core_sleeve(
     """Canonical operator state for the deterministic fallback sleeve."""
     selection = load_core_selection(conn)
     mandate = load_core_mandate(conn)
+    resume_authority = load_core_resume_authority(conn)
     blockers: list[CoreSleeveBlockerResponse] = []
     if not selection.ready:
         if selection.configuration_error is not None:
@@ -3489,14 +3515,44 @@ def read_core_sleeve(
                 detail="The current core/cash mandate is disabled.",
             )
         )
-    # This first product slice intentionally exposes no acting endpoint. Keeping
-    # this explicit prevents a ready mandate being presented as executable while
-    # the idempotent submitter remains under construction.
-    blockers.append(
-        CoreSleeveBlockerResponse(
-            code="core_submitter_unavailable",
-            detail="Attended demo rebalance submission is not deployed yet.",
+    elif selection.ready and mandate.core_instrument_id != selection.selected_instrument_id:
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_mandate_selection_mismatch",
+                detail=(
+                    "The enabled mandate names a different instrument from the reviewed core selection; "
+                    "save a reviewed mandate revision before rebalancing."
+                ),
+            )
         )
+    if settings.etoro_env != "demo":
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_demo_required",
+                detail="Core sleeve execution is available only while the broker environment is demo.",
+            )
+        )
+    if resume_authority is not None:
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_order_unresolved",
+                detail=(
+                    f"Order {resume_authority.order_id} is unresolved; the next attended action resumes or "
+                    "reconciles that exact order and cannot create a new rebalance."
+                ),
+            )
+        )
+    base_ready = (
+        selection.ready
+        and mandate is not None
+        and mandate.enabled
+        and mandate.core_instrument_id == selection.selected_instrument_id
+        and settings.etoro_env == "demo"
+    )
+    can_rebalance = base_ready and resume_authority is None
+    can_resume = settings.etoro_env == "demo" and resume_authority is not None
+    execution_action: Literal["blocked", "rebalance", "resume"] = (
+        "resume" if can_resume else "rebalance" if can_rebalance else "blocked"
     )
     return CoreSleeveResponse(
         state=selection.state,
@@ -3518,9 +3574,101 @@ def read_core_sleeve(
         ],
         mandate=_core_mandate_response(mandate),
         can_configure=selection.ready,
-        can_rebalance=False,
+        can_rebalance=can_rebalance,
+        can_resume=can_resume,
+        pending_order_id=None if resume_authority is None else resume_authority.order_id,
+        execution_action=execution_action,
         blockers=blockers,
+        environment=cast(Literal["demo", "real"], settings.etoro_env),
     )
+
+
+def _core_rebalance_response(result: CoreExecutionResult) -> CoreRebalanceResponse:
+    return CoreRebalanceResponse(
+        state=result.state,
+        reason_code=result.reason_code,
+        intent_id=result.intent_id,
+        trade_id=result.trade_id,
+        order_id=result.order_id,
+        amount=result.amount,
+        submission_policy_version=result.submission_policy_version,
+        preflight_policy_version=result.preflight_policy_version,
+        broker_preflight_policy_version=result.broker_preflight_policy_version,
+    )
+
+
+@router.post(
+    "/core-sleeve/rebalance",
+    response_model=CoreRebalanceResponse,
+    status_code=status.HTTP_200_OK,
+)
+def rebalance_core_sleeve(
+    request: Request,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CoreRebalanceResponse:
+    """Run one operator-attended, demo-only core rebalance evaluation."""
+    if settings.etoro_env != "demo":
+        raise HTTPException(status_code=409, detail="Core sleeve execution is available only for the demo account.")
+    audit_pool = getattr(request.app.state, "audit_pool", None)
+    resume_authority = load_core_resume_authority(conn)
+    try:
+        with conn.transaction():
+            if not ensure_broker_key_loaded(conn):
+                raise CredentialCryptoConfigError("broker credential key is unavailable")
+            api_key = load_credential_with_id_for_provider_use(
+                conn,
+                operator_id=session.operator_id,
+                provider="etoro",
+                label="api_key",
+                environment="demo",
+                caller="strategy_core_rebalance",
+                audit_pool=audit_pool,
+            )
+            user_key = load_credential_with_id_for_provider_use(
+                conn,
+                operator_id=session.operator_id,
+                provider="etoro",
+                label="user_key",
+                environment="demo",
+                caller="strategy_core_rebalance",
+                audit_pool=audit_pool,
+            )
+            if resume_authority is not None and (
+                api_key.id,
+                user_key.id,
+            ) != (
+                resume_authority.api_key_credential_id,
+                resume_authority.user_key_credential_id,
+            ):
+                raise StrategyCoreExecutionError(
+                    "the unresolved core order belongs to credentials that are no longer live; "
+                    "reconciliation against a different account is refused"
+                )
+    except CredentialNotFound as exc:
+        raise HTTPException(status_code=503, detail="Demo broker credentials are not configured.") from exc
+    except StrategyCoreExecutionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (CredentialDecryptError, CredentialCryptoConfigError, MasterKeyError) as exc:
+        logger.error("core rebalance: credential loading failed", exc_info=True)
+        raise HTTPException(status_code=503, detail="Demo broker credentials could not be loaded.") from exc
+
+    try:
+        with EtoroBrokerProvider(api_key=api_key.plaintext, user_key=user_key.plaintext, env="demo") as broker:
+            if resume_authority is not None:
+                result = resume_core_submission(conn, broker=broker, authority=resume_authority)
+            else:
+                result = execute_core_rebalance(
+                    conn,
+                    broker=broker,
+                    operator_id=session.operator_id,
+                    api_key_credential_id=api_key.id,
+                    user_key_credential_id=user_key.id,
+                    recorded_by=session.username,
+                )
+    except (CoreEligibilityError, CoreSelectionError, StrategyCoreExecutionError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _core_rebalance_response(result)
 
 
 @router.put("/core-mandate", response_model=CoreMandateResponse, status_code=status.HTTP_200_OK)

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -156,12 +156,33 @@ class BrokerStrategyOrder:
 
 
 @dataclass(frozen=True)
+class BrokerCoreOrder:
+    """The fixed, buy-only order shape for the deterministic core sleeve."""
+
+    instrument_id: int
+    amount: Decimal
+
+    def __post_init__(self) -> None:
+        if self.instrument_id <= 0 or self.amount <= 0:
+            raise ValueError("core order instrument and amount must be positive")
+
+
+@dataclass(frozen=True)
 class BrokerOrderSubmission:
     """Broker acceptance identity; execution detail is reconciled separately."""
 
     broker_order_ref: str
     reference_id: UUID
     token: UUID
+
+
+@dataclass(frozen=True)
+class BrokerCoreOrderSubmission:
+    """Normalized core-order acceptance without retaining the response token."""
+
+    broker_order_ref: str
+    reference_id: UUID
+    response_digest: str
 
 
 @dataclass(frozen=True)
@@ -667,6 +688,15 @@ class BrokerProvider(ABC):
         must treat ``NotImplementedError`` as refusal, never fall back to the
         generic/live-capable writer.
         """
+        raise NotImplementedError
+
+    def place_demo_core_order(
+        self,
+        order: BrokerCoreOrder,
+        *,
+        request_id: UUID,
+    ) -> BrokerCoreOrderSubmission:
+        """Submit a demo-only underlying x1 core buy without synthetic exits."""
         raise NotImplementedError
 
     def get_account_risk_snapshot(self) -> BrokerAccountRiskSnapshot:

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -12,6 +12,8 @@ Trading endpoints are environment-scoped: /demo/ prefix for demo, no prefix for 
 from __future__ import annotations
 
 import decimal
+import hashlib
+import json
 import logging
 import re
 from collections.abc import Callable, Sequence
@@ -28,6 +30,8 @@ from app.providers.broker import (
     BrokerAccountRiskSnapshot,
     BrokerClosedTrade,
     BrokerCloseOrderDetail,
+    BrokerCoreOrder,
+    BrokerCoreOrderSubmission,
     BrokerCostComponent,
     BrokerEligibilityResponse,
     BrokerInstrumentEligibility,
@@ -404,6 +408,64 @@ class EtoroBrokerProvider(BrokerProvider):
         if broker_order_id <= 0 or reference_id != request_id:
             raise BrokerOrderSubmissionUncertain("demo strategy order response identity does not match intent")
         return BrokerOrderSubmission(str(broker_order_id), reference_id, token)
+
+    def place_demo_core_order(
+        self,
+        order: BrokerCoreOrder,
+        *,
+        request_id: UUID,
+    ) -> BrokerCoreOrderSubmission:
+        """Submit one demo-only underlying core buy with no SL/TP fields."""
+        refuse_broker_mutation_if_unattended("place_demo_core_order")
+        if self._env != "demo":
+            raise BrokerOrderSubmissionError("core orders require demo credentials")
+        body: dict[str, Any] = {
+            "action": "open",
+            "transaction": "buy",
+            "instrumentId": order.instrument_id,
+            "settlementType": "real",
+            "orderType": "mkt",
+            "leverage": 1,
+            "amount": float(order.amount),
+            "orderCurrency": "usd",
+        }
+        try:
+            response = self._http_write.post(
+                "/api/v2/trading/execution/demo/orders",
+                json=body,
+                headers=self._request_headers(request_id),
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if 400 <= exc.response.status_code < 500:
+                raise BrokerOrderSubmissionError(
+                    f"demo core order rejected with HTTP {exc.response.status_code}"
+                ) from exc
+            raise BrokerOrderSubmissionUncertain("demo core order returned a server error") from exc
+        except httpx.HTTPError as exc:
+            raise BrokerOrderSubmissionUncertain("demo core order transport failed") from exc
+        try:
+            raw = response.json()
+        except ValueError as exc:
+            raise BrokerOrderSubmissionUncertain("demo core order returned non-JSON data") from exc
+        if not isinstance(raw, dict):
+            raise BrokerOrderSubmissionUncertain("demo core order response must be an object")
+        try:
+            broker_order_id = int(raw["orderId"])
+            reference_id = UUID(str(raw["referenceId"]))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BrokerOrderSubmissionUncertain("demo core order response identity is malformed") from exc
+        if broker_order_id <= 0 or reference_id != request_id:
+            raise BrokerOrderSubmissionUncertain("demo core order response identity does not match intent")
+        try:
+            canonical = json.dumps(raw, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise BrokerOrderSubmissionUncertain("demo core order response cannot be fingerprinted") from exc
+        return BrokerCoreOrderSubmission(
+            broker_order_ref=str(broker_order_id),
+            reference_id=reference_id,
+            response_digest=hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+        )
 
     def close_position(
         self,

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -71,6 +71,15 @@ logger = logging.getLogger(__name__)
 # reach here. HOLD does not produce broker calls at all.
 _ALLOWED_PLACE_ORDER_ACTIONS = frozenset({"BUY", "ADD"})
 
+
+def _exact_json_decimal(value: Decimal) -> float:
+    """Return a JSON-native number only when its emitted decimal is unchanged."""
+    encoded = float(value)
+    if Decimal(str(encoded)) != value:
+        raise BrokerOrderSubmissionError("core order amount cannot be represented exactly in the broker JSON payload")
+    return encoded
+
+
 # Map eToro statusID values to our OrderStatus.
 # Populated from documented API responses. Edge-case status values
 # may need live validation — unknown statuses default to "pending".
@@ -426,7 +435,7 @@ class EtoroBrokerProvider(BrokerProvider):
             "settlementType": "real",
             "orderType": "mkt",
             "leverage": 1,
-            "amount": float(order.amount),
+            "amount": _exact_json_decimal(order.amount),
             "orderCurrency": "usd",
         }
         try:

--- a/app/services/broker_credentials.py
+++ b/app/services/broker_credentials.py
@@ -81,6 +81,14 @@ class CredentialMetadata:
     revoked_at: datetime | None
 
 
+@dataclass(frozen=True)
+class LoadedCredential:
+    """One decrypted secret plus the immutable row identity it came from."""
+
+    id: UUID
+    plaintext: str
+
+
 # ---------------------------------------------------------------------------
 # Exceptions
 # ---------------------------------------------------------------------------
@@ -100,6 +108,10 @@ class CredentialAlreadyExists(CredentialError):
 
 class CredentialNotFound(CredentialError):
     """Raised when no active credential matches the lookup."""
+
+
+class CredentialInUse(CredentialError):
+    """Raised when rotation would strand an unresolved broker authority."""
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +312,33 @@ def revoke_credential(
     ``with conn.transaction():`` at the call site to get clean
     rollback-on-exception semantics.
     """
+    # A core mutation holds this key through the broker response. Credential
+    # revocation/replacement takes the same key transactionally so decrypted
+    # credentials cannot become revoked between durable authority and HTTP I/O.
+    from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
+
+    conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
     with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM strategy_core_eligibility_proofs proof
+                JOIN strategy_trades trade
+                  ON trade.core_eligibility_proof_id=proof.core_eligibility_proof_id
+                JOIN strategy_trade_orders link ON link.strategy_trade_id=trade.strategy_trade_id
+                JOIN strategy_order_reconciliation_state state ON state.order_id=link.order_id
+                WHERE %s IN (proof.api_key_credential_id, proof.user_key_credential_id)
+                  AND state.state NOT IN ('resolved','rejected')
+            )
+            """,
+            (credential_id,),
+        )
+        in_use = cur.fetchone()
+        if in_use == (True,):
+            raise CredentialInUse(
+                "credential rotation is refused while an unresolved core order requires this exact account"
+            )
         cur.execute(
             """
             UPDATE broker_credentials
@@ -410,7 +448,7 @@ def _write_durable_audit(
         )
 
 
-def load_credential_for_provider_use(
+def load_credential_with_id_for_provider_use(
     conn: psycopg.Connection[object],
     *,
     operator_id: UUID,
@@ -419,8 +457,8 @@ def load_credential_for_provider_use(
     environment: str,
     caller: str,
     audit_pool: ConnectionPool[psycopg.Connection[Any]] | None = None,
-) -> str:
-    """Decrypt and return the plaintext secret for internal provider use.
+) -> LoadedCredential:
+    """Decrypt a secret and return its row identity for account provenance.
 
     Both ``label`` and ``environment`` are required -- no defaults, no
     fallback from env-specific to global. If the credential is missing
@@ -553,4 +591,26 @@ def load_credential_for_provider_use(
                 success=True,
                 failure_reason=None,
             )
-    return plaintext
+    return LoadedCredential(id=row["id"], plaintext=plaintext)  # type: ignore[arg-type]
+
+
+def load_credential_for_provider_use(
+    conn: psycopg.Connection[object],
+    *,
+    operator_id: UUID,
+    provider: str,
+    label: str,
+    environment: str,
+    caller: str,
+    audit_pool: ConnectionPool[psycopg.Connection[Any]] | None = None,
+) -> str:
+    """Decrypt and return plaintext while preserving the established API."""
+    return load_credential_with_id_for_provider_use(
+        conn,
+        operator_id=operator_id,
+        provider=provider,
+        label=label,
+        environment=environment,
+        caller=caller,
+        audit_pool=audit_pool,
+    ).plaintext

--- a/app/services/broker_credentials.py
+++ b/app/services/broker_credentials.py
@@ -42,6 +42,7 @@ from app.security.secrets_crypto import (
     decrypt,
     encrypt,
 )
+from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
 
 logger = logging.getLogger(__name__)
 
@@ -315,8 +316,6 @@ def revoke_credential(
     # A core mutation holds this key through the broker response. Credential
     # revocation/replacement takes the same key transactionally so decrypted
     # credentials cannot become revoked between durable authority and HTTP I/O.
-    from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
-
     conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
     with conn.cursor() as cur:
         cur.execute(

--- a/app/services/credential_health.py
+++ b/app/services/credential_health.py
@@ -283,6 +283,13 @@ def _do_health_transition(
     ``record_row_health_transition``, which provides the side-tx
     + PoolTimeout semantics.
     """
+    # Every broker_credentials UPDATE participates in the core safety-write
+    # trigger. Take its advisory key before the explicit credential row lock;
+    # otherwise a health writer can hold the row while waiting for a core
+    # submission that already holds the advisory key and needs that same row.
+    from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
+
+    conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """

--- a/app/services/credential_health.py
+++ b/app/services/credential_health.py
@@ -34,6 +34,8 @@ import psycopg
 import psycopg.rows
 from psycopg_pool import ConnectionPool, PoolTimeout
 
+from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
+
 logger = logging.getLogger(__name__)
 
 
@@ -287,8 +289,6 @@ def _do_health_transition(
     # trigger. Take its advisory key before the explicit credential row lock;
     # otherwise a health writer can hold the row while waiting for a core
     # submission that already holds the advisory key and needs that same row.
-    from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
-
     conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -894,6 +894,13 @@ def activate_kill_switch(
         raise ValueError("activate_kill_switch: reason is required when activating")
     now = now or _utcnow()
     with conn.transaction():
+        # A core broker mutation holds this key as a session lock. Taking the
+        # same key transactionally makes emergency activation and mutation a
+        # single ordered history: after activation commits, no core order can
+        # still pass a pre-activation check and reach the broker.
+        from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
+
+        conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute("SELECT is_active FROM kill_switch WHERE id = TRUE FOR UPDATE")
             prior = cur.fetchone()
@@ -962,6 +969,12 @@ def deactivate_kill_switch(
         raise ValueError("deactivate_kill_switch: reason is required for attribution")
     now = now or _utcnow()
     with conn.transaction():
+        # Use the same advisory-before-row order as activation. The database
+        # trigger also takes this key on UPDATE, so taking the row first here
+        # would deadlock a concurrent emergency activation.
+        from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
+
+        conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute("SELECT is_active FROM kill_switch WHERE id = TRUE FOR UPDATE")
             prior = cur.fetchone()

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -50,6 +50,7 @@ from app.services.runtime_config import (
     insert_runtime_config_audit_row,
     write_kill_switch_audit,
 )
+from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
 
 if TYPE_CHECKING:
     # layer_types sits at the bottom of the orchestrator import graph, but
@@ -898,8 +899,6 @@ def activate_kill_switch(
         # same key transactionally makes emergency activation and mutation a
         # single ordered history: after activation commits, no core order can
         # still pass a pre-activation check and reach the broker.
-        from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
-
         conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute("SELECT is_active FROM kill_switch WHERE id = TRUE FOR UPDATE")
@@ -972,8 +971,6 @@ def deactivate_kill_switch(
         # Use the same advisory-before-row order as activation. The database
         # trigger also takes this key on UPDATE, so taking the row first here
         # would deadlock a concurrent emergency activation.
-        from app.services.strategy_core_submission_gate import CORE_SUBMISSION_ADVISORY_LOCK
-
         conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute("SELECT is_active FROM kill_switch WHERE id = TRUE FOR UPDATE")

--- a/app/services/strategy_core_eligibility.py
+++ b/app/services/strategy_core_eligibility.py
@@ -130,6 +130,10 @@ class CoreEligibilityProof:
     verdict: CoreEligibilityVerdict
     reason_code: str | None
     age_seconds: Decimal
+    response_currency: str
+    min_position_amount: Decimal | None
+    min_position_exposure: Decimal | None
+    max_units_per_order: Decimal | None
     #: ⚠ READ BACK SINCE #2603 step 3a, and NOT part of ``verdict``.  A passing
     #: verdict requires ``allow_open_position`` (``evaluate_core_eligibility``) and says
     #: nothing about closing.  A rebalance SELL is a partial close -- never a full
@@ -327,7 +331,9 @@ def load_latest_core_eligibility_proof(
         SELECT core_eligibility_proof_id, instrument_id, operator_id, provider, environment,
                api_key_credential_id, user_key_credential_id, observed_at, verdict, reason_code,
                EXTRACT(EPOCH FROM (now() - observed_at))::numeric AS age_seconds, policy_version,
-               allow_close_position, allow_partial_close_position
+               allow_close_position, allow_partial_close_position,
+               response_currency, min_position_amount, min_position_exposure,
+               max_units_per_order
         FROM strategy_core_eligibility_proofs
         WHERE instrument_id = %s AND operator_id = %s AND provider = %s AND environment = %s
         ORDER BY observed_at DESC, core_eligibility_proof_id DESC
@@ -356,6 +362,10 @@ def load_latest_core_eligibility_proof(
         # other way round once someone writes `not proof.allow_partial_close`).
         allow_close_position=None if row[12] is None else bool(row[12]),
         allow_partial_close_position=None if row[13] is None else bool(row[13]),
+        response_currency=str(row[14]),
+        min_position_amount=None if row[15] is None else Decimal(str(row[15])),
+        min_position_exposure=None if row[16] is None else Decimal(str(row[16])),
+        max_units_per_order=None if row[17] is None else Decimal(str(row[17])),
     )
 
 

--- a/app/services/strategy_core_executor.py
+++ b/app/services/strategy_core_executor.py
@@ -1,0 +1,502 @@
+"""Attended, demo-only execution path for the deterministic core/cash sleeve."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+import psycopg
+from psycopg.pq import TransactionStatus
+
+from app.providers.broker import (
+    BrokerCoreOrder,
+    BrokerOrderSubmissionError,
+    BrokerOrderSubmissionUncertain,
+    BrokerProvider,
+)
+from app.services.strategy_control_plane import link_strategy_order
+from app.services.strategy_core_allocator import evaluate_core_rebalance
+from app.services.strategy_core_broker_preflight import (
+    CORE_BROKER_PREFLIGHT_POLICY_VERSION,
+    assess_core_broker_preflight,
+)
+from app.services.strategy_core_eligibility import require_core_eligibility
+from app.services.strategy_core_mandate import load_core_mandate
+from app.services.strategy_core_preflight import CORE_PREFLIGHT_POLICY_VERSION, preflight_core_submission
+from app.services.strategy_core_rebalance_intent import record_core_rebalance_intent
+from app.services.strategy_core_selection import require_selected_core_instrument
+from app.services.strategy_core_sleeve import observe_core_sleeve
+from app.services.strategy_core_submission_gate import (
+    CORE_SUBMISSION_POLICY_VERSION,
+    admit_core_rebalance_intent,
+    core_submission_lock,
+)
+from app.services.strategy_order_reconciliation import reconcile_strategy_order
+
+CoreExecutionState = Literal["held", "refused", "submitted", "submission_uncertain"]
+
+
+class StrategyCoreExecutionError(RuntimeError):
+    """The attended executor was called without a usable selected mandate."""
+
+
+@dataclass(frozen=True)
+class CoreExecutionResult:
+    state: CoreExecutionState
+    reason_code: str
+    intent_id: int | None
+    trade_id: int | None
+    order_id: int | None
+    amount: Decimal
+    submission_policy_version: str = CORE_SUBMISSION_POLICY_VERSION
+    preflight_policy_version: str = CORE_PREFLIGHT_POLICY_VERSION
+    broker_preflight_policy_version: str = CORE_BROKER_PREFLIGHT_POLICY_VERSION
+
+
+@dataclass(frozen=True)
+class CoreResumeAuthority:
+    intent_id: int
+    trade_id: int
+    order_id: int
+    instrument_id: int
+    amount: Decimal
+    request_id: UUID
+    broker_order_ref: str | None
+    eligibility_proof_id: int
+    operator_id: UUID
+    api_key_credential_id: UUID
+    user_key_credential_id: UUID
+
+
+def _result(
+    state: CoreExecutionState,
+    reason_code: str,
+    *,
+    intent_id: int | None = None,
+    trade_id: int | None = None,
+    order_id: int | None = None,
+    amount: Decimal = Decimal("0"),
+) -> CoreExecutionResult:
+    return CoreExecutionResult(state, reason_code, intent_id, trade_id, order_id, amount)
+
+
+def load_core_resume_authority(conn: psycopg.Connection[Any]) -> CoreResumeAuthority | None:
+    """Load the one non-terminal core order and the exact account that owns it."""
+    row = conn.execute(
+        """
+        SELECT t.core_rebalance_intent_id, t.strategy_trade_id, o.order_id,
+               o.instrument_id, o.requested_amount, o.strategy_request_id,
+               o.broker_order_ref, proof.core_eligibility_proof_id,
+               proof.operator_id, proof.api_key_credential_id,
+               proof.user_key_credential_id
+        FROM strategy_order_reconciliation_state state
+        JOIN orders o ON o.order_id=state.order_id
+        JOIN strategy_trade_orders link ON link.order_id=o.order_id
+        JOIN strategy_trades t ON t.strategy_trade_id=link.strategy_trade_id
+        JOIN strategy_core_eligibility_proofs proof
+          ON proof.core_eligibility_proof_id=t.core_eligibility_proof_id
+        WHERE t.core_rebalance_intent_id IS NOT NULL
+          AND state.state NOT IN ('resolved','rejected')
+        ORDER BY state.first_unresolved_at, state.order_id
+        LIMIT 1
+        """
+    ).fetchone()
+    conn.commit()
+    if row is None:
+        return None
+    if row[0] is None or row[4] is None or row[5] is None:
+        raise StrategyCoreExecutionError("core resume authority is incomplete")
+    return CoreResumeAuthority(
+        intent_id=int(row[0]),
+        trade_id=int(row[1]),
+        order_id=int(row[2]),
+        instrument_id=int(row[3]),
+        amount=Decimal(str(row[4])),
+        request_id=UUID(str(row[5])),
+        broker_order_ref=None if row[6] is None else str(row[6]),
+        eligibility_proof_id=int(row[7]),
+        operator_id=row[8],
+        api_key_credential_id=row[9],
+        user_key_credential_id=row[10],
+    )
+
+
+def _persist_core_acceptance(
+    conn: psycopg.Connection[Any],
+    *,
+    authority: CoreResumeAuthority,
+    broker_order_ref: str,
+    response_digest: str,
+) -> CoreExecutionResult:
+    with conn.transaction():
+        conn.execute(
+            "UPDATE orders SET broker_order_ref=%s WHERE order_id=%s",
+            (broker_order_ref, authority.order_id),
+        )
+        conn.execute(
+            "UPDATE strategy_trades SET status='submitted', updated_at=now() WHERE strategy_trade_id=%s",
+            (authority.trade_id,),
+        )
+        conn.execute(
+            """
+            UPDATE strategy_order_reconciliation_state
+            SET state='pending', broker_status='accepted', last_attempt_at=now(),
+                attempt_count=attempt_count+1, last_payload_sha256=%s,
+                last_error_code=NULL, updated_at=now()
+            WHERE order_id=%s
+            """,
+            (response_digest, authority.order_id),
+        )
+    return _result(
+        "submitted",
+        "broker_accepted_pending_reconciliation",
+        intent_id=authority.intent_id,
+        trade_id=authority.trade_id,
+        order_id=authority.order_id,
+        amount=authority.amount,
+    )
+
+
+def _reconcile_core_authority(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    authority: CoreResumeAuthority,
+) -> CoreExecutionResult:
+    reconciled = reconcile_strategy_order(conn, broker=broker, order_id=authority.order_id)
+    if reconciled.state == "resolved":
+        return _result(
+            "held",
+            "core_order_reconciled",
+            intent_id=authority.intent_id,
+            trade_id=authority.trade_id,
+            order_id=authority.order_id,
+            amount=authority.amount,
+        )
+    if reconciled.state == "rejected":
+        return _result(
+            "refused",
+            "core_order_rejected",
+            intent_id=authority.intent_id,
+            trade_id=authority.trade_id,
+            order_id=authority.order_id,
+            amount=authority.amount,
+        )
+    return _result(
+        "submission_uncertain",
+        f"core_order_reconciliation_{reconciled.state}",
+        intent_id=authority.intent_id,
+        trade_id=authority.trade_id,
+        order_id=authority.order_id,
+        amount=authority.amount,
+    )
+
+
+def resume_core_submission(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    authority: CoreResumeAuthority,
+) -> CoreExecutionResult:
+    """Reconcile one committed authority without ever retrying its mutation.
+
+    A broker lookup miss is only an observation that the order is not visible
+    yet, not proof that an uncertain submission had no effect. It therefore
+    remains unresolved and blocks every new core authority.
+    """
+    if conn.info.transaction_status != TransactionStatus.IDLE:
+        raise StrategyCoreExecutionError("core resume requires an idle connection")
+    with core_submission_lock(conn):
+        current = load_core_resume_authority(conn)
+        if current is None:
+            return _result("held", "core_resume_already_resolved")
+        if current.order_id != authority.order_id or current.request_id != authority.request_id:
+            raise StrategyCoreExecutionError("core resume authority changed before use")
+        return _reconcile_core_authority(conn, broker=broker, authority=current)
+
+
+def _submit_core_authority(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    authority: CoreResumeAuthority,
+) -> CoreExecutionResult:
+    """Submit one durable authority while the caller retains the core lock."""
+    try:
+        submission = broker.place_demo_core_order(
+            BrokerCoreOrder(instrument_id=authority.instrument_id, amount=authority.amount),
+            request_id=authority.request_id,
+        )
+    except BrokerOrderSubmissionError as exc:
+        uncertain = isinstance(exc, BrokerOrderSubmissionUncertain)
+        with conn.transaction():
+            if uncertain:
+                conn.execute(
+                    """
+                    UPDATE strategy_trades SET status='reconcile_required', updated_at=now()
+                    WHERE strategy_trade_id=%s
+                    """,
+                    (authority.trade_id,),
+                )
+                conn.execute(
+                    """
+                    UPDATE strategy_order_reconciliation_state
+                    SET state='error', last_attempt_at=now(), attempt_count=attempt_count+1,
+                        last_error_code='broker_submission_uncertain', updated_at=now()
+                    WHERE order_id=%s
+                    """,
+                    (authority.order_id,),
+                )
+            else:
+                conn.execute("UPDATE orders SET status='rejected' WHERE order_id=%s", (authority.order_id,))
+                conn.execute(
+                    "UPDATE strategy_trades SET status='failed', updated_at=now() WHERE strategy_trade_id=%s",
+                    (authority.trade_id,),
+                )
+                conn.execute(
+                    """
+                    UPDATE strategy_order_reconciliation_state
+                    SET state='rejected', reconciled_at=now(), last_attempt_at=now(),
+                        attempt_count=attempt_count+1, last_error_code='broker_submission_rejected', updated_at=now()
+                    WHERE order_id=%s
+                    """,
+                    (authority.order_id,),
+                )
+        return _result(
+            "submission_uncertain" if uncertain else "refused",
+            "broker_submission_uncertain" if uncertain else "broker_submission_rejected",
+            intent_id=authority.intent_id,
+            trade_id=authority.trade_id,
+            order_id=authority.order_id,
+            amount=authority.amount,
+        )
+    except Exception:
+        # Acceptance may precede an unexpected provider error. Preserve the
+        # request UUID and make reconciliation the only safe next action.
+        with conn.transaction():
+            conn.execute(
+                """
+                UPDATE strategy_trades SET status='reconcile_required', updated_at=now()
+                WHERE strategy_trade_id=%s
+                """,
+                (authority.trade_id,),
+            )
+            conn.execute(
+                """
+                UPDATE strategy_order_reconciliation_state
+                SET state='error', last_attempt_at=now(), attempt_count=attempt_count+1,
+                    last_error_code='broker_submission_exception', updated_at=now()
+                WHERE order_id=%s
+                """,
+                (authority.order_id,),
+            )
+        raise
+
+    return _persist_core_acceptance(
+        conn,
+        authority=authority,
+        broker_order_ref=submission.broker_order_ref,
+        response_digest=submission.response_digest,
+    )
+
+
+def execute_core_rebalance(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    operator_id: UUID,
+    api_key_credential_id: UUID,
+    user_key_credential_id: UUID,
+    recorded_by: str,
+    provider: str = "etoro",
+    environment: str = "demo",
+    clock: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> CoreExecutionResult:
+    """Observe, record, admit and submit one guarded core rebalance.
+
+    The decisive broker observation and preflight happen while submissions are
+    serialised, so a concurrent fill cannot leave this request sizing from a
+    pre-fill snapshot. The durable request UUID, trade, order, proof provenance
+    and reconciliation row commit before the sole mutating broker call.
+    """
+    if conn.info.transaction_status != TransactionStatus.IDLE:
+        raise StrategyCoreExecutionError("core execution requires an idle connection")
+    if environment != "demo":
+        raise StrategyCoreExecutionError("core execution is demo-only")
+
+    # Preliminary DB facts are deliberately re-proved under the submission lock
+    # below. This short transaction exists only to source the broker reads without
+    # keeping row/advisory locks across network I/O.
+    with conn.transaction():
+        mandate = load_core_mandate(conn)
+        if mandate is None or not mandate.enabled or mandate.core_instrument_id is None:
+            raise StrategyCoreExecutionError("an enabled core mandate is required")
+        require_selected_core_instrument(conn, instrument_id=mandate.core_instrument_id)
+        proof = require_core_eligibility(
+            conn,
+            instrument_id=mandate.core_instrument_id,
+            operator_id=operator_id,
+            provider=provider,
+            environment=environment,
+        )
+        if (proof.api_key_credential_id, proof.user_key_credential_id) != (
+            api_key_credential_id,
+            user_key_credential_id,
+        ):
+            raise StrategyCoreExecutionError("loaded broker credentials do not match the eligibility proof")
+
+    request_id: UUID | None = None
+    trade_id: int | None = None
+    order_id: int | None = None
+    amount = Decimal("0")
+    with core_submission_lock(conn):
+        # This observation must be inside the same serialised section as the
+        # mutation. Otherwise request B can observe, wait while request A fills,
+        # then submit a duplicate order from B's still-fresh pre-fill snapshot.
+        try:
+            snapshot = broker.get_account_risk_snapshot()
+            state = observe_core_sleeve(snapshot, core_instrument_id=mandate.core_instrument_id)
+        except Exception as exc:
+            raise StrategyCoreExecutionError("the broker account snapshot could not describe the core sleeve") from exc
+        decision = evaluate_core_rebalance(mandate, state)
+        broker_verdict = None
+        if decision.action in ("buy_core", "sell_core"):
+            broker_verdict = assess_core_broker_preflight(
+                broker,
+                mandate=mandate,
+                decision=decision,
+                core_instrument_id=mandate.core_instrument_id,
+                eligibility_response_currency=proof.response_currency,
+                eligibility_min_position_exposure=proof.min_position_exposure,
+                eligibility_min_position_amount=proof.min_position_amount,
+                clock=clock,
+            )
+        with conn.transaction():
+            current = load_core_mandate(conn)
+            if current is None or not current.enabled or current.core_instrument_id is None:
+                raise StrategyCoreExecutionError("the core mandate changed before submission")
+            if current.event_id != mandate.event_id:
+                raise StrategyCoreExecutionError("the core mandate was revised during broker preflight")
+            require_selected_core_instrument(conn, instrument_id=current.core_instrument_id)
+            intent = record_core_rebalance_intent(conn, state=state, recorded_by=recorded_by)
+            intent_id = intent.core_rebalance_intent_id
+            if intent.decision.action == "hold":
+                return _result("held", intent.decision.reason_code or "core_hold", intent_id=intent_id)
+            if intent.decision.action == "refused":
+                return _result("refused", intent.decision.reason_code or "core_allocator_refused", intent_id=intent_id)
+
+            admission = admit_core_rebalance_intent(
+                conn,
+                intent_id=intent_id,
+                operator_id=operator_id,
+                provider=provider,
+                environment=environment,
+            )
+            if not admission.admitted or admission.eligibility_proof_id is None:
+                return _result("refused", admission.reason_code or "core_submission_refused", intent_id=intent_id)
+            binding_proof = require_core_eligibility(
+                conn,
+                instrument_id=current.core_instrument_id,
+                operator_id=operator_id,
+                provider=provider,
+                environment=environment,
+            )
+            if (
+                binding_proof.proof_id != proof.proof_id
+                or binding_proof.proof_id != admission.eligibility_proof_id
+                or (
+                    binding_proof.api_key_credential_id,
+                    binding_proof.user_key_credential_id,
+                )
+                != (api_key_credential_id, user_key_credential_id)
+            ):
+                return _result("refused", "core_credential_provenance_changed", intent_id=intent_id)
+
+            db_preflight = preflight_core_submission(
+                conn,
+                core_instrument_id=current.core_instrument_id,
+                action=intent.decision.action,
+                now=clock(),
+            )
+            if not db_preflight.admitted:
+                return _result("refused", db_preflight.reason_code or "core_preflight_refused", intent_id=intent_id)
+            if broker_verdict is None or not broker_verdict.admitted:
+                reason = None if broker_verdict is None else broker_verdict.reason_code
+                return _result("refused", reason or "core_broker_preflight_refused", intent_id=intent_id)
+            broker_evidence_age = (
+                None
+                if broker_verdict.snapshot_observed_at is None
+                else (clock() - broker_verdict.snapshot_observed_at).total_seconds()
+            )
+            if broker_evidence_age is None or not (
+                0 <= broker_evidence_age <= broker_verdict.max_account_risk_age_seconds
+            ):
+                return _result("refused", "core_account_risk_stale", intent_id=intent_id)
+
+            amount = broker_verdict.amount
+            request_id = uuid4()
+            trade_row = conn.execute(
+                """
+                INSERT INTO strategy_trades (
+                    core_rebalance_intent_id, core_eligibility_proof_id,
+                    instrument_id, status
+                ) VALUES (%s, %s, %s, 'planned')
+                RETURNING strategy_trade_id
+                """,
+                (intent_id, binding_proof.proof_id, current.core_instrument_id),
+            ).fetchone()
+            if trade_row is None:
+                raise StrategyCoreExecutionError("core trade INSERT did not return an id")
+            trade_id = int(trade_row[0])
+            order_row = conn.execute(
+                """
+                INSERT INTO orders (
+                    instrument_id, action, order_type, requested_amount, status,
+                    raw_payload_json, execution_origin, strategy_request_id
+                ) VALUES (%s, 'BUY', 'MARKET', %s, 'submitted', NULL, 'strategy', %s)
+                RETURNING order_id
+                """,
+                (current.core_instrument_id, amount, request_id),
+            ).fetchone()
+            if order_row is None:
+                raise StrategyCoreExecutionError("core order INSERT did not return an id")
+            order_id = int(order_row[0])
+            link_strategy_order(conn, strategy_trade_id=trade_id, order_id=order_id, purpose="entry")
+            conn.execute(
+                "INSERT INTO strategy_order_reconciliation_state (order_id) VALUES (%s)",
+                (order_id,),
+            )
+
+        if request_id is None or trade_id is None or order_id is None:
+            raise StrategyCoreExecutionError("core submission authority was not persisted")
+        return _submit_core_authority(
+            conn,
+            broker=broker,
+            authority=CoreResumeAuthority(
+                intent_id=intent_id,
+                trade_id=trade_id,
+                order_id=order_id,
+                instrument_id=mandate.core_instrument_id,
+                amount=amount,
+                request_id=request_id,
+                broker_order_ref=None,
+                eligibility_proof_id=binding_proof.proof_id,
+                operator_id=operator_id,
+                api_key_credential_id=api_key_credential_id,
+                user_key_credential_id=user_key_credential_id,
+            ),
+        )
+
+
+__all__ = [
+    "CoreExecutionResult",
+    "CoreResumeAuthority",
+    "StrategyCoreExecutionError",
+    "execute_core_rebalance",
+    "load_core_resume_authority",
+    "resume_core_submission",
+]

--- a/app/services/strategy_order_reconciliation.py
+++ b/app/services/strategy_order_reconciliation.py
@@ -478,8 +478,11 @@ def reconcile_backlog(
             SELECT state.order_id
             FROM strategy_order_reconciliation_state state
             JOIN orders o ON o.order_id = state.order_id
+            JOIN strategy_trade_orders link ON link.order_id=o.order_id
+            JOIN strategy_trades trade ON trade.strategy_trade_id=link.strategy_trade_id
             WHERE state.state NOT IN ('resolved', 'rejected')
               AND o.execution_origin = 'strategy'
+              AND trade.core_rebalance_intent_id IS NULL
             ORDER BY state.first_unresolved_at, state.order_id
             LIMIT %s
             """,

--- a/docs/proposals/ta/2026-08-24-core-cash-operator.md
+++ b/docs/proposals/ta/2026-08-24-core-cash-operator.md
@@ -26,9 +26,18 @@ the server reports `evidence_collecting`, offers no instrument and refuses enabl
 - One server-side selection invariant is called by mandate configuration **and** by the
   acting path while the mandate lock is held. A legacy enabled mandate naming any other
   instrument is refused; checking only the endpoint would be a bypass.
-- `core_submission_lock` spans the DB decision phase: record -> admit -> DB preflight ->
-  durable order authority. The request UUID is committed before mutating broker I/O and
-  reused after uncertainty. No second request identity is generated.
+- `core_submission_lock` spans record -> admit -> DB preflight -> durable order authority
+  -> broker mutation -> durable outcome. The request UUID is committed before mutating
+  broker I/O and reused after uncertainty. Kill-switch activation takes the same lock, so
+  an activation commit cannot race a previously admitted core mutation. No second request
+  identity is generated. Credential revocation/replacement takes that lock as well, so a
+  decrypted credential cannot become revoked during the broker-mutation window.
+- Database statement triggers take the same lock before writes to runtime configuration,
+  execution blocks, the kill switch or broker credentials. This makes the safety boundary
+  apply to every writer and acquires it before any target-row lock.
+- Credential rotation is refused at both the service and database boundary while an
+  unresolved core authority references that exact credential pair; reconciliation must
+  become terminal before the account identity can be removed.
 - Broker mutation remains refused from linked worktrees. The UI calls the main-checkout
   dev API; tests use broker doubles. A real demo acceptance is an attended post-merge
   check only after #2833 passes and the operator has deliberately cleared every gate.
@@ -67,11 +76,11 @@ Authenticated, attended request; no amount or instrument in the body. The server
 
 1. requires global demo configuration and loads the session operator's current demo
    credential ids and secrets. Those exact ids remain attached to the broker handle;
-2. outside a DB transaction, loads the fresh broker account snapshot and informational
-   cost quote inputs. No database lock is held across retryable network I/O;
-3. opens `core_submission_lock` and one short transaction, re-loads the mandate, checks
-   the server selection invariant, observes the already-fetched sleeve and records one
-   immutable intent;
+2. opens `core_submission_lock`, then loads the fresh broker account snapshot and
+   informational cost quote inputs. Holding the lock across these reads prevents a
+   second request from sizing against a snapshot taken before the first request fills;
+3. in one short transaction, re-loads the mandate, checks the server selection
+   invariant, observes the fresh sleeve and records one immutable intent;
 4. admits that exact intent, runs DB/clock preflight, and verifies the admission proof's
    credential ids equal the already-loaded pair. The `FOR SHARE` lock prevents a swap
    until this transaction commits; the broker handle then continues with the exact
@@ -131,6 +140,14 @@ Save, and a separate
 instrument, maximum mandate exposure, demo environment and buy-only limitation. It is
 disabled with visible reasons whenever the server says `can_rebalance=false`. A
 `submitted` result is labelled broker-accepted/pending reconciliation, never filled.
+If an authority is already unresolved, the read model instead exposes its order id and
+labels the sole action `Resume demo order`; that action uses the proof's exact credential
+row identities and original request UUID to reconcile only. A lookup miss remains
+non-terminal because delayed broker visibility cannot prove that an uncertain submission
+had no effect. The unresolved authority continues to block every new rebalance until the
+broker reports a terminal accepted or rejected outcome; resume never submits again.
+Real-environment deployments expose a demo-required blocker rather than an actionable
+button.
 
 Alpha Automation remains separate and disabled when no strategy passed. Core holdings
 continue through the existing positions/P&L panels under the `Core / cash mandate`
@@ -142,7 +159,8 @@ presentation identity.
   enabled eligible-but-unselected mandate), orchestration order,
   every early refusal, hold, accepted buy, explicit rejection, uncertainty, duplicate
   request/reconcile, credential replacement, exact proof provenance, older blocking
-  trades and lock/transaction boundaries.
+  trades and lock/transaction boundaries. The submission lock remains held from final
+  mandate validation through broker mutation and durable outcome persistence.
 - Provider tests for exact core request shape, demo-only refusal, reference mismatch,
   raw payload and unattended guard inventory.
 - API tests for auth, honest collecting state, enable refusal and response shapes.

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -3,6 +3,9 @@ import type {
   AllocationUpdateRequest,
   AllocationUpdateResponse,
   CoreSleeveResponse,
+  CoreMandate,
+  CoreMandateUpdate,
+  CoreRebalanceResponse,
   FiredSignalsResponse,
   StrategyAdvanceResponse,
   StrategyOperatorAction,
@@ -21,6 +24,17 @@ export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
 
 export function fetchCoreSleeve(): Promise<CoreSleeveResponse> {
   return apiFetch("/strategies/core-sleeve");
+}
+
+export function updateCoreMandate(body: CoreMandateUpdate): Promise<CoreMandate> {
+  return apiFetch("/strategies/core-mandate", {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+export function rebalanceCoreSleeve(): Promise<CoreRebalanceResponse> {
+  return apiFetch("/strategies/core-sleeve/rebalance", { method: "POST" });
 }
 
 export function requestStrategyEvidenceRefresh(): Promise<StrategyEvidenceRefreshResponse> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2969,14 +2969,41 @@ export interface CoreSleeveResponse {
   mandate: CoreMandate;
   can_configure: boolean;
   can_rebalance: boolean;
+  can_resume: boolean;
+  pending_order_id: number | null;
+  execution_action: "blocked" | "rebalance" | "resume";
   blockers: Array<{
-    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_submitter_unavailable";
+    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_mandate_selection_mismatch" | "core_demo_required" | "core_order_unresolved";
     detail: string;
   }>;
-  environment: "demo";
+  environment: "demo" | "real";
   buy_only: boolean;
   alpha_input_used: boolean;
   household_tax_caveat: string;
+}
+
+export interface CoreMandateUpdate {
+  enabled: boolean;
+  core_instrument_id: number | null;
+  core_target_pct: string;
+  liquidity_reserve_pct: string;
+  rebalance_band_pct: string;
+  min_rebalance_amount: string;
+  reason: string;
+  provider: "etoro";
+  environment: "demo";
+}
+
+export interface CoreRebalanceResponse {
+  state: "held" | "refused" | "submitted" | "submission_uncertain";
+  reason_code: string;
+  intent_id: number | null;
+  trade_id: number | null;
+  order_id: number | null;
+  amount: string;
+  submission_policy_version: string;
+  preflight_policy_version: string;
+  broker_preflight_policy_version: string;
 }
 
 export interface StrategyPortfolioMandate {

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -107,15 +107,40 @@ const CORE_COLLECTING = {
   mandate: { configured: false },
   can_configure: false,
   can_rebalance: false,
+  can_resume: false,
+  pending_order_id: null,
+  execution_action: "blocked",
   blockers: [
     { code: "core_evidence_collecting", detail: "#2833 has 1 of 5 required trading days; cash remains the fallback." },
     { code: "core_mandate_unconfigured", detail: "No core/cash mandate has been configured." },
-    { code: "core_submitter_unavailable", detail: "Attended demo rebalance submission is not deployed yet." },
   ],
   environment: "demo",
   buy_only: true,
   alpha_input_used: false,
   household_tax_caveat: "A UK ISA at another broker tax-dominates this engine sleeve for eligible household capital.",
+} as const;
+
+const CORE_READY = {
+  ...CORE_COLLECTING,
+  state: "ready",
+  selected_instrument_id: 3417,
+  selected_symbol: "SPY.RTH",
+  evidence_ref: "#2833 verdict",
+  observed_trading_days: 5,
+  mandate: {
+    configured: true,
+    enabled: true,
+    core_instrument_id: 3417,
+    core_target_pct: "80",
+    liquidity_reserve_pct: "10",
+    rebalance_band_pct: "5",
+    min_rebalance_amount: "25",
+  },
+  can_configure: true,
+  can_rebalance: true,
+  can_resume: false,
+  execution_action: "rebalance",
+  blockers: [],
 } as const;
 
 function renderLens() {
@@ -145,6 +170,101 @@ describe("StrategyPortfolioLens", () => {
     expect(screen.getByText("No sleeve adopted")).toBeInTheDocument();
     expect(screen.getByText(/cash remains the fallback/i)).toBeInTheDocument();
     expect(screen.getByText(/UK ISA at another broker tax-dominates/i)).toBeInTheDocument();
+  });
+
+  it("saves a materially changed ready mandate with an explicit audit reason", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue(CORE_READY as never);
+    const save = vi.spyOn(strategiesApi, "updateCoreMandate").mockResolvedValue(CORE_READY.mandate as never);
+    renderLens();
+
+    const target = await screen.findByLabelText("Core target %");
+    await userEvent.clear(target);
+    await userEvent.type(target, "75");
+    await userEvent.type(await screen.findByLabelText("Audit reason"), "Adopt reviewed #2833 sleeve");
+    await userEvent.click(screen.getByRole("button", { name: "Save mandate" }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+    expect(save.mock.calls[0]?.[0]).toMatchObject({
+      enabled: true,
+      core_instrument_id: 3417,
+      core_target_pct: "75",
+      reason: "Adopt reviewed #2833 sleeve",
+      environment: "demo",
+    });
+  });
+
+  it("does not offer a reason-only save for an unchanged configured mandate", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue(CORE_READY as never);
+    renderLens();
+
+    await userEvent.type(await screen.findByLabelText("Audit reason"), "No material change");
+
+    expect(screen.getByRole("button", { name: "Save mandate" })).toBeDisabled();
+  });
+
+  it("cannot confirm a rebalance against unsaved mandate edits", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue(CORE_READY as never);
+    renderLens();
+
+    const target = await screen.findByLabelText("Core target %");
+    await userEvent.clear(target);
+    await userEvent.type(target, "70");
+
+    expect(screen.getByRole("button", { name: "Rebalance demo now" })).toBeDisabled();
+  });
+
+  it("confirms a demo rebalance and labels acceptance as pending reconciliation", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue(CORE_READY as never);
+    const rebalance = vi.spyOn(strategiesApi, "rebalanceCoreSleeve").mockResolvedValue({
+      state: "submitted",
+      reason_code: "broker_accepted_pending_reconciliation",
+      intent_id: 11,
+      trade_id: 21,
+      order_id: 31,
+      amount: "49.9",
+      submission_policy_version: "core-submission-v1",
+      preflight_policy_version: "core-preflight-v2",
+      broker_preflight_policy_version: "core-broker-preflight-v1",
+    });
+    renderLens();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Rebalance demo now" }));
+    expect(rebalance).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: "Confirm demo rebalance" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Broker accepted; fill reconciliation is pending");
+    expect(rebalance).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels an unresolved authority as resume and cannot present it as a new rebalance", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue({
+      ...CORE_READY,
+      can_rebalance: false,
+      can_resume: true,
+      pending_order_id: 31,
+      execution_action: "resume",
+      blockers: [{ code: "core_order_unresolved", detail: "Order 31 is unresolved." }],
+    } as never);
+    const resume = vi.spyOn(strategiesApi, "rebalanceCoreSleeve").mockResolvedValue({
+      state: "held",
+      reason_code: "core_order_reconciled",
+      intent_id: 11,
+      trade_id: 21,
+      order_id: 31,
+      amount: "49.9",
+      submission_policy_version: "core-submission-v1",
+      preflight_policy_version: "core-preflight-v2",
+      broker_preflight_policy_version: "core-broker-preflight-v1",
+    });
+    renderLens();
+
+    expect(await screen.findByText("Order 31 is unresolved.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Rebalance demo now" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Resume demo order" }));
+    expect(screen.getByRole("heading", { name: "Resume demo order 31?" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Confirm resume" }));
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole("status")).toHaveTextContent("existing broker order was reconciled");
   });
 
   it("states what is blocking as facts, and offers the control for the one that has one", async () => {

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -7,8 +7,10 @@ import {
   fetchStrategyOverview,
   fetchStrategyOwnedPositions,
   fetchStrategyPnlHistory,
+  rebalanceCoreSleeve,
+  updateCoreMandate,
 } from "@/api/strategies";
-import type { StrategyOverviewResponse, StrategyOwnedPosition } from "@/api/types";
+import type { CoreSleeveResponse, StrategyOverviewResponse, StrategyOwnedPosition } from "@/api/types";
 import { ApiError } from "@/api/client";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { StatTile } from "@/components/dashboard/StatTile";
@@ -66,6 +68,167 @@ function BlockerRow({
       </span>
       {action}
     </div>
+  );
+}
+
+function CoreSleeveControl({
+  sleeve,
+  busy,
+  setBusy,
+  onError,
+  onUpdated,
+}: {
+  sleeve: CoreSleeveResponse;
+  busy: boolean;
+  setBusy: (busy: boolean) => void;
+  onError: (message: string | null) => void;
+  onUpdated: () => void;
+}) {
+  const mandate = sleeve.mandate;
+  const [enabled, setEnabled] = useState(mandate.enabled ?? false);
+  const [target, setTarget] = useState(mandate.core_target_pct ?? "80");
+  const [reserve, setReserve] = useState(mandate.liquidity_reserve_pct ?? "10");
+  const [band, setBand] = useState(mandate.rebalance_band_pct ?? "5");
+  const [minimum, setMinimum] = useState(mandate.min_rebalance_amount ?? "25");
+  const [reason, setReason] = useState("");
+  const [confirmRebalance, setConfirmRebalance] = useState(false);
+  const [outcome, setOutcome] = useState<string | null>(null);
+  const showMandate = sleeve.can_configure || mandate.configured;
+  const mandateDirty =
+    enabled !== (mandate.enabled ?? false) ||
+    Number(target) !== Number(mandate.core_target_pct ?? "80") ||
+    Number(reserve) !== Number(mandate.liquidity_reserve_pct ?? "10") ||
+    Number(band) !== Number(mandate.rebalance_band_pct ?? "5") ||
+    Number(minimum) !== Number(mandate.min_rebalance_amount ?? "25");
+
+  async function saveMandate() {
+    setBusy(true);
+    onError(null);
+    setOutcome(null);
+    try {
+      await updateCoreMandate({
+        enabled,
+        core_instrument_id: sleeve.selected_instrument_id ?? mandate.core_instrument_id,
+        core_target_pct: target,
+        liquidity_reserve_pct: reserve,
+        rebalance_band_pct: band,
+        min_rebalance_amount: minimum,
+        reason: reason.trim(),
+        provider: "etoro",
+        environment: "demo",
+      });
+      setReason("");
+      onUpdated();
+    } catch (error) {
+      onError(error instanceof ApiError ? error.message : "The core mandate could not be saved.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function rebalance() {
+    setBusy(true);
+    onError(null);
+    setOutcome(null);
+    try {
+      const result = await rebalanceCoreSleeve();
+      const label =
+        result.state === "submitted"
+          ? "Broker accepted; fill reconciliation is pending."
+          : result.state === "submission_uncertain"
+            ? "Submission outcome is uncertain; reconciliation is required before retrying."
+            : result.reason_code === "core_order_reconciled"
+              ? "The existing broker order was reconciled; holdings and fill state have been refreshed."
+              : result.state === "held"
+                ? "No trade required; the sleeve remains inside its band."
+              : `Rebalance refused: ${result.reason_code}.`;
+      setOutcome(label);
+      onUpdated();
+    } catch (error) {
+      onError(error instanceof ApiError ? error.message : "The demo rebalance could not be evaluated.");
+    } finally {
+      setBusy(false);
+      setConfirmRebalance(false);
+    }
+  }
+
+  return (
+    <>
+      {showMandate ? (
+        <div className="mt-5 border-t border-slate-200 pt-4 dark:border-slate-800">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              ["Core target %", target, setTarget],
+              ["Cash reserve %", reserve, setReserve],
+              ["Rebalance band %", band, setBand],
+              ["Minimum amount", minimum, setMinimum],
+            ].map(([label, value, setter]) => (
+              <label key={label as string} className="text-xs font-medium text-slate-600 dark:text-slate-300">
+                {label as string}
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={value as string}
+                  onChange={(event) => (setter as (value: string) => void)(event.target.value)}
+                  className="mt-1 min-h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-950"
+                />
+              </label>
+            ))}
+          </div>
+          <label className="mt-3 flex min-h-11 items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={enabled}
+              disabled={!sleeve.can_configure && !enabled}
+              onChange={(event) => setEnabled(event.target.checked)}
+            />
+            Enable demo core sleeve
+          </label>
+          <label className="mt-3 block text-xs font-medium text-slate-600 dark:text-slate-300">
+            Audit reason
+            <input
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              className="mt-1 min-h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-950"
+            />
+          </label>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={busy || reason.trim().length === 0 || (enabled && !sleeve.can_configure) || (mandate.configured && !mandateDirty)}
+              onClick={() => void saveMandate()}
+              className="min-h-11 rounded-md border border-slate-300 px-3 text-sm font-medium disabled:opacity-50 dark:border-slate-700"
+            >
+              {busy ? "Saving…" : "Save mandate"}
+            </button>
+            <button
+              type="button"
+              disabled={busy || (!sleeve.can_rebalance && !sleeve.can_resume) || (!sleeve.can_resume && mandateDirty)}
+              onClick={() => setConfirmRebalance(true)}
+              className="min-h-11 rounded-md bg-sky-700 px-3 text-sm font-medium text-white disabled:opacity-50"
+            >
+              {sleeve.can_resume ? "Resume demo order" : "Rebalance demo now"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+      {outcome ? <p role="status" className="mt-3 text-sm text-slate-700 dark:text-slate-200">{outcome}</p> : null}
+      <Modal isOpen={confirmRebalance} onRequestClose={() => setConfirmRebalance(false)} labelledBy="core-rebalance-title">
+        <h2 id="core-rebalance-title" className="text-base font-semibold">
+          {sleeve.can_resume ? `Resume demo order ${sleeve.pending_order_id}?` : `Rebalance ${sleeve.selected_symbol} in demo?`}
+        </h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          {sleeve.can_resume
+            ? "The server will look up and reconcile the already-authorised order using its original request ID and account credentials. It cannot create a second order."
+            : `The server will size within the ${target}% core mandate and every live guard. This path can buy only; it cannot sell or use alpha signals.`}
+        </p>
+        <div className="mt-4 flex justify-end gap-2">
+          <button type="button" onClick={() => setConfirmRebalance(false)} className="min-h-11 rounded-md border border-slate-300 px-3 text-sm dark:border-slate-700">Cancel</button>
+          <button type="button" disabled={busy} onClick={() => void rebalance()} className="min-h-11 rounded-md bg-sky-700 px-3 text-sm font-medium text-white disabled:opacity-50">{busy ? "Evaluating…" : sleeve.can_resume ? "Confirm resume" : "Confirm demo rebalance"}</button>
+        </div>
+      </Modal>
+    </>
   );
 }
 
@@ -259,6 +422,18 @@ export function StrategyPortfolioLens() {
               <p className="mt-4 border-t border-slate-200 pt-3 text-xs text-slate-500 dark:border-slate-800">
                 Demo only · buy only · no alpha signal. {coreSleeve.data.household_tax_caveat}
               </p>
+              <CoreSleeveControl
+                sleeve={coreSleeve.data}
+                busy={busy}
+                setBusy={setBusy}
+                onError={setActionError}
+                onUpdated={() => {
+                  void coreSleeve.refetch();
+                  void ownedPositions.refetch();
+                  void overview.refetch();
+                  void pnlHistory.refetch();
+                }}
+              />
             </section>
           ) : null}
           <AutomationControl overview={data} onUpdated={overview.refetch} />

--- a/sql/371_core_trade_account_provenance.sql
+++ b/sql/371_core_trade_account_provenance.sql
@@ -1,0 +1,20 @@
+-- 371_core_trade_account_provenance.sql
+--
+-- #2603 attended core submitter. A core trade must retain the exact eligibility
+-- proof whose credential ids were held and compared before broker I/O. The
+-- signal arm has different deployment provenance and must not claim this field.
+
+ALTER TABLE strategy_trades
+    ADD COLUMN IF NOT EXISTS core_eligibility_proof_id BIGINT
+        REFERENCES strategy_core_eligibility_proofs(core_eligibility_proof_id)
+        ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_trades_core_eligibility_proof
+    ON strategy_trades (core_eligibility_proof_id)
+    WHERE core_eligibility_proof_id IS NOT NULL;
+
+COMMENT ON COLUMN strategy_trades.core_eligibility_proof_id IS
+    'Exact account-specific proof admitted by the attended core executor. Nullable '
+    'for historical/directly-seeded rows; the production writer always supplies it. The proof retains '
+    'the api_key/user_key credential row ids; reconciliation must use those ids '
+    'rather than inheriting whichever account is current later.';

--- a/sql/372_core_submission_safety_serialization.sql
+++ b/sql/372_core_submission_safety_serialization.sql
@@ -1,0 +1,36 @@
+-- Serialize every durable safety-control change against core broker mutation.
+-- Statement-level BEFORE triggers acquire the advisory lock before PostgreSQL
+-- takes any target-row lock, preserving the executor's lock order.
+
+CREATE OR REPLACE FUNCTION serialize_core_submission_safety_write()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(2603, 3);
+    RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_core_safety_runtime_config ON runtime_config;
+CREATE TRIGGER trg_core_safety_runtime_config
+BEFORE INSERT OR UPDATE OR DELETE ON runtime_config
+FOR EACH STATEMENT EXECUTE FUNCTION serialize_core_submission_safety_write();
+
+DROP TRIGGER IF EXISTS trg_core_safety_execution_blocks ON strategy_execution_blocks;
+CREATE TRIGGER trg_core_safety_execution_blocks
+BEFORE INSERT OR UPDATE OR DELETE ON strategy_execution_blocks
+FOR EACH STATEMENT EXECUTE FUNCTION serialize_core_submission_safety_write();
+
+DROP TRIGGER IF EXISTS trg_core_safety_kill_switch ON kill_switch;
+CREATE TRIGGER trg_core_safety_kill_switch
+BEFORE INSERT OR UPDATE OR DELETE ON kill_switch
+FOR EACH STATEMENT EXECUTE FUNCTION serialize_core_submission_safety_write();
+
+DROP TRIGGER IF EXISTS trg_core_safety_broker_credentials ON broker_credentials;
+CREATE TRIGGER trg_core_safety_broker_credentials
+BEFORE INSERT OR UPDATE OR DELETE ON broker_credentials
+FOR EACH STATEMENT EXECUTE FUNCTION serialize_core_submission_safety_write();
+
+COMMENT ON FUNCTION serialize_core_submission_safety_write() IS
+    'Orders safety-control writes before core broker mutation using advisory key (2603,3).';

--- a/sql/373_core_unresolved_credential_guard.sql
+++ b/sql/373_core_unresolved_credential_guard.sql
@@ -1,0 +1,37 @@
+-- An unresolved core order can be looked up only through the exact account
+-- recorded on its immutable eligibility proof. Do not allow any writer to
+-- revoke/delete either credential until reconciliation is terminal.
+
+CREATE OR REPLACE FUNCTION prevent_unresolved_core_credential_removal()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' AND NOT (OLD.revoked_at IS NULL AND NEW.revoked_at IS NOT NULL) THEN
+        RETURN NEW;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM strategy_core_eligibility_proofs proof
+        JOIN strategy_trades trade
+          ON trade.core_eligibility_proof_id=proof.core_eligibility_proof_id
+        JOIN strategy_trade_orders link ON link.strategy_trade_id=trade.strategy_trade_id
+        JOIN strategy_order_reconciliation_state state ON state.order_id=link.order_id
+        WHERE OLD.id IN (proof.api_key_credential_id, proof.user_key_credential_id)
+          AND state.state NOT IN ('resolved','rejected')
+    ) THEN
+        RAISE EXCEPTION 'credential is required by an unresolved core order'
+            USING ERRCODE = '23503';
+    END IF;
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_unresolved_core_credential_removal ON broker_credentials;
+CREATE TRIGGER trg_prevent_unresolved_core_credential_removal
+BEFORE UPDATE OF revoked_at OR DELETE ON broker_credentials
+FOR EACH ROW EXECUTE FUNCTION prevent_unresolved_core_credential_removal();
+
+COMMENT ON FUNCTION prevent_unresolved_core_credential_removal() IS
+    'Keeps exact account credentials available until every referencing core order is reconciled.';

--- a/tests/test_2603_core_executor.py
+++ b/tests/test_2603_core_executor.py
@@ -1,0 +1,412 @@
+"""#2603 attended core executor orchestration; broker and DB are deterministic doubles."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import contextmanager, nullcontext
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+from psycopg.pq import TransactionStatus
+
+from app.providers.broker import (
+    BrokerCoreOrderSubmission,
+    BrokerOrderNotFound,
+    BrokerOrderSubmissionError,
+    BrokerOrderSubmissionUncertain,
+)
+from app.services.broker_credentials import CredentialInUse, revoke_credential
+from app.services.strategy_core_executor import (
+    CoreExecutionResult,
+    CoreResumeAuthority,
+    execute_core_rebalance,
+    resume_core_submission,
+)
+
+OPERATOR = UUID("73d8ad78-3062-4ef5-8f0a-7428865e23d7")
+API_CREDENTIAL = UUID("ba39f751-d4bd-4553-ab25-d9acbb73fbe8")
+USER_CREDENTIAL = UUID("f7306e0b-9494-415e-85fd-97874510cc83")
+
+
+class FakeResult:
+    def __init__(self, row: tuple[int] | None = None) -> None:
+        self._row = row
+
+    def fetchone(self) -> tuple[int] | None:
+        return self._row
+
+
+class FakeConn:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.info = SimpleNamespace(transaction_status=TransactionStatus.IDLE)
+
+    def transaction(self) -> nullcontext[None]:
+        return nullcontext()
+
+    def commit(self) -> None:
+        return None
+
+    def execute(self, sql: str, _params: object = None) -> FakeResult:
+        normalized = " ".join(sql.split())
+        if normalized.startswith("INSERT INTO strategy_trades"):
+            self.events.append("persist_trade")
+            return FakeResult((21,))
+        if normalized.startswith("INSERT INTO orders"):
+            self.events.append("persist_order")
+            return FakeResult((31,))
+        if normalized.startswith("INSERT INTO strategy_order_reconciliation_state"):
+            self.events.append("persist_reconciliation")
+        if normalized.startswith("UPDATE orders SET broker_order_ref"):
+            self.events.append("persist_acceptance")
+        if "state='rejected'" in normalized:
+            self.events.append("persist_rejection")
+        if "state='error'" in normalized:
+            self.events.append("persist_uncertainty")
+        return FakeResult()
+
+
+class FakeBroker:
+    def __init__(self, events: list[str], submission: object) -> None:
+        self.events = events
+        self.submission = submission
+
+    def get_account_risk_snapshot(self) -> object:
+        self.events.append("read_snapshot")
+        return object()
+
+    def place_demo_core_order(self, _order: object, *, request_id: UUID) -> BrokerCoreOrderSubmission:
+        assert request_id is not None
+        assert "persist_order" in self.events
+        assert "persist_reconciliation" in self.events
+        self.events.append("broker_submit")
+        if isinstance(self.submission, Exception):
+            raise self.submission
+        assert isinstance(self.submission, BrokerCoreOrderSubmission)
+        return self.submission
+
+
+@contextmanager
+def _tracking_lock(events: list[str]):
+    events.append("lock_enter")
+    try:
+        yield
+    finally:
+        events.append("lock_exit")
+
+
+def _decision(action: str = "buy_core") -> SimpleNamespace:
+    return SimpleNamespace(action=action, reason_code="within_band" if action == "hold" else None)
+
+
+def _run(
+    submission: object,
+    *,
+    action: str = "buy_core",
+    snapshot_observed_at: datetime | None = None,
+    clock: Callable[[], datetime] | None = None,
+    binding_proof_id: int = 7,
+) -> tuple[CoreExecutionResult, list[str]]:
+    events: list[str] = []
+    conn = FakeConn(events)
+    mandate = SimpleNamespace(event_id=1, enabled=True, core_instrument_id=3417)
+    proof = SimpleNamespace(
+        proof_id=7,
+        api_key_credential_id=API_CREDENTIAL,
+        user_key_credential_id=USER_CREDENTIAL,
+        response_currency="USD",
+        min_position_exposure=Decimal("10"),
+        min_position_amount=Decimal("10"),
+    )
+    binding_proof = SimpleNamespace(**{**proof.__dict__, "proof_id": binding_proof_id})
+    decision = _decision(action)
+    intent = SimpleNamespace(core_rebalance_intent_id=11, decision=decision)
+    admission = SimpleNamespace(admitted=True, eligibility_proof_id=7, reason_code=None)
+    db_preflight = SimpleNamespace(admitted=True, reason_code=None)
+    broker_preflight = SimpleNamespace(
+        admitted=True,
+        reason_code=None,
+        amount=Decimal("49.9"),
+        snapshot_observed_at=snapshot_observed_at or datetime.now(UTC),
+        max_account_risk_age_seconds=30,
+    )
+
+    with (
+        patch("app.services.strategy_core_executor.load_core_mandate", return_value=mandate),
+        patch("app.services.strategy_core_executor.require_selected_core_instrument"),
+        patch("app.services.strategy_core_executor.require_core_eligibility", side_effect=[proof, binding_proof]),
+        patch("app.services.strategy_core_executor.observe_core_sleeve", return_value=object()),
+        patch("app.services.strategy_core_executor.evaluate_core_rebalance", return_value=decision),
+        patch("app.services.strategy_core_executor.assess_core_broker_preflight", return_value=broker_preflight),
+        patch("app.services.strategy_core_executor.core_submission_lock", return_value=_tracking_lock(events)),
+        patch("app.services.strategy_core_executor.record_core_rebalance_intent", return_value=intent),
+        patch("app.services.strategy_core_executor.admit_core_rebalance_intent", return_value=admission),
+        patch("app.services.strategy_core_executor.preflight_core_submission", return_value=db_preflight),
+        patch(
+            "app.services.strategy_core_executor.link_strategy_order",
+            side_effect=lambda *_a, **_k: events.append("link"),
+        ),
+    ):
+        kwargs = {} if clock is None else {"clock": clock}
+        result = execute_core_rebalance(
+            conn,  # type: ignore[arg-type]
+            broker=FakeBroker(events, submission),  # type: ignore[arg-type]
+            operator_id=OPERATOR,
+            api_key_credential_id=API_CREDENTIAL,
+            user_key_credential_id=USER_CREDENTIAL,
+            recorded_by="operator",
+            **kwargs,  # type: ignore[arg-type]
+        )
+    return result, events
+
+
+def test_acceptance_identity_is_persisted_after_authority_commits() -> None:
+    result, events = _run(
+        BrokerCoreOrderSubmission(
+            broker_order_ref="9001",
+            reference_id=UUID("bd779053-d550-4bb4-9f8d-f3b2fa5633ac"),
+            response_digest="a" * 64,
+        )
+    )
+
+    assert result.state == "submitted"
+    assert result.reason_code == "broker_accepted_pending_reconciliation"
+    assert events.index("persist_order") < events.index("broker_submit") < events.index("persist_acceptance")
+    assert events.index("lock_enter") < events.index("broker_submit") < events.index("lock_exit")
+
+
+@pytest.mark.parametrize(
+    ("error", "state", "evidence_event"),
+    [
+        (BrokerOrderSubmissionError("rejected"), "refused", "persist_rejection"),
+        (BrokerOrderSubmissionUncertain("timeout"), "submission_uncertain", "persist_uncertainty"),
+    ],
+)
+def test_rejection_and_uncertainty_have_distinct_durable_outcomes(
+    error: Exception,
+    state: str,
+    evidence_event: str,
+) -> None:
+    result, events = _run(error)
+
+    assert result.state == state
+    assert evidence_event in events
+
+
+def test_hold_records_an_intent_without_creating_or_submitting_an_order() -> None:
+    result, events = _run(AssertionError("must not submit"), action="hold")
+
+    assert result.state == "held"
+    assert result.intent_id == 11
+    assert "persist_order" not in events
+    assert "broker_submit" not in events
+
+
+def test_snapshot_that_expires_while_waiting_for_the_lock_is_not_submitted() -> None:
+    observed = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+    result, events = _run(
+        AssertionError("must not submit"),
+        snapshot_observed_at=observed,
+        clock=lambda: datetime(2026, 8, 24, 12, 1, tzinfo=UTC),
+    )
+
+    assert result.state == "refused"
+    assert result.reason_code == "core_account_risk_stale"
+    assert "broker_submit" not in events
+
+
+def test_eligibility_refresh_during_broker_preflight_is_not_submitted() -> None:
+    result, events = _run(AssertionError("must not submit"), binding_proof_id=8)
+
+    assert result.state == "refused"
+    assert result.reason_code == "core_credential_provenance_changed"
+    assert "broker_submit" not in events
+
+
+def test_credential_revocation_takes_the_core_mutation_lock() -> None:
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (False,)
+    cursor.rowcount = 1
+    conn.cursor.return_value.__enter__.return_value = cursor
+
+    revoke_credential(conn, credential_id=API_CREDENTIAL, operator_id=OPERATOR)
+
+    lock_call = conn.execute.call_args_list[0]
+    assert "pg_advisory_xact_lock" in lock_call.args[0]
+    assert lock_call.args[1] == (2603, 3)
+
+
+def test_credential_rotation_is_refused_while_core_reconciliation_needs_it() -> None:
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (True,)
+    conn.cursor.return_value.__enter__.return_value = cursor
+
+    with pytest.raises(CredentialInUse, match="unresolved core order"):
+        revoke_credential(conn, credential_id=API_CREDENTIAL, operator_id=OPERATOR)
+
+    assert all("UPDATE broker_credentials" not in call.args[0] for call in cursor.execute.call_args_list)
+
+
+def test_resume_keeps_the_committed_authority_unresolved_when_not_found() -> None:
+    events: list[str] = []
+    conn = FakeConn(events)
+    authority = CoreResumeAuthority(
+        intent_id=11,
+        trade_id=21,
+        order_id=31,
+        instrument_id=3417,
+        amount=Decimal("49.9"),
+        request_id=UUID("bd779053-d550-4bb4-9f8d-f3b2fa5633ac"),
+        broker_order_ref=None,
+        eligibility_proof_id=7,
+        operator_id=OPERATOR,
+        api_key_credential_id=API_CREDENTIAL,
+        user_key_credential_id=USER_CREDENTIAL,
+    )
+    broker = MagicMock()
+    broker.lookup_order.side_effect = BrokerOrderNotFound("not found")
+    broker.place_demo_core_order.return_value = BrokerCoreOrderSubmission(
+        broker_order_ref="9001",
+        reference_id=authority.request_id,
+        response_digest="a" * 64,
+    )
+    with (
+        patch("app.services.strategy_core_executor.core_submission_lock", return_value=nullcontext()),
+        patch("app.services.strategy_core_executor.load_core_resume_authority", return_value=authority),
+        patch(
+            "app.services.strategy_core_executor.reconcile_strategy_order",
+            return_value=SimpleNamespace(state="not_found"),
+        ),
+        patch(
+            "app.services.strategy_core_executor.load_core_mandate",
+            return_value=SimpleNamespace(enabled=True, core_instrument_id=3417),
+        ),
+        patch("app.services.strategy_core_executor.require_selected_core_instrument"),
+        patch(
+            "app.services.strategy_core_executor.require_core_eligibility",
+            return_value=SimpleNamespace(
+                proof_id=7,
+                api_key_credential_id=API_CREDENTIAL,
+                user_key_credential_id=USER_CREDENTIAL,
+                response_currency="USD",
+                min_position_exposure=Decimal("10"),
+                min_position_amount=Decimal("10"),
+            ),
+        ),
+        patch("app.services.strategy_core_executor.observe_core_sleeve", return_value=object()),
+        patch(
+            "app.services.strategy_core_executor.evaluate_core_rebalance",
+            return_value=SimpleNamespace(action="buy_core"),
+        ),
+        patch(
+            "app.services.strategy_core_executor.assess_core_broker_preflight",
+            return_value=SimpleNamespace(admitted=True, reason_code=None, amount=authority.amount),
+        ),
+        patch(
+            "app.services.strategy_core_executor.preflight_core_submission",
+            return_value=SimpleNamespace(admitted=True, reason_code=None),
+        ),
+    ):
+        result = resume_core_submission(conn, broker=broker, authority=authority)  # type: ignore[arg-type]
+
+    assert result.state == "submission_uncertain"
+    assert result.reason_code == "core_order_reconciliation_not_found"
+    broker.place_demo_core_order.assert_not_called()
+
+
+def test_resume_reconciles_a_found_order_without_resubmitting() -> None:
+    events: list[str] = []
+    conn = FakeConn(events)
+    authority = CoreResumeAuthority(
+        intent_id=11,
+        trade_id=21,
+        order_id=31,
+        instrument_id=3417,
+        amount=Decimal("49.9"),
+        request_id=UUID("bd779053-d550-4bb4-9f8d-f3b2fa5633ac"),
+        broker_order_ref=None,
+        eligibility_proof_id=7,
+        operator_id=OPERATOR,
+        api_key_credential_id=API_CREDENTIAL,
+        user_key_credential_id=USER_CREDENTIAL,
+    )
+    broker = MagicMock()
+    reconcile = MagicMock(return_value=SimpleNamespace(state="resolved"))
+    with (
+        patch("app.services.strategy_core_executor.core_submission_lock", return_value=nullcontext()),
+        patch("app.services.strategy_core_executor.load_core_resume_authority", return_value=authority),
+        patch("app.services.strategy_core_executor.reconcile_strategy_order", reconcile),
+    ):
+        result = resume_core_submission(conn, broker=broker, authority=authority)  # type: ignore[arg-type]
+
+    assert result.reason_code == "core_order_reconciled"
+    reconcile.assert_called_once_with(conn, broker=broker, order_id=31)
+    broker.place_demo_core_order.assert_not_called()
+
+
+def test_resume_lookup_miss_never_reaches_fresh_safety_or_resubmission() -> None:
+    events: list[str] = []
+    conn = FakeConn(events)
+    authority = CoreResumeAuthority(
+        intent_id=11,
+        trade_id=21,
+        order_id=31,
+        instrument_id=3417,
+        amount=Decimal("49.9"),
+        request_id=UUID("bd779053-d550-4bb4-9f8d-f3b2fa5633ac"),
+        broker_order_ref=None,
+        eligibility_proof_id=7,
+        operator_id=OPERATOR,
+        api_key_credential_id=API_CREDENTIAL,
+        user_key_credential_id=USER_CREDENTIAL,
+    )
+    broker = MagicMock()
+    broker.lookup_order.side_effect = BrokerOrderNotFound("not found")
+    with (
+        patch("app.services.strategy_core_executor.core_submission_lock", return_value=nullcontext()),
+        patch("app.services.strategy_core_executor.load_core_resume_authority", return_value=authority),
+        patch(
+            "app.services.strategy_core_executor.reconcile_strategy_order",
+            return_value=SimpleNamespace(state="not_found"),
+        ),
+        patch(
+            "app.services.strategy_core_executor.load_core_mandate",
+            return_value=SimpleNamespace(enabled=True, core_instrument_id=3417),
+        ),
+        patch("app.services.strategy_core_executor.require_selected_core_instrument"),
+        patch(
+            "app.services.strategy_core_executor.require_core_eligibility",
+            return_value=SimpleNamespace(
+                proof_id=7,
+                api_key_credential_id=API_CREDENTIAL,
+                user_key_credential_id=USER_CREDENTIAL,
+                response_currency="USD",
+                min_position_exposure=Decimal("10"),
+                min_position_amount=Decimal("10"),
+            ),
+        ),
+        patch("app.services.strategy_core_executor.observe_core_sleeve", return_value=object()),
+        patch(
+            "app.services.strategy_core_executor.evaluate_core_rebalance",
+            return_value=SimpleNamespace(action="buy_core"),
+        ),
+        patch(
+            "app.services.strategy_core_executor.assess_core_broker_preflight",
+            return_value=SimpleNamespace(admitted=True, reason_code=None, amount=authority.amount),
+        ),
+        patch(
+            "app.services.strategy_core_executor.preflight_core_submission",
+            return_value=SimpleNamespace(admitted=False, reason_code="core_kill_switch_active"),
+        ),
+    ):
+        result = resume_core_submission(conn, broker=broker, authority=authority)  # type: ignore[arg-type]
+
+    assert result.state == "submission_uncertain"
+    assert result.reason_code == "core_order_reconciliation_not_found"
+    broker.place_demo_core_order.assert_not_called()

--- a/tests/test_2603_core_executor_db.py
+++ b/tests/test_2603_core_executor_db.py
@@ -1,0 +1,27 @@
+"""#2603 durable account provenance for core trades, against migrated Postgres."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+
+
+def test_core_trade_proof_column_references_the_immutable_evidence_table(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    row = ebull_test_conn.execute(
+        """
+        SELECT pg_get_constraintdef(c.oid)
+        FROM pg_constraint c
+        WHERE c.conrelid='strategy_trades'::regclass
+          AND c.contype='f'
+          AND pg_get_constraintdef(c.oid) LIKE '%core_eligibility_proof_id%'
+        ORDER BY c.conname
+        LIMIT 1
+        """
+    ).fetchone()
+    assert row is not None
+    definition = str(row[0])
+    assert "strategy_core_eligibility_proofs" in definition
+    assert "ON DELETE RESTRICT" in definition

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -17,11 +17,13 @@ service tests cannot see:
 from __future__ import annotations
 
 import inspect
+from contextlib import nullcontext
 from decimal import Decimal
 from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 from fastapi.params import Depends as DependsParam
 from fastapi.routing import APIRoute
 
@@ -29,19 +31,23 @@ from app.api.strategies import (
     CoreMandateUpdateRequest,
     _core_mandate_response,
     read_core_sleeve,
+    rebalance_core_sleeve,
     router,
     update_core_mandate,
 )
 from app.services.broker_credentials import (
     CredentialValidationError,
+    LoadedCredential,
     normalise_environment,
     normalise_provider,
 )
+from app.services.strategy_core_executor import CoreExecutionResult, CoreResumeAuthority
 from app.services.strategy_core_mandate import CoreMandate
 from app.services.strategy_core_selection import CoreCandidateCoverage, CoreSelection
 
 CORE_MANDATE_PATH = "/strategies/core-mandate"
 CORE_SLEEVE_PATH = "/strategies/core-sleeve"
+CORE_REBALANCE_PATH = "/strategies/core-sleeve/rebalance"
 
 
 def _routes() -> list[APIRoute]:
@@ -99,6 +105,11 @@ class TestTheRouteTable:
         paths = [route.path for route in _routes()]
         first_param_route = next(index for index, path in enumerate(paths) if "{strategy_id}" in path)
         assert paths.index(CORE_SLEEVE_PATH) < first_param_route
+        assert paths.index(CORE_REBALANCE_PATH) < first_param_route
+
+    def test_the_attended_rebalance_is_post_only(self) -> None:
+        methods = {method for route in _routes() if route.path == CORE_REBALANCE_PATH for method in route.methods}
+        assert methods == {"POST"}
 
 
 def test_collecting_state_reports_cash_and_server_derived_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -120,17 +131,171 @@ def test_collecting_state_reports_cash_and_server_derived_coverage(monkeypatch: 
     )
     monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
     monkeypatch.setattr("app.api.strategies.load_core_mandate", lambda _conn: None)
+    monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: None)
     response = read_core_sleeve(cast(Any, MagicMock()))
     assert response.state == "evidence_collecting"
     assert response.selected_instrument_id is None
     assert response.observed_trading_days == 1
     assert response.can_configure is False
     assert response.can_rebalance is False
+    assert response.can_resume is False
+    assert response.execution_action == "blocked"
     assert [blocker.code for blocker in response.blockers] == [
         "core_evidence_collecting",
         "core_mandate_unconfigured",
-        "core_submitter_unavailable",
     ]
+
+
+def test_rebalance_passes_the_exact_loaded_credential_ids_to_the_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from uuid import UUID
+
+    api = LoadedCredential(UUID("ba39f751-d4bd-4553-ab25-d9acbb73fbe8"), "api-secret")
+    user = LoadedCredential(UUID("f7306e0b-9494-415e-85fd-97874510cc83"), "user-secret")
+    monkeypatch.setattr("app.api.strategies.ensure_broker_key_loaded", lambda _conn: True)
+    monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: None)
+    monkeypatch.setattr(
+        "app.api.strategies.load_credential_with_id_for_provider_use",
+        MagicMock(side_effect=[api, user]),
+    )
+    execute = MagicMock(return_value=CoreExecutionResult("held", "within_band", 11, None, None, Decimal("0")))
+    monkeypatch.setattr("app.api.strategies.execute_core_rebalance", execute)
+
+    class BrokerContext:
+        def __enter__(self) -> object:
+            return object()
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    monkeypatch.setattr("app.api.strategies.EtoroBrokerProvider", lambda **_kwargs: BrokerContext())
+    conn = MagicMock()
+    conn.transaction.return_value = nullcontext()
+    request = MagicMock()
+    request.app.state.audit_pool = None
+    session = MagicMock(operator_id=UUID("73d8ad78-3062-4ef5-8f0a-7428865e23d7"), username="operator")
+
+    response = rebalance_core_sleeve(request=request, session=session, conn=cast(Any, conn))
+
+    assert response.state == "held"
+    assert response.submission_policy_version == "core-submission-v1"
+    assert response.preflight_policy_version == "core-preflight-v2"
+    assert response.broker_preflight_policy_version == "core-broker-preflight-v1"
+    assert execute.call_args.kwargs["api_key_credential_id"] == api.id
+    assert execute.call_args.kwargs["user_key_credential_id"] == user.id
+
+
+def test_operator_view_labels_an_unresolved_order_as_resume_not_rebalance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from uuid import UUID
+
+    selection = CoreSelection(
+        state="ready",
+        selected_instrument_id=3417,
+        selected_symbol="SPY.RTH",
+        evidence_ref="#2833 verdict",
+        required_trading_days=5,
+        observed_trading_days=5,
+        max_cost_bps=60,
+        candidates=(),
+        missing_candidate_ids=(),
+        configuration_error=None,
+    )
+    authority = CoreResumeAuthority(
+        intent_id=11,
+        trade_id=21,
+        order_id=31,
+        instrument_id=3417,
+        amount=Decimal("49.9"),
+        request_id=UUID("bd779053-d550-4bb4-9f8d-f3b2fa5633ac"),
+        broker_order_ref=None,
+        eligibility_proof_id=7,
+        operator_id=UUID("73d8ad78-3062-4ef5-8f0a-7428865e23d7"),
+        api_key_credential_id=UUID("ba39f751-d4bd-4553-ab25-d9acbb73fbe8"),
+        user_key_credential_id=UUID("f7306e0b-9494-415e-85fd-97874510cc83"),
+    )
+    monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
+    monkeypatch.setattr("app.api.strategies.load_core_mandate", lambda _conn: _mandate(core_instrument_id=3417))
+    monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: authority)
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "demo")
+
+    response = read_core_sleeve(cast(Any, MagicMock()))
+
+    assert response.can_rebalance is False
+    assert response.can_resume is True
+    assert response.execution_action == "resume"
+    assert response.pending_order_id == 31
+    assert [blocker.code for blocker in response.blockers] == ["core_order_unresolved"]
+
+
+def test_operator_view_refuses_a_mandate_for_the_previous_reviewed_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selection = CoreSelection(
+        state="ready",
+        selected_instrument_id=3434,
+        selected_symbol="CSPX.L",
+        evidence_ref="#2833 revised verdict",
+        required_trading_days=5,
+        observed_trading_days=5,
+        max_cost_bps=60,
+        candidates=(),
+        missing_candidate_ids=(),
+        configuration_error=None,
+    )
+    monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
+    monkeypatch.setattr("app.api.strategies.load_core_mandate", lambda _conn: _mandate(core_instrument_id=3417))
+    monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: None)
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "demo")
+
+    response = read_core_sleeve(cast(Any, MagicMock()))
+
+    assert response.can_rebalance is False
+    assert response.execution_action == "blocked"
+    assert [blocker.code for blocker in response.blockers] == ["core_mandate_selection_mismatch"]
+
+
+def test_resume_refuses_credentials_from_a_different_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from uuid import UUID
+
+    authority = CoreResumeAuthority(
+        intent_id=11,
+        trade_id=21,
+        order_id=31,
+        instrument_id=3417,
+        amount=Decimal("49.9"),
+        request_id=UUID("bd779053-d550-4bb4-9f8d-f3b2fa5633ac"),
+        broker_order_ref=None,
+        eligibility_proof_id=7,
+        operator_id=UUID("73d8ad78-3062-4ef5-8f0a-7428865e23d7"),
+        api_key_credential_id=UUID("ba39f751-d4bd-4553-ab25-d9acbb73fbe8"),
+        user_key_credential_id=UUID("f7306e0b-9494-415e-85fd-97874510cc83"),
+    )
+    replacement = LoadedCredential(UUID("c05aa4fd-984b-47d0-a823-3728d95041fb"), "replacement")
+    monkeypatch.setattr("app.api.strategies.ensure_broker_key_loaded", lambda _conn: True)
+    monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: authority)
+    monkeypatch.setattr(
+        "app.api.strategies.load_credential_with_id_for_provider_use",
+        MagicMock(return_value=replacement),
+    )
+    broker_factory = MagicMock()
+    monkeypatch.setattr("app.api.strategies.EtoroBrokerProvider", broker_factory)
+    conn = MagicMock()
+    conn.transaction.return_value = nullcontext()
+    request = MagicMock()
+    request.app.state.audit_pool = None
+    session = MagicMock(operator_id=UUID("73d8ad78-3062-4ef5-8f0a-7428865e23d7"), username="operator")
+
+    with pytest.raises(HTTPException) as raised:
+        rebalance_core_sleeve(request=request, session=session, conn=cast(Any, conn))
+
+    assert raised.value.status_code == 409
+    assert "different account" in str(raised.value.detail)
+    broker_factory.assert_not_called()
 
 
 class TestTheAuthDependency:
@@ -166,6 +331,16 @@ class TestTheAuthDependency:
             if isinstance(parameter.default, DependsParam) and parameter.default.dependency is not None
         }
         assert declared, "no Depends markers on the endpoint — this test can no longer fail"
+        assert "require_session" in declared
+
+    def test_the_rebalance_route_requires_a_named_session(self) -> None:
+        signature = inspect.signature(rebalance_core_sleeve)
+        declared = {
+            parameter.default.dependency.__name__
+            for parameter in signature.parameters.values()
+            if isinstance(parameter.default, DependsParam) and parameter.default.dependency is not None
+        }
+        assert declared
         assert "require_session" in declared
 
 

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -18,10 +18,12 @@ import httpx
 import pytest
 
 from app.providers.broker import (
+    BrokerCoreOrder,
     BrokerMirror,
     BrokerMirrorPosition,
     BrokerOrderNotFound,
     BrokerOrderSubmissionError,
+    BrokerOrderSubmissionUncertain,
     BrokerPortfolio,
     BrokerPositionMutationError,
     BrokerStrategyOrder,
@@ -685,6 +687,67 @@ class TestDemoStrategyOrder:
                 pass
             else:  # pragma: no cover
                 raise AssertionError("real credentials must not reach the paper writer")
+
+
+class TestDemoCoreOrder:
+    def test_writer_is_demo_only_buy_x1_real_usd_without_synthetic_exits(self) -> None:
+        request_id = UUID("1c94300c-90aa-4303-9d00-dec376d74efb")
+        raw = {
+            "token": "066faaee-e1e9-49d2-a568-c6e1cc336ad8",
+            "orderId": 13902598,
+            "referenceId": str(request_id),
+        }
+        response = MagicMock()
+        response.json.return_value = raw
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.post.return_value = response
+            result = broker.place_demo_core_order(
+                BrokerCoreOrder(instrument_id=3417, amount=Decimal("250")),
+                request_id=request_id,
+            )
+            call = broker._http_write.post.call_args
+
+        assert call.args[0] == "/api/v2/trading/execution/demo/orders"
+        assert call.kwargs["headers"] == {"x-request-id": str(request_id)}
+        assert call.kwargs["json"] == {
+            "action": "open",
+            "transaction": "buy",
+            "instrumentId": 3417,
+            "settlementType": "real",
+            "orderType": "mkt",
+            "leverage": 1,
+            "amount": 250.0,
+            "orderCurrency": "usd",
+        }
+        assert result.broker_order_ref == "13902598"
+        assert result.reference_id == request_id
+        assert result.response_digest == "0caf67206160f1c97554b988d9ff09aa6bec3813df377e1fc4aeb8f2f231c513"
+        assert not hasattr(result, "token")
+
+    def test_real_credentials_cannot_select_the_core_writer(self) -> None:
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="real") as broker:
+            with pytest.raises(BrokerOrderSubmissionError, match="demo credentials"):
+                broker.place_demo_core_order(
+                    BrokerCoreOrder(instrument_id=3417, amount=Decimal("250")),
+                    request_id=uuid4(),
+                )
+
+    def test_reference_mismatch_is_uncertain(self) -> None:
+        response = MagicMock()
+        response.json.return_value = {
+            "token": "066faaee-e1e9-49d2-a568-c6e1cc336ad8",
+            "orderId": 13902598,
+            "referenceId": str(uuid4()),
+        }
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.post.return_value = response
+            with pytest.raises(BrokerOrderSubmissionUncertain, match="does not match"):
+                broker.place_demo_core_order(
+                    BrokerCoreOrder(instrument_id=3417, amount=Decimal("250")),
+                    request_id=uuid4(),
+                )
 
 
 class TestDemoStrategyPositionMutations:

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -725,6 +725,16 @@ class TestDemoCoreOrder:
         assert result.response_digest == "0caf67206160f1c97554b988d9ff09aa6bec3813df377e1fc4aeb8f2f231c513"
         assert not hasattr(result, "token")
 
+    def test_writer_refuses_an_amount_that_would_change_in_json(self) -> None:
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            with pytest.raises(BrokerOrderSubmissionError, match="represented exactly"):
+                broker.place_demo_core_order(
+                    BrokerCoreOrder(instrument_id=3417, amount=Decimal("9007199254.740991")),
+                    request_id=uuid4(),
+                )
+            broker._http_write.post.assert_not_called()
+
     def test_real_credentials_cannot_select_the_core_writer(self) -> None:
         with EtoroBrokerProvider(api_key="k", user_key="u", env="real") as broker:
             with pytest.raises(BrokerOrderSubmissionError, match="demo credentials"):

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -579,10 +579,12 @@ class TestKillSwitch:
 
         result = activate_kill_switch(conn, reason="data corruption", activated_by="ops", now=_NOW)
 
-        # The UPDATE happens through the second cursor; the audit INSERT is the
-        # only conn.execute() call.
-        assert conn.execute.call_count == 1
-        audit_call = conn.execute.call_args_list[0]
+        # Activation first serialises with a core broker mutation, then writes
+        # the audit row. The kill-switch UPDATE uses the second cursor.
+        assert conn.execute.call_count == 2
+        lock_call, audit_call = conn.execute.call_args_list
+        assert "pg_advisory_xact_lock" in lock_call[0][0]
+        assert lock_call[0][1] == (2603, 3)
         assert "INSERT INTO runtime_config_audit" in audit_call[0][0]
         assert audit_call[0][1]["field"] == "kill_switch"
         assert audit_call[0][1]["new"] == "true"
@@ -615,8 +617,10 @@ class TestKillSwitch:
 
         deactivate_kill_switch(conn, deactivated_by="ops", reason="resolved", now=_NOW)
 
-        assert conn.execute.call_count == 2
-        update_call, audit_call = conn.execute.call_args_list
+        assert conn.execute.call_count == 3
+        lock_call, update_call, audit_call = conn.execute.call_args_list
+        assert "pg_advisory_xact_lock" in lock_call[0][0]
+        assert lock_call[0][1] == (2603, 3)
         # Order matters: UPDATE must precede the audit INSERT so the audit row
         # records committed state, not a speculative future state.
         assert "UPDATE kill_switch" in update_call[0][0]

--- a/tests/test_unattended_broker_mutation_guard.py
+++ b/tests/test_unattended_broker_mutation_guard.py
@@ -57,6 +57,7 @@ _MUTATING: Final[frozenset[str]] = frozenset(
         "close_demo_strategy_position",
         "close_position",
         "edit_demo_strategy_position",
+        "place_demo_core_order",
         "place_demo_strategy_order",
         "place_order",
     }


### PR DESCRIPTION
## Summary
- make the Portfolio core/cash sleeve configurable and actionable from the page
- add attended demo-only allocation, durable order authority, exact account/proof provenance, and reconciliation-only resume
- serialize broker mutation against mandate and safety changes; refuse stale, changed, real-environment, or unresolved authority
- retain the honest #2833 evidence gate, so the live page cannot submit until selection reaches its verdict

## Verification
- required `codex exec review --base origin/main`: clean
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not db"` (9,799 passed, 14 skipped)
- `uv run pytest tests/smoke` (161 passed, 3 skipped)
- `uv run pytest tests/test_2603_core_executor_db.py tests/smoke/test_schema_drift.py -q`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend test:unit` (1,617 passed)
- `pnpm --dir frontend dark:check`
- `pnpm --dir frontend pills:check`
- repository pre-push gates

Refs #2603
Refs #2833