### PR TITLE
Mark the pre-recovery R6 verdict superseded

### DIFF
--- a/docs/proposals/ta/2026-08-23-r6-programme-verdict.md
+++ b/docs/proposals/ta/2026-08-23-r6-programme-verdict.md
@@ -1,6 +1,17 @@
-# R6 programme verdict and sleeve specification (#2899)
+# Historical R6 programme verdict before point-in-time recovery (#2899)
 
-Verdict: **NO DEPLOYABLE R6 SLEEVE — ALLOCATION £0**.
+> **SUPERSEDED 2026-08-24. Do not use this document as the current sleeve
+> specification.** #2900 was subsequently repaired and passed its adversarial
+> leak test, and #2908 then completed a frozen full-population cycle. The
+> authoritative verdict is
+> [`2026-08-24-r6-sleeve-verdict.md`](2026-08-24-r6-sleeve-verdict.md): R6 still
+> receives £0, but because its exclusion overlay lost to identical annual 1/N,
+> not because no arm could be measured.
+
+The remainder records the earlier 2026-08-23 gate verdict for audit history.
+Its present-tense claims must be read as historical statements at that date.
+
+Historical verdict as of 2026-08-23: **NO DEPLOYABLE R6 SLEEVE — ALLOCATION £0**.
 
 This is the programme's permitted no-sleeve ending, not a strategy failure or
 a zero-return backtest. The point-in-time gate failed before any Tier 2 arm

--- a/docs/proposals/ta/2026-08-24-r6-sleeve-verdict.md
+++ b/docs/proposals/ta/2026-08-24-r6-sleeve-verdict.md
@@ -1,5 +1,10 @@
 # R6 deployable-sleeve verdict after #2908
 
+Status: **AUTHORITATIVE CURRENT R6 VERDICT.** This supersedes
+[`2026-08-23-r6-programme-verdict.md`](2026-08-23-r6-programme-verdict.md),
+whose no-arm rationale predated the repaired #2900 point-in-time path and the
+completed #2908 cycle.
+
 Verdict: **£0 — NO ACTIVE R6 SLEEVE IS JUSTIFIED**
 
 The research cycle found a clean point-in-time spine and an apparent robust return versus literal buy-and-hold,


### PR DESCRIPTION
## Summary

- mark the 23 August no-arm verdict as historical and superseded
- point it to the authoritative 24 August post-#2908 sleeve verdict
- mark the recovered verdict itself as the current authoritative R6 specification

## Why

The earlier document correctly recorded the state before #2900 was repaired, but it still says no Tier 2 arm was measured and did not identify itself as obsolete. #2924 later completed the repaired point-in-time path and the frozen #2908 cycle. Both documents still conclude £0, but for materially different reasons. An operator must not mistake the historical no-data rationale for the current evidence that the exclusion overlay lost to identical annual 1/N.

## Verification

- cross-links are relative links between files in the same directory
- `git diff --check` passed
- mandatory pre-push gate passed in full

## Scope

Documentation provenance only. No declaration, result, allocation, mandate, evidence, control or broker state changes.

Refs #2899. Refs #2900. Refs #2908.
