### PR TITLE
Align core sleeve ISA caveat with quantified verdict

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -1031,7 +1031,9 @@ class CoreSleeveResponse(BaseModel):
     buy_only: bool = True
     alpha_input_used: bool = False
     household_tax_caveat: str = (
-        "A UK ISA at another broker tax-dominates this engine sleeve for eligible household capital."
+        "No supported public-API route into eToro's Stocks & Shares ISA is established. "
+        "Compare an ISA elsewhere using personal tax, FX and dealing costs, and expected turnover; "
+        "#2915's £50,000 sensitivity was mixed, not a universal ISA advantage."
     )
 
 

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -142,7 +142,8 @@ const CORE_COLLECTING = {
   environment: "demo",
   buy_only: true,
   alpha_input_used: false,
-  household_tax_caveat: "A UK ISA at another broker tax-dominates this engine sleeve for eligible household capital.",
+  household_tax_caveat:
+    "No supported public-API route into eToro's Stocks & Shares ISA is established. Compare an ISA elsewhere using personal tax, FX and dealing costs, and expected turnover; #2915's £50,000 sensitivity was mixed, not a universal ISA advantage.",
 } as const;
 
 const CORE_READY = {
@@ -197,7 +198,8 @@ describe("StrategyPortfolioLens", () => {
     expect(screen.getByText("02 Sept 2026")).toBeInTheDocument();
     expect(screen.getByText(/Lower bound if all five common sessions complete/i)).toBeInTheDocument();
     expect(screen.getByText(/cash remains the fallback/i)).toBeInTheDocument();
-    expect(screen.getByText(/UK ISA at another broker tax-dominates/i)).toBeInTheDocument();
+    expect(screen.getByText(/No supported public-API route into eToro's Stocks & Shares ISA/i)).toBeInTheDocument();
+    expect(screen.getByText(/£50,000 sensitivity was mixed, not a universal ISA advantage/i)).toBeInTheDocument();
     const coverage = screen.getByRole("table", { name: "Core candidate evidence coverage" });
     expect(within(coverage).getByText("SPY.RTH")).toBeInTheDocument();
     expect(within(coverage).getByText("25 Aug 2026 – 25 Aug 2026")).toBeInTheDocument();

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -163,6 +163,9 @@ def test_collecting_state_reports_cash_and_server_derived_coverage(monkeypatch: 
     assert response.can_rebalance is False
     assert response.can_resume is False
     assert response.execution_action == "blocked"
+    assert "No supported public-API route into eToro's Stocks & Shares ISA" in response.household_tax_caveat
+    assert "#2915's £50,000 sensitivity was mixed" in response.household_tax_caveat
+    assert "tax-dominates" not in response.household_tax_caveat
     assert [blocker.code for blocker in response.blockers] == [
         "core_paper_pool_unconfigured",
         "core_evidence_collecting",


### PR DESCRIPTION
Fixes #2936.
Refs #2603.
Refs #2915.

## What

Replaces the unconditional claim that an ISA elsewhere `tax-dominates` the engine sleeve with the facts established in #2915:

- no supported public-API route into eToro’s Stocks & Shares ISA is established
- an ISA elsewhere must be compared using personal tax, FX/dealing costs and expected turnover
- the frozen £50,000 sensitivity was mixed rather than a universal ISA advantage

The server response and rendered page contract both pin the corrected wording and explicitly reject the old phrase.

## Safety

Copy and contract tests only. No strategy evidence, mandate, capital, execution, safety-control or broker behavior changes.

## Verification

- Ruff and formatting checks
- pyright: 0 errors
- rendered `StrategyPortfolioLens`: 28 passed
- core mandate/API: 22 passed
- complete repository pre-push hook: green