### PR TITLE
Expose core mandate units on Portfolio page

### DIFF
--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -200,6 +200,9 @@ describe("StrategyPortfolioLens", () => {
     expect(screen.getByText(/cash remains the fallback/i)).toBeInTheDocument();
     expect(screen.getByText(/No supported public-API route into eToro's Stocks & Shares ISA/i)).toBeInTheDocument();
     expect(screen.getByText(/£50,000 sensitivity was mixed, not a universal ISA advantage/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Minimum cash reserve %")).toHaveValue(10);
+    expect(screen.getByLabelText("Rebalance band (pp)")).toHaveValue(5);
+    expect(screen.getByLabelText("Minimum amount (USD)")).toHaveValue(25);
     const coverage = screen.getByRole("table", { name: "Core candidate evidence coverage" });
     expect(within(coverage).getByText("SPY.RTH")).toBeInTheDocument();
     expect(within(coverage).getByText("25 Aug 2026 – 25 Aug 2026")).toBeInTheDocument();

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -218,9 +218,9 @@ function CoreSleeveControl({
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {[
             ["Core target %", target, setTarget],
-            ["Cash reserve %", reserve, setReserve],
-            ["Rebalance band %", band, setBand],
-            ["Minimum amount", minimum, setMinimum],
+            ["Minimum cash reserve %", reserve, setReserve],
+            ["Rebalance band (pp)", band, setBand],
+            ["Minimum amount (USD)", minimum, setMinimum],
           ].map(([label, value, setter]) => (
             <label key={label as string} className="text-xs font-medium text-slate-600 dark:text-slate-300">
               {label as string}


### PR DESCRIPTION
Fixes #2938.
Refs #2603.

## What

Makes the core/cash mandate controls state the server’s existing semantics:

- `Minimum cash reserve %` — a minimum, not a target
- `Rebalance band (pp)` — absolute percentage-point drift
- `Minimum amount (USD)` — fixed mandate base currency

All three labels and default displayed values are pinned in the rendered page contract.

## Safety

UI copy and test only. No defaults, arithmetic, API, evidence, capital, safety-control, or broker path changes.

## Verification

- rendered `StrategyPortfolioLens`: 28 passed
- TypeScript `--noEmit`: green
- complete repository pre-push hook: green