### PR TITLE
fix(#2603): expose core evidence coverage

### DIFF
--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as configApi from "@/api/config";
 import * as strategiesApi from "@/api/strategies";
-import type { StrategyOverviewResponse } from "@/api/types";
+import type { CoreSleeveResponse, StrategyOverviewResponse } from "@/api/types";
 import { BENCHMARK_REFUSALS } from "@/components/strategies/__fixtures__/benchmarkRefusals";
 import { StrategiesHubPage } from "@/pages/StrategiesHubPage";
 import { StrategyPortfolioLens } from "@/pages/StrategyPortfolioLens";
@@ -104,7 +104,29 @@ const CORE_COLLECTING = {
   required_trading_days: 5,
   observed_trading_days: 1,
   max_cost_bps: 60,
-  candidates: [],
+  candidates: [
+    {
+      instrument_id: 3417,
+      symbol: "SPY.RTH",
+      observed_trading_days: 1,
+      first_observed_date: "2026-08-25",
+      last_observed_date: "2026-08-25",
+    },
+    {
+      instrument_id: 3434,
+      symbol: "CSPX.L",
+      observed_trading_days: 0,
+      first_observed_date: null,
+      last_observed_date: null,
+    },
+    {
+      instrument_id: 3075,
+      symbol: "IUSA.L",
+      observed_trading_days: 0,
+      first_observed_date: null,
+      last_observed_date: null,
+    },
+  ],
   mandate: { configured: false },
   can_configure: false,
   can_enable_pool: false,
@@ -169,10 +191,90 @@ describe("StrategyPortfolioLens", () => {
   it("shows cash as the evidence-gated fallback instead of an approved strategy", async () => {
     renderLens();
     expect(await screen.findByRole("heading", { name: "Core & cash" })).toBeInTheDocument();
-    expect(screen.getByText("1 / 5")).toBeInTheDocument();
+    expect(screen.getAllByText("1 / 5")).toHaveLength(2);
     expect(screen.getByText("No sleeve adopted")).toBeInTheDocument();
     expect(screen.getByText(/cash remains the fallback/i)).toBeInTheDocument();
     expect(screen.getByText(/UK ISA at another broker tax-dominates/i)).toBeInTheDocument();
+    const coverage = screen.getByRole("table", { name: "Core candidate evidence coverage" });
+    expect(within(coverage).getByText("SPY.RTH")).toBeInTheDocument();
+    expect(within(coverage).getByText("25 Aug 2026 – 25 Aug 2026")).toBeInTheDocument();
+    expect(within(coverage).getAllByText("Awaiting first date")).toHaveLength(2);
+  });
+
+  it("refreshes the evidence status without hiding the current coverage", async () => {
+    const refreshed = {
+      ...CORE_COLLECTING,
+      observed_trading_days: 2,
+      candidates: CORE_COLLECTING.candidates.map((candidate) => ({
+        ...candidate,
+        observed_trading_days: 2,
+        first_observed_date: "2026-08-25",
+        last_observed_date: "2026-08-26",
+      })),
+      blockers: [{
+        code: "core_evidence_collecting",
+        detail: "#2833 has 2 of 5 required trading days; cash remains the fallback.",
+      }],
+    } as unknown as CoreSleeveResponse;
+    let finishRefresh!: (value: CoreSleeveResponse) => void;
+    vi.mocked(strategiesApi.fetchCoreSleeve)
+      .mockResolvedValueOnce(CORE_COLLECTING as never)
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        finishRefresh = resolve;
+      }));
+    renderLens();
+
+    await waitFor(() => expect(screen.getAllByText("1 / 5")).toHaveLength(2));
+    await userEvent.click(screen.getByRole("button", { name: "Refresh status" }));
+
+    expect(screen.getByRole("button", { name: "Refreshing…" })).toBeDisabled();
+    expect(screen.getByRole("table", { name: "Core candidate evidence coverage" })).toBeInTheDocument();
+    expect(screen.getAllByText("1 / 5")).toHaveLength(2);
+    await act(async () => finishRefresh(refreshed));
+    await waitFor(() => expect(strategiesApi.fetchCoreSleeve).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getAllByText("2 / 5")).toHaveLength(4));
+    const coverage = screen.getByRole("table", { name: "Core candidate evidence coverage" });
+    expect(within(coverage).getAllByText("25 Aug 2026 – 26 Aug 2026")).toHaveLength(3);
+  });
+
+  it("marks preserved status stale and withholds ready actions while refreshing", async () => {
+    let finishRefresh!: (value: CoreSleeveResponse) => void;
+    vi.mocked(strategiesApi.fetchCoreSleeve)
+      .mockResolvedValueOnce(CORE_READY as never)
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        finishRefresh = resolve;
+      }));
+    renderLens();
+
+    const rebalance = await screen.findByRole("button", { name: "Rebalance demo now" });
+    await userEvent.selectOptions(screen.getByLabelText("Risk profile"), "balanced");
+    const entries = screen.getByRole("checkbox", { name: "Allow new automated entries" });
+    expect(rebalance).not.toBeDisabled();
+    expect(entries).not.toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: "Refresh status" }));
+
+    expect(screen.getByText("Status is stale — refreshing")).toBeInTheDocument();
+    expect(rebalance).toBeDisabled();
+    expect(entries).toBeDisabled();
+    await act(async () => finishRefresh(CORE_READY as unknown as CoreSleeveResponse));
+    await waitFor(() => expect(rebalance).not.toBeDisabled());
+    expect(entries).not.toBeDisabled();
+  });
+
+  it("renders an actionable empty state when candidate coverage is unavailable", async () => {
+    vi.mocked(strategiesApi.fetchCoreSleeve).mockResolvedValue({
+      ...CORE_COLLECTING,
+      state: "unavailable",
+      candidates: [],
+      blockers: [{
+        code: "core_candidates_missing",
+        detail: "#2833 cannot collect evidence because candidate instrument ids are missing: 3417.",
+      }],
+    } as never);
+    renderLens();
+
+    expect(await screen.findByText(/candidate instrument ids are missing: 3417/i)).toBeInTheDocument();
+    expect(screen.getByText(/No candidate coverage is available; the blocker above names what must be restored/i)).toBeInTheDocument();
   });
 
   it("lets the operator save a disabled draft while evidence is still collecting", async () => {

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -26,11 +26,16 @@ import {
 } from "@/components/strategies/StrategyPortfolioPanels";
 import { Badge } from "@/components/ui/Badge";
 import { Modal } from "@/components/ui/Modal";
-import { formatMoney, formatNumber, formatPct } from "@/lib/format";
+import { formatDate, formatMoney, formatNumber, formatPct } from "@/lib/format";
 import { aggregate } from "@/lib/strategyAggregate";
 import { number } from "@/lib/strategyFormat";
 import { strategyPortfolioStatus } from "@/lib/strategyPortfolioStatus";
 import { useAsync } from "@/lib/useAsync";
+
+// The server currently returns exactly the three preregistered #2833
+// candidates. Keep a defensive render cap anyway: API array types carry no
+// size bound, and a malformed response must not create an unbounded DOM.
+const CORE_CANDIDATE_RENDER_CAP = 10;
 
 /**
  * The fenced-off pot — a control panel, not a status page (#2868, reshaped on
@@ -67,6 +72,53 @@ function BlockerRow({
         <span className="text-slate-700 dark:text-slate-200">{label}</span>
       </span>
       {action}
+    </div>
+  );
+}
+
+function CoreCandidateCoverageTable({ sleeve }: { sleeve: CoreSleeveResponse }) {
+  return (
+    <div className="mt-4 border-t border-slate-200 pt-3 dark:border-slate-800">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Candidate coverage</h3>
+      <p className="mt-1 text-xs text-slate-500">Overall evidence counts only dates shared by every candidate.</p>
+      <div className="mt-2 overflow-x-auto">
+        <table className="w-full text-left text-sm" aria-label="Core candidate evidence coverage">
+          <thead className="text-xs text-slate-500">
+            <tr>
+              <th scope="col" className="py-1 pr-4 font-medium">Instrument</th>
+              <th scope="col" className="py-1 pr-4 font-medium">Evidence</th>
+              <th scope="col" className="py-1 font-medium">Prospective dates</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sleeve.candidates.slice(0, CORE_CANDIDATE_RENDER_CAP).map((candidate) => (
+              <tr key={candidate.instrument_id} className="border-t border-slate-100 dark:border-slate-800">
+                <th scope="row" className="py-2 pr-4 font-semibold">{candidate.symbol}</th>
+                <td className="py-2 pr-4 tabular-nums">
+                  {candidate.observed_trading_days} / {sleeve.required_trading_days}
+                </td>
+                <td className="py-2 text-slate-500">
+                  {candidate.first_observed_date && candidate.last_observed_date
+                    ? `${formatDate(candidate.first_observed_date)} – ${formatDate(candidate.last_observed_date)}`
+                    : "Awaiting first date"}
+                </td>
+              </tr>
+            ))}
+            {sleeve.candidates.length === 0 ? (
+              <tr className="border-t border-slate-100 dark:border-slate-800">
+                <td colSpan={3} className="py-2 text-slate-500">
+                  No candidate coverage is available; the blocker above names what must be restored.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+      {sleeve.candidates.length > CORE_CANDIDATE_RENDER_CAP ? (
+        <p className="mt-2 text-xs text-slate-500">
+          Showing {CORE_CANDIDATE_RENDER_CAP} of {sleeve.candidates.length} candidates.
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -241,7 +293,7 @@ function CoreSleeveControl({
 
 export function StrategyPortfolioLens() {
   const overview = useAsync(fetchStrategyOverview, []);
-  const coreSleeve = useAsync(fetchCoreSleeve, []);
+  const coreSleeve = useAsync(fetchCoreSleeve, [], { preserveOnRefetch: true });
   const ownedPositions = useAsync(fetchStrategyOwnedPositions, []);
   const pnlHistory = useAsync(fetchStrategyPnlHistory, []);
   const [closeFor, setCloseFor] = useState<StrategyOwnedPosition | null>(null);
@@ -397,9 +449,22 @@ export function StrategyPortfolioLens() {
                     Deterministic fallback when no strategy has earned capital.
                   </p>
                 </div>
-                <Badge tone={coreSleeve.data.state === "ready" ? "ok" : "warn"}>
-                  {coreSleeve.data.state === "ready" ? "Ready" : "Cash"}
-                </Badge>
+                <div className="flex items-center gap-2">
+                  {coreSleeve.isRevalidating ? (
+                    <span className="text-xs text-amber-700 dark:text-amber-300">Status is stale — refreshing</span>
+                  ) : null}
+                  <button
+                    type="button"
+                    disabled={coreSleeve.isRevalidating}
+                    onClick={coreSleeve.refetch}
+                    className="min-h-11 rounded-md border border-slate-300 px-3 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700"
+                  >
+                    {coreSleeve.isRevalidating ? "Refreshing…" : "Refresh status"}
+                  </button>
+                  <Badge tone={coreSleeve.data.state === "ready" ? "ok" : "warn"}>
+                    {coreSleeve.data.state === "ready" ? "Ready" : "Cash"}
+                  </Badge>
+                </div>
               </div>
               <div className="mt-5 grid grid-cols-2 gap-x-6 sm:grid-cols-3">
                 <StatTile
@@ -426,12 +491,13 @@ export function StrategyPortfolioLens() {
                   <BlockerRow key={blocker.code} tone="warn" label={blocker.detail} />
                 ))}
               </div>
+              <CoreCandidateCoverageTable sleeve={coreSleeve.data} />
               <p className="mt-4 border-t border-slate-200 pt-3 text-xs text-slate-500 dark:border-slate-800">
                 Demo only · buy only · no alpha signal. {coreSleeve.data.household_tax_caveat}
               </p>
               <CoreSleeveControl
                 sleeve={coreSleeve.data}
-                busy={busy}
+                busy={busy || coreSleeve.isRevalidating}
                 setBusy={setBusy}
                 onError={setActionError}
                 onUpdated={() => {
@@ -445,7 +511,10 @@ export function StrategyPortfolioLens() {
           ) : null}
           <AutomationControl
             overview={data}
-            coreSleeve={coreSleeve.data}
+            // A preserved core snapshot is visibly stale during revalidation
+            // and must not authorise the independent core activation lane.
+            // Alpha readiness remains available from `overview` on its own.
+            coreSleeve={coreSleeve.isRevalidating ? null : coreSleeve.data}
             onUpdated={() => {
               void overview.refetch();
               void coreSleeve.refetch();


### PR DESCRIPTION
## What changed

- render each declared core candidate with its prospective date count and observed date range
- state that overall progress counts only dates shared by every candidate
- add an explicit status refresh that preserves the last confirmed readout while visibly marking it stale
- withhold core mandate, rebalance and core-based pool activation authority during that refresh
- handle missing and unexpectedly oversized candidate arrays without a dead-end or unbounded DOM

## Why

The API already carried the evidence needed to diagnose a stalled candidate, but the Portfolio page hid it behind one aggregate count. A page left open also had no way to re-read the multi-day collection state without a browser reload.

## Verification

- focused Portfolio interaction suite: 28 passed
- full frontend suite: 141 files / 1,625 tests passed
- frontend typecheck and dark/pill/chart integrity gates passed
- full repository pre-push gate passed

Refs #2603
Refs #2833