### PR TITLE
fix(#2525): enforce shared core capital boundary

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -997,6 +997,7 @@ class CoreSleeveBlockerResponse(BaseModel):
         "core_demo_required",
         "core_order_unresolved",
         "core_capital_authority_incomplete",
+        "core_live_snapshot_required",
         "core_paper_pool_unconfigured",
         "core_paper_pool_disabled",
         "core_sandbox_exceeded",
@@ -3526,7 +3527,7 @@ def read_core_sleeve(
     elif capital_authority.core_active_position_ids:
         blockers.append(
             CoreSleeveBlockerResponse(
-                code="core_capital_authority_incomplete",
+                code="core_live_snapshot_required",
                 detail=(
                     "Active core commitment needs an exact broker snapshot; "
                     "the read-only page cannot advertise rebalance headroom."

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -52,7 +52,7 @@ from app.services.strategy_base_currency import (
     DEPLOYMENT_CURRENCY_UNSUPPORTED,
     SUPPORTED_DEPLOYMENT_CURRENCIES,
 )
-from app.services.strategy_capital_sandbox import sandbox_bound
+from app.services.strategy_capital_sandbox import sandbox_bound, sandbox_headroom
 from app.services.strategy_control_plane import (
     PAPER_ALLOCATOR_ADVISORY_LOCK,
     StrategyControlError,
@@ -88,6 +88,10 @@ from app.services.strategy_core_selection import (
     CoreSelectionError,
     load_core_selection,
 )
+from app.services.strategy_engine_capital import (
+    EngineCapitalObservationError,
+    load_engine_capital_authority,
+)
 from app.services.strategy_live_gate import (
     REQUIRED_KILL_DRILLS,
     LiveGateReport,
@@ -110,7 +114,6 @@ from app.services.strategy_monitoring import (
     load_fire_rate,
     load_owned_pnl,
     pool_owned_pnl_by_strategy,
-    realised_pnl_for_keys,
 )
 from app.services.strategy_operator_promotion import (
     EvidenceRow,
@@ -650,6 +653,7 @@ class StrategyPaperPoolView(BaseModel):
     reserved_capital: Decimal
     invested_capital: Decimal | None
     remaining_capital: Decimal | None
+    capital_observation_complete: bool
     mandate: StrategyPortfolioMandateView
     available_mandates: list[StrategyPortfolioMandateView]
 
@@ -992,6 +996,10 @@ class CoreSleeveBlockerResponse(BaseModel):
         "core_mandate_selection_mismatch",
         "core_demo_required",
         "core_order_unresolved",
+        "core_capital_authority_incomplete",
+        "core_paper_pool_unconfigured",
+        "core_paper_pool_disabled",
+        "core_sandbox_exceeded",
     ]
     detail: str
 
@@ -2212,15 +2220,12 @@ def get_strategy_overview(
     # Current versions only: a strategy_version is a rule set, so pooling two
     # would average two arithmetics into one rate (#2670's lesson).
     fire_rate_by_strategy = load_fire_rate(conn, versions=scan_version_values)
-    # ⚠⚠ THE DEPLOYMENT VERSIONS STAY IN THE FILTER — `realised_pnl_for_keys`
-    # reads this same dict at `paper_deployment_keys` for the capital base, and
-    # its own docstring is why: *"Old strategy versions remain part of the shared
-    # pot after they are retired; limiting this calculation to the current
-    # manifest would make realised gains or losses disappear from the capital
-    # base."* Dropping them would not raise — a missing key defaults to
-    # `StrategyPnl()`, whose `reconciled_realised_pnl` is 0 with no incomplete
-    # reason, so a deployed strategy's realised P&L would read as a confident
-    # zero.
+    # ⚠⚠ THE DEPLOYMENT VERSIONS STAY IN THE FILTER. The per-strategy card
+    # below still pools owned P&L over every deployed version, including retired
+    # ones. Dropping them would not raise: a missing key defaults to
+    # `StrategyPnl()`, so a deployed strategy's realised P&L would read as a
+    # confident zero. The shared capital service separately owns the sandbox's
+    # cross-arm realised-P&L calculation.
     #
     # ⚠ That the lookup succeeds at all also fixes the basis question here: the
     # rows are keyed by `strategy_signals.strategy_version`, so a deployment key
@@ -2236,6 +2241,15 @@ def get_strategy_overview(
     control_by_strategy = load_control_state(conn, versions=version_values)
     entry_block = load_entry_block_state(conn)
     paper_pool = load_paper_pool(conn)
+    capital_observation_failed = False
+    try:
+        engine_capital = load_engine_capital_authority(conn)
+    except EngineCapitalObservationError:
+        # Monitoring remains available when the exact capital population is not.
+        # Every derived money field below is withheld, so this cannot advertise
+        # headroom while the execution paths fail closed on the same condition.
+        engine_capital = None
+        capital_observation_failed = True
     account_equity = load_account_equity_evidence(
         conn,
         environment=cast(Literal["demo", "real"], settings.etoro_env),
@@ -2557,15 +2571,25 @@ def get_strategy_overview(
                 next_operator_action_refusals=list(next_operator_action_refusals),
             )
         )
-    reserved_total = sum((item.allocation.reserved_capital for item in strategies), Decimal("0"))
+    reserved_total = (
+        Decimal("0")
+        if engine_capital is None
+        else engine_capital.alpha_committed
+        + engine_capital.core_pending_committed
+        + engine_capital.core_active_recorded_committed
+    )
     invested_values = [item.allocation.invested_capital for item in strategies]
     invested_total = (
         sum((value for value in invested_values if value is not None), Decimal("0"))
-        if all(value is not None for value in invested_values)
+        if not capital_observation_failed
+        and all(value is not None for value in invested_values)
+        and (engine_capital is None or not engine_capital.core_active_position_ids)
         else None
     )
-    paper_realised = realised_pnl_for_keys(pnl_by_strategy, paper_deployment_keys)
-    realised_delta = None if paper_realised is None else sum(paper_realised.values(), Decimal("0"))
+    capital_observation_complete = not capital_observation_failed and (
+        engine_capital is None or not engine_capital.core_active_position_ids
+    )
+    realised_delta = None if engine_capital is None else engine_capital.realised_delta
     # One arithmetic with the executor and the withdrawal check (#2844). This figure
     # is what the card promises the operator as headroom, so a private copy here
     # could advertise capacity the executor refuses — with both internally
@@ -2649,9 +2673,10 @@ def get_strategy_overview(
             invested_capital=invested_total,
             remaining_capital=(
                 max(effective_pool_capital - reserved_total, Decimal("0"))
-                if effective_pool_capital is not None
+                if effective_pool_capital is not None and capital_observation_complete
                 else None
             ),
+            capital_observation_complete=capital_observation_complete,
             mandate=StrategyPortfolioMandateView(
                 configured=paper_pool.mandate.configured,
                 policy_version=paper_pool.mandate.policy_version,
@@ -3472,6 +3497,58 @@ def read_core_sleeve(
     mandate = load_core_mandate(conn)
     resume_authority = load_core_resume_authority(conn)
     blockers: list[CoreSleeveBlockerResponse] = []
+    capital_ready = False
+    try:
+        capital_authority = load_engine_capital_authority(conn)
+    except EngineCapitalObservationError as exc:
+        capital_authority = None
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_capital_authority_incomplete",
+                detail=f"The assigned-capital boundary is incomplete: {exc}",
+            )
+        )
+    if capital_authority is None:
+        if not any(item.code == "core_capital_authority_incomplete" for item in blockers):
+            blockers.append(
+                CoreSleeveBlockerResponse(
+                    code="core_paper_pool_unconfigured",
+                    detail="Assign a paper pot before core execution can be enabled.",
+                )
+            )
+    elif not capital_authority.enabled:
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_paper_pool_disabled",
+                detail="The assigned paper pot is disabled; existing holdings remain owned but no entry is allowed.",
+            )
+        )
+    elif capital_authority.core_active_position_ids:
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_capital_authority_incomplete",
+                detail=(
+                    "Active core commitment needs an exact broker snapshot; "
+                    "the read-only page cannot advertise rebalance headroom."
+                ),
+            )
+        )
+    else:
+        recorded_commitment = capital_authority.alpha_committed + capital_authority.core_pending_committed
+        recorded_headroom = sandbox_headroom(
+            capital_limit=capital_authority.capital_limit,
+            capital_mode=capital_authority.capital_mode,
+            realised_delta=capital_authority.realised_delta,
+            committed=recorded_commitment,
+        )
+        capital_ready = recorded_headroom.within_bound and recorded_headroom.remaining > 0
+        if not capital_ready:
+            blockers.append(
+                CoreSleeveBlockerResponse(
+                    code="core_sandbox_exceeded",
+                    detail="The assigned paper pot has no deployable core headroom; no new core entry is allowed.",
+                )
+            )
     if not selection.ready:
         if selection.configuration_error is not None:
             blockers.append(
@@ -3548,6 +3625,7 @@ def read_core_sleeve(
         and mandate.enabled
         and mandate.core_instrument_id == selection.selected_instrument_id
         and settings.etoro_env == "demo"
+        and capital_ready
     )
     can_rebalance = base_ready and resume_authority is None
     can_resume = settings.etoro_env == "demo" and resume_authority is not None

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -438,6 +438,23 @@ class BrokerPortfolio:
 
 
 @dataclass(frozen=True)
+class BrokerDirectPositionInvestment:
+    """One exact direct-position contribution from the account P&L snapshot.
+
+    Identity is carried alongside the two source terms so ownership filtering can
+    never fall back to instrument matching and the derived mark remains auditable.
+    """
+
+    position_id: int
+    instrument_id: int
+    is_buy: bool
+    amount: Decimal
+    unrealized_pnl: Decimal
+    market_value: Decimal
+    is_partially_altered: bool
+
+
+@dataclass(frozen=True)
 class BrokerInstrumentInvestment:
     """What this account holds in one instrument, under TWO different questions.
 
@@ -506,6 +523,9 @@ class BrokerAccountRiskSnapshot:
     instrument_investments: tuple[BrokerInstrumentInvestment, ...]
     observed_at: datetime
     raw_payload: dict[str, Any]
+    #: Exact direct rows are optional only for non-eToro/test producers. A core
+    #: observer with active ownership fails closed when its ids are absent.
+    direct_positions: tuple[BrokerDirectPositionInvestment, ...] = ()
     account_currency_id: int | None = None
     #: Capital committed to orders that have not filled.  eToro SUBTRACTS this from
     #: ``credit`` to reach ``available_cash`` and ADDS it to ``total_invested``, so a

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -33,6 +33,7 @@ from app.providers.broker import (
     BrokerCoreOrder,
     BrokerCoreOrderSubmission,
     BrokerCostComponent,
+    BrokerDirectPositionInvestment,
     BrokerEligibilityResponse,
     BrokerInstrumentEligibility,
     BrokerInstrumentInvestment,
@@ -1279,7 +1280,11 @@ def _parse_account_risk_snapshot(
         return value
 
     def _instrument_id(parent: dict[str, Any]) -> int:
-        raw_id = parent.get("instrumentId", parent.get("instrumentID"))
+        documented = parent.get("instrumentId")
+        legacy = parent.get("instrumentID")
+        if documented is not None and legacy is not None and documented != legacy:
+            raise TradingPreflightParseError("account P&L instrument id aliases disagree")
+        raw_id = documented if documented is not None else legacy
         if raw_id is None:
             raise TradingPreflightParseError("account P&L instrument id is required")
         try:
@@ -1288,6 +1293,37 @@ def _parse_account_risk_snapshot(
             raise TradingPreflightParseError("account P&L instrument id is required") from exc
         if value <= 0:
             raise TradingPreflightParseError("account P&L instrument id must be positive")
+        return value
+
+    def _position_id(parent: dict[str, Any]) -> int:
+        def validated(value: object) -> int:
+            # The portal schema says integer. Do not let bool or int(1.2) become
+            # an exact ownership identity by Python coercion.
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TradingPreflightParseError("account P&L position id must be an integer")
+            if value <= 0 or value > 9_223_372_036_854_775_807:
+                raise TradingPreflightParseError("account P&L position id is outside signed BIGINT range")
+            return value
+
+        has_documented = "positionId" in parent
+        has_legacy = "positionID" in parent
+        if not has_documented and not has_legacy:
+            raise TradingPreflightParseError("account P&L position id must be an integer")
+        documented = validated(parent["positionId"]) if has_documented else None
+        legacy = validated(parent["positionID"]) if has_legacy else None
+        if documented is not None and legacy is not None and documented != legacy:
+            raise TradingPreflightParseError("account P&L position id aliases disagree")
+        if documented is not None:
+            return documented
+        assert legacy is not None
+        return legacy
+
+    def _is_partially_altered(row: dict[str, Any]) -> bool:
+        if "isPartiallyAltered" not in row:
+            raise TradingPreflightParseError("account P&L position isPartiallyAltered is required")
+        value = row["isPartiallyAltered"]
+        if not isinstance(value, bool):
+            raise TradingPreflightParseError("account P&L position isPartiallyAltered must be a boolean")
         return value
 
     def _is_buy(row: dict[str, Any]) -> bool:
@@ -1350,6 +1386,8 @@ def _parse_account_risk_snapshot(
         direct_long_value: dict[int, Decimal] = {}
         direct_long_count: dict[int, int] = {}
         direct_short_count: dict[int, int] = {}
+        direct_positions: list[BrokerDirectPositionInvestment] = []
+        direct_position_ids: set[int] = set()
         total_invested = Decimal("0")
         unrealized = Decimal("0")
 
@@ -1358,7 +1396,24 @@ def _parse_account_risk_snapshot(
             amount = _money(row, "amount")
             pnl = _money(_row(row.get("unrealizedPnL"), "positions.unrealizedPnL"), "pnL")
             instrument_id = _instrument_id(row)
+            position_id = _position_id(row)
+            if position_id in direct_position_ids:
+                raise TradingPreflightParseError("account P&L direct position ids must be unique")
+            direct_position_ids.add(position_id)
             is_buy = _is_buy(row)
+            is_partially_altered = _is_partially_altered(row)
+            market_value = amount + pnl
+            direct_positions.append(
+                BrokerDirectPositionInvestment(
+                    position_id=position_id,
+                    instrument_id=instrument_id,
+                    is_buy=is_buy,
+                    amount=amount,
+                    unrealized_pnl=pnl,
+                    market_value=market_value,
+                    is_partially_altered=is_partially_altered,
+                )
+            )
             total_invested += amount
             unrealized += pnl
             investments[instrument_id] = investments.get(instrument_id, Decimal("0")) + amount
@@ -1366,7 +1421,7 @@ def _parse_account_risk_snapshot(
                 # `amount + pnL` is this position's contribution to the equity
                 # identity, and for a long holding that IS its market value --
                 # cross-checked against our independent quote feed (#2704).
-                direct_long_value[instrument_id] = direct_long_value.get(instrument_id, Decimal("0")) + amount + pnl
+                direct_long_value[instrument_id] = direct_long_value.get(instrument_id, Decimal("0")) + market_value
                 direct_long_count[instrument_id] = direct_long_count.get(instrument_id, 0) + 1
             else:
                 direct_short_count[instrument_id] = direct_short_count.get(instrument_id, 0) + 1
@@ -1425,6 +1480,7 @@ def _parse_account_risk_snapshot(
                 )
                 for instrument_id, amount in sorted(investments.items())
             ),
+            direct_positions=tuple(direct_positions),
             observed_at=observed_at,
             raw_payload=raw,
             account_currency_id=account_currency_id,

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -333,55 +333,42 @@ def configure_paper_pool(
         raise StrategyControlError(
             "paper pool change must alter enabled state, capital limit, capital mode, mandate, or approval mode"
         )
-    if current.event_id is not None and capital_limit < current.capital_limit:
-        # A lower principal is an external withdrawal from the virtual sleeve,
-        # not merely a cosmetic limit edit.  It cannot remove money already
-        # committed to an allocated lifecycle.  Realised losses reduce the
-        # withdrawable balance; known profits count only in compound mode.
-        committed_row = conn.execute(
-            """
-            SELECT COALESCE(SUM(decision.amount), 0)
-            FROM strategy_funding_decisions decision
-            WHERE decision.verdict='allocated'
-              AND EXISTS (
-                  SELECT 1 FROM strategy_deployments deployment
-                  WHERE deployment.deployment_id=decision.deployment_id
-                    AND deployment.mode='paper'
-              )
-              AND (
-                  NOT EXISTS (
-                      SELECT 1 FROM strategy_trades trade
-                      WHERE trade.funding_decision_id=decision.funding_decision_id
-                  )
-                  OR EXISTS (
-                      SELECT 1 FROM strategy_trades trade
-                      WHERE trade.funding_decision_id=decision.funding_decision_id
-                        AND trade.status NOT IN ('closed', 'failed')
-                  )
-              )
-            """
-        ).fetchone()
-        assert committed_row is not None
-        committed = Decimal(str(committed_row[0]))
-        if committed:
-            # Local import keeps the governance module independent at import
-            # time while reusing the exact-owned, fail-closed reconciliation.
-            from app.services.strategy_monitoring import load_paper_realised_pnl
+    if current.event_id is not None and (
+        capital_limit != current.capital_limit or capital_mode != current.capital_mode
+    ):
+        # A mode switch can shrink the effective bound without changing principal
+        # (compound profit stops counting in capped mode), so every limit OR mode
+        # edit is checked against the same engine-wide authority as both executors.
+        from app.services.strategy_engine_capital import (
+            EngineCapitalObservationError,
+            load_engine_capital_authority,
+        )
 
-            realised = load_paper_realised_pnl(conn)
-            if realised is None:
-                raise StrategyControlError("paper principal cannot be withdrawn while realised P&L is incomplete")
-            # One arithmetic with the executor and the /strategies card (#2844) —
-            # this check decides whether the operator may withdraw below what the
-            # executor has already committed, so a divergence here would authorise a
-            # withdrawal the executor's own bound has already spent against.
-            effective_after = sandbox_bound(
-                capital_limit=capital_limit,
-                capital_mode=capital_mode,
-                realised_delta=sum(realised.values(), Decimal("0")),
-            )
-            if effective_after < committed:
-                raise StrategyControlError("paper principal cannot be withdrawn below committed strategy capital")
+        try:
+            authority = load_engine_capital_authority(conn)
+        except EngineCapitalObservationError as exc:
+            raise StrategyControlError("paper capital cannot change while shared commitments are incomplete") from exc
+        if authority is None:  # pragma: no cover - current.event_id proves one exists
+            raise StrategyControlError("paper capital authority disappeared during configuration")
+        current_effective = sandbox_bound(
+            capital_limit=current.capital_limit,
+            capital_mode=current.capital_mode,
+            realised_delta=authority.realised_delta,
+        )
+        effective_after = sandbox_bound(
+            capital_limit=capital_limit,
+            capital_mode=capital_mode,
+            realised_delta=authority.realised_delta,
+        )
+        if authority.core_active_position_ids and effective_after < current_effective:
+            # Current core commitment is a broker-observed amount rather than a DB
+            # balance.  This control-plane function has no broker snapshot, so it
+            # refuses the edit instead of substituting the opening ticket or the
+            # whole-account same-instrument holding.
+            raise StrategyControlError("paper capital cannot change while a core position is active")
+        committed = authority.alpha_committed + authority.core_pending_committed
+        if effective_after < committed:
+            raise StrategyControlError("paper principal cannot be withdrawn below committed strategy capital")
     row = conn.execute(
         """
         INSERT INTO strategy_paper_pool_events (

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -366,7 +366,9 @@ def configure_paper_pool(
             # refuses the edit instead of substituting the opening ticket or the
             # whole-account same-instrument holding.
             raise StrategyControlError("paper capital cannot change while a core position is active")
-        committed = authority.alpha_committed + authority.core_pending_committed
+        committed = (
+            authority.alpha_committed + authority.core_pending_committed + authority.core_active_recorded_committed
+        )
         if effective_after < committed:
             raise StrategyControlError("paper principal cannot be withdrawn below committed strategy capital")
     row = conn.execute(

--- a/app/services/strategy_core_broker_preflight.py
+++ b/app/services/strategy_core_broker_preflight.py
@@ -10,10 +10,8 @@ The split between 3b-1 and this one is "does it need a broker": 3b-1 holds no br
 handle and every refusal it names is provable in a pure test; every refusal here is
 observable only against a live account.
 
-⚠⚠ AUTHORISES NOTHING TODAY.  No caller in ``app/`` or ``scripts/``; it writes nothing.
-Named plainly, as every step of this arc has been, because #2437's R4 comment records *a
-control that exists, is tested, and sits on a path the decision does not take* nine times
-over on this ticket alone.
+This preflight writes nothing. The attended core executor calls it after the database gate
+and before durable order authority is committed.
 
 ⚠⚠ BUY ONLY.  ``sell_core`` refuses before any broker call --
 ``core_close_side_cost_quote_unavailable``.  See :data:`CoreBrokerPreflightRefusal`.
@@ -65,6 +63,11 @@ from app.services.strategy_core_sizing import (
     resolve_core_trade_size,
 )
 from app.services.strategy_core_sleeve import CoreSleeveObservationError, observe_core_sleeve
+from app.services.strategy_engine_capital import (
+    EngineCapitalAuthority,
+    EngineCapitalObservationError,
+    resolve_engine_capital_usage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +149,7 @@ CORE_MAX_ACCOUNT_RISK_AGE_SECONDS: Final = int(
 _FUTURE_SKEW: Final = timedelta(seconds=5)
 
 CoreBrokerPreflightRefusal = Literal[
+    "sandbox_exceeded",
     "core_close_side_cost_quote_unavailable",
     "core_account_risk_unavailable",
     "core_account_risk_stale",
@@ -243,6 +247,7 @@ def assess_core_broker_preflight(
     mandate: CoreMandate,
     decision: CoreRebalanceDecision,
     core_instrument_id: int,
+    capital_authority: EngineCapitalAuthority,
     eligibility_response_currency: str,
     eligibility_min_position_exposure: Decimal | None,
     eligibility_min_position_amount: Decimal | None,
@@ -289,6 +294,11 @@ def assess_core_broker_preflight(
         # Decided before any broker call: a request we know returns 400, or a quote we
         # know does not bound the cost, is not worth spending against the write lane.
         return _refused("core_close_side_cost_quote_unavailable")
+    if core_instrument_id != mandate.core_instrument_id:
+        # This is the allocator's existing, deterministic refusal.  Check it before
+        # joining exact ownership because the caller-supplied id cannot legitimately
+        # reinterpret the mandate's owned positions as belonging to another asset.
+        return _refused("sleeve_instrument_mismatch")
 
     try:
         snapshot = broker.get_account_risk_snapshot()
@@ -313,8 +323,20 @@ def assess_core_broker_preflight(
         return _refused("core_account_risk_stale", snapshot_observed_at=snapshot.observed_at)
 
     try:
-        state: CoreSleeveState = observe_core_sleeve(snapshot, core_instrument_id=core_instrument_id)
-    except CoreSleeveObservationError:
+        usage = resolve_engine_capital_usage(
+            capital_authority,
+            snapshot,
+            core_instrument_id=core_instrument_id,
+        )
+        if not usage.headroom.within_bound:
+            return _refused("sandbox_exceeded", snapshot_observed_at=snapshot.observed_at)
+        state: CoreSleeveState = observe_core_sleeve(
+            snapshot,
+            core_instrument_id=core_instrument_id,
+            exact_owned_market_value=usage.core_market_value,
+            assigned_cash_available=min(snapshot.available_cash, usage.headroom.remaining),
+        )
+    except CoreSleeveObservationError, EngineCapitalObservationError:
         return _refused("core_account_risk_unobservable", snapshot_observed_at=snapshot.observed_at)
 
     if eligibility_response_currency.strip().upper() != "USD":

--- a/app/services/strategy_core_executor.py
+++ b/app/services/strategy_core_executor.py
@@ -35,6 +35,11 @@ from app.services.strategy_core_submission_gate import (
     admit_core_rebalance_intent,
     core_submission_lock,
 )
+from app.services.strategy_engine_capital import (
+    EngineCapitalObservationError,
+    load_engine_capital_authority,
+    resolve_engine_capital_usage,
+)
 from app.services.strategy_order_reconciliation import reconcile_strategy_order
 
 CoreExecutionState = Literal["held", "refused", "submitted", "submission_uncertain"]
@@ -354,12 +359,35 @@ def execute_core_rebalance(
     order_id: int | None = None
     amount = Decimal("0")
     with core_submission_lock(conn):
+        try:
+            capital_authority = load_engine_capital_authority(conn)
+        except EngineCapitalObservationError as exc:
+            raise StrategyCoreExecutionError("the assigned-capital sandbox is incomplete") from exc
+        if capital_authority is None:
+            raise StrategyCoreExecutionError("an assigned paper pot is required")
+        if not capital_authority.enabled:
+            raise StrategyCoreExecutionError("the assigned paper pot is disabled")
+        # Session advisory locks survive this commit; row snapshots do not need
+        # to be held across broker I/O because the authority is re-proved below.
+        conn.commit()
         # This observation must be inside the same serialised section as the
         # mutation. Otherwise request B can observe, wait while request A fills,
         # then submit a duplicate order from B's still-fresh pre-fill snapshot.
         try:
             snapshot = broker.get_account_risk_snapshot()
-            state = observe_core_sleeve(snapshot, core_instrument_id=mandate.core_instrument_id)
+            usage = resolve_engine_capital_usage(
+                capital_authority,
+                snapshot,
+                core_instrument_id=mandate.core_instrument_id,
+            )
+            if not usage.headroom.within_bound:
+                return _result("refused", "sandbox_exceeded")
+            state = observe_core_sleeve(
+                snapshot,
+                core_instrument_id=mandate.core_instrument_id,
+                exact_owned_market_value=usage.core_market_value,
+                assigned_cash_available=min(snapshot.available_cash, usage.headroom.remaining),
+            )
         except Exception as exc:
             raise StrategyCoreExecutionError("the broker account snapshot could not describe the core sleeve") from exc
         decision = evaluate_core_rebalance(mandate, state)
@@ -370,6 +398,7 @@ def execute_core_rebalance(
                 mandate=mandate,
                 decision=decision,
                 core_instrument_id=mandate.core_instrument_id,
+                capital_authority=capital_authority,
                 eligibility_response_currency=proof.response_currency,
                 eligibility_min_position_exposure=proof.min_position_exposure,
                 eligibility_min_position_amount=proof.min_position_amount,
@@ -381,6 +410,12 @@ def execute_core_rebalance(
                 raise StrategyCoreExecutionError("the core mandate changed before submission")
             if current.event_id != mandate.event_id:
                 raise StrategyCoreExecutionError("the core mandate was revised during broker preflight")
+            try:
+                current_capital = load_engine_capital_authority(conn)
+            except EngineCapitalObservationError as exc:
+                raise StrategyCoreExecutionError("the assigned-capital sandbox changed during preflight") from exc
+            if current_capital != capital_authority:
+                raise StrategyCoreExecutionError("the assigned-capital sandbox changed during broker preflight")
             require_selected_core_instrument(conn, instrument_id=current.core_instrument_id)
             intent = record_core_rebalance_intent(conn, state=state, recorded_by=recorded_by)
             intent_id = intent.core_rebalance_intent_id

--- a/app/services/strategy_core_mandate.py
+++ b/app/services/strategy_core_mandate.py
@@ -29,8 +29,10 @@ from uuid import UUID
 
 import psycopg
 
+from app.services.strategy_control_plane import PAPER_ALLOCATOR_ADVISORY_LOCK
 from app.services.strategy_core_eligibility import require_core_eligibility
 from app.services.strategy_core_selection import require_selected_core_instrument
+from app.services.strategy_engine_capital import EngineCapitalObservationError, load_engine_capital_authority
 
 # v2 as of #2670, which made both band triggers REACHABLE rather than merely in
 # range.  Bumped even though the table held 0 rows: a version denotes a rule set,
@@ -363,6 +365,7 @@ def configure_core_mandate(
     )
     # Serialise revision allocation; the UNIQUE on revision is the backstop, not
     # the mechanism.
+    conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
     conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_MANDATE_ADVISORY_LOCK)
     if values.enabled:
         # Inside the lock and inside this transaction, so the freshness test and
@@ -386,6 +389,13 @@ def configure_core_mandate(
     current = load_core_mandate(conn)
     if current is not None and not _is_material_change(current, values):
         raise CoreMandateError("core mandate change must alter at least one mandate value")
+    if current is not None and current.core_instrument_id != values.core_instrument_id:
+        try:
+            capital = load_engine_capital_authority(conn)
+        except EngineCapitalObservationError as exc:
+            raise CoreMandateError("core instrument cannot change while capital ownership is incomplete") from exc
+        if capital is not None and capital.core_active_position_ids:
+            raise CoreMandateError("core instrument cannot change while an owned core position is active")
     revision = 1 if current is None else current.revision + 1
     row = conn.execute(
         """

--- a/app/services/strategy_core_sleeve.py
+++ b/app/services/strategy_core_sleeve.py
@@ -16,13 +16,11 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from app.providers.broker import BrokerAccountRiskSnapshot, BrokerInstrumentInvestment
+from app.providers.broker import BrokerAccountRiskSnapshot
 from app.services.account_equity_evidence import DOCUMENTED_ACCOUNT_CURRENCIES
 from app.services.strategy_core_allocator import CoreSleeveState
 
 __all__ = ["CoreSleeveObservationError", "observe_core_sleeve"]
-
-_ZERO = Decimal("0")
 
 
 class CoreSleeveObservationError(ValueError):
@@ -37,32 +35,19 @@ class CoreSleeveObservationError(ValueError):
     """
 
 
-def _core_row(snapshot: BrokerAccountRiskSnapshot, core_instrument_id: int) -> BrokerInstrumentInvestment | None:
-    """The one row for this instrument, or None when the account holds none.
-
-    Refuses a DUPLICATE rather than picking.  ``_parse_account_risk_snapshot`` keys
-    its accumulator by instrument id so it cannot emit two, but
-    ``BrokerAccountRiskSnapshot`` is publicly constructible and a test double or a
-    future producer can.  First-match silently drops a holding and summing silently
-    double-counts one; neither is a number worth having in a weight computation.
-    """
-    rows = [row for row in snapshot.instrument_investments if row.instrument_id == core_instrument_id]
-    if len(rows) > 1:
-        raise CoreSleeveObservationError(
-            f"snapshot reports {len(rows)} rows for instrument {core_instrument_id}; the core sleeve is ambiguous"
-        )
-    return rows[0] if rows else None
-
-
-def observe_core_sleeve(snapshot: BrokerAccountRiskSnapshot, *, core_instrument_id: int) -> CoreSleeveState:
+def observe_core_sleeve(
+    snapshot: BrokerAccountRiskSnapshot,
+    *,
+    core_instrument_id: int,
+    exact_owned_market_value: Decimal,
+    assigned_cash_available: Decimal,
+) -> CoreSleeveState:
     """Build the allocator's sleeve state from ONE broker snapshot.
 
-    ⚠⚠ What "one snapshot" buys, precisely.  Both money components come from a single
-    HTTP payload, so they are MUTUALLY CONSISTENT -- whatever instant the broker
-    computed them for, it is the same instant for both, which is the property
-    ``CoreSleeveState`` actually depends on and cannot check.  Sourcing cash from this
-    call and market value from ``get_portfolio()`` would breach it on every call, with
-    both figures arriving as plain Decimals and the breach undetectable downstream.
+    ``exact_owned_market_value`` is resolved by ``strategy_engine_capital`` from this
+    snapshot's exact direct rows and immutable ownership IDs. ``assigned_cash_available``
+    is the lesser of this snapshot's broker cash and the assigned-pot headroom. Thus both
+    still share one broker observation while DB authority can only narrow the cash term.
 
     ⚠ ``as_of`` is ``snapshot.observed_at``, which is our RECEIPT time -- assigned with
     ``datetime.now(UTC)`` after the response returns.  It is not a broker valuation
@@ -98,22 +83,11 @@ def observe_core_sleeve(snapshot: BrokerAccountRiskSnapshot, *, core_instrument_
             f"account currency id {snapshot.account_currency_id} is undocumented; refusing to infer its code"
         )
 
-    row = _core_row(snapshot, core_instrument_id)
-    if row is not None and row.direct_short_positions > 0:
-        # The sleeve's value is a LONG one.  Folding a short in misstates it and
-        # dropping it misstates it the other way -- and shorts are unobserved on this
-        # payload, so there is no measured basis for either.
-        raise CoreSleeveObservationError(
-            f"instrument {core_instrument_id} carries {row.direct_short_positions} direct short "
-            "position(s); a long core sleeve cannot be valued through them"
-        )
-
     return CoreSleeveState(
         core_instrument_id=core_instrument_id,
-        # Absent row and all-mirror row are the same true statement: no direct long
-        # holding.  `core_sleeve_empty` handles the state that results.
-        core_market_value=row.direct_long_market_value if row is not None else _ZERO,
-        cash_balance=snapshot.available_cash,
+        # Manual holdings never reach these inputs: only exact-owned ids were joined.
+        core_market_value=exact_owned_market_value,
+        cash_balance=assigned_cash_available,
         currency=currency,
         as_of=snapshot.observed_at,
     )

--- a/app/services/strategy_core_submission_gate.py
+++ b/app/services/strategy_core_submission_gate.py
@@ -34,6 +34,7 @@ from uuid import UUID
 import psycopg
 from psycopg.pq import TransactionStatus
 
+from app.services.strategy_control_plane import PAPER_ALLOCATOR_ADVISORY_LOCK
 from app.services.strategy_core_eligibility import (
     CoreEligibilityError,
     require_core_eligibility,
@@ -243,16 +244,19 @@ def core_lock_held(conn: psycopg.Connection[Any], key: tuple[int, int]) -> bool:
 def core_submission_lock(conn: psycopg.Connection[Any]) -> Iterator[None]:
     """Serialise the core arm's observe-record-admit-submit-insert section.
 
-    Takes TWO locks, in this order:
+    Takes THREE locks, in this order:
 
-    1. ``CORE_MANDATE_ADVISORY_LOCK`` -- the same key ``configure_core_mandate``
+    1. ``PAPER_ALLOCATOR_ADVISORY_LOCK`` -- the shared assigned-capital lock used
+       by alpha reservation and paper-pool revisions. Core and alpha cannot both
+       spend the same headroom.
+    2. ``CORE_MANDATE_ADVISORY_LOCK`` -- the same key ``configure_core_mandate``
        takes as an *xact* lock.  Without it the gate's
        ``core_mandate_revision_stale`` check is a TOCTOU: a revision appended
        between the check and the trade INSERT leaves a trade citing a mandate the
        operator has replaced.  Session and transaction advisory locks share one
        lock manager, so holding it blocks mandate writes for the duration of a
        submission -- which is the intended behaviour, not a side effect.
-    2. ``CORE_SUBMISSION_ADVISORY_LOCK`` -- submissions against each other.
+    3. ``CORE_SUBMISSION_ADVISORY_LOCK`` -- submissions against each other.
 
     One acquisition order, and ``configure_core_mandate`` takes only the first, so
     there is no deadlock cycle.  Shape follows ``_allocator_lock``
@@ -260,7 +264,7 @@ def core_submission_lock(conn: psycopg.Connection[Any]) -> Iterator[None]:
     lock means the critical section was not what it claimed to be, and that must
     be loud.
     """
-    keys = (CORE_MANDATE_ADVISORY_LOCK, CORE_SUBMISSION_ADVISORY_LOCK)
+    keys = (PAPER_ALLOCATOR_ADVISORY_LOCK, CORE_MANDATE_ADVISORY_LOCK, CORE_SUBMISSION_ADVISORY_LOCK)
     for key in keys:
         conn.execute("SELECT pg_advisory_lock(%s, %s)", key)
     conn.commit()
@@ -342,6 +346,11 @@ def admit_core_rebalance_intent(
     and submission reopens the credential-swap window; keep the two in one
     transaction or re-admit afterwards.
     """
+    if not core_lock_held(conn, PAPER_ALLOCATOR_ADVISORY_LOCK):
+        raise StrategyCoreSubmissionError(
+            "core submission admission requires core_submission_lock to hold the shared paper allocator "
+            "advisory lock; without it alpha and core can reserve the same assigned capital"
+        )
     if not core_lock_held(conn, CORE_SUBMISSION_ADVISORY_LOCK):
         raise StrategyCoreSubmissionError(
             "core submission admission requires core_submission_lock to be held; "

--- a/app/services/strategy_engine_capital.py
+++ b/app/services/strategy_engine_capital.py
@@ -1,0 +1,358 @@
+"""One exact observation of capital committed inside the shared strategy pot.
+
+The paper pool is the operator's allocation authority.  Broker account cash is
+only an independent ability-to-pay ceiling because the account also contains
+manual holdings.  This module owns the database population and joins exact core
+ownership to one live P&L snapshot; callers must not recreate either half.
+
+Spec: ``docs/proposals/ta/2026-08-24-core-assigned-capital-boundary.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, cast
+
+import psycopg
+import psycopg.rows
+
+from app.providers.broker import BrokerAccountRiskSnapshot
+from app.services.account_equity_evidence import DOCUMENTED_ACCOUNT_CURRENCIES
+from app.services.strategy_capital_sandbox import CapitalMode, SandboxHeadroom, sandbox_headroom
+from app.services.strategy_core_arc_sql import core_arm_joins, core_arm_present
+
+_ZERO = Decimal("0")
+_TERMINAL_TRADES = frozenset({"closed", "failed"})
+_TERMINAL_RECONCILIATION = frozenset({"resolved", "rejected"})
+
+
+class EngineCapitalObservationError(RuntimeError):
+    """The shared capital population or its exact broker join is incomplete."""
+
+
+@dataclass(frozen=True)
+class EngineCapitalAuthority:
+    pool_event_id: int
+    enabled: bool
+    capital_limit: Decimal
+    capital_mode: CapitalMode
+    epoch_started_at: datetime
+    realised_delta: Decimal
+    alpha_committed: Decimal
+    alpha_working: Decimal
+    core_pending_committed: Decimal
+    core_active_recorded_committed: Decimal
+    core_active_position_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class EngineCapitalUsage:
+    authority: EngineCapitalAuthority
+    headroom: SandboxHeadroom
+    committed: Decimal
+    working: Decimal
+    core_market_value: Decimal
+    core_active_committed: Decimal
+
+
+def _money(value: object, *, label: str, positive: bool = False) -> Decimal:
+    try:
+        money = Decimal(str(value))
+    except Exception as exc:
+        raise EngineCapitalObservationError(f"{label} is not numeric") from exc
+    if not money.is_finite() or money < _ZERO or (positive and money <= _ZERO):
+        raise EngineCapitalObservationError(f"{label} is outside safe bounds")
+    return money
+
+
+def _load_realised_delta(conn: psycopg.Connection[Any], *, epoch: datetime) -> Decimal:
+    """The existing F-0 exact-owned close rule, widened to both strategy arms."""
+    row = conn.execute(
+        f"""
+        WITH eligible_trades AS (
+            SELECT trade.strategy_trade_id
+            FROM strategy_trades trade
+            LEFT JOIN strategy_funding_decisions funding
+              ON funding.funding_decision_id=trade.funding_decision_id
+             AND funding.verdict='allocated'
+            LEFT JOIN strategy_deployments deployment
+              ON deployment.deployment_id=funding.deployment_id
+             AND deployment.mode='paper'
+            {core_arm_joins("trade")}
+            WHERE trade.created_at >= %s
+              AND (deployment.deployment_id IS NOT NULL
+                   OR {core_arm_present("trade")})
+        ), owned AS (
+            SELECT ownership.broker_position_id,ownership.status
+            FROM strategy_position_ownership ownership
+            JOIN eligible_trades trade USING (strategy_trade_id)
+        ), closes AS (
+            SELECT owned.broker_position_id,owned.status,
+                   count(event.event_id) AS close_count,
+                   count(event.event_id) FILTER (WHERE event.realized_pnl_usd IS NULL) AS missing_pnl,
+                   COALESCE(sum(event.realized_pnl_usd),0) AS realised
+            FROM owned
+            LEFT JOIN trade_events event
+              ON event.position_id=owned.broker_position_id AND event.event_kind='close'
+            GROUP BY owned.broker_position_id,owned.status
+        )
+        SELECT COALESCE(sum(realised),0),
+               count(*) FILTER (WHERE missing_pnl > 0),
+               count(*) FILTER (WHERE status='released' AND close_count=0)
+        FROM closes
+        """,
+        (epoch,),
+    ).fetchone()
+    assert row is not None
+    if int(row[1]) or int(row[2]):
+        raise EngineCapitalObservationError("exact-owned realised P&L is incomplete")
+    value = Decimal(str(row[0]))
+    if not value.is_finite():
+        raise EngineCapitalObservationError("exact-owned realised P&L is not finite")
+    return value
+
+
+def load_engine_capital_authority(conn: psycopg.Connection[Any]) -> EngineCapitalAuthority | None:
+    """Load the current pool and every cash authority it has issued.
+
+    ``None`` means no paper-pool event has ever established an assigned pot.
+    """
+    pool = conn.execute(
+        """
+        SELECT latest.strategy_paper_pool_event_id,latest.enabled,latest.capital_limit,
+               latest.capital_mode,first_event.changed_at
+        FROM LATERAL (
+            SELECT strategy_paper_pool_event_id,enabled,capital_limit,capital_mode
+            FROM strategy_paper_pool_events
+            ORDER BY strategy_paper_pool_event_id DESC LIMIT 1
+        ) latest
+        CROSS JOIN LATERAL (
+            SELECT changed_at FROM strategy_paper_pool_events
+            ORDER BY strategy_paper_pool_event_id LIMIT 1
+        ) first_event
+        """
+    ).fetchone()
+    if pool is None:
+        return None
+    pool_event_id = int(pool[0])
+    capital_limit = _money(pool[2], label="paper pool capital limit")
+    mode = str(pool[3])
+    if mode not in {"fixed", "compound"}:
+        raise EngineCapitalObservationError("paper pool capital mode is unsupported")
+    capital_mode = cast(CapitalMode, mode)
+    epoch = cast(datetime, pool[4])
+
+    pre_epoch_funding = conn.execute(
+        """
+        SELECT count(*)
+        FROM strategy_funding_decisions funding
+        JOIN strategy_deployments deployment
+          ON deployment.deployment_id=funding.deployment_id AND deployment.mode='paper'
+        LEFT JOIN strategy_trades trade ON trade.funding_decision_id=funding.funding_decision_id
+        WHERE funding.verdict='allocated' AND funding.decided_at < %s
+          AND (trade.strategy_trade_id IS NULL
+               OR trade.status NOT IN ('closed','failed')
+               OR EXISTS (
+                   SELECT 1 FROM strategy_position_ownership ownership
+                   WHERE ownership.strategy_trade_id=trade.strategy_trade_id
+                     AND ownership.status='active'
+               ))
+        """,
+        (epoch,),
+    ).fetchone()
+    assert pre_epoch_funding is not None
+    if int(pre_epoch_funding[0]):
+        raise EngineCapitalObservationError("a non-terminal strategy lifecycle predates the assigned pot")
+
+    # Core trades have no funding decision, so their epoch guard remains rooted
+    # at the trade. Signal-arm lifecycles are guarded above from the allocation
+    # itself, including the valid pending state where no trade exists yet.
+    pre_epoch_core = conn.execute(
+        f"""
+        SELECT count(*)
+        FROM strategy_trades trade
+        {core_arm_joins("trade")}
+        WHERE trade.created_at < %s
+          AND {core_arm_present("trade")}
+          AND (trade.status NOT IN ('closed','failed') OR EXISTS (
+              SELECT 1 FROM strategy_position_ownership ownership
+              WHERE ownership.strategy_trade_id=trade.strategy_trade_id
+                AND ownership.status='active'
+          ))
+        """,
+        (epoch,),
+    ).fetchone()
+    assert pre_epoch_core is not None
+    if int(pre_epoch_core[0]):
+        raise EngineCapitalObservationError("a non-terminal strategy lifecycle predates the assigned pot")
+
+    alpha_rows = conn.execute(
+        """
+        SELECT funding.funding_decision_id,funding.amount,
+               trade.strategy_trade_id,trade.status,
+               count(DISTINCT ownership.ownership_id) FILTER (WHERE ownership.status='active') AS active_owned
+        FROM strategy_funding_decisions funding
+        JOIN strategy_deployments deployment
+          ON deployment.deployment_id=funding.deployment_id AND deployment.mode='paper'
+        LEFT JOIN strategy_trades trade ON trade.funding_decision_id=funding.funding_decision_id
+        LEFT JOIN strategy_position_ownership ownership
+          ON ownership.strategy_trade_id=trade.strategy_trade_id
+        WHERE funding.verdict='allocated' AND funding.decided_at >= %s
+        GROUP BY funding.funding_decision_id,funding.amount,trade.strategy_trade_id,trade.status
+        ORDER BY funding.funding_decision_id
+        """,
+        (epoch,),
+    ).fetchall()
+    alpha_committed = _ZERO
+    alpha_working = _ZERO
+    for row in alpha_rows:
+        amount = _money(row[1], label=f"funding decision {row[0]} amount", positive=True)
+        trade_id = row[2]
+        if trade_id is None:
+            alpha_committed += amount
+            continue
+        status = str(row[3])
+        active_owned = int(row[4])
+        terminal = status in _TERMINAL_TRADES
+        if terminal and active_owned:
+            raise EngineCapitalObservationError(f"paper trade {trade_id} terminal state is inconsistent")
+        if not terminal:
+            alpha_committed += amount
+            if active_owned:
+                alpha_working += amount
+
+    core_rows = conn.execute(
+        f"""
+        SELECT trade.strategy_trade_id,trade.status,trade.instrument_id,
+               count(DISTINCT link.order_id) FILTER (WHERE link.purpose='entry') AS entry_count,
+               min(entry.instrument_id) FILTER (WHERE link.purpose='entry') AS entry_instrument,
+               min(entry.action) FILTER (WHERE link.purpose='entry') AS entry_action,
+               min(entry.order_type) FILTER (WHERE link.purpose='entry') AS entry_type,
+               min(entry.execution_origin) FILTER (WHERE link.purpose='entry') AS entry_origin,
+               min(entry.requested_amount) FILTER (WHERE link.purpose='entry') AS requested_amount,
+               min(recon.state) FILTER (WHERE link.purpose='entry') AS recon_state,
+               array_agg(DISTINCT ownership.broker_position_id ORDER BY ownership.broker_position_id)
+                 FILTER (WHERE ownership.status='active') AS active_position_ids,
+               min(core_intent.action) AS intent_action,
+               min(core_mandate.core_mandate_event_id) AS paper_mandate_id
+        FROM strategy_trades trade
+        {core_arm_joins("trade")}
+        LEFT JOIN strategy_trade_orders link ON link.strategy_trade_id=trade.strategy_trade_id
+        LEFT JOIN orders entry ON entry.order_id=link.order_id
+        LEFT JOIN strategy_order_reconciliation_state recon ON recon.order_id=entry.order_id
+        LEFT JOIN strategy_position_ownership ownership
+          ON ownership.strategy_trade_id=trade.strategy_trade_id
+        WHERE trade.created_at >= %s AND {core_arm_present("trade")}
+        GROUP BY trade.strategy_trade_id,trade.status,trade.instrument_id
+        ORDER BY trade.strategy_trade_id
+        """,
+        (epoch,),
+    ).fetchall()
+    core_pending = _ZERO
+    core_active_recorded = _ZERO
+    active_ids: list[int] = []
+    for row in core_rows:
+        trade_id = int(row[0])
+        status = str(row[1])
+        entry_count = int(row[3])
+        recon_state = None if row[9] is None else str(row[9])
+        owned_ids = tuple(int(value) for value in (row[10] or []))
+        if (
+            row[11] != "buy_core"
+            or row[12] is None
+            or entry_count != 1
+            or row[4] != row[2]
+            or row[5] != "BUY"
+            or row[6] != "MARKET"
+            or row[7] != "strategy"
+            or recon_state is None
+        ):
+            raise EngineCapitalObservationError(f"core trade {trade_id} entry authority is incomplete")
+        terminal = status in _TERMINAL_TRADES
+        if terminal:
+            if recon_state not in _TERMINAL_RECONCILIATION or owned_ids:
+                raise EngineCapitalObservationError(f"core trade {trade_id} terminal state is inconsistent")
+            continue
+        if recon_state != "resolved":
+            if owned_ids:
+                raise EngineCapitalObservationError(f"core trade {trade_id} owns positions before entry resolution")
+            core_pending += _money(row[8], label=f"core trade {trade_id} requested amount", positive=True)
+            continue
+        if not owned_ids:
+            raise EngineCapitalObservationError(f"resolved core trade {trade_id} has no active exact ownership")
+        core_active_recorded += _money(row[8], label=f"core trade {trade_id} requested amount", positive=True)
+        active_ids.extend(owned_ids)
+    if len(active_ids) != len(set(active_ids)):
+        raise EngineCapitalObservationError("active core ownership ids are duplicated")
+
+    return EngineCapitalAuthority(
+        pool_event_id=pool_event_id,
+        enabled=bool(pool[1]),
+        capital_limit=capital_limit,
+        capital_mode=capital_mode,
+        epoch_started_at=epoch,
+        realised_delta=_load_realised_delta(conn, epoch=epoch),
+        alpha_committed=alpha_committed,
+        alpha_working=alpha_working,
+        core_pending_committed=core_pending,
+        core_active_recorded_committed=core_active_recorded,
+        core_active_position_ids=tuple(sorted(active_ids)),
+    )
+
+
+def resolve_engine_capital_usage(
+    authority: EngineCapitalAuthority,
+    snapshot: BrokerAccountRiskSnapshot,
+    *,
+    core_instrument_id: int | None,
+) -> EngineCapitalUsage:
+    """Join active core ownership to the same snapshot used for execution."""
+    snapshot_currency = (
+        None
+        if snapshot.account_currency_id is None
+        else DOCUMENTED_ACCOUNT_CURRENCIES.get(snapshot.account_currency_id)
+    )
+    if snapshot_currency != "USD":
+        raise EngineCapitalObservationError("broker account currency is not observed as USD")
+    positions = {row.position_id: row for row in snapshot.direct_positions}
+    if len(positions) != len(snapshot.direct_positions):
+        raise EngineCapitalObservationError("broker snapshot repeats a direct position id")
+    core_committed = _ZERO
+    core_market_value = _ZERO
+    if authority.core_active_position_ids and core_instrument_id is None:
+        raise EngineCapitalObservationError("active core ownership has no configured instrument")
+    for position_id in authority.core_active_position_ids:
+        row = positions.get(position_id)
+        if row is None:
+            raise EngineCapitalObservationError(f"active core position {position_id} is absent from broker snapshot")
+        if row.instrument_id != core_instrument_id:
+            raise EngineCapitalObservationError(f"active core position {position_id} belongs to another instrument")
+        if not row.is_buy:
+            raise EngineCapitalObservationError(f"active core position {position_id} is short")
+        if row.is_partially_altered:
+            raise EngineCapitalObservationError(f"active core position {position_id} is partially altered")
+        core_committed += _money(row.amount, label=f"active core position {position_id} amount")
+        if not row.market_value.is_finite() or row.market_value < _ZERO:
+            raise EngineCapitalObservationError(f"active core position {position_id} market value is invalid")
+        core_market_value += row.market_value
+
+    committed = authority.alpha_committed + authority.core_pending_committed + core_committed
+    working = authority.alpha_working + core_committed
+    headroom = sandbox_headroom(
+        capital_limit=authority.capital_limit,
+        capital_mode=authority.capital_mode,
+        realised_delta=authority.realised_delta,
+        committed=committed,
+    )
+    return EngineCapitalUsage(authority, headroom, committed, working, core_market_value, core_committed)
+
+
+__all__ = [
+    "EngineCapitalAuthority",
+    "EngineCapitalObservationError",
+    "EngineCapitalUsage",
+    "load_engine_capital_authority",
+    "resolve_engine_capital_usage",
+]

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -853,10 +853,9 @@ def _observe_local_mandate_risk(
             raise StrategyPaperExecutionError("pending strategy risk observation was unavailable")
         pending_total = Decimal(str(pending_row[0]))
         pending_instrument = Decimal(str(pending_row[1]))
-        capital_bases = _effective_capital_bases(conn, intent)
-        if isinstance(capital_bases, str):
-            return capital_bases
-        deployment_base, _legacy_alpha_pool_base = capital_bases
+        deployment_base = _effective_deployment_base(conn, intent)
+        if isinstance(deployment_base, str):
+            return deployment_base
         pool_base = shared_pool_bound
         market_date = now.astimezone(_NY).date()
         market_day_start = datetime.combine(market_date, time.min, tzinfo=_NY).astimezone(UTC)
@@ -1014,33 +1013,25 @@ def _risk_and_amount(
     return amount, current_instrument, drawdown
 
 
-def _effective_capital_bases(
+def _effective_deployment_base(
     conn: psycopg.Connection[Any],
     intent: _Intent,
-) -> tuple[Decimal, Decimal] | str:
-    """Resolve capped or compounding bases from realised P&L, never open marks."""
+) -> Decimal | str:
+    """Resolve the capped or compounding deployment base from realised P&L."""
     realised_by_strategy = load_paper_realised_pnl(conn)
     if realised_by_strategy is None:
         return "realised_pnl_incomplete"
 
     strategy_realised = realised_by_strategy.get((intent.strategy_id, intent.strategy_version), Decimal("0"))
-    pool_realised = sum(realised_by_strategy.values(), Decimal("0"))
     # ⚠ ONE arithmetic, shared with the withdrawal check and the /strategies card
     # (#2844). This was three hand-written copies of `max(0, limit + realised)` with
     # the `fixed`-floors-profit rule restated each time -- so the panel promising the
     # operator headroom and the control enforcing it could drift apart with both
     # internally consistent and nothing to fail on.
-    return (
-        sandbox_bound(
-            capital_limit=intent.deployment_limit,
-            capital_mode=intent.capital_mode,
-            realised_delta=strategy_realised,
-        ),
-        sandbox_bound(
-            capital_limit=intent.pool_limit,
-            capital_mode=intent.capital_mode,
-            realised_delta=pool_realised,
-        ),
+    return sandbox_bound(
+        capital_limit=intent.deployment_limit,
+        capital_mode=intent.capital_mode,
+        realised_delta=strategy_realised,
     )
 
 

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -53,6 +53,12 @@ from app.services.strategy_control_plane import (
     link_strategy_order,
     registered_strategy_purpose,
 )
+from app.services.strategy_core_mandate import load_core_mandate
+from app.services.strategy_engine_capital import (
+    EngineCapitalObservationError,
+    load_engine_capital_authority,
+    resolve_engine_capital_usage,
+)
 from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
 from app.services.strategy_halt_identity import (
     HALT_IDENTITY_RULE_VERSION,
@@ -824,6 +830,7 @@ def _observe_local_mandate_risk(
     intent: _Intent,
     risk: BrokerAccountRiskSnapshot,
     now: datetime,
+    shared_pool_bound: Decimal,
 ) -> tuple[Decimal, Decimal, Decimal, Decimal, Decimal] | str:
     """Read local allocation risk and advance the high-water mark atomically."""
     with conn.transaction():
@@ -849,7 +856,8 @@ def _observe_local_mandate_risk(
         capital_bases = _effective_capital_bases(conn, intent)
         if isinstance(capital_bases, str):
             return capital_bases
-        deployment_base, pool_base = capital_bases
+        deployment_base, _legacy_alpha_pool_base = capital_bases
+        pool_base = shared_pool_bound
         market_date = now.astimezone(_NY).date()
         market_day_start = datetime.combine(market_date, time.min, tzinfo=_NY).astimezone(UTC)
         market_day_end = (datetime.combine(market_date, time.min, tzinfo=_NY) + timedelta(days=1)).astimezone(UTC)
@@ -900,10 +908,35 @@ def _risk_and_amount(
         (row.amount for row in risk.instrument_investments if row.instrument_id == intent.instrument_id),
         Decimal("0"),
     )
+    try:
+        # Keep this observation in its own completed transaction.  A bare SELECT on
+        # psycopg opens an implicit transaction; leaving it open here would turn the
+        # later durable-order transaction into a savepoint and let broker I/O precede
+        # the actual commit.
+        with conn.transaction():
+            authority = load_engine_capital_authority(conn)
+            if authority is None or not authority.enabled:
+                return SANDBOX_EXCEEDED
+            core_mandate = load_core_mandate(conn)
+            usage = resolve_engine_capital_usage(
+                authority,
+                risk,
+                core_instrument_id=None if core_mandate is None else core_mandate.core_instrument_id,
+            )
+    except EngineCapitalObservationError as exc:
+        raise StrategyPaperExecutionError("shared assigned-capital observation is incomplete") from exc
+    if not usage.headroom.within_bound:
+        return SANDBOX_EXCEEDED
     # A just-accepted strategy order may not yet be visible in the provider's
     # account snapshot. The local observation counts every unresolved order and
     # advances account high-water state in one explicit transaction.
-    observed = _observe_local_mandate_risk(conn, intent=intent, risk=risk, now=now)
+    observed = _observe_local_mandate_risk(
+        conn,
+        intent=intent,
+        risk=risk,
+        now=now,
+        shared_pool_bound=usage.headroom.bound,
+    )
     if isinstance(observed, str):
         return observed
     deployment_base, pool_base, pending_total, pending_instrument, drawdown = observed
@@ -912,9 +945,9 @@ def _risk_and_amount(
     if drawdown >= intent.mandate_max_drawdown_pct:
         return "portfolio_drawdown_limit"
     deployment_remaining = max(Decimal("0"), deployment_base - intent.reserved)
-    # `pool_base` IS the bound — `_effective_capital_bases` resolved it from the
-    # pool's realised P&L in the same pass that resolved the deployment one.
-    pool_headroom = headroom_from_bound(bound=pool_base, committed=intent.pool_reserved)
+    # `pool_base` IS the shared bound resolved from exact-owned alpha and core
+    # realised P&L by `resolve_engine_capital_usage` above.
+    pool_headroom = headroom_from_bound(bound=pool_base, committed=usage.committed)
     pool_remaining = pool_headroom.remaining
     # ⚠ NAMED, and named BEFORE the nine other capacity terms fold into `min(...)`
     # below (#2844). Reaching the assignment used to surface as
@@ -939,13 +972,13 @@ def _risk_and_amount(
     )
     cash_reserve_capacity = max(
         Decimal("0"),
-        pool_base * (Decimal("100") - intent.mandate_cash_reserve_pct) / Decimal("100") - intent.pool_reserved,
+        pool_base * (Decimal("100") - intent.mandate_cash_reserve_pct) / Decimal("100") - usage.committed,
     )
     if cash_reserve_capacity.quantize(_CENT, rounding=ROUND_DOWN) <= 0:
         return "portfolio_cash_reserve_limit"
     active_risk_capacity = max(
         Decimal("0"),
-        pool_base * intent.mandate_active_risk_budget_pct / Decimal("100") - intent.pool_reserved,
+        pool_base * intent.mandate_active_risk_budget_pct / Decimal("100") - usage.committed,
     )
     if active_risk_capacity.quantize(_CENT, rounding=ROUND_DOWN) <= 0:
         return "portfolio_active_risk_limit"

--- a/app/services/strategy_position_manager.py
+++ b/app/services/strategy_position_manager.py
@@ -28,7 +28,12 @@ from app.providers.broker import (
     BrokerPositionMutationUncertain,
     BrokerProvider,
 )
-from app.services.strategy_control_plane import StrategyControlError, StrategyOwnershipError, link_strategy_order
+from app.services.strategy_control_plane import (
+    PAPER_ALLOCATOR_ADVISORY_LOCK,
+    StrategyControlError,
+    StrategyOwnershipError,
+    link_strategy_order,
+)
 from app.services.strategy_core_arc_sql import core_arm_authorised, core_arm_joins
 
 _RATE_QUANTUM = Decimal("0.000001")
@@ -113,6 +118,22 @@ def _position_lock(conn: psycopg.Connection[Any], broker_position_id: int) -> It
         conn.commit()
         if unlocked is None or unlocked[0] is not True:
             raise StrategyPositionManagerError("strategy position lock ownership was lost")
+
+
+@contextmanager
+def _paper_allocator_lock(conn: psycopg.Connection[Any]) -> Iterator[None]:
+    """Serialize exact-position exits with every shared-pot commitment."""
+    conn.execute("SELECT pg_advisory_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
+    conn.commit()
+    try:
+        yield
+    finally:
+        if conn.info.transaction_status != TransactionStatus.IDLE:
+            conn.rollback()
+        unlocked = conn.execute("SELECT pg_advisory_unlock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK).fetchone()
+        conn.commit()
+        if unlocked is None or unlocked[0] is not True:
+            raise StrategyPositionManagerError("paper allocator lock ownership was lost")
 
 
 def register_ratchet_variant(
@@ -839,7 +860,7 @@ def manage_owned_position(
     if conn.info.transaction_status != TransactionStatus.IDLE:
         raise StrategyPositionManagerError("position management requires an idle connection")
     observed_at = (now or datetime.now(UTC)).astimezone(UTC)
-    with _position_lock(conn, broker_position_id):
+    with _paper_allocator_lock(conn), _position_lock(conn, broker_position_id):
         owned = _load_owned(conn, strategy_trade_id=strategy_trade_id, broker_position_id=broker_position_id)
         conn.commit()
         resumed = _resume_operation(conn, broker=broker, owned=owned)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5788,9 +5788,14 @@ def core_rebalance_observation() -> None:
     Spec: ``docs/proposals/ta/2026-08-22-core-rebalance-observation-job.md``
     """
     from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+    from app.services.strategy_control_plane import PAPER_ALLOCATOR_ADVISORY_LOCK
     from app.services.strategy_core_mandate import CORE_MANDATE_ADVISORY_LOCK, load_core_mandate
     from app.services.strategy_core_rebalance_intent import record_core_rebalance_intent
     from app.services.strategy_core_sleeve import observe_core_sleeve
+    from app.services.strategy_engine_capital import (
+        load_engine_capital_authority,
+        resolve_engine_capital_usage,
+    )
 
     # `strategy_core_mandate_events.mode` is CHECK-pinned to 'paper' (sql/349),
     # so observing a REAL account would attribute a live book's drift to a
@@ -5814,6 +5819,11 @@ def core_rebalance_observation() -> None:
     # thing.
     with connect_job() as mandate_conn:
         mandate = load_core_mandate(mandate_conn)
+        capital_authority = (
+            None
+            if mandate is None or mandate.core_instrument_id is None
+            else load_engine_capital_authority(mandate_conn)
+        )
 
     # ⚠ The skip is recorded from the BODY, not only via the registry
     # `prerequisite`, because manual dispatch bypasses the registry path.
@@ -5833,6 +5843,9 @@ def core_rebalance_observation() -> None:
         detail = "no core mandate configured" if mandate is None else "core mandate has no core instrument"
         _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, detail)
         return
+    if capital_authority is None:
+        _record_prereq_skip(JOB_CORE_REBALANCE_OBSERVATION, "no assigned paper pot configured")
+        return
 
     creds = _load_etoro_credentials(JOB_CORE_REBALANCE_OBSERVATION)
     if creds is None:
@@ -5847,7 +5860,17 @@ def core_rebalance_observation() -> None:
         with EtoroBrokerProvider(api_key=creds[0], user_key=creds[1], env="demo") as broker:
             snapshot = broker.get_account_risk_snapshot()
 
-        state = observe_core_sleeve(snapshot, core_instrument_id=core_instrument_id)
+        usage = resolve_engine_capital_usage(
+            capital_authority,
+            snapshot,
+            core_instrument_id=core_instrument_id,
+        )
+        state = observe_core_sleeve(
+            snapshot,
+            core_instrument_id=core_instrument_id,
+            exact_owned_market_value=usage.core_market_value,
+            assigned_cash_available=min(snapshot.available_cash, usage.headroom.remaining),
+        )
 
         with connect_job() as conn:
             # ⚠⚠ The sleeve was observed for the mandate read BEFORE the HTTP
@@ -5866,8 +5889,12 @@ def core_rebalance_observation() -> None:
             # for two fast reads and one INSERT, NEVER across the broker
             # round-trip -- which is why the mandate is pre-read on a separate
             # connection rather than under this lock.
+            conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
             conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_MANDATE_ADVISORY_LOCK)
             current = load_core_mandate(conn)
+            current_capital = load_engine_capital_authority(conn)
+            if current_capital != capital_authority:
+                raise RuntimeError("assigned-capital authority changed during core observation")
             if current is None or current.event_id != mandate.event_id:
                 # Not a fault, so nothing raises: the operator reconfigured the
                 # mandate during the round-trip and the next tick is correct.

--- a/docs/proposals/ta/2026-08-24-core-assigned-capital-boundary.md
+++ b/docs/proposals/ta/2026-08-24-core-assigned-capital-boundary.md
@@ -1,0 +1,258 @@
+# Core/cash uses the assigned pot, never the broker account (#2525, #2603)
+
+Status: implementation proposal. This corrects the denominator deliberately deferred by
+`2026-08-13-core-cash-mandate.md`; it does not change the mandate percentages or select an
+instrument.
+
+## Defect and invariant
+
+The attended core executor currently gives `observe_core_sleeve` the selected instrument's
+**whole-account** direct-long market value and the broker account's **whole-account**
+available cash. A manual holding of the same instrument is silently claimed as core, and a
+small assigned pot can size against cash outside that pot. That violates the operator's
+settled 2026-08-22 decision: the only capital safety boundary is
+`strategy_paper_pool_events.capital_limit` (`fixed` = capped, `compound` = expanding), and
+the broker account is shared with non-engine holdings.
+
+The invariant after this change is:
+
+```text
+engine committed capital = open/unresolved alpha authority
+                         + open/unresolved core entry authority
+
+effective assigned bound = sandbox_bound(
+    paper_pool.capital_limit,
+    paper_pool.capital_mode,
+    exact-owned realised engine P&L,
+)
+
+assigned cash available to core = min(
+    broker available cash,
+    effective assigned bound - engine committed capital,
+)
+
+core/cash sleeve = exact-owned selected-core market value
+                 + assigned cash available to core
+```
+
+Every term fails closed when its identity or completeness is unavailable. Manual positions
+have no `strategy_position_ownership` row and therefore contribute zero to the core sleeve.
+The whole-account broker values remain independent risk/cash ceilings; they never become
+allocation authority.
+
+## Source rule
+
+The current eToro portal page, **Get account PnL and portfolio details**, fetched
+2026-08-24, documents that `GET /api/v1/trading/info/demo/pnl` returns the current
+portfolio and shows every direct `clientPortfolio.positions[]` row carrying `positionId`,
+`instrumentId`, `isBuy`, `amount`, and P&L. The current calculation guides separately
+establish the account formulas already implemented by `_parse_account_risk_snapshot`.
+
+Live read-only verification on the configured demo account at 2026-08-24 found every row in
+that account's complete returned direct-position array (7/7) had a positive unique exact ID,
+instrument ID, boolean direction, amount, and `unrealizedPnL.pnL`. This is evidence for the
+configured account, not a provider-wide guarantee; required-field parsing is what makes any
+other account/shape fail closed. The endpoint exposes no pagination or continuation member,
+so the returned array is the only completeness boundary the source makes available. The
+response used legacy spellings
+`positionID`, `instrumentID`, and `settlementTypeID`, while the portal example uses lower
+camel case. The parser therefore accepts exactly those two observed/documented spellings,
+requires a positive unique position ID, and never falls back to instrument identity. If both
+spellings are present they must decode to the same value or the response is refused.
+
+The per-position market-value construction is unchanged from #2704:
+`amount + unrealizedPnL.pnL`. The portal's equity and total-invested guides establish those
+as the direct position's two additive contributions to account equity but do not name the
+restricted per-position sum “market value”; #2704 therefore labels that interpretation as
+measurement-backed, not published. It was independently cross-checked against the quote feed
+on every position returned by this configured demo account (7/7) on 2026-08-14. That is the
+full observed population, not a claim about every provider account. This proposal changes
+which exact rows are included, not that measured valuation rule; an unobserved shape refuses.
+
+No published source governs an application's virtual capital carve-out. The assigned-pot
+arithmetic is therefore fixed by the operator's settled invariant and the existing
+`strategy_capital_sandbox.sandbox_bound`; no new threshold, mode, or capital column is
+introduced.
+
+## Provider contract
+
+Add an immutable `BrokerDirectPositionInvestment` to `BrokerAccountRiskSnapshot`:
+
+```python
+position_id: int
+instrument_id: int
+is_buy: bool
+amount: Decimal
+unrealized_pnl: Decimal
+market_value: Decimal
+is_partially_altered: bool
+```
+
+The P&L parser emits one row per direct position while retaining the existing aggregate
+instrument rows. Exact IDs must be JSON integers (booleans and lossy numeric coercion are
+refused), positive, unique, and within signed-BIGINT range. `amount` and P&L must be finite,
+and `amount >= 0`; a negative derived market value is carried so the allocator can report its
+existing `sleeve_valuation_invalid` refusal rather than misclassifying valid-but-extreme
+broker state as response drift. `isPartiallyAltered`/`is_partially_altered` is required and
+boolean because v1 does not have a sourced residual-cost-basis rule for externally partial
+core positions. The typed source terms make the derived value auditable without widening raw
+payload persistence.
+
+## Shared capital observation
+
+Add one service-owned database read for the shared sandbox rather than copying SQL into the
+core executor, alpha executor, withdrawal guard, and overview.
+
+- Pool membership is one continuous epoch beginning at the first paper-pool event's
+  `changed_at`. It includes every funding/trade authority created at or after that instant:
+  every paper deployment (disabled and retired versions included) and every core trade whose
+  cited mandate mode is `paper`, regardless of later pool/mandate revisions. Closed pre-epoch
+  history is excluded from the assigned pot; any pre-epoch non-terminal strategy lifecycle
+  makes the observation unavailable rather than being silently adopted or ignored. Disabling
+  pauses entries; it does not reset P&L or free exposure. Principal revisions are external
+  flows, not epoch boundaries.
+- Alpha committed capital remains positive finite allocated
+  `strategy_funding_decisions.amount` for a paper deployment whose trade is absent or whose
+  authority/ownership/reconciliation state is non-terminal.
+- Core committed capital has two disjoint sources. Before entry reconciliation is terminal it
+  is the positive finite entry order `requested_amount`. After a filled entry has exact active
+  ownership it is the sum of the current P&L snapshot's per-position `amount` across every
+  owned execution. This authoritative remaining cost basis handles partial fills and releases
+  principal after a broker-side partial close; because v1 refuses an externally partially
+  altered core position, that release cannot silently fund another order until the state is
+  reconciled/closed. `planned`, submitted-unreconciled and `reconcile_required` therefore
+  cannot reopen headroom. A terminal trade with unresolved entry reconciliation or active
+  ownership is inconsistent and makes the observation unavailable.
+- The entry must be one `BUY MARKET` order with `execution_origin='strategy'`, the same
+  instrument as its trade, one `purpose='entry'` link, and a reconciliation row. Missing,
+  duplicate, null, malformed, or cross-linked authority is incomplete, never zero. Queries
+  aggregate each authority in its own CTE before summing, so later one-to-many joins cannot
+  multiply money.
+- The existing core gate allows multiple resolved open core trades/lots, but at most one
+  **unresolved entry**: `core_trade_in_flight` is produced only when a non-terminal trade has
+  a missing/non-terminal entry reconciliation row. Therefore a submitted-but-unowned core
+  order is included in commitment and categorically blocks another evaluation; resolved open
+  lots are all included in exact ownership and may be rebalanced with another entry.
+- Pool realised P&L reuses #2602's existing exact-owned F-0 rule over both arms: every close
+  slice for an owned position is included, `SUM` is accompanied by `BOOL_AND` non-null
+  completeness, and released ownership without reconciled close history is unavailable.
+  Active-position partial-close rows are subject to the same non-null check. The existing
+  trade ledger defines `realized_pnl_usd` as the broker's realised P&L and keeps fees
+  separately; until #2602 proves whether that field is net of every cost, the sandbox uses
+  the same reconciled value already used today and the limitation remains named. No new,
+  more optimistic P&L interpretation is introduced here. Fixed mode includes losses and
+  excludes profits; compound mode includes both through `sandbox_bound`.
+- Page `committed` is the same combined authority total execution uses. Page `working` is
+  the subset whose trade has complete active exact ownership; `reserved` is renamed
+  `committed` in the UI, and `available = max(0, bound - committed)`. Working is explicitly
+  a subset of committed, never an additive bucket. These are DB-authority observations, not
+  claims to be simultaneous broker valuations; live value/P&L remains on the exact-position
+  and EOD wealth surfaces.
+
+The existing per-deployment alpha realised/commitment calculations remain for deployment
+ceilings. Only the shared pool figures widen to both authorised arms.
+
+## Core observation and submission
+
+`observe_core_sleeve` receives the active exact core position IDs and an explicitly derived
+`available_core_cash`; it no longer reads whole-account aggregate instrument value or treats
+broker cash as the sleeve cash. The existing account-currency, timezone, freshness/future
+timestamp, and P&L-pending-order checks remain in their current observer/preflight layers;
+the pool and snapshot must both resolve to USD before money is compared.
+
+It refuses when:
+
+- an active owned ID is absent from the broker snapshot;
+- an owned row belongs to another instrument;
+- an owned row is short;
+- an owned row is externally partially altered;
+- duplicate ownership IDs are supplied;
+- derived assigned cash is negative or otherwise invalid.
+
+An empty ownership set is a genuine empty core sleeve only when the core submission gate also
+proves there is no non-terminal core trade. It remains empty even if the operator manually
+owns the selected instrument.
+
+Before any core decision, the executor requires a configured, enabled USD paper pool and a
+complete sandbox observation. The core critical section acquires the existing shared paper
+allocator lock before its mandate/submission locks. This serialises core submission against
+alpha reservation and paper-pool revision. Under the lock it re-reads the pool event,
+ownership and commitments, obtains the one broker snapshot, derives the sleeve, and later
+re-proves the same pool revision before durable authority is committed. Exact-position close
+and ownership-release paths take the shared allocator lock too. The final transaction locks
+the relevant trade/order/ownership rows and compares a deterministic fingerprint of pool
+event ID, mandate event ID, active core ownership IDs, non-terminal core trade/order IDs,
+combined committed amount, and realised-P&L total. A changed fingerprint refuses; a new or
+released position cannot slip through the network interval.
+
+The broker preflight's second P&L snapshot is filtered through the same frozen exact-owned ID
+set and assigned-cash ceiling. A moved market value can change the trade verdict as today;
+a changed DB authority or pool revision refuses before submission. The final requested amount
+must be no greater than both assigned headroom and broker available cash. The measured eToro
+cost is price-embedded: the requested cash amount already includes it and the sizing solver
+reduces acquired core value accordingly, so adding cost a second time to commitment would
+double-charge it. Manual account activity after the final snapshot remains a broker race the
+API cannot make atomic; rejection/uncertainty follows the existing durable reconciliation
+path and never retries as a new order.
+
+The kill switch, demo-only guard, eligibility proof, account credential binding, submission
+UUID, reconciliation-only resume, and buy-only limitation remain mandatory and unchanged.
+Resume reloads the original request UUID, order ID and amount, performs lookup/reconciliation
+only, and cannot re-price, insert an entry order, or run after its reconciliation becomes
+terminal. Resume never creates a new capital commitment.
+
+The execution arm remains buy-only because eToro's close-cost quote requires exact position
+IDs and one cash amount may span several lots; no sourced lot-allocation rule exists yet.
+An overweight holding returns `core_close_side_cost_quote_unavailable`, remains visible, and
+can be fully closed through the existing exact-owned operator control. This is a disclosed
+v1 limitation, not a claim that both mandate directions are automated.
+
+## Control plane and page
+
+Any principal or mode change whose resulting effective bound is below **combined** alpha and
+core commitment refuses. Disabling is always allowed because it removes entry authority and
+does not release or resize holdings. Market appreciation may make current market value exceed
+the original committed cash; that is investment return, not newly committed capital, and does
+not force a sale. The boundary limits additional cash authority, while the page separately
+shows live market value and P&L.
+
+The `/strategies` paper-pool view reports combined committed, working, and remaining capital,
+so the visible `Pot`, `Working`, `Committed`, and `Available` figures agree with the execution
+control. The core card names `paper_pool_unconfigured`,
+`paper_pool_disabled`, `sandbox_observation_incomplete`, or `sandbox_exceeded` as blockers and
+does not offer rebalance while any applies.
+
+The existing form remains the sole place to assign capital and choose fixed/compound mode;
+the core mandate form continues to express only percentages and rebalance policy. This avoids
+a fourth capital surface.
+
+## Tests and acceptance
+
+Provider tests cover documented lower-camel IDs, live legacy-uppercase IDs, absent/malformed/
+duplicate IDs, and preservation of aggregate account formulas.
+
+Service/DB/API tests prove:
+
+1. a manual same-instrument position contributes zero to core market value;
+2. two exact-owned core lots sum and a missing/wrong-instrument/short owned lot refuses;
+3. a pending core order consumes headroom before it appears at the broker;
+4. an open core holding and an alpha allocation cannot together exceed the assigned bound;
+5. fixed and compound modes use combined exact-owned realised P&L correctly;
+6. lowering principal below combined commitment refuses;
+7. core and alpha submissions serialize on the shared allocator lock;
+8. a concurrent pool revision is detected before core authority is committed;
+9. broker cash below assigned headroom caps the sleeve; broker cash above it cannot enlarge it;
+10. the overview and page report the same bound/commitment/headroom used by execution;
+11. unconfigured, disabled, incomplete, exhausted, kill-switch, real-environment, and uncertain
+    submission paths remain non-mutating;
+12. the existing operator close path can close an exact core position and the released close
+    P&L becomes available only after authoritative history reconciliation and subsequently
+    changes only the mode-permitted bound;
+13. repeated calls while a core entry is pending cannot pyramid, lifecycle inconsistencies
+    refuse, and external partial alteration refuses;
+14. USD mismatch, costs near headroom, mandate-instrument revision, and concurrent
+    ownership/reconciliation mutation all fail in the conservative direction.
+
+After local semantic tests and full gates, checkpoint 2 reviews the staged branch before its
+first push. Demo mutation remains prohibited until the PR is approved, green, merged, and the
+operator is present for the lifecycle.

--- a/docs/proposals/ta/2026-08-24-core-assigned-capital-boundary.md
+++ b/docs/proposals/ta/2026-08-24-core-assigned-capital-boundary.md
@@ -142,12 +142,16 @@ core executor, alpha executor, withdrawal guard, and overview.
   the same reconciled value already used today and the limitation remains named. No new,
   more optimistic P&L interpretation is introduced here. Fixed mode includes losses and
   excludes profits; compound mode includes both through `sandbox_bound`.
-- Page `committed` is the same combined authority total execution uses. Page `working` is
-  the subset whose trade has complete active exact ownership; `reserved` is renamed
-  `committed` in the UI, and `available = max(0, bound - committed)`. Working is explicitly
-  a subset of committed, never an additive bucket. These are DB-authority observations, not
-  claims to be simultaneous broker valuations; live value/P&L remains on the exact-position
-  and EOD wealth surfaces.
+- With no active core ownership, page `committed` is the same combined authority total
+  execution uses and `available = max(0, bound - committed)`. While core ownership is active,
+  the database can identify the exact broker position IDs but cannot value their remaining
+  cost basis without a live snapshot. The page therefore marks the capital observation
+  incomplete and renders `working`, `committed`, and `available` unavailable rather than
+  presenting the original request as current commitment. The database-only core status
+  endpoint does not advertise rebalance readiness in that state; scheduled or explicitly
+  invoked execution obtains the exact-position snapshot and applies the authoritative bound
+  before it can submit. These are deliberately not claims to be simultaneous broker
+  valuations; live value/P&L remains on the exact-position and EOD wealth surfaces.
 
 The existing per-deployment alpha realised/commitment calculations remain for deployment
 ceilings. Only the shared pool figures widen to both authorised arms.
@@ -216,9 +220,10 @@ the original committed cash; that is investment return, not newly committed capi
 not force a sale. The boundary limits additional cash authority, while the page separately
 shows live market value and P&L.
 
-The `/strategies` paper-pool view reports combined committed, working, and remaining capital,
-so the visible `Pot`, `Working`, `Committed`, and `Available` figures agree with the execution
-control. The core card names `paper_pool_unconfigured`,
+The `/strategies` paper-pool view reports combined committed, working, and remaining capital
+when those figures are complete. With active core ownership it reports the observation as
+incomplete and withholds those three figures, so the visible `Pot`, `Working`, `Committed`,
+and `Available` surface never overstates executable headroom. The core card names `paper_pool_unconfigured`,
 `paper_pool_disabled`, `sandbox_observation_incomplete`, or `sandbox_exceeded` as blockers and
 does not offer rebalance while any applies.
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2974,7 +2974,7 @@ export interface CoreSleeveResponse {
   pending_order_id: number | null;
   execution_action: "blocked" | "rebalance" | "resume";
   blockers: Array<{
-    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_mandate_selection_mismatch" | "core_demo_required" | "core_order_unresolved" | "core_capital_authority_incomplete" | "core_paper_pool_unconfigured" | "core_paper_pool_disabled" | "core_sandbox_exceeded";
+    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_mandate_selection_mismatch" | "core_demo_required" | "core_order_unresolved" | "core_capital_authority_incomplete" | "core_live_snapshot_required" | "core_paper_pool_unconfigured" | "core_paper_pool_disabled" | "core_sandbox_exceeded";
     detail: string;
   }>;
   environment: "demo" | "real";

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2932,6 +2932,7 @@ export interface StrategyPaperPool {
   reserved_capital: string;
   invested_capital: string | null;
   remaining_capital: string | null;
+  capital_observation_complete: boolean;
   mandate: StrategyPortfolioMandate;
   available_mandates: StrategyPortfolioMandate[];
 }
@@ -2973,7 +2974,7 @@ export interface CoreSleeveResponse {
   pending_order_id: number | null;
   execution_action: "blocked" | "rebalance" | "resume";
   blockers: Array<{
-    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_mandate_selection_mismatch" | "core_demo_required" | "core_order_unresolved";
+    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_mandate_selection_mismatch" | "core_demo_required" | "core_order_unresolved" | "core_capital_authority_incomplete" | "core_paper_pool_unconfigured" | "core_paper_pool_disabled" | "core_sandbox_exceeded";
     detail: string;
   }>;
   environment: "demo" | "real";

--- a/frontend/src/components/strategies/StrategyPortfolioPanels.tsx
+++ b/frontend/src/components/strategies/StrategyPortfolioPanels.tsx
@@ -464,9 +464,14 @@ export function AutomationControl({
       <dl className="mt-5 grid grid-cols-2 gap-3 border-t border-slate-200 pt-4 text-xs sm:grid-cols-4 dark:border-slate-800">
         <div><dt className="text-slate-500">Risk base</dt><dd className="font-semibold tabular-nums">{money(pool.effective_capital)}</dd></div>
         <div><dt className="text-slate-500">Working</dt><dd className="font-semibold tabular-nums">{money(pool.invested_capital)}</dd></div>
-        <div><dt className="text-slate-500">Reserved</dt><dd className="font-semibold tabular-nums">{money(pool.reserved_capital)}</dd></div>
-        <div><dt className="text-slate-500">Available</dt><dd className="font-semibold tabular-nums">{money(pool.remaining_capital)}</dd></div>
+        <div><dt className="text-slate-500">Committed</dt><dd className="font-semibold tabular-nums">{money(pool.capital_observation_complete === false ? null : pool.reserved_capital)}</dd></div>
+        <div><dt className="text-slate-500">Available</dt><dd className="font-semibold tabular-nums">{money(pool.capital_observation_complete === false ? null : pool.remaining_capital)}</dd></div>
       </dl>
+      <p className="mt-2 text-xs text-slate-500">
+        Working is marked value when the full owned population is observable here; it is unavailable while core is
+        active. Committed is the engine authority already issued, including pending orders and core. These figures
+        overlap and must not be added together.
+      </p>
       {!canEnable ? (
         <p className="mt-4 text-xs text-amber-700 dark:text-amber-300">
           {!accountEligible

--- a/frontend/src/lib/strategyPortfolioStatus.test.ts
+++ b/frontend/src/lib/strategyPortfolioStatus.test.ts
@@ -32,6 +32,7 @@ function overview(patch: Record<string, unknown> = {}): StrategyOverviewResponse
       reserved_capital: "0",
       invested_capital: "0",
       remaining_capital: "10000",
+      capital_observation_complete: true,
       mandate: { configured: true, risk_profile: "balanced" },
       available_mandates: [],
     },

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -156,6 +156,7 @@ const OVERVIEW: StrategyOverviewResponse = {
     reserved_capital: "0.000000",
     invested_capital: "0.000000",
     remaining_capital: "1000.000000",
+    capital_observation_complete: true,
     mandate: {
       configured: true,
       policy_version: "portfolio-mandate-v1",

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -39,6 +39,7 @@ const BLOCKED = {
     reserved_capital: "0",
     invested_capital: "0",
     remaining_capital: "0",
+    capital_observation_complete: true,
     mandate: { configured: false, policy_version: "portfolio-mandate-unconfigured", risk_profile: "unconfigured" },
     available_mandates: [{ risk_profile: "cautious" }, { risk_profile: "balanced" }, { risk_profile: "growth" }],
   },

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -331,7 +331,7 @@ export function StrategyPortfolioLens() {
             toneHint
           />
           <StatTile label="Open" value={formatNumber(summary.activePositions, 0)} hint={`${formatNumber(summary.approved, 0)} strategies approved`} />
-          <StatTile label="Available" value={formatMoney(number(pool.remaining_capital), pool.currency)} hint="To deploy" />
+          <StatTile label="Available" value={formatMoney(number(pool.capital_observation_complete === false ? null : pool.remaining_capital), pool.currency)} hint={pool.capital_observation_complete === false ? "Checked at action" : "To deploy"} />
         </div>
 
         {actionError ? (

--- a/tests/test_2525_engine_capital.py
+++ b/tests/test_2525_engine_capital.py
@@ -1,0 +1,246 @@
+"""Exact broker join for the engine-wide assigned-capital boundary (#2525)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.providers.broker import BrokerAccountRiskSnapshot, BrokerDirectPositionInvestment
+from app.services.strategy_control_plane import configure_paper_pool
+from app.services.strategy_core_allocator import CoreSleeveState
+from app.services.strategy_core_mandate import CORE_MANDATE_POLICY_VERSION
+from app.services.strategy_core_rebalance_intent import record_core_rebalance_intent
+from app.services.strategy_engine_capital import (
+    EngineCapitalAuthority,
+    EngineCapitalObservationError,
+    load_engine_capital_authority,
+    resolve_engine_capital_usage,
+)
+
+NOW = datetime(2026, 8, 24, tzinfo=UTC)
+
+
+def authority(*, ids: tuple[int, ...] = (11,), alpha: str = "200", pending: str = "100") -> EngineCapitalAuthority:
+    return EngineCapitalAuthority(
+        pool_event_id=1,
+        enabled=True,
+        capital_limit=Decimal("1000"),
+        capital_mode="fixed",
+        epoch_started_at=NOW,
+        realised_delta=Decimal("0"),
+        alpha_committed=Decimal(alpha),
+        alpha_working=Decimal("150"),
+        core_pending_committed=Decimal(pending),
+        core_active_recorded_committed=Decimal("300") if ids else Decimal("0"),
+        core_active_position_ids=ids,
+    )
+
+
+def position(
+    position_id: int,
+    *,
+    instrument_id: int = 42,
+    amount: str = "300",
+    market_value: str = "330",
+    is_buy: bool = True,
+    partial: bool = False,
+) -> BrokerDirectPositionInvestment:
+    return BrokerDirectPositionInvestment(
+        position_id=position_id,
+        instrument_id=instrument_id,
+        is_buy=is_buy,
+        amount=Decimal(amount),
+        unrealized_pnl=Decimal(market_value) - Decimal(amount),
+        market_value=Decimal(market_value),
+        is_partially_altered=partial,
+    )
+
+
+def snapshot(
+    *rows: BrokerDirectPositionInvestment,
+    account_currency_id: int | None = 1,
+) -> BrokerAccountRiskSnapshot:
+    return BrokerAccountRiskSnapshot(
+        available_cash=Decimal("5000"),
+        total_invested=Decimal("9000"),
+        unrealized_pnl=Decimal("0"),
+        equity=Decimal("14000"),
+        instrument_investments=(),
+        observed_at=NOW,
+        raw_payload={},
+        direct_positions=rows,
+        account_currency_id=account_currency_id,
+    )
+
+
+def test_only_exact_owned_positions_enter_the_shared_boundary() -> None:
+    usage = resolve_engine_capital_usage(
+        authority(),
+        snapshot(position(11), position(99, amount="8000", market_value="9000")),
+        core_instrument_id=42,
+    )
+
+    assert usage.core_active_committed == Decimal("300")
+    assert usage.core_market_value == Decimal("330")
+    assert usage.committed == Decimal("600")
+    assert usage.working == Decimal("450")
+    assert usage.headroom.remaining == Decimal("400")
+
+
+@pytest.mark.parametrize(
+    ("rows", "instrument_id", "message"),
+    [
+        ((), 42, "absent"),
+        ((position(11, instrument_id=43),), 42, "another instrument"),
+        ((position(11, is_buy=False),), 42, "short"),
+        ((position(11, partial=True),), 42, "partially altered"),
+        ((position(11),), None, "no configured instrument"),
+    ],
+)
+def test_an_inexact_active_core_population_refuses(
+    rows: tuple[BrokerDirectPositionInvestment, ...], instrument_id: int | None, message: str
+) -> None:
+    with pytest.raises(EngineCapitalObservationError, match=message):
+        resolve_engine_capital_usage(authority(), snapshot(*rows), core_instrument_id=instrument_id)
+
+
+def test_no_core_positions_need_no_core_mandate() -> None:
+    usage = resolve_engine_capital_usage(authority(ids=()), snapshot(position(99)), core_instrument_id=None)
+    assert usage.core_active_committed == 0
+    assert usage.committed == Decimal("300")
+
+
+@pytest.mark.parametrize("account_currency_id", [None, 2])
+def test_shared_boundary_refuses_a_snapshot_not_observed_as_usd(account_currency_id: int | None) -> None:
+    with pytest.raises(EngineCapitalObservationError, match="not observed as USD"):
+        resolve_engine_capital_usage(
+            authority(ids=()),
+            snapshot(account_currency_id=account_currency_id),
+            core_instrument_id=None,
+        )
+
+
+def test_database_authority_begins_at_the_first_assigned_pool_event(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    assert load_engine_capital_authority(conn) is None
+
+    pool = configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("1250"),
+        capital_mode="fixed",
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="assign the engine pot",
+    )
+    loaded = load_engine_capital_authority(conn)
+
+    assert loaded is not None
+    assert loaded.pool_event_id == pool.event_id
+    assert loaded.capital_limit == Decimal("1250")
+    assert loaded.alpha_committed == 0
+    assert loaded.core_pending_committed == 0
+    assert loaded.core_active_recorded_committed == 0
+    assert loaded.core_active_position_ids == ()
+
+
+def test_a_pending_allocation_before_the_assigned_pot_refuses_instead_of_disappearing(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,is_tradable) "
+        "VALUES (42,'ALPHA.PRE','Pre-pot allocation',TRUE)"
+    )
+    signal = conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id,strategy_version,instrument_id,signal_bar_date,
+            signal_kind,verdict,fill_bar_date,fill_price,universe,input_rule_set_versions
+        ) VALUES ('pre_pot','v1',42,DATE '2026-08-20','entry','fired',
+                  DATE '2026-08-21',10,'survivor_only','{"test":"v1"}'::jsonb)
+        RETURNING signal_id
+        """
+    ).fetchone()
+    deployment = conn.execute(
+        """
+        INSERT INTO strategy_deployments (
+            strategy_id,strategy_version,mode,capital_limit,currency,enabled,updated_by,reason
+        ) VALUES ('pre_pot','v1','paper',1000,'USD',TRUE,'test','test')
+        RETURNING deployment_id
+        """
+    ).fetchone()
+    assert signal is not None and deployment is not None
+    conn.execute(
+        """
+        INSERT INTO strategy_funding_decisions (
+            signal_id,deployment_id,verdict,amount,reason_code,decided_at
+        ) VALUES (%s,%s,'allocated',100,'pre_pot',now() - interval '1 hour')
+        """,
+        (signal[0], deployment[0]),
+    )
+    configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("1250"),
+        capital_mode="fixed",
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="assign the engine pot",
+    )
+
+    with pytest.raises(EngineCapitalObservationError, match="predates the assigned pot"):
+        load_engine_capital_authority(conn)
+
+
+def test_a_trade_backed_by_a_non_actionable_core_intent_refuses_instead_of_disappearing(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("1250"),
+        capital_mode="fixed",
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="assign the engine pot",
+    )
+    conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,is_tradable) "
+        "VALUES (42,'CORE.BAD','Malformed core authority',TRUE)"
+    )
+    row = conn.execute(
+        """
+        INSERT INTO strategy_core_mandate_events (
+            revision,enabled,base_currency,core_instrument_id,core_target_pct,
+            liquidity_reserve_pct,rebalance_band_pct,min_rebalance_amount,
+            policy_version,changed_by,reason,mode
+        ) VALUES (1,FALSE,'USD',42,60,5,5,10,%s,'test','test','paper')
+        RETURNING core_mandate_event_id
+        """,
+        (CORE_MANDATE_POLICY_VERSION,),
+    ).fetchone()
+    assert row is not None
+    intent = record_core_rebalance_intent(
+        conn,
+        state=CoreSleeveState(42, Decimal("600"), Decimal("400"), "USD", NOW),
+        recorded_by="test",
+    )
+    assert intent.decision.action == "refused"
+    conn.execute(
+        "INSERT INTO strategy_trades (core_rebalance_intent_id,instrument_id,status) VALUES (%s,42,'planned')",
+        (intent.core_rebalance_intent_id,),
+    )
+
+    with pytest.raises(EngineCapitalObservationError, match="entry authority is incomplete"):
+        load_engine_capital_authority(conn)

--- a/tests/test_2603_core_broker_preflight.py
+++ b/tests/test_2603_core_broker_preflight.py
@@ -18,6 +18,7 @@ import pytest
 from app.providers.broker import (
     BrokerAccountRiskSnapshot,
     BrokerCostComponent,
+    BrokerDirectPositionInvestment,
     BrokerInstrumentInvestment,
     BrokerWhatIfCostResponse,
     BrokerWhatIfOrder,
@@ -33,6 +34,7 @@ from app.services.strategy_core_broker_preflight import (
     assess_core_broker_preflight,
 )
 from app.services.strategy_core_mandate import CORE_MANDATE_POLICY_VERSION, CoreMandate
+from app.services.strategy_engine_capital import EngineCapitalAuthority
 
 CORE_ID = 4242
 NOW = datetime(2026, 8, 23, 14, 30, tzinfo=UTC)
@@ -73,6 +75,17 @@ def snapshot(
         equity=Decimal(core_market_value) + Decimal(cash),
         instrument_investments=(
             BrokerInstrumentInvestment(CORE_ID, Decimal(core_market_value), Decimal(core_market_value), 1, shorts),
+        ),
+        direct_positions=(
+            BrokerDirectPositionInvestment(
+                position_id=9001,
+                instrument_id=CORE_ID,
+                is_buy=shorts == 0,
+                amount=Decimal(core_market_value),
+                unrealized_pnl=Decimal("0"),
+                market_value=Decimal(core_market_value),
+                is_partially_altered=False,
+            ),
         ),
         observed_at=observed_at,
         raw_payload={},
@@ -137,7 +150,28 @@ def decision(*, amount: Decimal | None = None) -> CoreRebalanceDecision:
 def _state() -> Any:
     from app.services.strategy_core_sleeve import observe_core_sleeve
 
-    return observe_core_sleeve(snapshot(), core_instrument_id=CORE_ID)
+    return observe_core_sleeve(
+        snapshot(),
+        core_instrument_id=CORE_ID,
+        exact_owned_market_value=Decimal(_CORE_MV),
+        assigned_cash_available=Decimal(_CASH),
+    )
+
+
+def capital_authority() -> EngineCapitalAuthority:
+    return EngineCapitalAuthority(
+        pool_event_id=1,
+        enabled=True,
+        capital_limit=Decimal("1000"),
+        capital_mode="fixed",
+        epoch_started_at=NOW,
+        realised_delta=Decimal("0"),
+        alpha_committed=Decimal("0"),
+        alpha_working=Decimal("0"),
+        core_pending_committed=Decimal("0"),
+        core_active_recorded_committed=Decimal("500"),
+        core_active_position_ids=(9001,),
+    )
 
 
 def assess(broker: FakeBroker, **overrides: Any) -> Any:
@@ -145,6 +179,7 @@ def assess(broker: FakeBroker, **overrides: Any) -> Any:
         "mandate": mandate(),
         "decision": decision(),
         "core_instrument_id": CORE_ID,
+        "capital_authority": capital_authority(),
         "eligibility_response_currency": "USD",
         "eligibility_min_position_exposure": Decimal("10"),
         "eligibility_min_position_amount": Decimal("10"),

--- a/tests/test_2603_core_executor.py
+++ b/tests/test_2603_core_executor.py
@@ -77,7 +77,7 @@ class FakeBroker:
 
     def get_account_risk_snapshot(self) -> object:
         self.events.append("read_snapshot")
-        return object()
+        return SimpleNamespace(available_cash=Decimal("500"))
 
     def place_demo_core_order(self, _order: object, *, request_id: UUID) -> BrokerCoreOrderSubmission:
         assert request_id is not None
@@ -134,9 +134,16 @@ def _run(
         snapshot_observed_at=snapshot_observed_at or datetime.now(UTC),
         max_account_risk_age_seconds=30,
     )
+    capital_authority = SimpleNamespace(enabled=True)
+    capital_usage = SimpleNamespace(
+        core_market_value=Decimal("500"),
+        headroom=SimpleNamespace(within_bound=True, remaining=Decimal("500")),
+    )
 
     with (
         patch("app.services.strategy_core_executor.load_core_mandate", return_value=mandate),
+        patch("app.services.strategy_core_executor.load_engine_capital_authority", return_value=capital_authority),
+        patch("app.services.strategy_core_executor.resolve_engine_capital_usage", return_value=capital_usage),
         patch("app.services.strategy_core_executor.require_selected_core_instrument"),
         patch("app.services.strategy_core_executor.require_core_eligibility", side_effect=[proof, binding_proof]),
         patch("app.services.strategy_core_executor.observe_core_sleeve", return_value=object()),

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -255,7 +255,7 @@ def test_operator_view_labels_an_unresolved_order_as_resume_not_rebalance(
 @pytest.mark.parametrize(
     ("capital_authority", "expected_blocker"),
     [
-        (_capital_authority(active_position_ids=(99,)), "core_capital_authority_incomplete"),
+        (_capital_authority(active_position_ids=(99,)), "core_live_snapshot_required"),
         (_capital_authority(alpha_committed=Decimal("1000")), "core_sandbox_exceeded"),
     ],
 )

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import inspect
 from contextlib import nullcontext
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -44,6 +45,24 @@ from app.services.broker_credentials import (
 from app.services.strategy_core_executor import CoreExecutionResult, CoreResumeAuthority
 from app.services.strategy_core_mandate import CoreMandate
 from app.services.strategy_core_selection import CoreCandidateCoverage, CoreSelection
+
+
+def _capital_authority(
+    *,
+    active_position_ids: tuple[int, ...] = (),
+    alpha_committed: Decimal = Decimal("0"),
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        enabled=True,
+        capital_limit=Decimal("1000"),
+        capital_mode="fixed",
+        realised_delta=Decimal("0"),
+        alpha_committed=alpha_committed,
+        core_pending_committed=Decimal("0"),
+        core_active_recorded_committed=Decimal("0"),
+        core_active_position_ids=active_position_ids,
+    )
+
 
 CORE_MANDATE_PATH = "/strategies/core-mandate"
 CORE_SLEEVE_PATH = "/strategies/core-sleeve"
@@ -132,6 +151,7 @@ def test_collecting_state_reports_cash_and_server_derived_coverage(monkeypatch: 
     monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
     monkeypatch.setattr("app.api.strategies.load_core_mandate", lambda _conn: None)
     monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: None)
+    monkeypatch.setattr("app.api.strategies.load_engine_capital_authority", lambda _conn: None)
     response = read_core_sleeve(cast(Any, MagicMock()))
     assert response.state == "evidence_collecting"
     assert response.selected_instrument_id is None
@@ -141,6 +161,7 @@ def test_collecting_state_reports_cash_and_server_derived_coverage(monkeypatch: 
     assert response.can_resume is False
     assert response.execution_action == "blocked"
     assert [blocker.code for blocker in response.blockers] == [
+        "core_paper_pool_unconfigured",
         "core_evidence_collecting",
         "core_mandate_unconfigured",
     ]
@@ -219,6 +240,7 @@ def test_operator_view_labels_an_unresolved_order_as_resume_not_rebalance(
     monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
     monkeypatch.setattr("app.api.strategies.load_core_mandate", lambda _conn: _mandate(core_instrument_id=3417))
     monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: authority)
+    monkeypatch.setattr("app.api.strategies.load_engine_capital_authority", lambda _conn: _capital_authority())
     monkeypatch.setattr("app.api.strategies.settings.etoro_env", "demo")
 
     response = read_core_sleeve(cast(Any, MagicMock()))
@@ -228,6 +250,46 @@ def test_operator_view_labels_an_unresolved_order_as_resume_not_rebalance(
     assert response.execution_action == "resume"
     assert response.pending_order_id == 31
     assert [blocker.code for blocker in response.blockers] == ["core_order_unresolved"]
+
+
+@pytest.mark.parametrize(
+    ("capital_authority", "expected_blocker"),
+    [
+        (_capital_authority(active_position_ids=(99,)), "core_capital_authority_incomplete"),
+        (_capital_authority(alpha_committed=Decimal("1000")), "core_sandbox_exceeded"),
+    ],
+)
+def test_operator_view_does_not_advertise_unavailable_core_headroom(
+    monkeypatch: pytest.MonkeyPatch,
+    capital_authority: SimpleNamespace,
+    expected_blocker: str,
+) -> None:
+    selection = CoreSelection(
+        state="ready",
+        selected_instrument_id=3417,
+        selected_symbol="SPY.RTH",
+        evidence_ref="#2833 verdict",
+        required_trading_days=5,
+        observed_trading_days=5,
+        max_cost_bps=60,
+        candidates=(),
+        missing_candidate_ids=(),
+        configuration_error=None,
+    )
+    monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
+    monkeypatch.setattr("app.api.strategies.load_core_mandate", lambda _conn: _mandate(core_instrument_id=3417))
+    monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: None)
+    monkeypatch.setattr(
+        "app.api.strategies.load_engine_capital_authority",
+        lambda _conn: capital_authority,
+    )
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "demo")
+
+    response = read_core_sleeve(cast(Any, MagicMock()))
+
+    assert response.can_rebalance is False
+    assert response.execution_action == "blocked"
+    assert [blocker.code for blocker in response.blockers] == [expected_blocker]
 
 
 def test_operator_view_refuses_a_mandate_for_the_previous_reviewed_selection(
@@ -248,6 +310,7 @@ def test_operator_view_refuses_a_mandate_for_the_previous_reviewed_selection(
     monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
     monkeypatch.setattr("app.api.strategies.load_core_mandate", lambda _conn: _mandate(core_instrument_id=3417))
     monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: None)
+    monkeypatch.setattr("app.api.strategies.load_engine_capital_authority", lambda _conn: _capital_authority())
     monkeypatch.setattr("app.api.strategies.settings.etoro_env", "demo")
 
     response = read_core_sleeve(cast(Any, MagicMock()))

--- a/tests/test_2603_core_rebalance_observation_job.py
+++ b/tests/test_2603_core_rebalance_observation_job.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -59,6 +60,7 @@ class _Harness:
         self.broker = MagicMock()
         self.broker.__enter__ = MagicMock(return_value=self.broker)
         self.broker.__exit__ = MagicMock(return_value=False)
+        self.broker.get_account_risk_snapshot.return_value = SimpleNamespace(available_cash=Decimal("4000"))
 
         self.tracker = MagicMock()
         self.tracker.__enter__ = MagicMock(return_value=self.tracker)
@@ -102,6 +104,11 @@ class _Harness:
         observe_kwargs: dict[str, Any] = (
             {"side_effect": observe} if isinstance(observe, Exception) else {"return_value": observe or _state()}
         )
+        capital_authority = SimpleNamespace(enabled=True)
+        capital_usage = SimpleNamespace(
+            core_market_value=Decimal("6000"),
+            headroom=SimpleNamespace(remaining=Decimal("4000"), within_bound=True),
+        )
 
         with (
             patch("app.workers.scheduler.settings.etoro_env", env),
@@ -111,6 +118,14 @@ class _Harness:
             patch("app.workers.scheduler.connect_job", return_value=self.conn),
             patch("app.providers.implementations.etoro_broker.EtoroBrokerProvider", return_value=self.broker) as prov,
             patch("app.services.strategy_core_mandate.load_core_mandate", **load_kwargs) as load,
+            patch(
+                "app.services.strategy_engine_capital.load_engine_capital_authority",
+                return_value=capital_authority,
+            ),
+            patch(
+                "app.services.strategy_engine_capital.resolve_engine_capital_usage",
+                return_value=capital_usage,
+            ),
             patch("app.services.strategy_core_sleeve.observe_core_sleeve", **observe_kwargs) as obs,
             patch(
                 "app.services.strategy_core_rebalance_intent.record_core_rebalance_intent",
@@ -243,8 +258,12 @@ class TestTheMandateRevisionRace:
         harness = _Harness()
         harness.run()
         locks = [c for c in harness.conn.execute.call_args_list if "pg_advisory_xact_lock" in str(c.args[0])]
-        assert len(locks) == 1
-        assert locks[0].args[1] == CORE_MANDATE_ADVISORY_LOCK
+        from app.services.strategy_control_plane import PAPER_ALLOCATOR_ADVISORY_LOCK
+
+        assert [call.args[1] for call in locks] == [
+            PAPER_ALLOCATOR_ADVISORY_LOCK,
+            CORE_MANDATE_ADVISORY_LOCK,
+        ]
 
 
 class TestTheHappyPath:
@@ -298,6 +317,17 @@ class TestTheHappyPath:
                 return_value=harness.broker,
             ) as provider,
             patch("app.services.strategy_core_mandate.load_core_mandate", return_value=_mandate()),
+            patch(
+                "app.services.strategy_engine_capital.load_engine_capital_authority",
+                return_value=SimpleNamespace(enabled=True),
+            ),
+            patch(
+                "app.services.strategy_engine_capital.resolve_engine_capital_usage",
+                return_value=SimpleNamespace(
+                    core_market_value=Decimal("6000"),
+                    headroom=SimpleNamespace(remaining=Decimal("4000")),
+                ),
+            ),
             patch("app.services.strategy_core_sleeve.observe_core_sleeve", return_value=_state()),
             patch(
                 "app.services.strategy_core_rebalance_intent.record_core_rebalance_intent",
@@ -314,7 +344,9 @@ class TestTheHappyPath:
         harness = _Harness()
         order: list[str] = []
         harness.conn.__exit__ = MagicMock(side_effect=lambda *_: order.append("conn_closed") or False)
-        harness.broker.get_account_risk_snapshot.side_effect = lambda: order.append("http") or MagicMock()
+        harness.broker.get_account_risk_snapshot.side_effect = lambda: (
+            order.append("http") or SimpleNamespace(available_cash=Decimal("4000"))
+        )
 
         harness.run()
 

--- a/tests/test_2603_core_submission_gate.py
+++ b/tests/test_2603_core_submission_gate.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from app.services.strategy_control_plane import PAPER_ALLOCATOR_ADVISORY_LOCK
 from app.services.strategy_core_mandate import CORE_MANDATE_ADVISORY_LOCK
 from app.services.strategy_core_submission_gate import (
     _ADMISSION_SQL,
@@ -78,7 +79,7 @@ def test_the_lock_assertion_pins_the_two_int4_advisory_encoding() -> None:
     assert "granted" in text
 
 
-def test_both_advisory_keys_are_positive_because_the_assertion_compares_unsigned() -> None:
+def test_all_advisory_keys_are_positive_and_distinct_because_the_assertion_compares_unsigned() -> None:
     """``pg_locks.classid``/``objid`` are OID-width; the lock functions take signed int4.
 
     A negative key component would be stored as its uint32 image and would not
@@ -86,9 +87,10 @@ def test_both_advisory_keys_are_positive_because_the_assertion_compares_unsigned
     a lock that IS held — and the gate would raise on every call.  Cheap to pin,
     invisible if it ever changes.
     """
-    for key in (CORE_MANDATE_ADVISORY_LOCK, CORE_SUBMISSION_ADVISORY_LOCK):
+    keys = (PAPER_ALLOCATOR_ADVISORY_LOCK, CORE_MANDATE_ADVISORY_LOCK, CORE_SUBMISSION_ADVISORY_LOCK)
+    for key in keys:
         assert all(component > 0 for component in key), key
-    assert CORE_MANDATE_ADVISORY_LOCK != CORE_SUBMISSION_ADVISORY_LOCK
+    assert len(set(keys)) == len(keys)
 
 
 def test_the_admission_query_is_one_statement() -> None:

--- a/tests/test_2603_core_submission_gate_db.py
+++ b/tests/test_2603_core_submission_gate_db.py
@@ -20,6 +20,7 @@ from uuid import UUID, uuid4
 import psycopg
 import pytest
 
+from app.services.strategy_control_plane import PAPER_ALLOCATOR_ADVISORY_LOCK
 from app.services.strategy_core_eligibility import CORE_ELIGIBILITY_POLICY_VERSION
 from app.services.strategy_core_mandate import CORE_MANDATE_MODE, CORE_MANDATE_POLICY_VERSION
 from app.services.strategy_core_submission_gate import (
@@ -274,6 +275,9 @@ def test_admission_without_the_lock_raises_rather_than_refusing(
     account = _seed_account(ebull_test_conn)
     _seed_proof(ebull_test_conn, account)
     intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    # Fixture setup acquires transaction-scoped credential and mandate locks;
+    # release them so this assertion really begins outside the critical section.
+    ebull_test_conn.commit()
     with pytest.raises(StrategyCoreSubmissionError, match="core_submission_lock"):
         admit_core_rebalance_intent(
             ebull_test_conn,
@@ -296,7 +300,8 @@ def test_holding_only_the_submission_lock_still_raises(
     account = _seed_account(ebull_test_conn)
     _seed_proof(ebull_test_conn, account)
     intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
-    ebull_test_conn.execute("SELECT pg_advisory_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
+    for key in (PAPER_ALLOCATOR_ADVISORY_LOCK, CORE_SUBMISSION_ADVISORY_LOCK):
+        ebull_test_conn.execute("SELECT pg_advisory_lock(%s, %s)", key)
     ebull_test_conn.commit()
     try:
         with pytest.raises(StrategyCoreSubmissionError, match="mandate advisory lock"):
@@ -308,7 +313,8 @@ def test_holding_only_the_submission_lock_still_raises(
                 environment="demo",
             )
     finally:
-        ebull_test_conn.execute("SELECT pg_advisory_unlock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
+        for key in (CORE_SUBMISSION_ADVISORY_LOCK, PAPER_ALLOCATOR_ADVISORY_LOCK):
+            ebull_test_conn.execute("SELECT pg_advisory_unlock(%s, %s)", key)
         ebull_test_conn.commit()
 
 

--- a/tests/test_2704_core_sleeve_observer.py
+++ b/tests/test_2704_core_sleeve_observer.py
@@ -16,7 +16,8 @@ from app.providers.broker import BrokerAccountRiskSnapshot, BrokerInstrumentInve
 from app.services.account_equity_evidence import DOCUMENTED_ACCOUNT_CURRENCIES
 from app.services.strategy_core_allocator import CoreSleeveState, evaluate_core_rebalance
 from app.services.strategy_core_mandate import CORE_MANDATE_POLICY_VERSION, CoreMandate
-from app.services.strategy_core_sleeve import CoreSleeveObservationError, observe_core_sleeve
+from app.services.strategy_core_sleeve import CoreSleeveObservationError
+from app.services.strategy_core_sleeve import observe_core_sleeve as _observe_core_sleeve
 
 CORE_ID = 2449001
 _NOW = datetime(2026, 8, 14, 13, 7, tzinfo=UTC)
@@ -50,6 +51,23 @@ def row(
     shorts: int = 0,
 ) -> BrokerInstrumentInvestment:
     return BrokerInstrumentInvestment(instrument_id, Decimal(amount), Decimal(market_value), longs, shorts)
+
+
+def observe_core_sleeve(broker_snapshot: BrokerAccountRiskSnapshot, *, core_instrument_id: int) -> CoreSleeveState:
+    """Adapt legacy #2704 fixtures to the now externally exact-owned inputs."""
+    matches = [item for item in broker_snapshot.instrument_investments if item.instrument_id == core_instrument_id]
+    if len(matches) > 1:
+        raise CoreSleeveObservationError("core sleeve is ambiguous")
+    value = matches[0].direct_long_market_value if matches else Decimal("0")
+    state = _observe_core_sleeve(
+        broker_snapshot,
+        core_instrument_id=core_instrument_id,
+        exact_owned_market_value=value,
+        assigned_cash_available=broker_snapshot.available_cash,
+    )
+    if matches and matches[0].direct_short_positions:
+        raise CoreSleeveObservationError("core sleeve contains a short")
+    return state
 
 
 def test_the_sleeve_reads_market_value_and_not_committed_capital() -> None:

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -26,6 +26,7 @@ from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_V
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.result_ledger import store_holdout_result, store_in_sample_result
+from app.services.strategy_engine_capital import EngineCapitalObservationError
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
 from app.services.strategy_regime_evidence import (
@@ -464,6 +465,23 @@ def test_empty_ledgers_still_return_all_manifest_strategies(
     s4 = next(item for item in overview.strategies if item.strategy_id == "s4-volatility-compression-breakout")
     assert s4.runnable
     assert s4.exclusion_reason is None
+
+
+def test_incomplete_shared_capital_keeps_overview_readable_but_withholds_headroom(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed_universe_anchor(ebull_test_conn)
+
+    def incomplete(_conn: object) -> None:
+        raise EngineCapitalObservationError("test incomplete ownership")
+
+    monkeypatch.setattr("app.api.strategies.load_engine_capital_authority", incomplete)
+    overview = get_strategy_overview(ebull_test_conn)
+
+    assert not overview.paper_pool.capital_observation_complete
+    assert overview.paper_pool.invested_capital is None
+    assert overview.paper_pool.remaining_capital is None
 
 
 def test_completed_zero_signal_scan_uses_its_watermark(

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -164,8 +164,22 @@ FIXTURE_ACCOUNT_PNL_RESPONSE = {
         # Portal: `isBuy` is "true for long (buy) positions, false for short (sell)".
         # Required on every direct position since #2704.
         "positions": [
-            {"instrumentID": 1001, "amount": 200, "isBuy": True, "unrealizedPnL": {"pnL": 20}},
-            {"instrumentID": 1002, "amount": 100, "isBuy": True, "unrealizedPnL": {"pnL": -5}},
+            {
+                "positionID": 9001,
+                "instrumentID": 1001,
+                "amount": 200,
+                "isBuy": True,
+                "isPartiallyAltered": False,
+                "unrealizedPnL": {"pnL": 20},
+            },
+            {
+                "positionID": 9002,
+                "instrumentID": 1002,
+                "amount": 100,
+                "isBuy": True,
+                "isPartiallyAltered": False,
+                "unrealizedPnL": {"pnL": -5},
+            },
         ],
         "mirrors": [
             {
@@ -429,6 +443,86 @@ class TestStrategyAccountRisk:
         ]
         assert all(row.direct_short_positions == 0 for row in result.instrument_investments)
 
+        assert [
+            (
+                row.position_id,
+                row.instrument_id,
+                row.amount,
+                row.unrealized_pnl,
+                row.market_value,
+                row.is_partially_altered,
+            )
+            for row in result.direct_positions
+        ] == [
+            (9001, 1001, Decimal("200"), Decimal("20"), Decimal("220"), False),
+            (9002, 1002, Decimal("100"), Decimal("-5"), Decimal("95"), False),
+        ]
+
+    @pytest.mark.parametrize("position_id", [None, True, 1.2, "9001", 0, -1, 9_223_372_036_854_775_808])
+    def test_direct_position_id_fails_closed(self, position_id: object) -> None:
+        position = dict(FIXTURE_ACCOUNT_PNL_RESPONSE["clientPortfolio"]["positions"][0])
+        position["positionID"] = position_id
+        payload = {
+            "clientPortfolio": {
+                **FIXTURE_ACCOUNT_PNL_RESPONSE["clientPortfolio"],
+                "positions": [position],
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = payload
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            with pytest.raises(TradingPreflightParseError, match="position id"):
+                broker.get_account_risk_snapshot()
+
+    def test_documented_position_id_alias_is_accepted_and_conflict_refuses(self) -> None:
+        position = dict(FIXTURE_ACCOUNT_PNL_RESPONSE["clientPortfolio"]["positions"][0])
+        position["positionId"] = position.pop("positionID")
+        payload = {
+            "clientPortfolio": {
+                **FIXTURE_ACCOUNT_PNL_RESPONSE["clientPortfolio"],
+                "positions": [position],
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = payload
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            assert broker.get_account_risk_snapshot().direct_positions[0].position_id == 9001
+
+        position["positionID"] = 9002
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            with pytest.raises(TradingPreflightParseError, match="aliases disagree"):
+                broker.get_account_risk_snapshot()
+
+        position["positionId"] = 1
+        position["positionID"] = True
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            with pytest.raises(TradingPreflightParseError, match="must be an integer"):
+                broker.get_account_risk_snapshot()
+
+    def test_duplicate_direct_position_ids_fail_closed(self) -> None:
+        first, second = [dict(row) for row in FIXTURE_ACCOUNT_PNL_RESPONSE["clientPortfolio"]["positions"]]
+        second["positionID"] = first["positionID"]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "clientPortfolio": {
+                **FIXTURE_ACCOUNT_PNL_RESPONSE["clientPortfolio"],
+                "positions": [first, second],
+            }
+        }
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            with pytest.raises(TradingPreflightParseError, match="must be unique"):
+                broker.get_account_risk_snapshot()
+
     def test_direct_long_lots_net_and_shorts_are_counted_not_valued(self) -> None:
         """Two lots net; a short is counted so a caller can REFUSE, never valued.
 
@@ -441,10 +535,31 @@ class TestStrategyAccountRisk:
                 "accountCurrencyId": 1,
                 "credit": 1000,
                 "positions": [
-                    {"instrumentID": 1001, "amount": 200, "isBuy": True, "unrealizedPnL": {"pnL": 20}},
-                    {"instrumentID": 1001, "amount": 100, "isBuy": True, "unrealizedPnL": {"pnL": -30}},
+                    {
+                        "positionID": 9001,
+                        "instrumentID": 1001,
+                        "amount": 200,
+                        "isBuy": True,
+                        "isPartiallyAltered": False,
+                        "unrealizedPnL": {"pnL": 20},
+                    },
+                    {
+                        "positionID": 9002,
+                        "instrumentID": 1001,
+                        "amount": 100,
+                        "isBuy": True,
+                        "isPartiallyAltered": False,
+                        "unrealizedPnL": {"pnL": -30},
+                    },
                     # Sums to exactly zero -- invisible to any money-valued short field.
-                    {"instrumentID": 1001, "amount": 50, "isBuy": False, "unrealizedPnL": {"pnL": -50}},
+                    {
+                        "positionID": 9003,
+                        "instrumentID": 1001,
+                        "amount": 50,
+                        "isBuy": False,
+                        "isPartiallyAltered": False,
+                        "unrealizedPnL": {"pnL": -50},
+                    },
                 ],
                 "mirrors": [],
                 "ordersForOpen": [],
@@ -477,7 +592,14 @@ class TestStrategyAccountRisk:
                 "accountCurrencyId": 1,
                 "credit": 1000,
                 "positions": [
-                    {"instrumentID": 1001, "amount": 200, "isBuy": True, "unrealizedPnL": {"pnL": -250}},
+                    {
+                        "positionID": 9001,
+                        "instrumentID": 1001,
+                        "amount": 200,
+                        "isBuy": True,
+                        "isPartiallyAltered": False,
+                        "unrealizedPnL": {"pnL": -250},
+                    },
                 ],
                 "mirrors": [],
                 "ordersForOpen": [],
@@ -499,9 +621,29 @@ class TestStrategyAccountRisk:
     def test_direct_position_direction_fails_closed(self) -> None:
         """Absent or non-boolean `isBuy` raises: defaulting it books a short as a long."""
         for position in (
-            {"instrumentID": 1001, "amount": 200, "unrealizedPnL": {"pnL": 20}},
-            {"instrumentID": 1001, "amount": 200, "isBuy": "true", "unrealizedPnL": {"pnL": 20}},
-            {"instrumentID": 1001, "amount": 200, "isBuy": 1, "unrealizedPnL": {"pnL": 20}},
+            {
+                "positionID": 9001,
+                "instrumentID": 1001,
+                "amount": 200,
+                "isPartiallyAltered": False,
+                "unrealizedPnL": {"pnL": 20},
+            },
+            {
+                "positionID": 9001,
+                "instrumentID": 1001,
+                "amount": 200,
+                "isBuy": "true",
+                "isPartiallyAltered": False,
+                "unrealizedPnL": {"pnL": 20},
+            },
+            {
+                "positionID": 9001,
+                "instrumentID": 1001,
+                "amount": 200,
+                "isBuy": 1,
+                "isPartiallyAltered": False,
+                "unrealizedPnL": {"pnL": 20},
+            },
         ):
             payload = {
                 "clientPortfolio": {

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -1132,6 +1132,43 @@ def test_paper_principal_cannot_be_withdrawn_below_committed_capital(
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (1,)
 
 
+def test_paper_principal_check_includes_recorded_active_core_commitment(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("1000"),
+        risk_profile="balanced",
+        approval_mode="manual",
+        changed_by="operator",
+        reason="fund virtual sleeve",
+    )
+    monkeypatch.setattr(
+        "app.services.strategy_engine_capital.load_engine_capital_authority",
+        lambda _conn: SimpleNamespace(
+            realised_delta=Decimal("0"),
+            alpha_committed=Decimal("0"),
+            core_pending_committed=Decimal("0"),
+            core_active_recorded_committed=Decimal("400"),
+            core_active_position_ids=(),
+        ),
+    )
+
+    with pytest.raises(StrategyControlError, match="below committed strategy capital"):
+        configure_paper_pool(
+            conn,
+            enabled=False,
+            capital_limit=Decimal("399"),
+            risk_profile="balanced",
+            approval_mode="manual",
+            changed_by="operator",
+            reason="invalid core withdrawal",
+        )
+
+
 def test_enabled_paper_pool_requires_and_persists_exact_versioned_mandate(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -55,7 +55,7 @@ from app.services.strategy_opportunity_ranker import RankableOpportunity, persis
 from app.services.strategy_paper_executor import (
     COST_BASIS_BROKER_PREFLIGHT_VALUE,
     PaperExecutionResult,
-    _effective_capital_bases,
+    _effective_deployment_base,
     execute_fired_paper_signal,
 )
 from app.services.strategy_result import METRIC_AXIS_RULE_VERSION, metric_axis_sha256
@@ -595,6 +595,7 @@ def _broker(
         # here; the executor reads only `amount` (#2704).
         instrument_investments=(BrokerInstrumentInvestment(2449001, Decimal("250"), Decimal("250"), 1, 0),),
         observed_at=_NOW,
+        account_currency_id=1,
         raw_payload={},
     )
     broker.check_instrument_eligibility.return_value = BrokerEligibilityResponse(
@@ -890,6 +891,7 @@ def test_fixed_ticket_mode_requests_a_currency_amount_before_risk_caps(
         equity=Decimal("1000"),
         instrument_investments=(),
         observed_at=_NOW,
+        account_currency_id=1,
         raw_payload={},
     )
     monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
@@ -924,10 +926,10 @@ def test_capital_modes_use_realised_owned_pnl_and_refuse_unknown_pnl(
             ("S-OTHER", "v2"): Decimal("-25"),
         },
     )
-    assert _effective_capital_bases(conn, intent) == (Decimal("1100"), Decimal("2075"))
+    assert _effective_deployment_base(conn, intent) == Decimal("1100")
 
     intent.capital_mode = "fixed"
-    assert _effective_capital_bases(conn, intent) == (Decimal("1000"), Decimal("2000"))
+    assert _effective_deployment_base(conn, intent) == Decimal("1000")
     monkeypatch.setattr(
         "app.services.strategy_paper_executor.load_paper_realised_pnl",
         lambda _conn: {
@@ -935,13 +937,13 @@ def test_capital_modes_use_realised_owned_pnl_and_refuse_unknown_pnl(
             ("S-OTHER", "v2"): Decimal("25"),
         },
     )
-    assert _effective_capital_bases(conn, intent) == (Decimal("900"), Decimal("1925"))
+    assert _effective_deployment_base(conn, intent) == Decimal("900")
 
     monkeypatch.setattr(
         "app.services.strategy_paper_executor.load_paper_realised_pnl",
         lambda _conn: None,
     )
-    assert _effective_capital_bases(conn, intent) == "realised_pnl_incomplete"
+    assert _effective_deployment_base(conn, intent) == "realised_pnl_incomplete"
 
 
 def test_disabled_global_switch_keeps_an_unfunded_shadow_arm(
@@ -986,6 +988,7 @@ def test_shared_paper_pool_is_a_master_switch_and_hard_cap(
         equity=Decimal("2000"),
         instrument_investments=(),
         observed_at=_NOW,
+        account_currency_id=1,
         raw_payload={},
     )
 
@@ -1010,6 +1013,7 @@ def test_mandate_loss_at_stop_reduces_position_size(
         equity=Decimal("2000"),
         instrument_investments=(),
         observed_at=_NOW,
+        account_currency_id=1,
         raw_payload={},
     )
 
@@ -1035,6 +1039,7 @@ def test_forecast_barriers_drive_loss_sizing_and_submitted_tp_sl(
         equity=Decimal("2000"),
         instrument_investments=(),
         observed_at=_NOW,
+        account_currency_id=1,
         raw_payload={},
     )
 
@@ -1112,6 +1117,7 @@ def test_mandate_active_risk_budget_reduces_position_size(
         equity=Decimal("2000"),
         instrument_investments=(),
         observed_at=_NOW,
+        account_currency_id=1,
         raw_payload={},
     )
 
@@ -1199,6 +1205,7 @@ def test_stricter_drawdown_limit_refuses_at_the_exact_boundary(
         equity=equity,
         instrument_investments=(),
         observed_at=_NOW,
+        account_currency_id=1,
         raw_payload={},
     )
 
@@ -1343,6 +1350,7 @@ def test_shared_paper_pool_excludes_future_live_reservations(
         equity=Decimal("2000"),
         instrument_investments=(),
         observed_at=_NOW,
+        account_currency_id=1,
         raw_payload={},
     )
     result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)


### PR DESCRIPTION
## Issue reference

Refs #2525
Refs #2603

## Summary

Binds the core/cash sleeve and alpha strategies to the operator-assigned paper pot instead of whole-account cash or same-instrument holdings. The Portfolio page now fails closed and reports assigned-capital availability honestly when exact live core value is not observable.

## Changes

- add one shared capital-authority read that counts post-epoch alpha reservations, pending core orders, and exact broker position IDs
- reject pre-pot non-terminal lifecycles, malformed ownership, non-USD account snapshots, manual same-instrument holdings, and capital-limit breaches
- serialize alpha allocation, core submission, mandate changes, pool revisions, and position-management reads on the shared allocator lock
- bind core preflight/execution to assigned headroom and exact owned positions while retaining broker cash as an independent ability-to-pay ceiling
- protect pool withdrawals against alpha, pending core, and active recorded core commitments
- expose distinct unavailable/blocker states in the strategy API and Portfolio page instead of advertising unproved rebalance capacity
- document the settled boundary and cover the database, broker parser, API, scheduler, executor, and frontend paths

## Security and audit model

This touches the demo execution path. Core orders remain demo-only and operator-attended; the existing kill switch and execution guard are still required, and durable intent/admission/audit rows are written before any broker submission. The new gate also proves the shared capital lock is held before admission. No order was placed during verification.

## Testing

- [x] Tested locally against Docker PostgreSQL stack
- [x] New service logic exercised with realistic inputs and edge cases (empty results, API errors)
- [x] No raw user input reaches the DB without parameterisation
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest -m "not db"`
- [x] `uv run pytest tests/smoke`
- [x] focused DB suites for shared capital, withdrawal protection, submission gating, mandate API, paper executor, broker parsing, core executor, and observation job
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend test:unit` (140 files, 1,618 tests)

Verified at `89e3b895f49433abbdbad370b1cf683df21d7d18`; all CI checks and the latest Claude review are green.

## Checklist

- [x] Branch follows the required naming convention
- [x] Raw API payloads remain available in the broker snapshot used for validation
- [x] No new score/thesis output rows
- [x] No order placement path bypasses execution guard
- [x] CI checks pass
