### PR TITLE
fix(#2603): expose draft core mandate setup

### DIFF
--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -172,6 +172,34 @@ describe("StrategyPortfolioLens", () => {
     expect(screen.getByText(/UK ISA at another broker tax-dominates/i)).toBeInTheDocument();
   });
 
+  it("lets the operator save a disabled draft while evidence is still collecting", async () => {
+    const save = vi.spyOn(strategiesApi, "updateCoreMandate").mockResolvedValue({
+      configured: true,
+      enabled: false,
+      core_instrument_id: null,
+      core_target_pct: "80",
+      liquidity_reserve_pct: "10",
+      rebalance_band_pct: "5",
+      min_rebalance_amount: "25",
+    } as never);
+    renderLens();
+
+    expect(await screen.findByText(/Save these values as a disabled draft now/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Enable demo core sleeve")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Rebalance demo now" })).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText("Audit reason"), "Prepare the core mandate before selection");
+    await userEvent.click(screen.getByRole("button", { name: "Save mandate" }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+    expect(save.mock.calls[0]?.[0]).toMatchObject({
+      enabled: false,
+      core_instrument_id: null,
+      core_target_pct: "80",
+      reason: "Prepare the core mandate before selection",
+    });
+  });
+
   it("saves a materially changed ready mandate with an explicit audit reason", async () => {
     vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue(CORE_READY as never);
     const save = vi.spyOn(strategiesApi, "updateCoreMandate").mockResolvedValue(CORE_READY.mandate as never);

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -173,6 +173,24 @@ describe("StrategyPortfolioLens", () => {
   });
 
   it("lets the operator save a disabled draft while evidence is still collecting", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve)
+      .mockResolvedValueOnce(CORE_COLLECTING as never)
+      .mockResolvedValue({
+        ...CORE_COLLECTING,
+        mandate: {
+          configured: true,
+          enabled: false,
+          core_instrument_id: null,
+          core_target_pct: "80",
+          liquidity_reserve_pct: "10",
+          rebalance_band_pct: "5",
+          min_rebalance_amount: "25",
+        },
+        blockers: [
+          CORE_COLLECTING.blockers[0],
+          { code: "core_mandate_disabled", detail: "The current core/cash mandate is disabled." },
+        ],
+      } as never);
     const save = vi.spyOn(strategiesApi, "updateCoreMandate").mockResolvedValue({
       configured: true,
       enabled: false,
@@ -198,6 +216,9 @@ describe("StrategyPortfolioLens", () => {
       core_target_pct: "80",
       reason: "Prepare the core mandate before selection",
     });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save mandate" })).toBeDisabled());
+    await userEvent.click(screen.getByRole("button", { name: "Save mandate" }));
+    expect(save).toHaveBeenCalledTimes(1);
   });
 
   it("saves a materially changed ready mandate with an explicit audit reason", async () => {

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -93,7 +93,6 @@ function CoreSleeveControl({
   const [reason, setReason] = useState("");
   const [confirmRebalance, setConfirmRebalance] = useState(false);
   const [outcome, setOutcome] = useState<string | null>(null);
-  const showMandate = sleeve.can_configure || mandate.configured;
   const mandateDirty =
     enabled !== (mandate.enabled ?? false) ||
     Number(target) !== Number(mandate.core_target_pct ?? "80") ||
@@ -108,7 +107,7 @@ function CoreSleeveControl({
     try {
       await updateCoreMandate({
         enabled,
-        core_instrument_id: sleeve.selected_instrument_id ?? mandate.core_instrument_id,
+        core_instrument_id: sleeve.selected_instrument_id ?? mandate.core_instrument_id ?? null,
         core_target_pct: target,
         liquidity_reserve_pct: reserve,
         rebalance_band_pct: band,
@@ -154,65 +153,69 @@ function CoreSleeveControl({
 
   return (
     <>
-      {showMandate ? (
-        <div className="mt-5 border-t border-slate-200 pt-4 dark:border-slate-800">
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {[
-              ["Core target %", target, setTarget],
-              ["Cash reserve %", reserve, setReserve],
-              ["Rebalance band %", band, setBand],
-              ["Minimum amount", minimum, setMinimum],
-            ].map(([label, value, setter]) => (
-              <label key={label as string} className="text-xs font-medium text-slate-600 dark:text-slate-300">
-                {label as string}
-                <input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={value as string}
-                  onChange={(event) => (setter as (value: string) => void)(event.target.value)}
-                  className="mt-1 min-h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-950"
-                />
-              </label>
-            ))}
-          </div>
-          <label className="mt-3 flex min-h-11 items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={enabled}
-              disabled={!sleeve.can_configure && !enabled}
-              onChange={(event) => setEnabled(event.target.checked)}
-            />
-            Enable demo core sleeve
-          </label>
-          <label className="mt-3 block text-xs font-medium text-slate-600 dark:text-slate-300">
-            Audit reason
-            <input
-              value={reason}
-              onChange={(event) => setReason(event.target.value)}
-              className="mt-1 min-h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-950"
-            />
-          </label>
-          <div className="mt-3 flex flex-wrap gap-2">
-            <button
-              type="button"
-              disabled={busy || reason.trim().length === 0 || (enabled && !sleeve.can_configure) || (mandate.configured && !mandateDirty)}
-              onClick={() => void saveMandate()}
-              className="min-h-11 rounded-md border border-slate-300 px-3 text-sm font-medium disabled:opacity-50 dark:border-slate-700"
-            >
-              {busy ? "Saving…" : "Save mandate"}
-            </button>
-            <button
-              type="button"
-              disabled={busy || (!sleeve.can_rebalance && !sleeve.can_resume) || (!sleeve.can_resume && mandateDirty)}
-              onClick={() => setConfirmRebalance(true)}
-              className="min-h-11 rounded-md bg-sky-700 px-3 text-sm font-medium text-white disabled:opacity-50"
-            >
-              {sleeve.can_resume ? "Resume demo order" : "Rebalance demo now"}
-            </button>
-          </div>
+      <div className="mt-5 border-t border-slate-200 pt-4 dark:border-slate-800">
+        {!sleeve.can_configure ? (
+          <p className="mb-3 text-xs text-slate-500">
+            Save these values as a disabled draft now. Enabling and demo rebalancing remain locked until the core instrument passes #2833.
+          </p>
+        ) : null}
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {[
+            ["Core target %", target, setTarget],
+            ["Cash reserve %", reserve, setReserve],
+            ["Rebalance band %", band, setBand],
+            ["Minimum amount", minimum, setMinimum],
+          ].map(([label, value, setter]) => (
+            <label key={label as string} className="text-xs font-medium text-slate-600 dark:text-slate-300">
+              {label as string}
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={value as string}
+                onChange={(event) => (setter as (value: string) => void)(event.target.value)}
+                className="mt-1 min-h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-950"
+              />
+            </label>
+          ))}
         </div>
-      ) : null}
+        <label className="mt-3 flex min-h-11 items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            disabled={!sleeve.can_configure && !enabled}
+            onChange={(event) => setEnabled(event.target.checked)}
+            className="disabled:cursor-not-allowed disabled:opacity-50"
+          />
+          Enable demo core sleeve
+        </label>
+        <label className="mt-3 block text-xs font-medium text-slate-600 dark:text-slate-300">
+          Audit reason
+          <input
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            className="mt-1 min-h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm dark:border-slate-700 dark:bg-slate-950"
+          />
+        </label>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            disabled={busy || reason.trim().length === 0 || (enabled && !sleeve.can_configure) || (mandate.configured && !mandateDirty)}
+            onClick={() => void saveMandate()}
+            className="min-h-11 rounded-md border border-slate-300 px-3 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700"
+          >
+            {busy ? "Saving…" : "Save mandate"}
+          </button>
+          <button
+            type="button"
+            disabled={busy || (!sleeve.can_rebalance && !sleeve.can_resume) || (!sleeve.can_resume && mandateDirty)}
+            onClick={() => setConfirmRebalance(true)}
+            className="min-h-11 rounded-md bg-sky-700 px-3 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {sleeve.can_resume ? "Resume demo order" : "Rebalance demo now"}
+          </button>
+        </div>
+      </div>
       {outcome ? <p role="status" className="mt-3 text-sm text-slate-700 dark:text-slate-200">{outcome}</p> : null}
       <Modal isOpen={confirmRebalance} onRequestClose={() => setConfirmRebalance(false)} labelledBy="core-rebalance-title">
         <h2 id="core-rebalance-title" className="text-base font-semibold">


### PR DESCRIPTION
## Issue reference

Refs #2603.

## Summary

Makes the Portfolio page actionable during #2833 evidence collection by exposing the backend-supported disabled core-mandate draft. Enablement and demo execution remain gated on a reviewed instrument selection.

## Changes

- Always render core target, reserve, band, minimum, and audit-reason controls.
- Permit only a disabled, instrument-free draft while `can_configure=false`; keep Enable and Rebalance visibly disabled with the gate explained.
- Add a regression test for the collecting-state draft payload.

## Security and audit model

No execution path touched. The existing backend rejects enabled mandates before #2833 selection, and the rebalance control remains disabled. Draft writes still require an authenticated session and an audit reason.

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest -m "not db"` — 9,800 passed, 14 skipped
- [x] `uv run pytest tests/smoke` — 161 passed, 3 skipped
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend test:unit` — 1,618 passed
- [x] pre-push dark/pill/chart and repository chokepoint gates