### PR TITLE
Clarify provisional core evidence dates

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -3620,8 +3620,9 @@ def read_core_sleeve(
                 CoreSleeveBlockerResponse(
                     code="core_evidence_collecting",
                     detail=(
-                        f"#2833 has {selection.observed_trading_days} of "
-                        f"{selection.required_trading_days} required trading days; cash remains the fallback."
+                        f"#2833 has observations on {selection.observed_trading_days} of "
+                        f"{selection.required_trading_days} required common dates. The sealed verifier checks "
+                        "the complete populations after the fifth date closes; cash remains the fallback."
                     ),
                 )
             )

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -136,7 +136,10 @@ const CORE_COLLECTING = {
   pending_order_id: null,
   execution_action: "blocked",
   blockers: [
-    { code: "core_evidence_collecting", detail: "#2833 has 1 of 5 required trading days; cash remains the fallback." },
+    {
+      code: "core_evidence_collecting",
+      detail: "#2833 has observations on 1 of 5 required common dates. The sealed verifier checks the complete populations after the fifth date closes; cash remains the fallback.",
+    },
     { code: "core_mandate_unconfigured", detail: "No core/cash mandate has been configured." },
   ],
   environment: "demo",
@@ -193,6 +196,8 @@ describe("StrategyPortfolioLens", () => {
   it("shows cash as the evidence-gated fallback instead of an approved strategy", async () => {
     renderLens();
     expect(await screen.findByRole("heading", { name: "Core & cash" })).toBeInTheDocument();
+    expect(screen.getByText("Common dates seen")).toBeInTheDocument();
+    expect(screen.getByText("Provisional until the sealed verifier opens")).toBeInTheDocument();
     expect(screen.getAllByText("1 / 5")).toHaveLength(2);
     expect(screen.getByText("No sleeve adopted")).toBeInTheDocument();
     expect(screen.getByText("02 Sept 2026")).toBeInTheDocument();
@@ -221,7 +226,7 @@ describe("StrategyPortfolioLens", () => {
       })),
       blockers: [{
         code: "core_evidence_collecting",
-        detail: "#2833 has 2 of 5 required trading days; cash remains the fallback.",
+        detail: "#2833 has observations on 2 of 5 required common dates. The sealed verifier checks the complete populations after the fifth date closes; cash remains the fallback.",
       }],
     } as unknown as CoreSleeveResponse;
     let finishRefresh!: (value: CoreSleeveResponse) => void;

--- a/frontend/src/pages/StrategyPortfolioLens.test.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.test.tsx
@@ -209,6 +209,7 @@ describe("StrategyPortfolioLens", () => {
     expect(screen.getByLabelText("Rebalance band (pp)")).toHaveValue(5);
     expect(screen.getByLabelText("Minimum amount (USD)")).toHaveValue(25);
     const coverage = screen.getByRole("table", { name: "Core candidate evidence coverage" });
+    expect(within(coverage).getByRole("columnheader", { name: "Dates seen" })).toBeInTheDocument();
     expect(within(coverage).getByText("SPY.RTH")).toBeInTheDocument();
     expect(within(coverage).getByText("25 Aug 2026 – 25 Aug 2026")).toBeInTheDocument();
     expect(within(coverage).getAllByText("Awaiting first date")).toHaveLength(2);

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -86,7 +86,7 @@ function CoreCandidateCoverageTable({ sleeve }: { sleeve: CoreSleeveResponse }) 
           <thead className="text-xs text-slate-500">
             <tr>
               <th scope="col" className="py-1 pr-4 font-medium">Instrument</th>
-              <th scope="col" className="py-1 pr-4 font-medium">Evidence</th>
+              <th scope="col" className="py-1 pr-4 font-medium">Dates seen</th>
               <th scope="col" className="py-1 font-medium">Prospective dates</th>
             </tr>
           </thead>

--- a/frontend/src/pages/StrategyPortfolioLens.tsx
+++ b/frontend/src/pages/StrategyPortfolioLens.tsx
@@ -469,9 +469,9 @@ export function StrategyPortfolioLens() {
               <div className="mt-5 grid grid-cols-2 gap-x-6 lg:grid-cols-4">
                 <StatTile
                   size="md"
-                  label="Evidence"
+                  label="Common dates seen"
                   value={`${coreSleeve.data.observed_trading_days} / ${coreSleeve.data.required_trading_days}`}
-                  hint="Trading days"
+                  hint="Provisional until the sealed verifier opens"
                 />
                 <StatTile
                   size="md"


### PR DESCRIPTION
## Summary

- rename the Portfolio evidence stat from an implied completed trading-day count to `Common dates seen`
- state that the visible count remains provisional until the sealed verifier opens
- make the server-authored blocker explain that #2833 checks complete populations only after the fifth date closes

## Why

The first prospective common date became visible at 14:23 UTC on 2026-08-25 as soon as each frozen candidate had an observed bucket. That is the correct progress count, but the existing `Trading days` hint and `has 1 of 5 required trading days` blocker overstated it: the date is not final evidence until its session has completed, the following UTC boundary has passed, and the sealed verifier has checked the full internal population. Actions already fail closed; this change makes the operator copy equally precise.

## Verification

- `uv run pytest -q tests/test_2603_core_selection.py tests/test_2603_core_mandate_api.py` — 28 passed
- `npm test -- --run src/pages/StrategyPortfolioLens.test.tsx` — 28 passed
- mandatory pre-push gate — green (ruff, format, pyright, invariant lints, full non-DB tier, smoke and frontend checks)
- live source state at discovery: common date 1/5, candidate intervals internally continuous, sealed verifier unopened

## Safety

Copy and test change only. No evidence row, declaration, verifier, mandate, capital boundary, kill switch or broker state is changed.

Refs #2603. Refs #2833.
