### PR TITLE
fix(#2603): show earliest core verdict boundary

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -1016,6 +1016,7 @@ class CoreSleeveResponse(BaseModel):
     evidence_ref: str | None
     required_trading_days: int
     observed_trading_days: int
+    earliest_possible_verdict_at: datetime
     max_cost_bps: int
     candidates: list[CoreCandidateCoverageResponse]
     mandate: CoreMandateResponse
@@ -3688,6 +3689,7 @@ def read_core_sleeve(
         evidence_ref=selection.evidence_ref,
         required_trading_days=selection.required_trading_days,
         observed_trading_days=selection.observed_trading_days,
+        earliest_possible_verdict_at=selection.earliest_possible_verdict_at,
         max_cost_bps=selection.max_cost_bps,
         candidates=[
             CoreCandidateCoverageResponse(

--- a/app/services/strategy_core_selection.py
+++ b/app/services/strategy_core_selection.py
@@ -15,6 +15,13 @@ CORE_SELECTION_MAX_COST_BPS: Final = 60
 # 2026-08-24 observations.  The operator surface must count the same population
 # the sealed verifier will open, or it reports progress that is not evidence.
 CORE_SELECTION_EVIDENCE_NOT_BEFORE: Final = datetime(2026, 8, 25, tzinfo=UTC)
+# Lower bound only, not an evidence-completion promise. The first five possible
+# common NYSE/LSE sessions after the prospective boundary are 25-28 August and
+# 1 September: LSE is closed for the 31 August Summer Bank Holiday, while NYSE
+# remains open. The frozen verdict opens at the following 00:00 UTC boundary.
+# Sources: londonstockexchange.com/equities-trading/business-days and
+# nyse.com/trade/hours-calendars (official venue calendars, checked 2026-08-24).
+CORE_SELECTION_EARLIEST_POSSIBLE_VERDICT_AT: Final = datetime(2026, 9, 2, tzinfo=UTC)
 
 # Populated only by the reviewed #2833 verdict. Choosing here before the
 # prospective five-day gate completes would be adoption before measurement.
@@ -53,6 +60,11 @@ class CoreSelection:
     @property
     def ready(self) -> bool:
         return self.state == "ready"
+
+    @property
+    def earliest_possible_verdict_at(self) -> datetime:
+        """Return #2833's calendar-derived lower bound, never a completion ETA."""
+        return CORE_SELECTION_EARLIEST_POSSIBLE_VERDICT_AT
 
 
 _COVERAGE_SQL: Final = """
@@ -162,6 +174,7 @@ def require_selected_core_instrument(conn: psycopg.Connection[Any], *, instrumen
 
 __all__ = [
     "CORE_SELECTION_CANDIDATE_IDS",
+    "CORE_SELECTION_EARLIEST_POSSIBLE_VERDICT_AT",
     "CORE_SELECTION_EVIDENCE_NOT_BEFORE",
     "CORE_SELECTION_MAX_COST_BPS",
     "CORE_SELECTION_REQUIRED_TRADING_DAYS",

--- a/docs/proposals/ta/2026-08-24-core-cash-operator.md
+++ b/docs/proposals/ta/2026-08-24-core-cash-operator.md
@@ -1,6 +1,6 @@
 # Core/cash operator surface and attended submitter (#2603)
 
-Status: proposed, 2026-08-24.
+Status: implemented; attended broker acceptance remains gated on #2833, 2026-08-25.
 
 ## Outcome
 
@@ -9,10 +9,19 @@ the programme's honest fallback — cash until the cap-weighted core sleeve pass
 preregistered cost gate — and, after that gate passes, let a named operator configure
 the mandate and request one guarded demo rebalance.
 
-This does **not** adopt a sleeve before #2833 has a verdict. On 2026-08-24 the dev store
-contains one trading day of observations and #2833 requires five; the earliest honest
-decision is 2026-08-28. Until a selected instrument is frozen in code from that verdict,
-the server reports `evidence_collecting`, offers no instrument and refuses enablement.
+This does **not** adopt a sleeve before #2833 has a verdict. The corrected prospective
+declaration excludes 2026-08-24 and requires the first five complete dates shared by all
+three candidates. The earliest possible verdict boundary is therefore
+`2026-09-02T00:00:00Z`: the first possible common sessions are 25-28 August and 1
+September because the LSE is closed for the 31 August Summer Bank Holiday. This is a
+lower bound, not a completion promise; incomplete or invalid observations move the
+verdict later. Until a selected instrument is frozen in code from that verdict, the
+server reports `evidence_collecting`, offers no instrument and refuses enablement.
+
+Calendar facts are from the official
+[LSE business-day calendar](https://www.londonstockexchange.com/equities-trading/business-days)
+and [NYSE hours and calendars](https://www.nyse.com/trade/hours-calendars), checked
+2026-08-24.
 
 ## Existing contracts retained
 
@@ -55,7 +64,8 @@ the server reports `evidence_collecting`, offers no instrument and refuses enabl
 One canonical operator view, assembled server-side:
 
 - selection: `evidence_collecting | ready | unavailable`, selected instrument identity
-  when frozen, evidence window/trading-day coverage and the #2833 threshold;
+  when frozen, evidence window/trading-day coverage, the calendar-derived earliest
+  possible verdict lower bound and the #2833 threshold;
 - current mandate revision (the existing `CoreMandateResponse` fields);
 - latest intent plus the independently selected blocking non-terminal core trade/order
   (which can belong to an older intent) and its reconciliation state;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2959,6 +2959,7 @@ export interface CoreSleeveResponse {
   evidence_ref: string | null;
   required_trading_days: number;
   observed_trading_days: number;
+  earliest_possible_verdict_at: string;
   max_cost_bps: number;
   candidates: Array<{
     instrument_id: number;

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -103,6 +103,7 @@ const CORE_COLLECTING = {
   evidence_ref: null,
   required_trading_days: 5,
   observed_trading_days: 1,
+  earliest_possible_verdict_at: "2026-09-02T00:00:00Z",
   max_cost_bps: 60,
   candidates: [
     {
@@ -193,6 +194,8 @@ describe("StrategyPortfolioLens", () => {
     expect(await screen.findByRole("heading", { name: "Core & cash" })).toBeInTheDocument();
     expect(screen.getAllByText("1 / 5")).toHaveLength(2);
     expect(screen.getByText("No sleeve adopted")).toBeInTheDocument();
+    expect(screen.getByText("02 Sept 2026")).toBeInTheDocument();
+    expect(screen.getByText(/Lower bound if all five common sessions complete/i)).toBeInTheDocument();
     expect(screen.getByText(/cash remains the fallback/i)).toBeInTheDocument();
     expect(screen.getByText(/UK ISA at another broker tax-dominates/i)).toBeInTheDocument();
     const coverage = screen.getByRole("table", { name: "Core candidate evidence coverage" });

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -466,7 +466,7 @@ export function StrategyPortfolioLens() {
                   </Badge>
                 </div>
               </div>
-              <div className="mt-5 grid grid-cols-2 gap-x-6 sm:grid-cols-3">
+              <div className="mt-5 grid grid-cols-2 gap-x-6 lg:grid-cols-4">
                 <StatTile
                   size="md"
                   label="Evidence"
@@ -478,6 +478,12 @@ export function StrategyPortfolioLens() {
                   label="Instrument"
                   value={coreSleeve.data.selected_symbol ?? "Cash"}
                   hint={coreSleeve.data.selected_symbol ? "Evidence-selected" : "No sleeve adopted"}
+                />
+                <StatTile
+                  size="md"
+                  label="Earliest verdict"
+                  value={formatDate(coreSleeve.data.earliest_possible_verdict_at)}
+                  hint="Lower bound if all five common sessions complete"
                 />
                 <StatTile
                   size="md"

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import inspect
 from contextlib import nullcontext
+from datetime import UTC, datetime
 from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any, cast
@@ -156,6 +157,7 @@ def test_collecting_state_reports_cash_and_server_derived_coverage(monkeypatch: 
     assert response.state == "evidence_collecting"
     assert response.selected_instrument_id is None
     assert response.observed_trading_days == 1
+    assert response.earliest_possible_verdict_at == datetime(2026, 9, 2, tzinfo=UTC)
     assert response.can_configure is False
     assert response.can_enable_pool is False
     assert response.can_rebalance is False


### PR DESCRIPTION
## Issue reference

Refs #2603.
Refs #2833.

## Summary

Expose the server-owned earliest possible #2833 verdict boundary on the Portfolio page and correct the stale operator spec. The value is explicitly a lower bound, not an evidence-completion estimate.

## Changes

- Pin `2026-09-02T00:00:00Z` from the first five possible common NYSE/LSE sessions after the prospective boundary, accounting for the LSE 31 August bank-holiday closure.
- Carry the boundary through `CoreSelection`, `GET /strategies/core-sleeve`, the frontend API type, and a dedicated page stat.
- Label the date as conditional on all five common sessions completing; incomplete or invalid observations still move the verdict later.
- Update the operator spec with official LSE and NYSE calendar sources and the corrected prospective-window facts.

## Invariants checked

- No instrument is selected and no execution action is enabled before the sealed #2833 verdict.
- Evidence progress remains the common-date intersection, not independent candidate counts.
- The displayed boundary is server-authored and UTC-stable; the frontend does not calculate a trading calendar.
- Existing stale-status action withholding remains unchanged.

## Security and audit model

No execution path touched. The kill switch, capital sandbox, demo-only gate, mandate selection invariant, submission lock, execution guard, and decision audit remain unchanged.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not db"` — 9,826 passed, 14 skipped
- `uv run pytest tests/smoke` — 161 passed, 3 skipped
- targeted core API/selection/verdict tests — 36 passed
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend test:unit` — 1,623 passed
- `pnpm --dir frontend test` — 1,625 passed
- `codex exec review --base origin/main` — no actionable correctness issue

## Checklist

- [x] Branch named `fix/2603-earliest-core-verdict`
- [x] No raw user input or database write added
- [x] No order placement path changed or bypassed
- [x] Required local gates pass
- [ ] CI checks pass