### PR TITLE
test(#2833): freeze prospective core selection verdict

### DIFF
--- a/docs/proposals/ta/2026-08-24-core-selection-declaration.json
+++ b/docs/proposals/ta/2026-08-24-core-selection-declaration.json
@@ -9,6 +9,9 @@
   "completion_rule": "evaluate only at or after 00:00Z following the fifth common UTC observation date",
   "descriptive_percentile": "0.50",
   "evidence_not_before": "2026-08-25T00:00:00Z",
+  "eligibility_account_rule": "sole operator, provider etoro, environment demo, and the current non-revoked api_key and user_key credential ids",
+  "eligibility_environment": "demo",
+  "eligibility_provider": "etoro",
   "fx_rule": "every included observed row must have conversion_rate exactly 1; otherwise the candidate fails fx_unmodelled",
   "issue": 2833,
   "missingness_rule": "within each candidate/date interval from its first through last observed hourly bucket, every hourly bucket must exist and be observed; otherwise the candidate fails incomplete_population",
@@ -19,5 +22,6 @@
   "required_common_utc_dates": 5,
   "schema_version": "core-selection-2833-v1",
   "selection_rule": "among passing candidates choose the lowest p75 full round-trip spread bps; break an exact tie by ascending instrument_id",
-  "spread_metric": "strategy_core_quote_observations.spread_bps, the full bid-ask spread divided by midpoint in basis points"
+  "spread_metric": "strategy_core_quote_observations.spread_bps, the full bid-ask spread divided by midpoint in basis points",
+  "supersedes_declaration_sha256": "e935af30754a72b685097b650acb28a21017e1ba321e9a55fa903d771ea20649"
 }

--- a/docs/proposals/ta/2026-08-24-core-selection-declaration.json
+++ b/docs/proposals/ta/2026-08-24-core-selection-declaration.json
@@ -1,0 +1,23 @@
+{
+  "all_in_cost_rule": "p75_full_round_trip_spread_bps; documented entry-sizing conversion markup is 0 bps; carry is structural zero only for a real long at x1",
+  "binding_percentile": "0.75",
+  "candidate_ids": [
+    3417,
+    3434,
+    3075
+  ],
+  "completion_rule": "evaluate only at or after 00:00Z following the fifth common UTC observation date",
+  "descriptive_percentile": "0.50",
+  "evidence_not_before": "2026-08-25T00:00:00Z",
+  "fx_rule": "every included observed row must have conversion_rate exactly 1; otherwise the candidate fails fx_unmodelled",
+  "issue": 2833,
+  "missingness_rule": "within each candidate/date interval from its first through last observed hourly bucket, every hourly bucket must exist and be observed; otherwise the candidate fails incomplete_population",
+  "no_pass_action": "cash",
+  "pass_bar_bps": "60",
+  "percentile_method": "continuous linear interpolation at (n - 1) * p, matching PostgreSQL percentile_cont",
+  "population_rule": "all immutable hourly rows in each candidate/date interval on the first five common UTC dates at or after evidence_not_before",
+  "required_common_utc_dates": 5,
+  "schema_version": "core-selection-2833-v1",
+  "selection_rule": "among passing candidates choose the lowest p75 full round-trip spread bps; break an exact tie by ascending instrument_id",
+  "spread_metric": "strategy_core_quote_observations.spread_bps, the full bid-ask spread divided by midpoint in basis points"
+}

--- a/scripts/verify_2833_core_selection.py
+++ b/scripts/verify_2833_core_selection.py
@@ -1,0 +1,314 @@
+"""Open #2833's prospective core-sleeve cost verdict without tuning.
+
+The declaration starts after the already-seen 2026-08-24 observations.  Before
+five complete common UTC dates exist this script reports readiness only: it does
+not compute or reveal a candidate spread statistic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Final, Literal
+
+import psycopg
+from psycopg.rows import dict_row
+
+from app.config import settings
+from scripts._dev_guard import assert_dev_environment
+
+DECLARATION_PATH: Final = Path("docs/proposals/ta/2026-08-24-core-selection-declaration.json")
+# Filled from the exact declaration bytes before the prospective boundary.
+DECLARATION_SHA256: Final = "e935af30754a72b685097b650acb28a21017e1ba321e9a55fa903d771ea20649"
+
+Verdict = Literal["PASS", "FAIL"]
+
+
+@dataclass(frozen=True)
+class Observation:
+    instrument_id: int
+    symbol: str
+    sample_bucket: datetime
+    status: str
+    spread_bps: Decimal | None
+    conversion_rate: Decimal | None
+
+
+@dataclass(frozen=True)
+class Eligibility:
+    instrument_id: int
+    observed_at: datetime | None
+    verdict: str | None
+    settlement_type: str | None
+    direction: str | None
+    leverage_values: tuple[int, ...] | None
+    allow_open_position: bool | None
+    response_digest: str | None
+
+
+@dataclass(frozen=True)
+class CandidateVerdict:
+    instrument_id: int
+    symbol: str
+    row_count: int
+    median_spread_bps: Decimal
+    p75_spread_bps: Decimal
+    verdict: Verdict
+    refusals: tuple[str, ...]
+    eligibility_observed_at: datetime | None
+    eligibility_response_digest: str | None
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_declaration(path: Path = DECLARATION_PATH) -> Mapping[str, Any]:
+    actual = _sha256(path)
+    if actual != DECLARATION_SHA256:
+        raise RuntimeError(f"declaration digest mismatch: expected {DECLARATION_SHA256}, got {actual}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("declaration must be a JSON object")
+    return payload
+
+
+def percentile_cont(values: Sequence[Decimal], percentile: Decimal) -> Decimal:
+    """Continuous interpolation matching PostgreSQL ``percentile_cont``."""
+    if not values:
+        raise ValueError("percentile_cont requires at least one value")
+    if percentile < 0 or percentile > 1:
+        raise ValueError("percentile must be in [0, 1]")
+    ordered = sorted(values)
+    rank = Decimal(len(ordered) - 1) * percentile
+    lower = int(rank)
+    upper = lower if rank == lower else lower + 1
+    fraction = rank - Decimal(lower)
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def _common_dates(observations: Sequence[Observation], candidate_ids: Sequence[int]) -> tuple[date, ...]:
+    dates_by_id = {
+        instrument_id: {
+            row.sample_bucket.astimezone(UTC).date()
+            for row in observations
+            if row.instrument_id == instrument_id and row.status == "observed"
+        }
+        for instrument_id in candidate_ids
+    }
+    return tuple(sorted(set.intersection(*(dates_by_id[instrument_id] for instrument_id in candidate_ids))))
+
+
+def _population_for(
+    observations: Sequence[Observation],
+    *,
+    instrument_id: int,
+    selected_dates: Sequence[date],
+) -> tuple[list[Observation], list[str]]:
+    population: list[Observation] = []
+    refusals: list[str] = []
+    for selected_date in selected_dates:
+        day_rows = sorted(
+            (
+                row
+                for row in observations
+                if row.instrument_id == instrument_id and row.sample_bucket.astimezone(UTC).date() == selected_date
+            ),
+            key=lambda row: row.sample_bucket,
+        )
+        observed = [row for row in day_rows if row.status == "observed"]
+        if not observed:
+            refusals.append("incomplete_population")
+            continue
+        first = observed[0].sample_bucket
+        last = observed[-1].sample_bucket
+        interval = [row for row in day_rows if first <= row.sample_bucket <= last]
+        expected_buckets = int((last - first).total_seconds() // 3600) + 1
+        if len(interval) != expected_buckets or any(row.status != "observed" for row in interval):
+            refusals.append("incomplete_population")
+        population.extend(row for row in interval if row.status == "observed")
+    return population, refusals
+
+
+def evaluate(
+    observations: Sequence[Observation],
+    eligibilities: Mapping[int, Eligibility],
+    declaration: Mapping[str, Any],
+    *,
+    now: datetime,
+) -> Mapping[str, Any]:
+    candidate_ids = tuple(int(value) for value in declaration["candidate_ids"])
+    not_before = datetime.fromisoformat(str(declaration["evidence_not_before"]).replace("Z", "+00:00"))
+    eligible_rows = [row for row in observations if row.sample_bucket >= not_before]
+    common_dates = _common_dates(eligible_rows, candidate_ids)
+    required_dates = int(declaration["required_common_utc_dates"])
+    if len(common_dates) < required_dates:
+        return {
+            "schema_version": declaration["schema_version"],
+            "outcome": "evidence_collecting",
+            "common_dates_observed": len(common_dates),
+            "required_common_dates": required_dates,
+            "declaration_sha256": DECLARATION_SHA256,
+        }
+
+    selected_dates = common_dates[:required_dates]
+    opens_at = datetime.combine(selected_dates[-1] + timedelta(days=1), time.min, tzinfo=UTC)
+    if now.astimezone(UTC) < opens_at:
+        return {
+            "schema_version": declaration["schema_version"],
+            "outcome": "evidence_collecting",
+            "common_dates_observed": len(common_dates),
+            "required_common_dates": required_dates,
+            "verdict_opens_at": opens_at,
+            "declaration_sha256": DECLARATION_SHA256,
+        }
+
+    pass_bar = Decimal(str(declaration["pass_bar_bps"]))
+    candidates: list[CandidateVerdict] = []
+    for instrument_id in candidate_ids:
+        population, refusals = _population_for(
+            eligible_rows,
+            instrument_id=instrument_id,
+            selected_dates=selected_dates,
+        )
+        spreads = [row.spread_bps for row in population if row.spread_bps is not None]
+        if len(spreads) != len(population) or not spreads:
+            refusals.append("spread_unmeasured")
+        if any(row.conversion_rate != Decimal(1) for row in population):
+            refusals.append("fx_unmodelled")
+        eligibility = eligibilities.get(instrument_id)
+        if eligibility is None or (
+            eligibility.verdict != "underlying"
+            or eligibility.settlement_type != "real"
+            or eligibility.direction != "long"
+            or eligibility.leverage_values != (1,)
+            or eligibility.allow_open_position is not True
+        ):
+            refusals.append("not_proved_real_long_x1")
+        median = percentile_cont(spreads, Decimal("0.50")) if spreads else Decimal("NaN")
+        p75 = percentile_cont(spreads, Decimal("0.75")) if spreads else Decimal("NaN")
+        if p75.is_finite() and p75 > pass_bar:
+            refusals.append("cost_above_60_bps")
+        candidates.append(
+            CandidateVerdict(
+                instrument_id=instrument_id,
+                symbol=next(row.symbol for row in eligible_rows if row.instrument_id == instrument_id),
+                row_count=len(population),
+                median_spread_bps=median,
+                p75_spread_bps=p75,
+                verdict="FAIL" if refusals else "PASS",
+                refusals=tuple(sorted(set(refusals))),
+                eligibility_observed_at=None if eligibility is None else eligibility.observed_at,
+                eligibility_response_digest=None if eligibility is None else eligibility.response_digest,
+            )
+        )
+    passing = [candidate for candidate in candidates if candidate.verdict == "PASS"]
+    selected = min(passing, key=lambda candidate: (candidate.p75_spread_bps, candidate.instrument_id), default=None)
+    return {
+        "schema_version": declaration["schema_version"],
+        "outcome": "pass" if selected is not None else "cash",
+        "selected_instrument_id": None if selected is None else selected.instrument_id,
+        "selected_symbol": None if selected is None else selected.symbol,
+        "window_dates": [value.isoformat() for value in selected_dates],
+        "declaration_sha256": DECLARATION_SHA256,
+        "candidates": [asdict(candidate) for candidate in candidates],
+    }
+
+
+_OBSERVATIONS_SQL: Final = """
+SELECT o.instrument_id, i.symbol, o.sample_bucket,
+       o.observation_status AS status, o.spread_bps, o.conversion_rate
+FROM strategy_core_quote_observations o
+JOIN instruments i USING (instrument_id)
+WHERE o.instrument_id = ANY(%(candidate_ids)s)
+  AND o.sample_bucket >= %(not_before)s
+ORDER BY o.instrument_id, o.sample_bucket
+"""
+
+_ELIGIBILITY_SQL: Final = """
+SELECT DISTINCT ON (instrument_id)
+       instrument_id, observed_at, verdict, settlement_type, direction,
+       leverage_values, allow_open_position, response_digest
+FROM strategy_core_eligibility_proofs
+WHERE instrument_id = ANY(%(candidate_ids)s)
+ORDER BY instrument_id, observed_at DESC, core_eligibility_proof_id DESC
+"""
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(("git", *args), check=True, text=True, capture_output=True).stdout.strip()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, help="write the completed canonical JSON result")
+    args = parser.parse_args(argv)
+    declaration = load_declaration()
+    declaration_commit = _git("log", "-1", "--format=%H", "--", str(DECLARATION_PATH))
+    execution_commit = _git("rev-parse", "HEAD")
+    subprocess.run(("git", "merge-base", "--is-ancestor", declaration_commit, execution_commit), check=True)
+    not_before = datetime.fromisoformat(str(declaration["evidence_not_before"]).replace("Z", "+00:00"))
+    candidate_ids = [int(value) for value in declaration["candidate_ids"]]
+    assert_dev_environment()
+    with psycopg.connect(settings.database_url) as conn, conn.cursor(row_factory=dict_row) as cursor:
+        observation_rows = cursor.execute(
+            _OBSERVATIONS_SQL,
+            {"candidate_ids": candidate_ids, "not_before": not_before},
+        ).fetchall()
+        eligibility_rows = cursor.execute(_ELIGIBILITY_SQL, {"candidate_ids": candidate_ids}).fetchall()
+        now_row = cursor.execute("SELECT now() AS now").fetchone()
+        if now_row is None:
+            raise RuntimeError("database clock query returned no row")
+        now = now_row["now"]
+    observations = [Observation(**row) for row in observation_rows]
+    eligibilities = {
+        int(row["instrument_id"]): Eligibility(
+            instrument_id=int(row["instrument_id"]),
+            observed_at=row["observed_at"],
+            verdict=row["verdict"],
+            settlement_type=row["settlement_type"],
+            direction=row["direction"],
+            leverage_values=None if row["leverage_values"] is None else tuple(row["leverage_values"]),
+            allow_open_position=row["allow_open_position"],
+            response_digest=row["response_digest"],
+        )
+        for row in eligibility_rows
+    }
+    result = dict(evaluate(observations, eligibilities, declaration, now=now))
+    result.update(
+        declaration_commit=declaration_commit,
+        execution_commit=execution_commit,
+        measured_at=now,
+    )
+    encoded = json.dumps(result, sort_keys=True, separators=(",", ":"), default=str, allow_nan=False) + "\n"
+    if args.output is not None:
+        if result["outcome"] == "evidence_collecting":
+            raise RuntimeError("refusing to write a result before the declared population is complete")
+        args.output.write_text(encoded, encoding="utf-8")
+    sys.stdout.write(encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "DECLARATION_PATH",
+    "DECLARATION_SHA256",
+    "CandidateVerdict",
+    "Eligibility",
+    "Observation",
+    "evaluate",
+    "load_declaration",
+    "main",
+    "percentile_cont",
+]

--- a/scripts/verify_2833_core_selection.py
+++ b/scripts/verify_2833_core_selection.py
@@ -23,11 +23,13 @@ import psycopg
 from psycopg.rows import dict_row
 
 from app.config import settings
+from app.services.operators import sole_operator_id
 from scripts._dev_guard import assert_dev_environment
 
 DECLARATION_PATH: Final = Path("docs/proposals/ta/2026-08-24-core-selection-declaration.json")
 # Filled from the exact declaration bytes before the prospective boundary.
-DECLARATION_SHA256: Final = "e935af30754a72b685097b650acb28a21017e1ba321e9a55fa903d771ea20649"
+DECLARATION_SHA256: Final = "5f3929e035c35d25254747512a3327adcec1863b9a5a5eb028706fcb95a66804"
+VERIFIER_PATH: Final = Path("scripts/verify_2833_core_selection.py")
 
 Verdict = Literal["PASS", "FAIL"]
 
@@ -44,6 +46,7 @@ class Observation:
 
 @dataclass(frozen=True)
 class Eligibility:
+    proof_id: int
     instrument_id: int
     observed_at: datetime | None
     verdict: str | None
@@ -64,6 +67,7 @@ class CandidateVerdict:
     verdict: Verdict
     refusals: tuple[str, ...]
     eligibility_observed_at: datetime | None
+    eligibility_proof_id: int | None
     eligibility_response_digest: str | None
 
 
@@ -189,7 +193,8 @@ def evaluate(
             eligibility.verdict != "underlying"
             or eligibility.settlement_type != "real"
             or eligibility.direction != "long"
-            or eligibility.leverage_values != (1,)
+            or eligibility.leverage_values is None
+            or 1 not in eligibility.leverage_values
             or eligibility.allow_open_position is not True
         ):
             refusals.append("not_proved_real_long_x1")
@@ -207,6 +212,7 @@ def evaluate(
                 verdict="FAIL" if refusals else "PASS",
                 refusals=tuple(sorted(set(refusals))),
                 eligibility_observed_at=None if eligibility is None else eligibility.observed_at,
+                eligibility_proof_id=None if eligibility is None else eligibility.proof_id,
                 eligibility_response_digest=None if eligibility is None else eligibility.response_digest,
             )
         )
@@ -235,10 +241,24 @@ ORDER BY o.instrument_id, o.sample_bucket
 
 _ELIGIBILITY_SQL: Final = """
 SELECT DISTINCT ON (instrument_id)
+       core_eligibility_proof_id AS proof_id,
        instrument_id, observed_at, verdict, settlement_type, direction,
        leverage_values, allow_open_position, response_digest
 FROM strategy_core_eligibility_proofs
 WHERE instrument_id = ANY(%(candidate_ids)s)
+  AND operator_id = %(operator_id)s
+  AND provider = %(provider)s
+  AND environment = %(environment)s
+  AND api_key_credential_id = (
+      SELECT id FROM broker_credentials
+      WHERE operator_id = %(operator_id)s AND provider = %(provider)s
+        AND environment = %(environment)s AND label = 'api_key' AND revoked_at IS NULL
+  )
+  AND user_key_credential_id = (
+      SELECT id FROM broker_credentials
+      WHERE operator_id = %(operator_id)s AND provider = %(provider)s
+        AND environment = %(environment)s AND label = 'user_key' AND revoked_at IS NULL
+  )
 ORDER BY instrument_id, observed_at DESC, core_eligibility_proof_id DESC
 """
 
@@ -247,23 +267,48 @@ def _git(*args: str) -> str:
     return subprocess.run(("git", *args), check=True, text=True, capture_output=True).stdout.strip()
 
 
+def assert_verifier_sources_clean() -> None:
+    """Refuse provenance that labels uncommitted verifier bytes as ``HEAD``."""
+    result = subprocess.run(
+        ("git", "diff", "--quiet", "HEAD", "--", str(DECLARATION_PATH), str(VERIFIER_PATH)),
+        check=False,
+    )
+    if result.returncode == 0:
+        return
+    if result.returncode == 1:
+        raise RuntimeError("declaration or verifier differs from HEAD; commit before opening evidence")
+    raise RuntimeError(f"git diff failed with exit {result.returncode}")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", type=Path, help="write the completed canonical JSON result")
     args = parser.parse_args(argv)
+    assert_verifier_sources_clean()
     declaration = load_declaration()
     declaration_commit = _git("log", "-1", "--format=%H", "--", str(DECLARATION_PATH))
     execution_commit = _git("rev-parse", "HEAD")
     subprocess.run(("git", "merge-base", "--is-ancestor", declaration_commit, execution_commit), check=True)
     not_before = datetime.fromisoformat(str(declaration["evidence_not_before"]).replace("Z", "+00:00"))
     candidate_ids = [int(value) for value in declaration["candidate_ids"]]
+    provider = str(declaration["eligibility_provider"])
+    environment = str(declaration["eligibility_environment"])
     assert_dev_environment()
     with psycopg.connect(settings.database_url) as conn, conn.cursor(row_factory=dict_row) as cursor:
+        operator_id = sole_operator_id(conn)
         observation_rows = cursor.execute(
             _OBSERVATIONS_SQL,
             {"candidate_ids": candidate_ids, "not_before": not_before},
         ).fetchall()
-        eligibility_rows = cursor.execute(_ELIGIBILITY_SQL, {"candidate_ids": candidate_ids}).fetchall()
+        eligibility_rows = cursor.execute(
+            _ELIGIBILITY_SQL,
+            {
+                "candidate_ids": candidate_ids,
+                "operator_id": operator_id,
+                "provider": provider,
+                "environment": environment,
+            },
+        ).fetchall()
         now_row = cursor.execute("SELECT now() AS now").fetchone()
         if now_row is None:
             raise RuntimeError("database clock query returned no row")
@@ -271,6 +316,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     observations = [Observation(**row) for row in observation_rows]
     eligibilities = {
         int(row["instrument_id"]): Eligibility(
+            proof_id=int(row["proof_id"]),
             instrument_id=int(row["instrument_id"]),
             observed_at=row["observed_at"],
             verdict=row["verdict"],
@@ -287,6 +333,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         declaration_commit=declaration_commit,
         execution_commit=execution_commit,
         measured_at=now,
+        eligibility_provider=provider,
+        eligibility_environment=environment,
+        query_sha256=hashlib.sha256((_OBSERVATIONS_SQL + "\0" + _ELIGIBILITY_SQL).encode()).hexdigest(),
+        verifier_sha256=_sha256(VERIFIER_PATH),
     )
     encoded = json.dumps(result, sort_keys=True, separators=(",", ":"), default=str, allow_nan=False) + "\n"
     if args.output is not None:
@@ -307,6 +357,8 @@ __all__ = [
     "CandidateVerdict",
     "Eligibility",
     "Observation",
+    "VERIFIER_PATH",
+    "assert_verifier_sources_clean",
     "evaluate",
     "load_declaration",
     "main",

--- a/tests/test_2833_core_selection_verdict.py
+++ b/tests/test_2833_core_selection_verdict.py
@@ -17,6 +17,7 @@ from scripts.verify_2833_core_selection import (
 
 def _eligibility(instrument_id: int) -> Eligibility:
     return Eligibility(
+        proof_id=instrument_id,
         instrument_id=instrument_id,
         observed_at=datetime(2026, 8, 24, tzinfo=UTC),
         verdict="underlying",
@@ -56,6 +57,7 @@ def test_frozen_declaration_digest_is_intact() -> None:
     declaration = load_declaration(DECLARATION_PATH)
     assert declaration["schema_version"] == "core-selection-2833-v1"
     assert declaration["evidence_not_before"] == "2026-08-25T00:00:00Z"
+    assert declaration["eligibility_environment"] == "demo"
 
 
 def test_percentile_matches_continuous_n_minus_one_interpolation() -> None:
@@ -119,3 +121,17 @@ def test_unproved_product_cannot_pass_on_a_tight_spread() -> None:
     )
     iusa = next(row for row in result["candidates"] if row["instrument_id"] == 3075)
     assert "not_proved_real_long_x1" in iusa["refusals"]
+
+
+def test_x1_may_be_one_of_several_supported_leverages() -> None:
+    eligibilities = {instrument_id: _eligibility(instrument_id) for instrument_id in (3417, 3434, 3075)}
+    base = eligibilities[3434]
+    eligibilities[3434] = Eligibility(**{**base.__dict__, "leverage_values": (1, 2)})
+    result = evaluate(
+        _population(non_usd_id=3075),
+        eligibilities,
+        load_declaration(),
+        now=datetime(2026, 8, 30, tzinfo=UTC),
+    )
+    cspx = next(row for row in result["candidates"] if row["instrument_id"] == 3434)
+    assert "not_proved_real_long_x1" not in cspx["refusals"]

--- a/tests/test_2833_core_selection_verdict.py
+++ b/tests/test_2833_core_selection_verdict.py
@@ -1,0 +1,121 @@
+"""Pure contract checks for #2833's prospective selection readout."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from scripts.verify_2833_core_selection import (
+    DECLARATION_PATH,
+    Eligibility,
+    Observation,
+    evaluate,
+    load_declaration,
+    percentile_cont,
+)
+
+
+def _eligibility(instrument_id: int) -> Eligibility:
+    return Eligibility(
+        instrument_id=instrument_id,
+        observed_at=datetime(2026, 8, 24, tzinfo=UTC),
+        verdict="underlying",
+        settlement_type="real",
+        direction="long",
+        leverage_values=(1,),
+        allow_open_position=True,
+        response_digest=f"digest-{instrument_id}",
+    )
+
+
+def _population(*, days: int = 5, broken_id: int | None = None, non_usd_id: int | None = None) -> list[Observation]:
+    rows: list[Observation] = []
+    start = datetime(2026, 8, 25, 10, tzinfo=UTC)
+    symbols = {3417: "SPY.RTH", 3434: "CSPX.L", 3075: "IUSA.L"}
+    spreads = {3417: Decimal("4"), 3434: Decimal("2"), 3075: Decimal("1")}
+    for day in range(days):
+        for instrument_id, symbol in symbols.items():
+            for hour in range(3):
+                status = "invalid" if instrument_id == broken_id and day == 2 and hour == 1 else "observed"
+                rows.append(
+                    Observation(
+                        instrument_id=instrument_id,
+                        symbol=symbol,
+                        sample_bucket=start + timedelta(days=day, hours=hour),
+                        status=status,
+                        spread_bps=spreads[instrument_id] if status == "observed" else None,
+                        conversion_rate=(Decimal("0.013") if instrument_id == non_usd_id else Decimal(1))
+                        if status == "observed"
+                        else None,
+                    )
+                )
+    return rows
+
+
+def test_frozen_declaration_digest_is_intact() -> None:
+    declaration = load_declaration(DECLARATION_PATH)
+    assert declaration["schema_version"] == "core-selection-2833-v1"
+    assert declaration["evidence_not_before"] == "2026-08-25T00:00:00Z"
+
+
+def test_percentile_matches_continuous_n_minus_one_interpolation() -> None:
+    assert percentile_cont([Decimal("0"), Decimal("10")], Decimal("0.75")) == Decimal("7.50")
+
+
+def test_no_candidate_metrics_are_revealed_before_five_common_dates() -> None:
+    result = evaluate(
+        _population(days=4),
+        {instrument_id: _eligibility(instrument_id) for instrument_id in (3417, 3434, 3075)},
+        load_declaration(),
+        now=datetime(2026, 9, 1, tzinfo=UTC),
+    )
+    assert result["outcome"] == "evidence_collecting"
+    assert "candidates" not in result
+
+
+def test_fifth_date_stays_sealed_until_the_following_utc_midnight() -> None:
+    result = evaluate(
+        _population(),
+        {instrument_id: _eligibility(instrument_id) for instrument_id in (3417, 3434, 3075)},
+        load_declaration(),
+        now=datetime(2026, 8, 29, 23, 59, tzinfo=UTC),
+    )
+    assert result["outcome"] == "evidence_collecting"
+    assert "candidates" not in result
+
+
+def test_winner_is_lowest_p75_among_candidates_that_close_every_cost() -> None:
+    result = evaluate(
+        _population(non_usd_id=3075),
+        {instrument_id: _eligibility(instrument_id) for instrument_id in (3417, 3434, 3075)},
+        load_declaration(),
+        now=datetime(2026, 8, 30, tzinfo=UTC),
+    )
+    assert result["outcome"] == "pass"
+    assert result["selected_instrument_id"] == 3434
+    iusa = next(row for row in result["candidates"] if row["instrument_id"] == 3075)
+    assert iusa["refusals"] == ("fx_unmodelled",)
+
+
+def test_an_internal_missing_bucket_fails_the_candidate() -> None:
+    result = evaluate(
+        _population(broken_id=3434),
+        {instrument_id: _eligibility(instrument_id) for instrument_id in (3417, 3434, 3075)},
+        load_declaration(),
+        now=datetime(2026, 8, 30, tzinfo=UTC),
+    )
+    cspx = next(row for row in result["candidates"] if row["instrument_id"] == 3434)
+    assert "incomplete_population" in cspx["refusals"]
+
+
+def test_unproved_product_cannot_pass_on_a_tight_spread() -> None:
+    eligibilities = {instrument_id: _eligibility(instrument_id) for instrument_id in (3417, 3434, 3075)}
+    eligibilities.pop(3075)
+    result = evaluate(
+        _population(),
+        eligibilities,
+        load_declaration(),
+        now=datetime(2026, 8, 30, tzinfo=UTC),
+    )
+    iusa = next(row for row in result["candidates"] if row["instrument_id"] == 3075)
+    assert "not_proved_real_long_x1" in iusa["refusals"]


### PR DESCRIPTION
## What this does

Freezes the missing prospective #2833 selection/readout contract before any included observation exists, and adds the deterministic verifier that will open it after five complete common UTC dates.

- starts the admissible population at `2026-08-25T00:00:00Z`, excluding the already-seen 2026-08-24 observations;
- binds p75 full round-trip spread, the 60 bps pass bar, exact-USD conversion closure, complete hourly interiors, real/long/x1 eligibility, and a deterministic lowest-cost/tie-break selection;
- scopes eligibility to the sole operator's current eToro demo credential pair;
- reveals no candidate metrics before the fifth common date is complete;
- refuses dirty declaration/verifier sources and records declaration, verifier, query, proof and execution provenance;
- falls back to cash if no candidate passes.

Declaration SHA-256: `5f3929e035c35d25254747512a3327adcec1863b9a5a5eb028706fcb95a66804` at `a3f59454ac1a1c0c8234b5fe074aa3e7649d3400` (2026-08-24 22:35 UTC), before the declared boundary.

## Verification

- Full pre-push gate green on `a3f59454` (ruff, format, pyright, invariant lints, pure suite, DB smoke, frontend static gates).
- `uv run pytest -q tests/test_2833_core_selection_verdict.py` — 8 passed.
- Real dev-DB sealed invocation: `outcome=evidence_collecting`, `common_dates_observed=0`, `required_common_dates=5`; no candidate metrics emitted.
- Codex review round 1: three findings fixed in `a3f59454` (account scope, clean-source provenance, x1 membership).
- Codex review round 2: no actionable correctness defect.

No broker call, order, position change, mandate change, or other broker mutation occurs in this PR.

Refs #2833. Refs #2603.
