### PR TITLE
fix(strategies): make core sleeve funding reachable

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -77,6 +77,8 @@ from app.services.strategy_core_executor import (
     resume_core_submission,
 )
 from app.services.strategy_core_mandate import (
+    CORE_MANDATE_ADVISORY_LOCK,
+    CORE_MANDATE_POLICY_VERSION,
     CORE_MANDATE_SERIES_ID,
     CORE_MANDATE_SERIES_TITLE,
     CoreMandate,
@@ -85,6 +87,7 @@ from app.services.strategy_core_mandate import (
     load_core_mandate,
 )
 from app.services.strategy_core_selection import (
+    CoreSelection,
     CoreSelectionError,
     load_core_selection,
 )
@@ -993,6 +996,7 @@ class CoreSleeveBlockerResponse(BaseModel):
         "core_selection_invalid",
         "core_mandate_unconfigured",
         "core_mandate_disabled",
+        "core_mandate_policy_unsupported",
         "core_mandate_selection_mismatch",
         "core_demo_required",
         "core_order_unresolved",
@@ -1016,6 +1020,7 @@ class CoreSleeveResponse(BaseModel):
     candidates: list[CoreCandidateCoverageResponse]
     mandate: CoreMandateResponse
     can_configure: bool
+    can_enable_pool: bool
     can_rebalance: bool
     can_resume: bool
     pending_order_id: int | None
@@ -1026,6 +1031,29 @@ class CoreSleeveResponse(BaseModel):
     alpha_input_used: bool = False
     household_tax_caveat: str = (
         "A UK ISA at another broker tax-dominates this engine sleeve for eligible household capital."
+    )
+
+
+def _core_pool_activation_ready(
+    *,
+    selection: CoreSelection,
+    mandate: CoreMandate | None,
+    environment: str,
+) -> bool:
+    """Whether core evidence can authorise the shared paper pot's first enable.
+
+    This deliberately excludes the pot itself: requiring an enabled pot here
+    would make the only endpoint that enables it unreachable. It also grants no
+    order authority. The attended executor separately re-proves current broker
+    eligibility, capital headroom, kill-switch state and every submission guard.
+    """
+    return (
+        selection.ready
+        and mandate is not None
+        and mandate.enabled
+        and mandate.policy_version == CORE_MANDATE_POLICY_VERSION
+        and mandate.core_instrument_id == selection.selected_instrument_id
+        and environment == "demo"
     )
 
 
@@ -3424,7 +3452,22 @@ def update_strategy_paper_pool(
             conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
             current_pool = load_paper_pool(conn)
             if body.enabled and not current_pool.enabled and readiness is not None and not readiness.ready:
-                raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
+                # Core and alpha are independent evidence lanes into this ONE
+                # capital boundary. Read the core mandate under the same lock
+                # order used by its writer (paper, then mandate), so a
+                # concurrent disable cannot slip between this decision and the
+                # pool event. Enabling the pool still submits no broker order.
+                conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_MANDATE_ADVISORY_LOCK)
+                core_ready = _core_pool_activation_ready(
+                    selection=load_core_selection(conn),
+                    mandate=load_core_mandate(conn),
+                    environment=settings.etoro_env,
+                )
+                if not core_ready:
+                    raise StrategyControlError(
+                        "automation cannot be enabled: "
+                        + ", ".join([*readiness.blockers, "core_sleeve_not_activation_ready"])
+                    )
             runtime = get_runtime_config(conn)
             # ⚠ Read INSIDE the advisory lock, and that only closes the race
             # because `app.api.config.patch_config` takes the SAME lock to
@@ -3593,6 +3636,13 @@ def read_core_sleeve(
                 detail="The current core/cash mandate is disabled.",
             )
         )
+    elif mandate.policy_version != CORE_MANDATE_POLICY_VERSION:
+        blockers.append(
+            CoreSleeveBlockerResponse(
+                code="core_mandate_policy_unsupported",
+                detail="The current core/cash mandate uses a superseded policy; save a reviewed revision.",
+            )
+        )
     elif selection.ready and mandate.core_instrument_id != selection.selected_instrument_id:
         blockers.append(
             CoreSleeveBlockerResponse(
@@ -3620,14 +3670,12 @@ def read_core_sleeve(
                 ),
             )
         )
-    base_ready = (
-        selection.ready
-        and mandate is not None
-        and mandate.enabled
-        and mandate.core_instrument_id == selection.selected_instrument_id
-        and settings.etoro_env == "demo"
-        and capital_ready
+    core_pool_ready = _core_pool_activation_ready(
+        selection=selection,
+        mandate=mandate,
+        environment=settings.etoro_env,
     )
+    base_ready = core_pool_ready and capital_ready
     can_rebalance = base_ready and resume_authority is None
     can_resume = settings.etoro_env == "demo" and resume_authority is not None
     execution_action: Literal["blocked", "rebalance", "resume"] = (
@@ -3653,6 +3701,7 @@ def read_core_sleeve(
         ],
         mandate=_core_mandate_response(mandate),
         can_configure=selection.ready,
+        can_enable_pool=core_pool_ready,
         can_rebalance=can_rebalance,
         can_resume=can_resume,
         pending_order_id=None if resume_authority is None else resume_authority.order_id,
@@ -3758,18 +3807,10 @@ def update_core_mandate(
 ) -> CoreMandateResponse:
     """Append one operator-authenticated core/cash mandate revision.
 
-    ⚠⚠ THIS IS THE ENTRY CONDITION FOR #2603 ITEM 3, AND ITS ABSENCE WAS THE
-    BLOCKER. ``configure_core_mandate`` had no caller anywhere in ``app/`` or
-    ``scripts/`` — only tests — so no mandate could be configured, therefore no
-    rebalance intent could cite one, therefore no core trade could exist. The
-    whole arc was unreachable from outside the test suite.
-
-    ⚠ Wiring this endpoint deliberately does NOT make the executor act on a
-    mandate. That is the correct intermediate state (step 1's posture), not a
-    gap to route around: a mandate becomes configurable here, and every
-    execution-time control — the one-trade-per-intent guard, the
-    no-open-core-trade precondition, the intent freshness bound — remains
-    unbuilt and is tracked on #2603.
+    This is the operator-authenticated entry condition for the attended core
+    executor. Saving a mandate submits no order: execution separately re-proves
+    the selected instrument, eligibility, capital ownership and every preflight
+    and submission guard.
 
     ⚠ ``require_session``, not the router's ``require_session_or_service_token``.
     A mandate revision is an operator authorisation and is recorded with a named

--- a/app/services/strategy_core_allocator.py
+++ b/app/services/strategy_core_allocator.py
@@ -3,19 +3,12 @@
 Mandate plus observed sleeve state in, one verdict out.  Pure: no connection, no
 clock, no broker, no persistence.
 
-⚠ This module AUTHORISES NOTHING, and that has not changed -- but "has NO CALLER",
-which this docstring said until #2684, has.  ``record_core_rebalance_intent``
-now calls ``evaluate_core_rebalance`` and stores the verdict in
-``strategy_core_rebalance_intents``.  That table is itself read by nothing and
-referenced by nothing, so no verdict returned here still causes anything to
-happen; the chain is one link longer and equally inert.  #2437's R4 comment
-records *a control on a path the decision does not take* seven times over, so the
-state is named here rather than left to be inferred, and re-stated each time it
-moves.  The acting caller is item 3's executor, which needs the operator-attended
-session #2603 reserves.
+This pure decision authorises nothing by itself. The attended executor records
+its verdict as a rebalance intent, then independently applies the submission,
+preflight, broker and capital gates before an order can be attempted.
 
-The verdict is emphatically NOT an eligibility finding: item 2 owns the proof that
-the core instrument is the underlying product and not a CFD, and has no table yet.
+The verdict is emphatically NOT an eligibility finding: the separate eligibility
+proof owns whether the core instrument is the underlying product and not a CFD.
 
 Spec: ``docs/proposals/ta/2026-08-13-core-cash-allocator.md``
 """

--- a/app/services/strategy_core_broker_preflight.py
+++ b/app/services/strategy_core_broker_preflight.py
@@ -25,8 +25,8 @@ set: broker REJECTION and the uncertain-submission resume path (both outcomes of
 submission, not preconditions); ``maxUnitsPerOrder`` (quoted in units while this sizes in
 currency, so it needs the price 3b-1 holds); and any coherence guarantee ACROSS the five
 reads that inform a submission -- the advisory lock serialises our actors, not the
-broker's.  The ticket owes "eligibility read and submission in ONE transaction" to the
-submitter, and this module does not discharge it.
+broker's. The attended executor owns that composition and re-proves eligibility in the
+transaction that records durable order authority.
 
 Spec: ``docs/proposals/ta/2026-08-23-core-broker-preflight.md``
 """
@@ -93,14 +93,15 @@ class StrategyCoreBrokerPreflightError(RuntimeError):
     """
 
 
-#: Frozen with the rule set it stamps.  v1 fixes, BY CONSTRUCTION: the account-risk age
-#: bound below, the buy-only restriction, and the refusal precedence order.
+#: Frozen with the rule set it stamps.  v2 retains v1's account-risk age bound,
+#: buy-only restriction and refusal precedence, and carries the exact account equity
+#: consumed by the executor's portfolio-drawdown gate.
 #:
 #: ⚠⚠ Widening the bound is a VERSION BUMP, never an edit to the constant.  Editing it in
 #: place silently re-verdicts every past comparison, including ones already read -- the
 #: rule ``account_equity_evidence.RECONCILIATION_RULE_VERSION`` states for the same
 #: reason.
-CORE_BROKER_PREFLIGHT_POLICY_VERSION: Final = "core-broker-preflight-v1"
+CORE_BROKER_PREFLIGHT_POLICY_VERSION: Final = "core-broker-preflight-v2"
 
 #: One write-lane throttle wait, ``etoro_broker._ETORO_WRITE_INTERVAL_S`` = 3.5 s.
 #: ``get_what_if_costs`` posts on ``_http_write``, NOT the 1.1 s read lane.
@@ -212,6 +213,7 @@ class CoreBrokerPreflightVerdict:
     amount: Decimal
     cost_rate: Decimal | None
     snapshot_observed_at: datetime | None
+    account_equity: Decimal | None
     max_account_risk_age_seconds: int = CORE_MAX_ACCOUNT_RISK_AGE_SECONDS
     policy_version: str = CORE_BROKER_PREFLIGHT_POLICY_VERSION
 
@@ -230,6 +232,7 @@ def _refused(
         amount=_ZERO,
         cost_rate=None,
         snapshot_observed_at=snapshot_observed_at,
+        account_equity=None,
     )
 
 
@@ -419,4 +422,5 @@ def assess_core_broker_preflight(
         amount=sized.amount,
         cost_rate=sized.cost_rate,
         snapshot_observed_at=snapshot.observed_at,
+        account_equity=snapshot.equity,
     )

--- a/app/services/strategy_core_executor.py
+++ b/app/services/strategy_core_executor.py
@@ -18,7 +18,7 @@ from app.providers.broker import (
     BrokerOrderSubmissionUncertain,
     BrokerProvider,
 )
-from app.services.strategy_control_plane import link_strategy_order
+from app.services.strategy_control_plane import link_strategy_order, load_paper_pool
 from app.services.strategy_core_allocator import evaluate_core_rebalance
 from app.services.strategy_core_broker_preflight import (
     CORE_BROKER_PREFLIGHT_POLICY_VERSION,
@@ -87,6 +87,59 @@ def _result(
     amount: Decimal = Decimal("0"),
 ) -> CoreExecutionResult:
     return CoreExecutionResult(state, reason_code, intent_id, trade_id, order_id, amount)
+
+
+def _observe_core_portfolio_drawdown(
+    conn: psycopg.Connection[Any],
+    *,
+    equity: Decimal,
+    observed_at: datetime,
+    max_drawdown_pct: Decimal,
+) -> str | None:
+    """Advance the shared account high-water mark and enforce the pool mandate.
+
+    The periodic health job derives its policy from enabled alpha deployments. A
+    core-only pool therefore cannot rely on its global ``drawdown`` block. This
+    submission-local observation uses the same shared risk-state row and refuses
+    before durable order authority is created.
+    """
+    if (
+        not equity.is_finite()
+        or equity <= 0
+        or not max_drawdown_pct.is_finite()
+        or not (Decimal("0") < max_drawdown_pct < Decimal("100"))
+        or observed_at.tzinfo is None
+    ):
+        return "core_account_risk_unobservable"
+    row = conn.execute(
+        """
+        SELECT equity_high_water, observed_at
+        FROM strategy_paper_account_risk_state
+        WHERE id=true
+        FOR UPDATE
+        """
+    ).fetchone()
+    if row is not None and row[1] > observed_at:
+        return "core_account_risk_stale"
+    previous_high_water = Decimal(str(row[0])) if row is not None else equity
+    if not previous_high_water.is_finite() or previous_high_water <= 0:
+        return "core_account_risk_unobservable"
+    high_water = max(previous_high_water, equity)
+    drawdown = (high_water - equity) / high_water * Decimal("100")
+    conn.execute(
+        """
+        INSERT INTO strategy_paper_account_risk_state (
+            id,equity_high_water,last_equity,last_drawdown_pct,observed_at
+        ) VALUES (true,%s,%s,%s,%s)
+        ON CONFLICT (id) DO UPDATE SET
+          equity_high_water=EXCLUDED.equity_high_water,
+          last_equity=EXCLUDED.last_equity,
+          last_drawdown_pct=EXCLUDED.last_drawdown_pct,
+          observed_at=EXCLUDED.observed_at
+        """,
+        (high_water, equity, drawdown, observed_at),
+    )
+    return "portfolio_drawdown_limit" if drawdown >= max_drawdown_pct else None
 
 
 def load_core_resume_authority(conn: psycopg.Connection[Any]) -> CoreResumeAuthority | None:
@@ -414,11 +467,29 @@ def execute_core_rebalance(
                 current_capital = load_engine_capital_authority(conn)
             except EngineCapitalObservationError as exc:
                 raise StrategyCoreExecutionError("the assigned-capital sandbox changed during preflight") from exc
-            if current_capital != capital_authority:
+            if current_capital is None or current_capital != capital_authority:
                 raise StrategyCoreExecutionError("the assigned-capital sandbox changed during broker preflight")
+            current_pool = load_paper_pool(conn)
+            if current_pool.event_id != current_capital.pool_event_id:
+                raise StrategyCoreExecutionError("the portfolio mandate changed during broker preflight")
+            drawdown_limit = current_pool.mandate.max_portfolio_drawdown_pct
+            if drawdown_limit is None:
+                raise StrategyCoreExecutionError("the portfolio mandate is unconfigured")
             require_selected_core_instrument(conn, instrument_id=current.core_instrument_id)
             intent = record_core_rebalance_intent(conn, state=state, recorded_by=recorded_by)
             intent_id = intent.core_rebalance_intent_id
+            # Observe EVERY attended evaluation, not only buys. Otherwise an
+            # in-band hold can be the account peak, and a later fall is measured
+            # from an older lower watermark. That understates drawdown precisely
+            # when this core-only path cannot rely on alpha's periodic health job.
+            initial_drawdown_refusal = _observe_core_portfolio_drawdown(
+                conn,
+                equity=snapshot.equity,
+                observed_at=snapshot.observed_at,
+                max_drawdown_pct=drawdown_limit,
+            )
+            if initial_drawdown_refusal is not None:
+                return _result("refused", initial_drawdown_refusal, intent_id=intent_id)
             if intent.decision.action == "hold":
                 return _result("held", intent.decision.reason_code or "core_hold", intent_id=intent_id)
             if intent.decision.action == "refused":
@@ -462,15 +533,25 @@ def execute_core_rebalance(
             if broker_verdict is None or not broker_verdict.admitted:
                 reason = None if broker_verdict is None else broker_verdict.reason_code
                 return _result("refused", reason or "core_broker_preflight_refused", intent_id=intent_id)
+            snapshot_observed_at = broker_verdict.snapshot_observed_at
             broker_evidence_age = (
-                None
-                if broker_verdict.snapshot_observed_at is None
-                else (clock() - broker_verdict.snapshot_observed_at).total_seconds()
+                None if snapshot_observed_at is None else (clock() - snapshot_observed_at).total_seconds()
             )
             if broker_evidence_age is None or not (
                 0 <= broker_evidence_age <= broker_verdict.max_account_risk_age_seconds
             ):
                 return _result("refused", "core_account_risk_stale", intent_id=intent_id)
+            account_equity = broker_verdict.account_equity
+            if account_equity is None or snapshot_observed_at is None:
+                return _result("refused", "core_account_risk_unobservable", intent_id=intent_id)
+            drawdown_refusal = _observe_core_portfolio_drawdown(
+                conn,
+                equity=account_equity,
+                observed_at=snapshot_observed_at,
+                max_drawdown_pct=drawdown_limit,
+            )
+            if drawdown_refusal is not None:
+                return _result("refused", drawdown_refusal, intent_id=intent_id)
 
             amount = broker_verdict.amount
             request_id = uuid4()

--- a/app/services/strategy_core_mandate.py
+++ b/app/services/strategy_core_mandate.py
@@ -4,18 +4,19 @@ Hold a benchmark instrument and cash to operator-declared weights, rebalance onl
 outside a declared band.  Event-shaped like the other capital authorities in
 ``strategy_control_plane``: one append-only row per operator change.
 
-⚠ This module AUTHORISES NOTHING.  Nothing reads ``strategy_core_mandate_events``
-to act -- the allocator (#2603 item 3) is its first such consumer and no endpoint
-is wired.  It is state, not a gate, and must not be cited as one.
+This is now an authority consumed by the attended core executor and configurable
+through the operator-authenticated core-mandate endpoint. It is still not order
+authority by itself: the executor re-proves eligibility and applies every
+capital, preflight, kill-switch and broker guard before submission.
 
 What it now DOES do is refuse to record an unproved authority: as of item 2,
 ``configure_core_mandate`` requires a fresh account-specific proof that an
 enabled mandate's core instrument is the underlying product and not a CFD.  That
 is a constraint on WRITES, not a control on trading -- see its docstring.
 
-``CoreMandateError`` is deliberately standalone rather than a
-``StrategyControlError`` subclass: no endpoint maps this path yet, so inheriting
-would buy coupling to a 1000-line module for an integration that does not exist.
+``CoreMandateError`` remains deliberately standalone rather than coupling this
+service to the API's ``StrategyControlError`` hierarchy; the endpoint maps it at
+the boundary.
 
 Spec: ``docs/proposals/ta/2026-08-13-core-cash-mandate.md``
 """
@@ -304,7 +305,8 @@ def load_core_mandate(conn: psycopg.Connection[Any]) -> CoreMandate | None:
 
 def _is_material_change(current: CoreMandate, values: CoreMandateValues) -> bool:
     return (
-        current.enabled != values.enabled
+        current.policy_version != CORE_MANDATE_POLICY_VERSION
+        or current.enabled != values.enabled
         or current.base_currency != values.base_currency
         or current.core_instrument_id != values.core_instrument_id
         or current.core_target_pct != values.core_target_pct
@@ -388,7 +390,9 @@ def configure_core_mandate(
         )
     current = load_core_mandate(conn)
     if current is not None and not _is_material_change(current, values):
-        raise CoreMandateError("core mandate change must alter at least one mandate value")
+        raise CoreMandateError(
+            "core mandate change must alter at least one mandate value or advance its policy version"
+        )
     if current is not None and current.core_instrument_id != values.core_instrument_id:
         try:
             capital = load_engine_capital_authority(conn)

--- a/app/services/strategy_core_preflight.py
+++ b/app/services/strategy_core_preflight.py
@@ -15,15 +15,14 @@ broker minimum, broker rejection -- stays with step 3b-2.  The split is on "does
 this need a broker", which is the line between a refusal provable in a pure test
 and one observable only against a live account.
 
-⚠⚠ AUTHORISES NOTHING TODAY.  No caller in ``app/`` or ``scripts/``; it writes
-nothing.  Named plainly, as every step of this arc has been, because #2437's R4
-comment records *a control that exists, is tested, and sits on a path the decision
-does not take* nine times over on this ticket alone.
+The attended core executor now calls this preflight after the stored-intent gate.
+It writes nothing and authorises nothing alone; the executor composes its verdict
+with broker preflight before durable order authority can be recorded.
 
 ⚠ NOT the complete vocabulary either.  It is the complete DB-and-clock vocabulary.
-A reader who takes this module plus step 3a for the whole set will conclude the
-core arm checks the broker's own view of the account before submitting.  It does
-not, YET.
+A reader who takes this module plus step 3a for the whole set will miss the
+broker's own view of the account. The executor's next layer,
+``strategy_core_broker_preflight``, performs those reads.
 
 Spec: ``docs/proposals/ta/2026-08-14-core-submission-preflight.md``
 """

--- a/app/services/strategy_core_rebalance_intent.py
+++ b/app/services/strategy_core_rebalance_intent.py
@@ -14,11 +14,9 @@ arrived as promised; the promise was not re-read when it did.  ⚠ It also cited
 **that file does not exist** anywhere in the repo, so the claim was never enforced by
 anything.  A named enforcement is only as good as its existence.
 
-What holds instead, weaker on purpose: a row here is submission-gate INPUT, not
-authority.  The gate has no acting caller in ``app/`` or ``scripts/``, so no path runs
-from a row to an order.  That is a fact about today's call graph, not a mechanical
-impossibility -- and saying so is the point, because the previous wording survived the
-change that falsified it by sounding structural.
+What holds instead: a row here is submission-gate INPUT, not authority. The
+attended executor is the acting caller and applies that gate plus the DB, broker,
+capital and kill-switch refusals before it can record order authority.
 
 The producer is ``app/workers/scheduler.py::core_rebalance_observation``.
 

--- a/app/services/strategy_core_sizing.py
+++ b/app/services/strategy_core_sizing.py
@@ -15,9 +15,8 @@ for the other is not a small error.
 Pure: no connection, no clock, no broker call, no writes.  Decodes one already-fetched
 what-if response and does arithmetic.
 
-⚠ AUTHORISES NOTHING.  No caller in ``app/`` or ``scripts/``.  Stated plainly, as every
-step of this arc has been, because #2437's R4 comment records *a control that exists, is
-tested, and sits on a path the decision does not take* many times over on this ticket.
+This pure calculation authorises nothing by itself. The broker preflight calls it inside
+the attended executor path, whose later durable submission gate owns order authority.
 
 ⚠⚠ THE SELL PATH IS NOW FEEDABLE -- corrected 2026-08-14 (#2712), and this docstring said
 the opposite for one merge.  ``get_what_if_costs`` DID hardcode ``"action": "open"``, but

--- a/app/services/strategy_core_submission_gate.py
+++ b/app/services/strategy_core_submission_gate.py
@@ -6,10 +6,9 @@ the observe -> record -> submit path that consumes it, and ships after this one
 deliberately -- the opposite order produces a writer whose preconditions are a
 comment.
 
-⚠⚠ AUTHORISES NOTHING TODAY.  It has no caller in ``app/`` or ``scripts/`` and it
-writes nothing.  Named plainly, as steps 1 and 2 named it, because #2437's R4
-comment records *a control that exists, is tested, and sits on a path the decision
-does not take* nine times over on this ticket alone.
+The attended core executor now calls this gate immediately before durable order
+authority is recorded. It writes nothing by itself and remains only one layer of
+the composed submission decision.
 
 ⚠⚠ THE VOCABULARY BELOW IS NOT THE COMPLETE SUBMISSION REFUSAL VOCABULARY.  The
 kill switch, ``enable_auto_trading``, the execution block, market-session state,
@@ -17,7 +16,8 @@ quote availability and staleness, account-risk availability, broker minimums,
 cost assessment and broker rejection are all real refusals of a core submission
 and NONE of them is here -- they belong to 3b, which is the code that holds a
 quote and a broker.  A reader who takes this module for the full set will
-conclude the core arm has no kill-switch check.  It has none YET.
+conclude the core arm has no kill-switch check. The executor composes this gate
+with the DB-and-clock and broker preflights that carry those refusals.
 
 Spec: ``docs/proposals/ta/2026-08-14-core-submission-gate.md``
 """

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5771,10 +5771,10 @@ def core_rebalance_observation() -> None:
     ⚠ It produces submission-gate INPUT, not authority.
     ``strategy_core_submission_gate`` reads ``strategy_core_rebalance_intents``
     (that module's own SELECT, and ``sql/349``'s FK from ``strategy_trades``),
-    so the "no module reads it" line in ``sql/348`` is stale.  What holds is
-    that the gate has no acting caller, and that the one provider method used
-    here is informational -- ``refuse_broker_mutation_if_unattended`` is
-    deliberately not reached (#2645).
+    so the "no module reads it" line in ``sql/348`` is stale. The attended
+    executor is now the acting consumer; this scheduled producer remains
+    informational and deliberately never reaches
+    ``refuse_broker_mutation_if_unattended`` (#2645).
 
     Failures PROPAGATE rather than being caught and noted.  An unobservable
     sleeve and an unavailable broker are both genuine faults, and there is no

--- a/docs/proposals/ta/2026-08-24-core-cash-operator.md
+++ b/docs/proposals/ta/2026-08-24-core-cash-operator.md
@@ -23,6 +23,10 @@ the server reports `evidence_collecting`, offers no instrument and refuses enabl
 - Demo only, underlying long, leverage 1, USD order currency. The global kill switch,
   runtime auto-trading flag, execution block, market session, halt feed, fresh quote,
   fresh account snapshot, fresh eligibility proof and cost quote all remain binding.
+- A core-only pool cannot rely on the periodic health job's alpha-deployment policy.
+  The attended executor therefore advances the shared account high-water row on every
+  fresh evaluation, including a hold, and enforces the pool's portfolio drawdown ceiling
+  before it creates durable order authority.
 - One server-side selection invariant is called by mandate configuration **and** by the
   acting path while the mandate lock is held. A legacy enabled mandate naming any other
   instrument is refused; checking only the endpoint would be a bypass.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2969,12 +2969,13 @@ export interface CoreSleeveResponse {
   }>;
   mandate: CoreMandate;
   can_configure: boolean;
+  can_enable_pool: boolean;
   can_rebalance: boolean;
   can_resume: boolean;
   pending_order_id: number | null;
   execution_action: "blocked" | "rebalance" | "resume";
   blockers: Array<{
-    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_mandate_selection_mismatch" | "core_demo_required" | "core_order_unresolved" | "core_capital_authority_incomplete" | "core_live_snapshot_required" | "core_paper_pool_unconfigured" | "core_paper_pool_disabled" | "core_sandbox_exceeded";
+    code: "core_evidence_collecting" | "core_candidates_missing" | "core_selection_invalid" | "core_mandate_unconfigured" | "core_mandate_disabled" | "core_mandate_policy_unsupported" | "core_mandate_selection_mismatch" | "core_demo_required" | "core_order_unresolved" | "core_capital_authority_incomplete" | "core_live_snapshot_required" | "core_paper_pool_unconfigured" | "core_paper_pool_disabled" | "core_sandbox_exceeded";
     detail: string;
   }>;
   environment: "demo" | "real";

--- a/frontend/src/components/strategies/StrategyPortfolioPanels.tsx
+++ b/frontend/src/components/strategies/StrategyPortfolioPanels.tsx
@@ -3,7 +3,7 @@ import type { FormEvent } from "react";
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import { updateStrategyPaperPool } from "@/api/strategies";
-import type { BenchmarkRefusal, StrategyOverviewResponse } from "@/api/types";
+import type { BenchmarkRefusal, CoreSleeveResponse, StrategyOverviewResponse } from "@/api/types";
 import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { Badge } from "@/components/ui/Badge";
 import { formatDate, formatMoney, formatNumber } from "@/lib/format";
@@ -287,9 +287,11 @@ export function EmptyPnlChart() {
 
 export function AutomationControl({
   overview,
+  coreSleeve,
   onUpdated,
 }: {
   overview: StrategyOverviewResponse;
+  coreSleeve: CoreSleeveResponse | null;
   onUpdated: () => void;
 }) {
   const pool = overview.paper_pool;
@@ -337,10 +339,13 @@ export function AutomationControl({
   // other control in the app sets that flag. Requiring it here made the first
   // enable unreachable from the repository's fail-closed default — the page
   // demanded the flag be true before it would call the only endpoint that
-  // turns it true. The backend's own first-enable gate is `readiness.ready`,
-  // which is what this mirrors. `enable_live_trading` is untouched by the flow.
+  // turns it true. Alpha and the deterministic core sleeve are independent
+  // evidence lanes into the same pot; the backend supplies the core predicate
+  // so this form does not reconstruct mandate/selection policy. System-wide
+  // live trading is untouched by the flow.
   const accountEligible = overview.demo_connection || overview.live_strategy_activation_available;
-  const canEnable = overview.automation_readiness.ready && accountEligible && riskProfile !== "unconfigured";
+  const evidenceReady = overview.automation_readiness.ready || coreSleeve?.can_enable_pool === true;
+  const canEnable = evidenceReady && accountEligible && riskProfile !== "unconfigured";
   const selectedMandate = riskProfile === pool.mandate.risk_profile && pool.mandate.configured
     ? pool.mandate
     : pool.available_mandates.find((mandate) => mandate.risk_profile === riskProfile) ?? null;
@@ -478,7 +483,7 @@ export function AutomationControl({
             ? "This account cannot run strategy automation. Connect the demo account, or complete real-money activation first."
             : riskProfile === "unconfigured"
               ? "Choose a risk profile before allowing new entries."
-            : "Automation stays off until at least one strategy passes validation."}
+            : "New entries stay off until an alpha strategy passes validation or the evidence-selected core sleeve has an enabled mandate."}
         </p>
       ) : null}
       {overview.entry_block.new_entries_blocked ? (

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -1002,7 +1002,7 @@ describe("StrategiesPage", () => {
     renderStrategies("portfolio");
     const master = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
     expect(master).toBeDisabled();
-    expect(screen.getByText("Automation stays off until at least one strategy passes validation.")).toBeInTheDocument();
+    expect(screen.getByText("New entries stay off until an alpha strategy passes validation or the evidence-selected core sleeve has an enabled mandate.")).toBeInTheDocument();
     expect(update).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -107,6 +107,7 @@ const CORE_COLLECTING = {
   candidates: [],
   mandate: { configured: false },
   can_configure: false,
+  can_enable_pool: false,
   can_rebalance: false,
   can_resume: false,
   pending_order_id: null,
@@ -138,6 +139,7 @@ const CORE_READY = {
     min_rebalance_amount: "25",
   },
   can_configure: true,
+  can_enable_pool: true,
   can_rebalance: true,
   can_resume: false,
   execution_action: "rebalance",
@@ -243,6 +245,31 @@ describe("StrategyPortfolioLens", () => {
     });
   });
 
+  it("can fund the evidence-ready core lane when no alpha strategy passed", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue(CORE_READY as never);
+    const update = vi.spyOn(strategiesApi, "updateStrategyPaperPool").mockResolvedValue({
+      ...BLOCKED.paper_pool,
+      configured: true,
+      enabled: true,
+      capital_limit: "1000.000000",
+    } as never);
+    renderLens();
+
+    const entries = await screen.findByRole("checkbox", { name: "Allow new automated entries" });
+    await userEvent.selectOptions(screen.getByLabelText("Risk profile"), "balanced");
+    expect(entries).not.toBeDisabled();
+    await userEvent.click(entries);
+    await userEvent.clear(screen.getByLabelText("Trading capital (USD)"));
+    await userEvent.type(screen.getByLabelText("Trading capital (USD)"), "1000");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: true,
+      capital_limit: "1000.000000",
+      risk_profile: "balanced",
+    })));
+  });
+
   it("does not offer a reason-only save for an unchanged configured mandate", async () => {
     vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue(CORE_READY as never);
     renderLens();
@@ -250,6 +277,32 @@ describe("StrategyPortfolioLens", () => {
     await userEvent.type(await screen.findByLabelText("Audit reason"), "No material change");
 
     expect(screen.getByRole("button", { name: "Save mandate" })).toBeDisabled();
+  });
+
+  it("offers a policy-only mandate upgrade without inventing a value change", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue({
+      ...CORE_READY,
+      mandate: { ...CORE_READY.mandate, policy_version: "core-mandate-v1" },
+      can_enable_pool: false,
+      can_rebalance: false,
+      execution_action: "blocked",
+      blockers: [{
+        code: "core_mandate_policy_unsupported",
+        detail: "The current core/cash mandate uses a superseded policy; save a reviewed revision.",
+      }],
+    } as never);
+    const save = vi.spyOn(strategiesApi, "updateCoreMandate").mockResolvedValue(CORE_READY.mandate as never);
+    renderLens();
+
+    await userEvent.type(await screen.findByLabelText("Audit reason"), "Advance reviewed policy stamp");
+    const button = screen.getByRole("button", { name: "Save mandate" });
+    expect(button).not.toBeDisabled();
+    await userEvent.click(button);
+
+    await waitFor(() => expect(save).toHaveBeenCalledWith(expect.objectContaining({
+      core_target_pct: "80",
+      reason: "Advance reviewed policy stamp",
+    })));
   });
 
   it("cannot confirm a rebalance against unsaved mandate edits", async () => {
@@ -274,7 +327,7 @@ describe("StrategyPortfolioLens", () => {
       amount: "49.9",
       submission_policy_version: "core-submission-v1",
       preflight_policy_version: "core-preflight-v2",
-      broker_preflight_policy_version: "core-broker-preflight-v1",
+      broker_preflight_policy_version: "core-broker-preflight-v2",
     });
     renderLens();
 
@@ -304,7 +357,7 @@ describe("StrategyPortfolioLens", () => {
       amount: "49.9",
       submission_policy_version: "core-submission-v1",
       preflight_policy_version: "core-preflight-v2",
-      broker_preflight_policy_version: "core-broker-preflight-v1",
+      broker_preflight_policy_version: "core-broker-preflight-v2",
     });
     renderLens();
 

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -93,7 +93,11 @@ function CoreSleeveControl({
   const [reason, setReason] = useState("");
   const [confirmRebalance, setConfirmRebalance] = useState(false);
   const [outcome, setOutcome] = useState<string | null>(null);
+  const policyUpgradeRequired = sleeve.blockers.some(
+    (blocker) => blocker.code === "core_mandate_policy_unsupported",
+  );
   const mandateDirty =
+    policyUpgradeRequired ||
     enabled !== (mandate.enabled ?? false) ||
     Number(target) !== Number(mandate.core_target_pct ?? "80") ||
     Number(reserve) !== Number(mandate.liquidity_reserve_pct ?? "10") ||
@@ -439,7 +443,14 @@ export function StrategyPortfolioLens() {
               />
             </section>
           ) : null}
-          <AutomationControl overview={data} onUpdated={overview.refetch} />
+          <AutomationControl
+            overview={data}
+            coreSleeve={coreSleeve.data}
+            onUpdated={() => {
+              void overview.refetch();
+              void coreSleeve.refetch();
+            }}
+          />
         </div>
       </section>
 

--- a/tests/test_2603_core_executor.py
+++ b/tests/test_2603_core_executor.py
@@ -23,6 +23,7 @@ from app.services.broker_credentials import CredentialInUse, revoke_credential
 from app.services.strategy_core_executor import (
     CoreExecutionResult,
     CoreResumeAuthority,
+    _observe_core_portfolio_drawdown,
     execute_core_rebalance,
     resume_core_submission,
 )
@@ -77,7 +78,11 @@ class FakeBroker:
 
     def get_account_risk_snapshot(self) -> object:
         self.events.append("read_snapshot")
-        return SimpleNamespace(available_cash=Decimal("500"))
+        return SimpleNamespace(
+            available_cash=Decimal("500"),
+            equity=Decimal("1000"),
+            observed_at=datetime.now(UTC),
+        )
 
     def place_demo_core_order(self, _order: object, *, request_id: UUID) -> BrokerCoreOrderSubmission:
         assert request_id is not None
@@ -110,6 +115,7 @@ def _run(
     snapshot_observed_at: datetime | None = None,
     clock: Callable[[], datetime] | None = None,
     binding_proof_id: int = 7,
+    drawdown_refusal: str | None = None,
 ) -> tuple[CoreExecutionResult, list[str]]:
     events: list[str] = []
     conn = FakeConn(events)
@@ -133,16 +139,26 @@ def _run(
         amount=Decimal("49.9"),
         snapshot_observed_at=snapshot_observed_at or datetime.now(UTC),
         max_account_risk_age_seconds=30,
+        account_equity=Decimal("1000"),
     )
-    capital_authority = SimpleNamespace(enabled=True)
+    capital_authority = SimpleNamespace(enabled=True, pool_event_id=5)
+    paper_pool = SimpleNamespace(
+        event_id=5,
+        mandate=SimpleNamespace(max_portfolio_drawdown_pct=Decimal("15")),
+    )
     capital_usage = SimpleNamespace(
         core_market_value=Decimal("500"),
         headroom=SimpleNamespace(within_bound=True, remaining=Decimal("500")),
     )
 
+    def observe_drawdown(*_args: object, **_kwargs: object) -> str | None:
+        events.append("drawdown_observation")
+        return drawdown_refusal
+
     with (
         patch("app.services.strategy_core_executor.load_core_mandate", return_value=mandate),
         patch("app.services.strategy_core_executor.load_engine_capital_authority", return_value=capital_authority),
+        patch("app.services.strategy_core_executor.load_paper_pool", return_value=paper_pool),
         patch("app.services.strategy_core_executor.resolve_engine_capital_usage", return_value=capital_usage),
         patch("app.services.strategy_core_executor.require_selected_core_instrument"),
         patch("app.services.strategy_core_executor.require_core_eligibility", side_effect=[proof, binding_proof]),
@@ -153,6 +169,10 @@ def _run(
         patch("app.services.strategy_core_executor.record_core_rebalance_intent", return_value=intent),
         patch("app.services.strategy_core_executor.admit_core_rebalance_intent", return_value=admission),
         patch("app.services.strategy_core_executor.preflight_core_submission", return_value=db_preflight),
+        patch(
+            "app.services.strategy_core_executor._observe_core_portfolio_drawdown",
+            side_effect=observe_drawdown,
+        ),
         patch(
             "app.services.strategy_core_executor.link_strategy_order",
             side_effect=lambda *_a, **_k: events.append("link"),
@@ -169,6 +189,62 @@ def _run(
             **kwargs,  # type: ignore[arg-type]
         )
     return result, events
+
+
+def test_core_drawdown_observation_refuses_at_the_portfolio_limit() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (
+        Decimal("1000"),
+        datetime(2026, 8, 24, 11, 59, tzinfo=UTC),
+    )
+
+    refusal = _observe_core_portfolio_drawdown(
+        conn,
+        equity=Decimal("850"),
+        observed_at=datetime(2026, 8, 24, 12, 0, tzinfo=UTC),
+        max_drawdown_pct=Decimal("15"),
+    )
+
+    assert refusal == "portfolio_drawdown_limit"
+    assert any("INSERT INTO strategy_paper_account_risk_state" in call.args[0] for call in conn.execute.call_args_list)
+
+
+def test_core_drawdown_observation_refuses_an_older_broker_snapshot() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (
+        Decimal("1000"),
+        datetime(2026, 8, 24, 12, 1, tzinfo=UTC),
+    )
+
+    refusal = _observe_core_portfolio_drawdown(
+        conn,
+        equity=Decimal("999"),
+        observed_at=datetime(2026, 8, 24, 12, 0, tzinfo=UTC),
+        max_drawdown_pct=Decimal("15"),
+    )
+
+    assert refusal == "core_account_risk_stale"
+    assert conn.execute.call_count == 1
+
+
+def test_core_drawdown_refusal_precedes_durable_order_authority() -> None:
+    result, events = _run(
+        AssertionError("must not submit"),
+        drawdown_refusal="portfolio_drawdown_limit",
+    )
+
+    assert result.state == "refused"
+    assert result.reason_code == "portfolio_drawdown_limit"
+    assert "persist_order" not in events
+    assert "broker_submit" not in events
+
+
+def test_hold_advances_the_shared_drawdown_high_water() -> None:
+    result, events = _run(AssertionError("must not submit"), action="hold")
+
+    assert result.state == "held"
+    assert events.count("drawdown_observation") == 1
+    assert "persist_order" not in events
 
 
 def test_acceptance_identity_is_persisted_after_authority_commits() -> None:

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -84,7 +84,7 @@ def _mandate(**overrides: object) -> CoreMandate:
         "liquidity_reserve_pct": Decimal("20"),
         "rebalance_band_pct": Decimal("5"),
         "min_rebalance_amount": Decimal("25"),
-        "policy_version": "core-mandate-v1",
+        "policy_version": "core-mandate-v2",
     }
     values.update(overrides)
     return CoreMandate(**values)  # type: ignore[arg-type]
@@ -157,6 +157,7 @@ def test_collecting_state_reports_cash_and_server_derived_coverage(monkeypatch: 
     assert response.selected_instrument_id is None
     assert response.observed_trading_days == 1
     assert response.can_configure is False
+    assert response.can_enable_pool is False
     assert response.can_rebalance is False
     assert response.can_resume is False
     assert response.execution_action == "blocked"
@@ -202,7 +203,7 @@ def test_rebalance_passes_the_exact_loaded_credential_ids_to_the_executor(
     assert response.state == "held"
     assert response.submission_policy_version == "core-submission-v1"
     assert response.preflight_policy_version == "core-preflight-v2"
-    assert response.broker_preflight_policy_version == "core-broker-preflight-v1"
+    assert response.broker_preflight_policy_version == "core-broker-preflight-v2"
     assert execute.call_args.kwargs["api_key_credential_id"] == api.id
     assert execute.call_args.kwargs["user_key_credential_id"] == user.id
 
@@ -246,6 +247,7 @@ def test_operator_view_labels_an_unresolved_order_as_resume_not_rebalance(
     response = read_core_sleeve(cast(Any, MagicMock()))
 
     assert response.can_rebalance is False
+    assert response.can_enable_pool is True
     assert response.can_resume is True
     assert response.execution_action == "resume"
     assert response.pending_order_id == 31
@@ -287,6 +289,7 @@ def test_operator_view_does_not_advertise_unavailable_core_headroom(
 
     response = read_core_sleeve(cast(Any, MagicMock()))
 
+    assert response.can_enable_pool is True
     assert response.can_rebalance is False
     assert response.execution_action == "blocked"
     assert [blocker.code for blocker in response.blockers] == [expected_blocker]
@@ -315,9 +318,39 @@ def test_operator_view_refuses_a_mandate_for_the_previous_reviewed_selection(
 
     response = read_core_sleeve(cast(Any, MagicMock()))
 
+    assert response.can_enable_pool is False
     assert response.can_rebalance is False
     assert response.execution_action == "blocked"
     assert [blocker.code for blocker in response.blockers] == ["core_mandate_selection_mismatch"]
+
+
+def test_operator_view_refuses_a_superseded_mandate_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    selection = CoreSelection(
+        state="ready",
+        selected_instrument_id=3417,
+        selected_symbol="SPY.RTH",
+        evidence_ref="#2833 verdict",
+        required_trading_days=5,
+        observed_trading_days=5,
+        max_cost_bps=60,
+        candidates=(),
+        missing_candidate_ids=(),
+        configuration_error=None,
+    )
+    monkeypatch.setattr("app.api.strategies.load_core_selection", lambda _conn: selection)
+    monkeypatch.setattr(
+        "app.api.strategies.load_core_mandate",
+        lambda _conn: _mandate(core_instrument_id=3417, policy_version="core-mandate-v1"),
+    )
+    monkeypatch.setattr("app.api.strategies.load_core_resume_authority", lambda _conn: None)
+    monkeypatch.setattr("app.api.strategies.load_engine_capital_authority", lambda _conn: _capital_authority())
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "demo")
+
+    response = read_core_sleeve(cast(Any, MagicMock()))
+
+    assert response.can_enable_pool is False
+    assert response.can_rebalance is False
+    assert [blocker.code for blocker in response.blockers] == ["core_mandate_policy_unsupported"]
 
 
 def test_resume_refuses_credentials_from_a_different_account(
@@ -474,7 +507,7 @@ class TestTheResponseMapping:
             response.rebalance_band_pct,
             response.min_rebalance_amount,
             response.policy_version,
-        ) == (True, 7, 3, True, "USD", 42, Decimal("60"), Decimal("20"), Decimal("5"), Decimal("25"), "core-mandate-v1")
+        ) == (True, 7, 3, True, "USD", 42, Decimal("60"), Decimal("20"), Decimal("5"), Decimal("25"), "core-mandate-v2")
 
     def test_cash_target_is_the_services_complement_and_not_recomputed(self) -> None:
         """⚠⚠ Cash has no stored column — it is `PERCENT_BASIS - core_target_pct`,

--- a/tests/test_2603_core_mandate_db.py
+++ b/tests/test_2603_core_mandate_db.py
@@ -23,6 +23,7 @@ import pytest
 from app.services.strategy_core_mandate import (
     CORE_MANDATE_MODE,
     CORE_MANDATE_POLICY_VERSION,
+    CoreMandate,
     CoreMandateError,
     configure_core_mandate,
     load_core_mandate,
@@ -411,3 +412,40 @@ def test_the_writer_appends_revisions_and_refuses_a_no_op(
             **account,
         )
     ebull_test_conn.rollback()
+
+
+def test_the_writer_can_advance_only_a_superseded_policy_stamp(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    instrument_id = _seed_instrument(ebull_test_conn)
+    account = _seed_proved_account(ebull_test_conn, instrument_id)
+    legacy = CoreMandate(
+        event_id=999,
+        revision=1,
+        enabled=True,
+        base_currency="USD",
+        core_instrument_id=instrument_id,
+        core_target_pct=Decimal("60"),
+        liquidity_reserve_pct=Decimal("20"),
+        rebalance_band_pct=Decimal("5"),
+        min_rebalance_amount=Decimal("25"),
+        policy_version="core-mandate-v1",
+    )
+    monkeypatch.setattr("app.services.strategy_core_mandate.load_core_mandate", lambda _conn: legacy)
+
+    upgraded = configure_core_mandate(
+        ebull_test_conn,
+        enabled=legacy.enabled,
+        core_instrument_id=legacy.core_instrument_id,
+        core_target_pct=legacy.core_target_pct,
+        liquidity_reserve_pct=legacy.liquidity_reserve_pct,
+        rebalance_band_pct=legacy.rebalance_band_pct,
+        min_rebalance_amount=legacy.min_rebalance_amount,
+        changed_by="test",
+        reason="advance reviewed mandate policy",
+        **account,
+    )
+
+    assert upgraded.revision == 2
+    assert upgraded.policy_version == CORE_MANDATE_POLICY_VERSION

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -33,6 +33,8 @@ from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_V
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.runtime_config import get_runtime_config, update_runtime_config
 from app.services.strategy_control_plane import configure_paper_pool, load_paper_pool
+from app.services.strategy_core_mandate import CoreMandate
+from app.services.strategy_core_selection import CoreSelection
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_monitoring import (
     load_attribution,
@@ -1352,6 +1354,74 @@ def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(
     assert exc_info.value.status_code == 409
     assert "no_capital_candidates" in str(exc_info.value.detail)
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
+
+
+def test_shared_paper_pool_accepts_evidence_ready_core_without_an_alpha_candidate(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deterministic fallback is an independent route into the shared pot.
+
+    This deliberately leaves the real alpha readiness at
+    ``no_capital_candidates``. Before #2603's activation fix, that alpha-only
+    gate made an otherwise executable core sleeve unreachable from the page.
+    """
+    conn = ebull_test_conn
+    seed_universe_anchor(conn)
+    if get_runtime_config(conn).enable_auto_trading:
+        update_runtime_config(
+            conn,
+            updated_by="test-precondition",
+            reason="establish disabled automation precondition",
+            enable_auto_trading=False,
+        )
+    conn.commit()
+    monkeypatch.setattr(
+        "app.api.strategies.load_core_selection",
+        lambda _conn: CoreSelection(
+            state="ready",
+            selected_instrument_id=3417,
+            selected_symbol="SPY.RTH",
+            evidence_ref="#2833 verdict",
+            required_trading_days=5,
+            observed_trading_days=5,
+            max_cost_bps=60,
+            candidates=(),
+            missing_candidate_ids=(),
+            configuration_error=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "app.api.strategies.load_core_mandate",
+        lambda _conn: CoreMandate(
+            event_id=1,
+            revision=1,
+            enabled=True,
+            base_currency="USD",
+            core_instrument_id=3417,
+            core_target_pct=Decimal("80"),
+            liquidity_reserve_pct=Decimal("10"),
+            rebalance_band_pct=Decimal("5"),
+            min_rebalance_amount=Decimal("25"),
+            policy_version="core-mandate-v2",
+        ),
+    )
+
+    response = update_strategy_paper_pool(
+        StrategyPaperPoolUpdateRequest(
+            enabled=True,
+            capital_limit=Decimal("750"),
+            capital_mode="fixed",
+            risk_profile="balanced",
+            reason="fund evidence-ready deterministic fallback",
+        ),
+        _session(),
+        conn,
+    )
+
+    assert response.enabled
+    assert response.capital_limit == Decimal("750")
+    assert get_runtime_config(conn).enable_auto_trading
 
 
 def _ready_overview_patch(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Outcome

Makes the deterministic core/cash fallback reachable from `/strategies` when no alpha candidate has passed. The shared paper pot may now be first-enabled by either an evidence-ready alpha lane or an evidence-ready core lane.

## Safety and operator contract

- Core activation requires the reviewed selection, an enabled matching current-policy mandate, and the demo environment.
- Pool enablement remains a configuration-only action and submits no broker order.
- The attended executor still re-proves eligibility, exact capital ownership, kill switch, execution blocks, market/quote freshness, costs, and credential provenance.
- Core-only evaluations now advance the shared account high-water mark on every evaluation, including holds, and enforce the selected portfolio drawdown ceiling before any durable order authority is created.
- Superseded core-mandate policies are visible and can be upgraded through a policy-only audited revision.
- The page exposes the core readiness route without reconstructing server policy in the browser.

## Evidence

- Exact DB-backed activation case: zero alpha candidates + reviewed core + matching enabled mandate.
- DB-backed policy-only mandate revision.
- Frontend tests for the no-alpha funding route and policy upgrade route.
- Core executor tests for drawdown-limit refusal, stale risk evidence, high-water updates on holds, and refusal before order authority.
- Independent Codex review: clean after resolving drawdown-policy and hold-high-water findings.
- Pre-push gate: green (ruff, format, pyright, repository lints, fast tests, smoke, frontend integrity gates).

Refs #2603
Refs #2525